### PR TITLE
 Updated model as per TAPI calls discussions (Aug 29, 2018 week)

### DIFF
--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -119,7 +119,10 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bfKooKeTEeeBGPv_1DT5og" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bfMd0KeTEeeBGPv_1DT5og" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xu4AcIk4Eeil5oKL3Vgl-g" name="supportedLayerProtocolQualifier" type="_-eq88Ik2Eeil5oKL3Vgl-g" isReadOnly="true"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xu4AcIk4Eeil5oKL3Vgl-g" name="supportedLayerProtocolQualifier" type="_-eq88Ik2Eeil5oKL3Vgl-g" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_N1oGwJWWEei22OmXOLe8nA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_N6FI8JWWEei22OmXOLe8nA" value="*"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_S3giA-_tEeWLlrwIF3w0vA" name="_state" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_S3giAO_tEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_AFxHsEwDEeewALXL7BvPYw" name="_capacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_AFtdUEwDEeewALXL7BvPYw"/>
       </packagedElement>

--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
   <notation:Diagram xmi:id="_w3tFAI6QEeeyZasfnNSonw" type="PapyrusUMLClassDiagram" name="PhotonicTypes" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_xnJk8I6QEeeyZasfnNSonw" type="DataType_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xnKMAI6QEeeyZasfnNSonw" type="DataType_NameLabel"/>
@@ -837,7 +837,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BQUWYnjqEeiO-c_khjKlFQ" x="-59" y="-447"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8QyEXiGEeiPPoPDo3q5jA" x="-269" y="-457" width="159" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8QyEXiGEeiPPoPDo3q5jA" x="-210" y="-456" width="351" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EqrGYHiHEeiPPoPDo3q5jA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_EqrtcHiHEeiPPoPDo3q5jA" type="Class_NameLabel"/>
@@ -899,6 +899,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_7gkK0I50EeeyZasfnNSonw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_UKIvVXZpEeiPPoPDo3q5jA"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_nIXsgJmrEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_l6_TYJmrEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nIXsgZmrEeiOmuqNbykpsw"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_NhvNtniHEeiPPoPDo3q5jA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_NhvNt3iHEeiPPoPDo3q5jA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_NhvNuHiHEeiPPoPDo3q5jA"/>
@@ -917,7 +921,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nhv0yXiHEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-350" y="-61" height="94"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-347" y="-42" height="109"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Nh1UVXiHEeiPPoPDo3q5jA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Nh1UVniHEeiPPoPDo3q5jA" showTitle="true"/>
@@ -975,7 +979,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7No-8HjAEeixydPRZ8lIKA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NoX0XjAEeixydPRZ8lIKA" x="225" y="-446" width="189" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NoX0XjAEeixydPRZ8lIKA" x="430" y="-457" width="595" height="67"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_7Nz-AHjAEeixydPRZ8lIKA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_7Nz-AXjAEeixydPRZ8lIKA" showTitle="true"/>
@@ -1011,6 +1015,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_aZkrcnk6EeiO-c_khjKlFQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_lOxTYXk6EeiO-c_khjKlFQ"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_KydRwJmpEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_w_nl05moEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_KydRwZmpEeiOmuqNbykpsw"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_O0bY1HkwEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_O0bY1XkwEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_O0bY1nkwEeiO-c_khjKlFQ"/>
@@ -1029,7 +1037,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0bY4XkwEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0VSMXkwEeiO-c_khjKlFQ" x="204" y="-297" height="71"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0VSMXkwEeiO-c_khjKlFQ" x="323" y="-297" height="80"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_O0hfiXkwEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_O0hfinkwEeiO-c_khjKlFQ" showTitle="true"/>
@@ -1057,6 +1065,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_MpIOQI51EeeyZasfnNSonw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="__0ThMXkyEeiO-c_khjKlFQ"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_lgWV4JmXEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_kt1T0JmXEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgWV4ZmXEeiOmuqNbykpsw"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_-Be4tnkyEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_-Be4t3kyEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_-Be4uHkyEeiO-c_khjKlFQ"/>
@@ -1075,7 +1087,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Be4w3kyEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Be4sXkyEeiO-c_khjKlFQ" x="-208" y="-140" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Be4sXkyEeiO-c_khjKlFQ" x="-167" y="-141" width="300" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_-BrF_HkyEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_-BrF_XkyEeiO-c_khjKlFQ" showTitle="true"/>
@@ -1125,7 +1137,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVoZYXk6EeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVnyQXk6EeiO-c_khjKlFQ" x="149" y="-62" width="373" height="116"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVnyQXk6EeiO-c_khjKlFQ" x="268" y="-62" width="373" height="116"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_XVyKYnk6EeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_XVyKY3k6EeiO-c_khjKlFQ" showTitle="true"/>
@@ -1167,6 +1179,214 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BEy6ZYuXEeiu6boZkiJHCA" x="404" y="-397"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_s3mNEJmTEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_s3sTsJmTEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_s3sTsZmTEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_s3sTspmTEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s3sTs5mTEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_FbD70JmUEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_8Tky45mTEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FbD70ZmUEeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s3sTtJmTEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s3sTtZmTEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s3sTtpmTEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3sTt5mTEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s3sTuJmTEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s3sTuZmTEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s3sTupmTEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s3sTu5mTEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3sTvJmTEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s3sTvZmTEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s3sTvpmTEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s3sTv5mTEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s3sTwJmTEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3sTwZmTEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3mNEZmTEeiOmuqNbykpsw" x="8" y="-304" height="66"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_s34g_pmTEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_s34g_5mTEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s34hAZmTEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s34hAJmTEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O4N9U5mVEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_O4N9VJmVEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O4N9VpmVEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O4N9VZmVEeiOmuqNbykpsw" x="164" y="-407"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XSxHw5mVEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XSxHxJmVEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XSxHxpmVEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XSxHxZmVEeiOmuqNbykpsw" x="164" y="-407"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EtIM4JmWEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EtIM4pmWEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EtIM45mWEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EtIM5JmWEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EtIM5ZmWEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_zAoOkJmYEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_nWzrw5mYEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zAoOkZmYEeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EtIM5pmWEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EtIM55mWEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EtIM6JmWEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM6ZmWEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EtIM6pmWEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EtIM65mWEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EtIM7JmWEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EtIM7ZmWEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM7pmWEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EtIM75mWEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EtIM8JmWEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EtIM8ZmWEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EtIM8pmWEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM85mWEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM4ZmWEeiOmuqNbykpsw" x="620" y="-295" width="280" height="67"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EtUaK5mWEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EtUaLJmWEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtUaLpmWEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtUaLZmWEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aw4GAJmYEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_aw4GApmYEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_aw4GA5mYEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_aw4GBJmYEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aw4GBZmYEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_jpxZUJmYEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_i18IoJmYEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jpxZUZmYEeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aw4GBpmYEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aw4GB5mYEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aw4GCJmYEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GCZmYEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aw4GCpmYEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aw4GC5mYEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aw4GDJmYEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aw4GDZmYEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GDpmYEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aw4GD5mYEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aw4GEJmYEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aw4GEZmYEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aw4GEpmYEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GE5mYEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GAZmYEeiOmuqNbykpsw" x="713" y="-127" width="308" height="63"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_axWnOZmYEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_axWnOpmYEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_axWnPJmYEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_axWnO5mYEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NCf3MJmoEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NCf3MpmoEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NCf3M5moEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NCf3NJmoEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NCf3NZmoEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Rqh80JmpEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_djchApmoEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rqh80ZmpEeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NCf3NpmoEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NCf3N5moEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NCf3OJmoEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NCf3OZmoEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NCf3OpmoEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NCf3O5moEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NCf3PJmoEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NCf3PZmoEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NCf3PpmoEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NCf3P5moEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NCf3QJmoEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NCf3QZmoEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NCf3QpmoEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NCf3Q5moEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NCZwkJmoEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NCf3MZmoEeiOmuqNbykpsw" x="918" y="-294" width="262" height="66"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NCsEiZmoEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NCsEipmoEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NCsEjJmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NCZwkJmoEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NCsEi5moEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_88g1o5moEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_88g1pJmoEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_88g1ppmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_88g1pZmoEeiOmuqNbykpsw" x="820" y="-395"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-IZZ85moEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-IZZ9JmoEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-IZZ9pmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_djQTwJmoEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-IZZ9ZmoEeiOmuqNbykpsw" x="1118" y="-394"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JEWKI5mpEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JEWKJJmpEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JEWKJpmpEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_w_nl0JmoEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JEWKJZmpEeiOmuqNbykpsw" x="523" y="-397"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_60fHQJmqEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_60fHQZmqEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_60fHQ5mqEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60fHQpmqEeiOmuqNbykpsw" x="820" y="-395"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FAuRw5mrEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FAuRxJmrEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FAuRxpmrEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_7n9LkJmqEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FAuRxZmrEeiOmuqNbykpsw" x="1118" y="-394"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_41c6YIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -1196,17 +1416,17 @@
     <edges xmi:type="notation:Connector" xmi:id="_Y9rskHiHEeiPPoPDo3q5jA" type="Abstraction_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_-8QyEHiGEeiPPoPDo3q5jA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Y9rsk3iHEeiPPoPDo3q5jA" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DoHywIuXEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y9rslHiHEeiPPoPDo3q5jA" x="21" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y9rslHiHEeiPPoPDo3q5jA" x="9" y="5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Y9rslXiHEeiPPoPDo3q5jA" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Dphg8IuXEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y9rslniHEeiPPoPDo3q5jA" x="1" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y9rslniHEeiPPoPDo3q5jA" x="-17" y="3"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Y9rskXiHEeiPPoPDo3q5jA"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y9rskniHEeiPPoPDo3q5jA" points="[-184, -319, -643984, -643984]$[-184, -395, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4HiHEeiPPoPDo3q5jA" id="(0.49122807017543857,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4XiHEeiPPoPDo3q5jA" id="(0.5345911949685535,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y9rskniHEeiPPoPDo3q5jA" points="[-160, -319, -643984, -643984]$[-160, -394, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4HiHEeiPPoPDo3q5jA" id="(0.49097472924187724,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4XiHEeiPPoPDo3q5jA" id="(0.14245014245014245,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_a58k9HiHEeiPPoPDo3q5jA" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_a58k8HiHEeiPPoPDo3q5jA">
       <styles xmi:type="notation:FontStyle" xmi:id="_a58k9XiHEeiPPoPDo3q5jA"/>
@@ -1255,13 +1475,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Xq0xxXkwEeiO-c_khjKlFQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_C85rgIuXEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xq0xxnkwEeiO-c_khjKlFQ" x="-13" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xq0xxnkwEeiO-c_khjKlFQ" x="-9" y="-6"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Xq0xwXkwEeiO-c_khjKlFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xq0xwnkwEeiO-c_khjKlFQ" points="[315, -297, -643984, -643984]$[315, -379, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrlmwHkwEeiO-c_khjKlFQ" id="(0.46835443037974683,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrlmwXkwEeiO-c_khjKlFQ" id="(0.47619047619047616,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xq0xwnkwEeiO-c_khjKlFQ" points="[485, -297, -643984, -643984]$[485, -390, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrlmwHkwEeiO-c_khjKlFQ" id="(0.6274509803921569,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrlmwXkwEeiO-c_khjKlFQ" id="(0.08907563025210084,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_cPqO53kwEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_cPqO43kwEeiO-c_khjKlFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_cPqO6HkwEeiO-c_khjKlFQ"/>
@@ -1305,28 +1525,34 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7cWEIIuWEeiu6boZkiJHCA" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_NhvNsHiHEeiPPoPDo3q5jA">
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWEI4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWEJIuWEeiu6boZkiJHCA" x="-16" y="-1"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eCQMoJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWEJIuWEeiu6boZkiJHCA" x="-8" y="8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrMIuWEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrMYuWEeiu6boZkiJHCA" x="-34" y="-15"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eEiroJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrMYuWEeiu6boZkiJHCA" x="-30" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrMouWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrM4uWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eGvEAJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrM4uWEeiu6boZkiJHCA" x="26" y="19"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrNIuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrNYuWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eI7cYJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrNYuWEeiu6boZkiJHCA" x="-28" y="18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrNouWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrN4uWEeiu6boZkiJHCA" x="-10" y="-17"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eLgPQJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrN4uWEeiu6boZkiJHCA" x="15" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrOIuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrOYuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ePIyEJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrOYuWEeiu6boZkiJHCA" x="-14" y="14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7cWEIYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-175, -235, -643984, -643984]$[-146, -61, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.10964912280701754,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.18544600938967137,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.12280701754385964,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.19953051643192488,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7cpmJIuWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_7cpmIIuWEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_7cpmJYuWEeiu6boZkiJHCA"/>
@@ -1338,29 +1564,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7cpmJ4uWEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7cpmKIuWEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_-Qj4MIuWEeiu6boZkiJHCA" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_-Be4sHkyEeiO-c_khjKlFQ">
+    <edges xmi:type="notation:Connector" xmi:id="_-Qj4MIuWEeiu6boZkiJHCA" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_-Be4sHkyEeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_-QkfQIuWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Y6wj0JmWEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfQYuWEeiu6boZkiJHCA" x="6" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-QkfQouWEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Y888MJmWEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfQ4uWEeiu6boZkiJHCA" x="-15" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-QkfRIuWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfRYuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Y_ocwJmWEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfRYuWEeiu6boZkiJHCA" x="13" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-QkfRouWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfR4uWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZB01IJmWEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfR4uWEeiu6boZkiJHCA" x="-14" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-QkfSIuWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfSYuWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZEfuoJmWEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfSYuWEeiu6boZkiJHCA" x="13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-QkfSouWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfS4uWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZGyNoJmWEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-QkfS4uWEeiu6boZkiJHCA" x="-16" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_-Qj4MYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_A-T2MHkzEeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-Qj4MouWEeiu6boZkiJHCA" points="[-164, -235, -643984, -643984]$[-121, -140, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AFvRIIuXEeiu6boZkiJHCA" id="(0.8771929824561403,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-Qj4MouWEeiu6boZkiJHCA" points="[-106, -235, -643984, -643984]$[-106, -186, -643984, -643984]$[-101, -186, -643984, -643984]$[-101, -141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AFvRIIuXEeiu6boZkiJHCA" id="(0.703971119133574,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TXlhEJmUEeiOmuqNbykpsw" id="(0.22,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_-Q0994uWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_-Qj4MIuWEeiu6boZkiJHCA" target="_-Q0984uWEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_-Q09-IuWEeiu6boZkiJHCA"/>
@@ -1372,29 +1605,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Q1lAIuWEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Q1lAYuWEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BDZzQIuXEeiu6boZkiJHCA" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_XVnyQHk6EeiO-c_khjKlFQ">
+    <edges xmi:type="notation:Connector" xmi:id="_BDZzQIuXEeiu6boZkiJHCA" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_XVnyQHk6EeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzQ4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRIuXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jikh8JmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRIuXEeiu6boZkiJHCA" x="-1" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzRYuXEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jlDOMJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRouXEeiu6boZkiJHCA" x="-18" y="5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzR4uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzSIuXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jnPmkJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzSIuXEeiu6boZkiJHCA" x="25" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzSYuXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzSouXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jpoMMJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzSouXEeiu6boZkiJHCA" x="-25" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzS4uXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzTIuXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jroXUJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzTIuXEeiu6boZkiJHCA" x="9" y="19"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzTYuXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzTouXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jtupEJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzTouXEeiu6boZkiJHCA" x="-14" y="25"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BDZzQYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDZzQouXEeiu6boZkiJHCA" points="[324, -226, -643984, -643984]$[332, -62, -643984, -643984]"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbbsIuXEeiu6boZkiJHCA" id="(0.46380697050938335,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDZzQouXEeiu6boZkiJHCA" points="[376, -226, -643984, -643984]$[376, -147, -643984, -643984]$[380, -147, -643984, -643984]$[380, -62, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_541CMJmoEeiOmuqNbykpsw" id="(0.2196078431372549,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbbsIuXEeiu6boZkiJHCA" id="(0.2975871313672922,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BEzhcIuXEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_BEy6Y4uXEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_BEzhcYuXEeiu6boZkiJHCA"/>
@@ -1406,34 +1646,287 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEzhc4uXEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEzhdIuXEeiu6boZkiJHCA"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_s34hApmTEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_s34g_pmTEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_s34hA5mTEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s34hB5mTEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_s34hBJmTEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s34hBZmTEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s34hBpmTEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8V3R4JmTEeiOmuqNbykpsw" type="Association_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_-Be4sHkyEeiO-c_khjKlFQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8V3R45mTEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GJu_sJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R5JmTEeiOmuqNbykpsw" x="11" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8V3R5ZmTEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GMOTAJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R5pmTEeiOmuqNbykpsw" x="-13" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8V3R55mTEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GOs_QJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R6JmTEeiOmuqNbykpsw" x="18" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8V3R6ZmTEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GQzRAJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R6pmTEeiOmuqNbykpsw" x="-19" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8V3R65mTEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GTFwAJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R7JmTEeiOmuqNbykpsw" x="8" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8V3R7ZmTEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GVMBwJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R7pmTEeiOmuqNbykpsw" x="-13" y="16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_8V3R4ZmTEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8V3R4pmTEeiOmuqNbykpsw" points="[91, -238, -643984, -643984]$[91, -141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8acP4JmTEeiOmuqNbykpsw" id="(0.2924187725631769,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8acP4ZmTEeiOmuqNbykpsw" id="(0.8533333333333334,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O4N9V5mVEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_O4N9U5mVEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_O4N9WJmVEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O4N9XJmVEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O4N9WZmVEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O4N9WpmVEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O4N9W5mVEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VE_BkJmVEeiOmuqNbykpsw" type="Abstraction_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_-8QyEHiGEeiPPoPDo3q5jA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_VE_Bk5mVEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e7fMoJmVEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VE_BlJmVEeiOmuqNbykpsw" x="10" y="4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VE_BlZmVEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9rlAJmVEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VE_BlpmVEeiOmuqNbykpsw" x="-8" y="1"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_VE_BkZmVEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VE_BkpmVEeiOmuqNbykpsw" points="[101, -304, -643984, -643984]$[101, -394, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VKa7MJmVEeiOmuqNbykpsw" id="(0.34296028880866425,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VKa7MZmVEeiOmuqNbykpsw" id="(0.8917378917378918,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XSxHx5mVEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_XSxHw5mVEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XSxHyJmVEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XSxHzJmVEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XSxHyZmVEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XSxHypmVEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XSxHy5mVEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EtUaL5mWEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_EtUaK5mWEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EtUaMJmWEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtUaNJmWEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EtUaMZmWEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtUaMpmWEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtUaM5mWEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_axWnPZmYEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_axWnOZmYEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_axWnPpmYEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_axWnQpmYEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_axWnP5mYEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_axWnQJmYEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_axWnQZmYEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nZkr4JmYEeiOmuqNbykpsw" type="Association_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_aw4GAJmYEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nZqygJmYEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wsOjAJmYEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nZqygZmYEeiOmuqNbykpsw" x="7" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nZqygpmYEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wvR3AJmYEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nZqyg5mYEeiOmuqNbykpsw" x="-14" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nZqyhJmYEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wzTbYJmYEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nZqyhZmYEeiOmuqNbykpsw" x="8" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nZqyhpmYEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_w2EbgJmYEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nZqyh5mYEeiOmuqNbykpsw" x="-8" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nZqyiJmYEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_w5T8wJmYEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nZqyiZmYEeiOmuqNbykpsw" x="8" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nZqyipmYEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_w8E84JmYEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nZqyi5mYEeiOmuqNbykpsw" x="-10" y="22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nZkr4ZmYEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nZkr4pmYEeiOmuqNbykpsw" points="[788, -228, -643984, -643984]$[788, -127, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoJmYEeiOmuqNbykpsw" id="(0.6,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoZmYEeiOmuqNbykpsw" id="(0.2435064935064935,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ObaTQJmaEeiOmuqNbykpsw" type="Abstraction_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_7NoX0HjAEeixydPRZ8lIKA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ObaTQ5maEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iI6RQJmdEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ObaTRJmaEeiOmuqNbykpsw" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ObaTRZmaEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iL3eoJmdEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ObaTRpmaEeiOmuqNbykpsw" x="-14" y="3"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ObaTQZmaEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ObaTQpmaEeiOmuqNbykpsw" points="[748, -295, -643984, -643984]$[748, -390, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgJmaEeiOmuqNbykpsw" id="(0.45714285714285713,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgZmaEeiOmuqNbykpsw" id="(0.534453781512605,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NCsEjZmoEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_NCf3MJmoEeiOmuqNbykpsw" target="_NCsEiZmoEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NCsEjpmoEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NCsEkpmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NCZwkJmoEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NCsEj5moEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NCsEkJmoEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NCsEkZmoEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dmTnwJmoEeiOmuqNbykpsw" type="Association_Edge" source="_NCf3MJmoEeiOmuqNbykpsw" target="_aw4GAJmYEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dmTnw5moEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ljfgwJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dmTnxJmoEeiOmuqNbykpsw" x="3" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dmTnxZmoEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lmi0wJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dmTnxpmoEeiOmuqNbykpsw" x="-13" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dmTnx5moEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lpT04JmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dmTnyJmoEeiOmuqNbykpsw" x="17" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dmTnyZmoEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lsFcEJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dmTnypmoEeiOmuqNbykpsw" x="-17" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dmTny5moEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lvO2sJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dmTnzJmoEeiOmuqNbykpsw" x="17" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dmTnzZmoEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lyZfcJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dmTnzpmoEeiOmuqNbykpsw" x="-17" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dmTnwZmoEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_djQTwJmoEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dmTnwpmoEeiOmuqNbykpsw" points="[987, -228, -643984, -643984]$[987, -127, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dsCcUJmoEeiOmuqNbykpsw" id="(0.2595419847328244,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dsCcUZmoEeiOmuqNbykpsw" id="(0.8863636363636364,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_xCM_wJmoEeiOmuqNbykpsw" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_aw4GAJmYEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_w5moEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yfbywJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_xJmoEeiOmuqNbykpsw" x="-24" y="-37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_xZmoEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yiHTUJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_xpmoEeiOmuqNbykpsw" x="-19" y="-57"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_x5moEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yksGMJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_yJmoEeiOmuqNbykpsw" x="43" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_yZmoEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yoH0sJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_ypmoEeiOmuqNbykpsw" x="-43" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_y5moEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yrkxUJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_zJmoEeiOmuqNbykpsw" x="8" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_zZmoEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yuDdkJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_zpmoEeiOmuqNbykpsw" x="-43" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_xCM_wZmoEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_w_nl0JmoEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xCM_wpmoEeiOmuqNbykpsw" points="[521, -226, -643984, -643984]$[521, -110, -643984, -643984]$[713, -110, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xITnwJmoEeiOmuqNbykpsw" id="(0.8627450980392157,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xITnwZmoEeiOmuqNbykpsw" id="(0.0,0.2698412698412698)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_88g1p5moEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_88g1o5moEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_88g1qJmoEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_88g1rJmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_88g1qZmoEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_88g1qpmoEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_88g1q5moEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-IZZ95moEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_dmTnwJmoEeiOmuqNbykpsw" target="_-IZZ85moEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-IZZ-JmoEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-IZZ_JmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_djQTwJmoEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-IZZ-ZmoEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-IZZ-pmoEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-IZZ-5moEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JEWKJ5mpEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_xCM_wJmoEeiOmuqNbykpsw" target="_JEWKI5mpEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JEWKKJmpEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JEWKLJmpEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_w_nl0JmoEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JEWKKZmpEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JEWKKpmpEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JEWKK5mpEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_60fHRJmqEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_60fHQJmqEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_60fHRZmqEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_60fuUpmqEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_60fHRpmqEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60fuUJmqEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60fuUZmqEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7oDSMJmqEeiOmuqNbykpsw" type="Abstraction_Edge" source="_NCf3MJmoEeiOmuqNbykpsw" target="_7NoX0HjAEeixydPRZ8lIKA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7oDSM5mqEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BLNYwJmrEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7oDSNJmqEeiOmuqNbykpsw" x="4" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7oDSNZmqEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BOKmIJmrEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7oDSNpmqEeiOmuqNbykpsw" x="-20" y="-6"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_7oDSMZmqEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_7n9LkJmqEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7oDSMpmqEeiOmuqNbykpsw" points="[981, -294, -643984, -643984]$[981, -390, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7vhMIJmqEeiOmuqNbykpsw" id="(0.24045801526717558,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7vhMIZmqEeiOmuqNbykpsw" id="(0.9260504201680673,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FAuRx5mrEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_7oDSMJmqEeiOmuqNbykpsw" target="_FAuRw5mrEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FAuRyJmrEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FAuRzJmrEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_7n9LkJmqEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FAuRyZmrEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FAuRypmrEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FAuRy5mrEeiOmuqNbykpsw"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="OtsiResourceSpec" measurementUnit="Pixel">
-    <children xmi:type="notation:Shape" xmi:id="_xbRtgXkvEeiO-c_khjKlFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbRtgnkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbRtg3kvEeiO-c_khjKlFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRthHkvEeiO-c_khjKlFQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRthXkvEeiO-c_khjKlFQ" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRthnkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRth3kvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRtiHkvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRtiXkvEeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRtinkvEeiO-c_khjKlFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRti3kvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRtjHkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRtjXkvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRtjnkvEeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRtj3kvEeiO-c_khjKlFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRtkHkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRtkXkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRtknkvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRtk3kvEeiO-c_khjKlFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRtvXkvEeiO-c_khjKlFQ" x="-12" y="-453" width="277" height="65"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRtvnkvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRtv3kvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRtwHkvEeiO-c_khjKlFQ" type="Class_FloatingNameLabel">
@@ -1462,37 +1955,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRt_HkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuMXkvEeiO-c_khjKlFQ" x="589" y="-148" width="213" height="62"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbRuMnkvEeiO-c_khjKlFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbRuM3kvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbRuNHkvEeiO-c_khjKlFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRuNXkvEeiO-c_khjKlFQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRuNnkvEeiO-c_khjKlFQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_xbRuN3kvEeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRuYnkvEeiO-c_khjKlFQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRuY3kvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRuZHkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRuZXkvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuZnkvEeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRuZ3kvEeiO-c_khjKlFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRuaHkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRuaXkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRuankvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRua3kvEeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRubHkvEeiO-c_khjKlFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRubXkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRubnkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRub3kvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRucHkvEeiO-c_khjKlFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRupXkvEeiO-c_khjKlFQ" x="51" y="-296" height="65"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuMXkvEeiO-c_khjKlFQ" x="243" y="-134" width="213" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRupnkvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRup3kvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1518,7 +1981,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuuHkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRu4nkvEeiO-c_khjKlFQ" x="492" y="-462" width="503" height="69"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRu4nkvEeiO-c_khjKlFQ" x="146" y="-448" width="503" height="69"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRu43kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRu5HkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1576,7 +2039,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRvTXkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRvgnkvEeiO-c_khjKlFQ" x="686" y="-79" width="369" height="173"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRvgnkvEeiO-c_khjKlFQ" x="340" y="-65" width="369" height="173"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRvg3kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRvhHkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1610,7 +2073,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRv7XkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwInkvEeiO-c_khjKlFQ" x="772" y="-314" width="263" height="81"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwInkvEeiO-c_khjKlFQ" x="426" y="-300" width="263" height="81"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRwI3kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRwJHkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1640,45 +2103,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwYXkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwlnkvEeiO-c_khjKlFQ" x="929" y="-146" width="225" height="59"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbRwl3kvEeiO-c_khjKlFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbRwmHkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbRwmXkvEeiO-c_khjKlFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRwmnkvEeiO-c_khjKlFQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRwm3kvEeiO-c_khjKlFQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_xbRwnHkvEeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_MpIOQI51EeeyZasfnNSonw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRwx3kvEeiO-c_khjKlFQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRwyHkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRwyXkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRwynkvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwy3kvEeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRwzHkvEeiO-c_khjKlFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRwzXkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRwznkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRwz3kvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRw0HkvEeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xbRw0XkvEeiO-c_khjKlFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xbRw0nkvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xbRw03kvEeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRw1HkvEeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRw1XkvEeiO-c_khjKlFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRxCnkvEeiO-c_khjKlFQ" x="32" y="-146" width="246" height="70"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbRxC3kvEeiO-c_khjKlFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xbRxDHkvEeiO-c_khjKlFQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbRxDXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRxGnkvEeiO-c_khjKlFQ" x="14" y="-385"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwlnkvEeiO-c_khjKlFQ" x="583" y="-132" width="225" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRxG3kvEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xbRxHHkvEeiO-c_khjKlFQ" showTitle="true"/>
@@ -1688,14 +2113,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRxKnkvEeiO-c_khjKlFQ" x="372" y="-387"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbRxK3kvEeiO-c_khjKlFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xbRxLHkvEeiO-c_khjKlFQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbRxLXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRxTnkvEeiO-c_khjKlFQ" x="106" y="-461"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRxT3kvEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xbRxUHkvEeiO-c_khjKlFQ" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbRxUXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
@@ -1703,14 +2120,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRxenkvEeiO-c_khjKlFQ" x="642" y="-124"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbRxe3kvEeiO-c_khjKlFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xbRxfHkvEeiO-c_khjKlFQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbRxfXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRxpnkvEeiO-c_khjKlFQ" x="14" y="-285"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRxp3kvEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xbRxqHkvEeiO-c_khjKlFQ" showTitle="true"/>
@@ -1735,14 +2144,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRyInkvEeiO-c_khjKlFQ" x="372" y="-319"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbRyI3kvEeiO-c_khjKlFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xbRyJHkvEeiO-c_khjKlFQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbRyJXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRyTnkvEeiO-c_khjKlFQ" x="13" y="-138"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRyc3kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRydHkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1776,7 +2177,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRysXkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRy5nkvEeiO-c_khjKlFQ" x="449" y="-312" width="309" height="79"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRy5nkvEeiO-c_khjKlFQ" x="103" y="-298" width="309" height="79"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRy53kvEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xbRy6HkvEeiO-c_khjKlFQ" showTitle="true"/>
@@ -1954,7 +2355,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_srfuOXk7EeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_qzTdgHk7EeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sregEXk7EeiO-c_khjKlFQ" x="365" y="-143" width="215" height="156"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sregEXk7EeiO-c_khjKlFQ" x="19" y="-129" width="215" height="156"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_srqGQ3k7EeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_srqGRHk7EeiO-c_khjKlFQ" showTitle="true"/>
@@ -2192,14 +2593,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_592F0ouWEeiu6boZkiJHCA" x="1129" y="-146"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_IiuEg4uXEeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_IiuEhIuXEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IiuEhouXEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IiuEhYuXEeiu6boZkiJHCA" x="251" y="-396"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_KoPmk4uXEeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_KoPmlIuXEeiu6boZkiJHCA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KoPmlouXEeiu6boZkiJHCA" name="BASE_ELEMENT">
@@ -2232,27 +2625,28 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tg96xYuXEeiu6boZkiJHCA" x="972" y="-414"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_1NbsEJmSEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1NbsEZmSEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NhysJmSEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1NbsEpmSEeiOmuqNbykpsw" x="1129" y="-146"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NXFW8JozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NXFW8ZozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NXFW85ozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NXFW8pozEeiOmuqNbykpsw" x="1129" y="-146"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_xbR3JHkvEeiO-c_khjKlFQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_xbR3JXkvEeiO-c_khjKlFQ"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_5yYcsIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
       <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    <edges xmi:type="notation:Connector" xmi:id="_xbR3J3kvEeiO-c_khjKlFQ" type="Abstraction_Edge" source="_xbRuMnkvEeiO-c_khjKlFQ" target="_xbRtgXkvEeiO-c_khjKlFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbR3KHkvEeiO-c_khjKlFQ" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Fj_CgIuXEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xbR3KXkvEeiO-c_khjKlFQ" x="4" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xbR3KnkvEeiO-c_khjKlFQ" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FmmRoIuXEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xbR3K3kvEeiO-c_khjKlFQ" x="-14" y="1"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_xbR3LHkvEeiO-c_khjKlFQ"/>
-      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3MHkvEeiO-c_khjKlFQ" points="[136, -296, -643984, -643984]$[136, -388, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3MXkvEeiO-c_khjKlFQ" id="(0.46994535519125685,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3MnkvEeiO-c_khjKlFQ" id="(0.5379061371841155,1.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR3SXkvEeiO-c_khjKlFQ" type="Abstraction_Edge" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_xbRupnkvEeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbR3SnkvEeiO-c_khjKlFQ" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GZXLUIuXEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2264,19 +2658,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3TnkvEeiO-c_khjKlFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3UnkvEeiO-c_khjKlFQ" points="[887, -314, -643984, -643984]$[887, -393, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3UnkvEeiO-c_khjKlFQ" points="[541, -300, -643984, -643984]$[541, -379, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3U3kvEeiO-c_khjKlFQ" id="(0.4448669201520912,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3VHkvEeiO-c_khjKlFQ" id="(0.7892644135188867,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xbR3fXkvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbR3J3kvEeiO-c_khjKlFQ" target="_xbRxC3kvEeiO-c_khjKlFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xbR3fnkvEeiO-c_khjKlFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbR3f3kvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3gHkvEeiO-c_khjKlFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3gXkvEeiO-c_khjKlFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3gnkvEeiO-c_khjKlFQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR3g3kvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="_xbRxG3kvEeiO-c_khjKlFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3hHkvEeiO-c_khjKlFQ"/>
@@ -2288,16 +2672,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3h3kvEeiO-c_khjKlFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3iHkvEeiO-c_khjKlFQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xbR3nXkvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbRtgXkvEeiO-c_khjKlFQ" target="_xbRxK3kvEeiO-c_khjKlFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xbR3nnkvEeiO-c_khjKlFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbR3n3kvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3oHkvEeiO-c_khjKlFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3oXkvEeiO-c_khjKlFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3onkvEeiO-c_khjKlFQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR3o3kvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_xbRxT3kvEeiO-c_khjKlFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3pHkvEeiO-c_khjKlFQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbR3pXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
@@ -2307,16 +2681,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3pnkvEeiO-c_khjKlFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3p3kvEeiO-c_khjKlFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3qHkvEeiO-c_khjKlFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xbR3qXkvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbRuMnkvEeiO-c_khjKlFQ" target="_xbRxe3kvEeiO-c_khjKlFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xbR3qnkvEeiO-c_khjKlFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbR3q3kvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3rHkvEeiO-c_khjKlFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3rXkvEeiO-c_khjKlFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3rnkvEeiO-c_khjKlFQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR3r3kvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="_xbRxp3kvEeiO-c_khjKlFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3sHkvEeiO-c_khjKlFQ"/>
@@ -2358,16 +2722,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3xXkvEeiO-c_khjKlFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3xnkvEeiO-c_khjKlFQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xbR3x3kvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbRwl3kvEeiO-c_khjKlFQ" target="_xbRyI3kvEeiO-c_khjKlFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xbR3yHkvEeiO-c_khjKlFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbR3yXkvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3ynkvEeiO-c_khjKlFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3y3kvEeiO-c_khjKlFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3zHkvEeiO-c_khjKlFQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR35XkvEeiO-c_khjKlFQ" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_xbRy53kvEeiO-c_khjKlFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR35nkvEeiO-c_khjKlFQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbR353kvEeiO-c_khjKlFQ" name="BASE_ELEMENT">
@@ -2390,14 +2744,16 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR393kvEeiO-c_khjKlFQ" type="Abstraction_Edge" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_xbRupnkvEeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbR3-HkvEeiO-c_khjKlFQ" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2PXbMJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xbR3-XkvEeiO-c_khjKlFQ" x="6" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_xbR3-nkvEeiO-c_khjKlFQ" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2SCUsJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xbR3-3kvEeiO-c_khjKlFQ" x="-8" y="-7"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3_HkvEeiO-c_khjKlFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR4AHkvEeiO-c_khjKlFQ" points="[29, 0, -114, 87]$[29, -87, -114, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR4AHkvEeiO-c_khjKlFQ" points="[315, -298, -643984, -643984]$[171, -379, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR4AXkvEeiO-c_khjKlFQ" id="(0.5922330097087378,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR4AnkvEeiO-c_khjKlFQ" id="(0.27634194831013914,1.0)"/>
     </edges>
@@ -2657,62 +3013,34 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_592F14uWEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_592F2IuWEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IiWREIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRuMnkvEeiO-c_khjKlFQ" target="_xbRwl3kvEeiO-c_khjKlFQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_IiW4IIuXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IiW4IYuXEeiu6boZkiJHCA" x="5" y="4"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_IiW4IouXEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IiW4I4uXEeiu6boZkiJHCA" x="-17" y="5"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_IiW4JIuXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IiW4JYuXEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_IiW4JouXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IiW4J4uXEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_IiW4KIuXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IiW4KYuXEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_IiW4KouXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IiW4K4uXEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_IiWREYuXEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IiWREouXEeiu6boZkiJHCA" points="[145, -231, -643984, -643984]$[152, -146, -643984, -643984]"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KCE-cIuXEeiu6boZkiJHCA" id="(0.44308943089430897,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IiuEh4uXEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_IiWREIuXEeiu6boZkiJHCA" target="_IiuEg4uXEeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_IiuEiIuXEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IiuEjIuXEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IiuEiYuXEeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IiuEiouXEeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IiuEi4uXEeiu6boZkiJHCA"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_KmsHYIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_sregEHk7EeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_KmsHY4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2ivDIJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHZIuXEeiu6boZkiJHCA" x="5" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_KmsHZYuXEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2lZ8oJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHZouXEeiu6boZkiJHCA" x="-10" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_KmsHZ4uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHaIuXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2pDGgJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHaIuXEeiu6boZkiJHCA" x="14" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_KmsHaYuXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHaouXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2rPe4Jo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHaouXEeiu6boZkiJHCA" x="-13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_KmsHa4uXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHbIuXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2tVwoJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHbIuXEeiu6boZkiJHCA" x="14" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_KmsHbYuXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHbouXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2v6jgJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHbouXEeiu6boZkiJHCA" x="-13" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_KmsHYYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_AMK4gHk8EeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KmsHYouXEeiu6boZkiJHCA" points="[578, -233, -643984, -643984]$[521, -143, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KmsHYouXEeiu6boZkiJHCA" points="[232, -219, -643984, -643984]$[175, -129, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LmPf4IuXEeiu6boZkiJHCA" id="(0.09385113268608414,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_KoPml4uXEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_KmsHYIuXEeiu6boZkiJHCA" target="_KoPmk4uXEeiu6boZkiJHCA">
@@ -2727,26 +3055,32 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MtNH8IuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_xbRyc3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH84uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2yA1QJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH9IuXEeiu6boZkiJHCA" x="-10" y="-6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH9YuXEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_20BAYJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH9ouXEeiu6boZkiJHCA" x="11" y="-6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH94uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH-IuXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_22fsoJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH-IuXEeiu6boZkiJHCA" x="13" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH-YuXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH-ouXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_24l-YJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH-ouXEeiu6boZkiJHCA" x="-13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH-4uXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH_IuXEeiu6boZkiJHCA" x="3" y="-14"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_26sQIJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH_IuXEeiu6boZkiJHCA" x="16" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH_YuXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH_ouXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_29pdgJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH_ouXEeiu6boZkiJHCA" x="-13" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_MtNH8YuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MtNH8ouXEeiu6boZkiJHCA" points="[677, -148, -643984, -643984]$[626, -233, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MtNH8ouXEeiu6boZkiJHCA" points="[331, -134, -643984, -643984]$[280, -219, -643984, -643984]"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYw8IuXEeiu6boZkiJHCA" id="(0.7864077669902912,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MtYHF4uXEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="_MtYHE4uXEeiu6boZkiJHCA">
@@ -2761,26 +3095,32 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QoX9AIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRu43kvEeiO-c_khjKlFQ" target="_xbRvg3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_QoX9A4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2Ua6UJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_QoX9BIuXEeiu6boZkiJHCA" x="8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QoYkEIuXEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2WnSsJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkEYuXEeiu6boZkiJHCA" x="23" y="5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QoYkEouXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkE4uXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2ZF-8Jo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkE4uXEeiu6boZkiJHCA" x="23" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QoYkFIuXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkFYuXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2bMQsJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkFYuXEeiu6boZkiJHCA" x="-23" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QoYkFouXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkF4uXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2dNC4Jo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkF4uXEeiu6boZkiJHCA" x="23" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QoYkGIuXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkGYuXEeiu6boZkiJHCA" x="15" y="18"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2f38YJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoYkGYuXEeiu6boZkiJHCA" x="-8" y="18"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_QoX9AYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QoX9AouXEeiu6boZkiJHCA" points="[880, -79, -643984, -643984]$[898, -233, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QoX9AouXEeiu6boZkiJHCA" points="[534, -65, -643984, -643984]$[552, -219, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SIuVcIuXEeiu6boZkiJHCA" id="(0.4173441734417344,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RzyAMIuXEeiu6boZkiJHCA" id="(0.2585551330798479,1.0)"/>
     </edges>
@@ -2796,26 +3136,32 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_TfVjEIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_xbRwI3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_TfVjE4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3BLSoJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKIIuXEeiu6boZkiJHCA" x="8" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_TfWKIYuXEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3EJuIJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKIouXEeiu6boZkiJHCA" x="-10" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_TfWKI4uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKJIuXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3HmqwJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKJIuXEeiu6boZkiJHCA" x="13" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_TfWKJYuXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKJouXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3J5JwJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKJouXEeiu6boZkiJHCA" x="-13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_TfWKJ4uXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKKIuXEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3MX2AJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKKIuXEeiu6boZkiJHCA" x="13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_TfWKKYuXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKKouXEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3OwboJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TfWKKouXEeiu6boZkiJHCA" x="-13" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_TfVjEYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_2YPCcI6dEeeyZasfnNSonw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TfVjEouXEeiu6boZkiJHCA" points="[939, -233, -643984, -643984]$[1015, -146, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TfVjEouXEeiu6boZkiJHCA" points="[593, -219, -643984, -643984]$[669, -132, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UP8goIuXEeiu6boZkiJHCA" id="(0.8859315589353612,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UrAE8IuXEeiu6boZkiJHCA" id="(0.3377777777777778,0.0)"/>
     </edges>
@@ -2829,13 +3175,874 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tg-h04uXEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tg-h1IuXEeiu6boZkiJHCA"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1NhysZmSEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_xbRwI3kvEeiO-c_khjKlFQ" target="_1NbsEJmSEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1NhyspmSEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NhytpmSEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1Nhys5mSEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NhytJmSEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NhytZmSEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NXFW9JozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_xbRwI3kvEeiO-c_khjKlFQ" target="_NXFW8JozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NXFW9ZozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NXFW-ZozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NXFW9pozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NXFW95ozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NXFW-JozEeiOmuqNbykpsw"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_3bpg4IoMEeivCevppATXng" type="PapyrusUMLClassDiagram" name="McResourceSpec" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_SvF9cJozEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SvF9cpozEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SvF9c5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SvF9dJozEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SvF9dZozEeiOmuqNbykpsw" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SvF9dpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SvF9d5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SvF9eJozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9eZozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SvF9epozEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SvF9e5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SvF9fJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SvF9fZozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9fpozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SvF9f5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SvF9gJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SvF9gZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SvF9gpozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9g5ozEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9cZozEeiOmuqNbykpsw" x="619" y="-442" width="485" height="65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SvSKs5ozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SvSKtJozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SvSKtpozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvSKtZozEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XddKAJozEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_XddKApozEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XddKA5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XddKBJozEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_XddKBZozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_QtPlAJo0EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_pVuME5ozEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QtPlAZo0EeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_XddKBpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_XddKB5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_XddKCJozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XddKCZozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_XddKCpozEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_XddKC5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_XddKDJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_XddKDZozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XddKDpozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_XddKD5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_XddKEJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_XddKEZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_XddKEpozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XddKE5ozEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Xa-dwJozEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XddKAZozEeiOmuqNbykpsw" x="622" y="-297"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XdjQuZozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XdjQupozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XdjQvJozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Xa-dwJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XdjQu5ozEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aNMGs5ozEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_aNMGtZozEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_aNMGtpozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_aNMGt5ozEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aNMGuJozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_PwqA8Jo0EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_p0WBw5ozEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PwqA8Zo0EeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aNMGuZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aNMGupozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aNMGu5ozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aNMGvJozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aNMGvZozEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aNMGvpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aNMGv5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aNMGwJozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aNMGwZozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aNMGwpozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aNMGw5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aNMGxJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aNMGxZozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aNMGxpozEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aNMGsJozEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aNMGtJozEeiOmuqNbykpsw" x="377" y="-293"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aNYUCZozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_aNYUCpozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aNYUDJozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aNMGsJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aNYUC5ozEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aiK4MJozEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_aiK4MpozEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_aiK4M5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_aiK4NJozEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aiK4NZozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_RtdE0Jo0EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qOx7ApozEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RtdE0Zo0EeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aiK4NpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aiK4N5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aiK4OJozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4OZozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aiK4OpozEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aiK4O5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aiK4PJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aiK4PZozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4PpozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_aiK4P5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_aiK4QJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_aiK4QZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_aiK4QpozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4Q5ozEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4MZozEeiOmuqNbykpsw" x="875" y="-294"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aiXFiZozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_aiXFipozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aiXFjJozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiXFi5ozEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_a2-DgpozEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_a2-DhJozEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_a2-DhZozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_a2-DhpozEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_a2-Dh5ozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Sx4WQJo0EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qtbl45ozEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Sx4WQZo0EeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_a2-DiJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_a2-DiZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_a2-DipozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-Di5ozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_a2-DjJozEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_a2-DjZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_a2-DjpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_a2-Dj5ozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-DkJozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_a2-DkZozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_a2-DkpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_a2-Dk5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_a2-DlJozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-DlZozEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-Dg5ozEeiOmuqNbykpsw" x="1131" y="-295"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_a3QXeZozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_a3QXepozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_a3QXfJozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a3QXe5ozEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_lvNYYJozEeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_lvNYYpozEeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lvNYY5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lvNYZJozEeiOmuqNbykpsw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_lvNYZZozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_m-ufgJozEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_J3v2UHZlEeiPPoPDo3q5jA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_m-ufgZozEeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_lvNYZpozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_lvNYZ5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_lvNYaJozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYaZozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_lvNYapozEeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_lvNYa5ozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_lvNYbJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_lvNYbZozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYbpozEeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_lvNYb5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_lvNYcJozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_lvNYcZozEeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_lvNYcpozEeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYc5ozEeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYYZozEeiOmuqNbykpsw" x="706" y="-59" width="314" height="87"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_lvfsQ5ozEeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_lvfsRJozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lvfsRpozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvfsRZozEeiOmuqNbykpsw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F5DNQpo1EeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNQ5o1EeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNRJo1EeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5DNRZo1EeiOmuqNbykpsw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5DNRpo1EeiOmuqNbykpsw" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5DNR5o1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5DNSJo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5DNSZo1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNSpo1EeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5DNS5o1EeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5DNTJo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5DNTZo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5DNTpo1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNT5o1EeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5DNUJo1EeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5DNUZo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5DNUpo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5DNU5o1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNVJo1EeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNfpo1EeiOmuqNbykpsw" x="3" y="-443" width="277" height="65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F5JT0Jo1EeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JT0Zo1EeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JT0po1EeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JT05o1EeiOmuqNbykpsw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JT1Jo1EeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_F5JT1Zo1EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUAJo1EeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUAZo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUApo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUA5o1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUBJo1EeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUBZo1EeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUBpo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUB5o1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUCJo1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUCZo1EeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUCpo1EeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUC5o1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUDJo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUDZo1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUDpo1EeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUQ5o1EeiOmuqNbykpsw" x="-5" y="-289" height="65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F5JUXpo1EeiOmuqNbykpsw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUX5o1EeiOmuqNbykpsw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUYJo1EeiOmuqNbykpsw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUYZo1EeiOmuqNbykpsw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUYpo1EeiOmuqNbykpsw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_F5JUY5o1EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_MpIOQI51EeeyZasfnNSonw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUjpo1EeiOmuqNbykpsw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_F5JUj5o1EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_kt1T0JmXEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUupo1EeiOmuqNbykpsw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUu5o1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUvJo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUvZo1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUvpo1EeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUv5o1EeiOmuqNbykpsw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUwJo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUwZo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUwpo1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUw5o1EeiOmuqNbykpsw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUxJo1EeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUxZo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUxpo1EeiOmuqNbykpsw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUx5o1EeiOmuqNbykpsw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUyJo1EeiOmuqNbykpsw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JU_Zo1EeiOmuqNbykpsw" x="7" y="-141" width="246" height="79"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F5n08Jo1EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_F5n08Zo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F5n085o1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5n08po1EeiOmuqNbykpsw" x="281" y="-443"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F6GWEJo1EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_F6GWEZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F6GWE5o1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F6GWEpo1EeiOmuqNbykpsw" x="261" y="-286"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F6SjUJo1EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_F6SjUZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F6SjU5o1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F6SjUpo1EeiOmuqNbykpsw" x="261" y="-386"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F6SjYJo1EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_F6SjYZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F6SjY5o1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F6SjYpo1EeiOmuqNbykpsw" x="261" y="-386"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F69RsJo1EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_F69RsZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F69Rs5o1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F69Rspo1EeiOmuqNbykpsw" x="256" y="-136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8Uolw5o2EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8UolxJo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8Uolxpo2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_cfC0kJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8UolxZo2EeiOmuqNbykpsw" x="577" y="-393"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9RU3gJo2EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9RU3gZo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9RU3g5o2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_b_2-MJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9RU3gpo2EeiOmuqNbykpsw" x="822" y="-397"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-R6x05o2EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-R6x1Jo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-R6x1po2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-R6x1Zo2EeiOmuqNbykpsw" x="1075" y="-394"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__hNPc5o2EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__hNPdJo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__hNPdpo2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__hNPdZo2EeiOmuqNbykpsw" x="1331" y="-395"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ax73g5o3EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ax73hJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ax73hpo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_p0WBwJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ax73hZo3EeiOmuqNbykpsw" x="577" y="-393"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CSUFI5o3EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CSUFJJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CSUFJpo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_pVuMEJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CSUFJZo3EeiOmuqNbykpsw" x="822" y="-397"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DQKNc5o3EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DQKNdJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQKNdpo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DQKNdZo3EeiOmuqNbykpsw" x="1075" y="-394"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EMTFk5o3EeiOmuqNbykpsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EMTFlJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EMTFlpo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EMTFlZo3EeiOmuqNbykpsw" x="1331" y="-395"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_3bpg4YoMEeivCevppATXng" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_3bpg4ooMEeivCevppATXng"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_6ePdIIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
       <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
+    <edges xmi:type="notation:Connector" xmi:id="_SvSKt5ozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_SvF9cJozEeiOmuqNbykpsw" target="_SvSKs5ozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SvSKuJozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SvSKvJozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SvSKuZozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SvSKupozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SvSKu5ozEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XdjQvZozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_XddKAJozEeiOmuqNbykpsw" target="_XdjQuZozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XdjQvpozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XdjQwpozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Xa-dwJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XdjQv5ozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdjQwJozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdjQwZozEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_aNYUDZozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_aNMGs5ozEeiOmuqNbykpsw" target="_aNYUCZozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_aNYUDpozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aNYUEpozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aNMGsJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aNYUD5ozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aNYUEJozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aNYUEZozEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_aiXFjZozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_aiK4MJozEeiOmuqNbykpsw" target="_aiXFiZozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_aiXFjpozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aiXFkpozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aiXFj5ozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aiXFkJozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aiXFkZozEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_a3QXfZozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_a2-DgpozEeiOmuqNbykpsw" target="_a3QXeZozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_a3QXfpozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_a3QXgpozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_a3QXf5ozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a3QXgJozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a3QXgZozEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_b_2-MZozEeiOmuqNbykpsw" type="Abstraction_Edge" source="_XddKAJozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_2-NJozEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4bFosJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_2-NZozEeiOmuqNbykpsw" x="8" y="4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_2-NpozEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4cCq8JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_2-N5ozEeiOmuqNbykpsw" x="-3" y="-4"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_b_2-MpozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_b_2-MJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b_2-M5ozEeiOmuqNbykpsw" points="[714, -297, -643984, -643984]$[714, -377, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cAt50JozEeiOmuqNbykpsw" id="(0.3948497854077253,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cAt50ZozEeiOmuqNbykpsw" id="(0.1958762886597938,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_cfC0kZozEeiOmuqNbykpsw" type="Abstraction_Edge" source="_aNMGs5ozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_cfC0lJozEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4MmgwJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cfC0lZozEeiOmuqNbykpsw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_cfC0lpozEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4NRPIJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cfC0l5ozEeiOmuqNbykpsw" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_cfC0kpozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_cfC0kJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cfC0k5ozEeiOmuqNbykpsw" points="[462, -293, -643984, -643984]$[462, -415, -643984, -643984]$[619, -415, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cgF9cJozEeiOmuqNbykpsw" id="(0.3881278538812785,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cgF9cZozEeiOmuqNbykpsw" id="(0.0,0.4153846153846154)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_c-z5wZozEeiOmuqNbykpsw" type="Abstraction_Edge" source="_aiK4MJozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_c-z5xJozEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_I9qDIJo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_c-z5xZozEeiOmuqNbykpsw" x="10" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_c-z5xpozEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_I-a4IJo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_c-z5x5ozEeiOmuqNbykpsw" x="-2" y="-5"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_c-z5wpozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c-z5w5ozEeiOmuqNbykpsw" points="[991, -294, -643984, -643984]$[991, -377, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c_q1YJozEeiOmuqNbykpsw" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c_q1YZozEeiOmuqNbykpsw" id="(0.7670103092783506,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dbbkUJozEeiOmuqNbykpsw" type="Abstraction_Edge" source="_a2-DgpozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dbbkU5ozEeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Jl7kEJo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dbbkVJozEeiOmuqNbykpsw" x="-11" y="-41"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dbbkVZozEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JmgL0Jo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dbbkVpozEeiOmuqNbykpsw" x="-17" y="-64"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dbbkUZozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dbbkUpozEeiOmuqNbykpsw" points="[1242, -295, -643984, -643984]$[1242, -407, -643984, -643984]$[1029, -407, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dcZNoJozEeiOmuqNbykpsw" id="(0.49333333333333335,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dcZNoZozEeiOmuqNbykpsw" id="(1.0,0.49230769230769234)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_lvfsR5ozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_lvNYYJozEeiOmuqNbykpsw" target="_lvfsQ5ozEeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_lvfsSJozEeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lvfsTJozEeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lvfsSZozEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lvfsSpozEeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lvfsS5ozEeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pWfBEJozEeiOmuqNbykpsw" type="Association_Edge" source="_XddKAJozEeiOmuqNbykpsw" target="_lvNYYJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pWfBE5ozEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4cnSsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pWfBFJozEeiOmuqNbykpsw" x="10" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pWfBFZozEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4dL6cJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pWfBFpozEeiOmuqNbykpsw" x="-6" y="4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pWfBF5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4d8vcJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pWfBGJozEeiOmuqNbykpsw" x="31" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pWfBGZozEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4ehXMJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pWfBGpozEeiOmuqNbykpsw" x="-31" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pWfBG5ozEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4fF-8JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pWfBHJozEeiOmuqNbykpsw" x="10" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pWfBHZozEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4fqmsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pWfBHpozEeiOmuqNbykpsw" x="-14" y="-22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_pWfBEZozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_pVuMEJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pWfBEpozEeiOmuqNbykpsw" points="[762, -197, -643984, -643984]$[762, -59, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pX6kcJozEeiOmuqNbykpsw" id="(0.6334841628959276,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pX6kcZozEeiOmuqNbykpsw" id="(0.17834394904458598,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_p1ZKoJozEeiOmuqNbykpsw" type="Association_Edge" source="_aNMGs5ozEeiOmuqNbykpsw" target="_lvNYYJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_p1ZKo5ozEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4N124JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_p1ZKpJozEeiOmuqNbykpsw" x="-15" y="-78"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_p1ZKpZozEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4OaeoJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_p1ZKppozEeiOmuqNbykpsw" x="-15" y="-95"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_p1ZKp5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4PFNAJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_p1ZKqJozEeiOmuqNbykpsw" x="30" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_p1ZKqZozEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4Pv7YJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_p1ZKqpozEeiOmuqNbykpsw" x="-30" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_p1ZKq5ozEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4QUjIJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_p1ZKrJozEeiOmuqNbykpsw" x="12" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_p1ZKrZozEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4Q-qcJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_p1ZKrpozEeiOmuqNbykpsw" x="-30" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_p1ZKoZozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_p0WBwJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_p1ZKopozEeiOmuqNbykpsw" points="[499, -193, -643984, -643984]$[499, -14, -643984, -643984]$[706, -14, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p3HB4JozEeiOmuqNbykpsw" id="(0.5238095238095238,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p3HB4ZozEeiOmuqNbykpsw" id="(0.0,0.5172413793103449)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qPcpYJozEeiOmuqNbykpsw" type="Association_Edge" source="_aiK4MJozEeiOmuqNbykpsw" target="_lvNYYJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vKZgcJozEeiOmuqNbykpsw" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vKZgcZozEeiOmuqNbykpsw" key="routing" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpY5ozEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__LT_UJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpZJozEeiOmuqNbykpsw" x="11" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpZZozEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__L4nEJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpZpozEeiOmuqNbykpsw" x="-4" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpZ5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__MdO0JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpaJozEeiOmuqNbykpsw" x="29" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpaZozEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__NH9MJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpapozEeiOmuqNbykpsw" x="-29" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpa5ozEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__Nsk8JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpbJozEeiOmuqNbykpsw" x="14" y="25"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpbZozEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__ORMsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpbpozEeiOmuqNbykpsw" x="-13" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_qPcpYZozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qPcpYpozEeiOmuqNbykpsw" points="[946, -194, -643984, -643984]$[946, -127, -643984, -643984]$[950, -127, -643984, -643984]$[950, -59, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qQr_gJozEeiOmuqNbykpsw" id="(0.3409090909090909,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qQr_gZozEeiOmuqNbykpsw" id="(0.7770700636942676,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_quGUQJozEeiOmuqNbykpsw" type="Association_Edge" source="_a2-DgpozEeiOmuqNbykpsw" target="_lvNYYJozEeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_quGUQ5ozEeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__PCBsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGURJozEeiOmuqNbykpsw" x="-17" y="102"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_quGURZozEeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__P49UJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGURpozEeiOmuqNbykpsw" x="-11" y="114"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_quGUR5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__QpyUJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUSJozEeiOmuqNbykpsw" x="41" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_quGUSZozEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__RUgsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUSpozEeiOmuqNbykpsw" x="-41" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_quGUS5ozEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__SFVsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUTJozEeiOmuqNbykpsw" x="13" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_quGUTZozEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__SwEEJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUTpozEeiOmuqNbykpsw" x="-23" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_quGUQZozEeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_quGUQpozEeiOmuqNbykpsw" points="[1227, -195, -643984, -643984]$[1227, -16, -643984, -643984]$[1020, -16, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvbxAJozEeiOmuqNbykpsw" id="(0.4507042253521127,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvbxAZozEeiOmuqNbykpsw" id="(1.0,0.4942528735632184)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F5DNMJo1EeiOmuqNbykpsw" type="Abstraction_Edge" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_F5DNQpo1EeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNMZo1EeiOmuqNbykpsw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5DNMpo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5DNM5o1EeiOmuqNbykpsw" x="4" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNNJo1EeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5DNNZo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5DNNpo1EeiOmuqNbykpsw" x="-14" y="1"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_F5DNN5o1EeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5DNO5o1EeiOmuqNbykpsw" points="[132, -289, -643984, -643984]$[132, -378, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5DNPJo1EeiOmuqNbykpsw" id="(0.49458483754512633,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5DNPZo1EeiOmuqNbykpsw" id="(0.4657039711191336,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F5JURJo1EeiOmuqNbykpsw" type="Association_Edge" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_F5JUXpo1EeiOmuqNbykpsw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JURZo1EeiOmuqNbykpsw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JURpo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUR5o1EeiOmuqNbykpsw" x="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUSJo1EeiOmuqNbykpsw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUSZo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUSpo1EeiOmuqNbykpsw" x="-8" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUS5o1EeiOmuqNbykpsw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUTJo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUTZo1EeiOmuqNbykpsw" x="12" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUTpo1EeiOmuqNbykpsw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUT5o1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUUJo1EeiOmuqNbykpsw" x="-14" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUUZo1EeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUUpo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUU5o1EeiOmuqNbykpsw" x="12" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUVJo1EeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUVZo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUVpo1EeiOmuqNbykpsw" x="-14" y="20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_F5JUV5o1EeiOmuqNbykpsw"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5JUW5o1EeiOmuqNbykpsw" points="[112, -224, -643984, -643984]$[112, -141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXJo1EeiOmuqNbykpsw" id="(0.4187725631768953,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXZo1EeiOmuqNbykpsw" id="(0.42276422764227645,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F5n09Jo1EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_F5DNQpo1EeiOmuqNbykpsw" target="_F5n08Jo1EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F5n09Zo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F5n0-Zo1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5n09po1EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5n095o1EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5n0-Jo1EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F6GWFJo1EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_F6GWEJo1EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F6GWFZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F6GWGZo1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F6GWFpo1EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F6GWF5o1EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F6GWGJo1EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F6SjVJo1EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_F5DNMJo1EeiOmuqNbykpsw" target="_F6SjUJo1EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F6SjVZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F6SjWZo1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F6SjVpo1EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F6SjV5o1EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F6SjWJo1EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F6Yp8Jo1EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_F5JURJo1EeiOmuqNbykpsw" target="_F6SjYJo1EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F6Yp8Zo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F6Yp9Zo1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F6Yp8po1EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F6Yp85o1EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F6Yp9Jo1EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F69RtJo1EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_F5JUXpo1EeiOmuqNbykpsw" target="_F69RsJo1EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F69RtZo1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F69RuZo1EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F69Rtpo1EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F69Rt5o1EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F69RuJo1EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8Uolx5o2EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_cfC0kZozEeiOmuqNbykpsw" target="_8Uolw5o2EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8UolyJo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8UolzJo2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_cfC0kJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8UolyZo2EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Uolypo2EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Uoly5o2EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9RU3hJo2EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_b_2-MZozEeiOmuqNbykpsw" target="_9RU3gJo2EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9RU3hZo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9RU3iZo2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_b_2-MJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9RU3hpo2EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9RU3h5o2EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9RU3iJo2EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-R6x15o2EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_c-z5wZozEeiOmuqNbykpsw" target="_-R6x05o2EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-R6x2Jo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-R6x3Jo2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-R6x2Zo2EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-R6x2po2EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-R6x25o2EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__hNPd5o2EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_dbbkUJozEeiOmuqNbykpsw" target="__hNPc5o2EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="__hNPeJo2EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__hNPfJo2EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__hNPeZo2EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__hNPepo2EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__hNPe5o2EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ax73h5o3EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_p1ZKoJozEeiOmuqNbykpsw" target="_Ax73g5o3EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ax73iJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ax73jJo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_p0WBwJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ax73iZo3EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ax73ipo3EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ax73i5o3EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CSUFJ5o3EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_pWfBEJozEeiOmuqNbykpsw" target="_CSUFI5o3EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CSUFKJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CSUFLJo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_pVuMEJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CSUFKZo3EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CSUFKpo3EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CSUFK5o3EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DQKNd5o3EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_qPcpYJozEeiOmuqNbykpsw" target="_DQKNc5o3EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DQKNeJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQKNfJo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DQKNeZo3EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQKNepo3EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQKNe5o3EeiOmuqNbykpsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EMTFl5o3EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_quGUQJozEeiOmuqNbykpsw" target="_EMTFk5o3EeiOmuqNbykpsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EMTFmJo3EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EMTFnJo3EeiOmuqNbykpsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EMTFmZo3EeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EMTFmpo3EeiOmuqNbykpsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EMTFm5o3EeiOmuqNbykpsw"/>
+    </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -9,19 +9,19 @@ Copyright (c) 2018 Open Networking Foundation (ONF). All rights reserved.&#xD;
 License: This module is distributed under the Apache License 2.0</body>
     </ownedComment>
     <packagedElement xmi:type="uml:Package" xmi:id="_KjQ3oBKOEeajhbtskMXJfw" name="Associations">
-      <packagedElement xmi:type="uml:Association" xmi:id="_KjQ3ohKOEeajhbtskMXJfw" name="OtsiCepSpecHasAdapterPac" memberEnd="_KjQ3oxKOEeajhbtskMXJfw _KjQ3rhKOEeajhbtskMXJfw">
+      <packagedElement xmi:type="uml:Association" xmi:id="_KjQ3ohKOEeajhbtskMXJfw" name="OtsiCepHasAdapterPac" memberEnd="_KjQ3oxKOEeajhbtskMXJfw _KjQ3rhKOEeajhbtskMXJfw">
         <ownedEnd xmi:type="uml:Property" xmi:id="_KjQ3oxKOEeajhbtskMXJfw" name="lpSpec" type="_mXvsEHZlEeiPPoPDo3q5jA" association="_KjQ3ohKOEeajhbtskMXJfw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3pBKOEeajhbtskMXJfw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3pRKOEeajhbtskMXJfw" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_KjQ3phKOEeajhbtskMXJfw" name="OtsiCepSpecHasTerminationPac" memberEnd="_KjQ3pxKOEeajhbtskMXJfw _KjQ3sRKOEeajhbtskMXJfw">
+      <packagedElement xmi:type="uml:Association" xmi:id="_KjQ3phKOEeajhbtskMXJfw" name="OtsiCepHasTerminationPac" memberEnd="_KjQ3pxKOEeajhbtskMXJfw _KjQ3sRKOEeajhbtskMXJfw">
         <ownedEnd xmi:type="uml:Property" xmi:id="_KjQ3pxKOEeajhbtskMXJfw" name="_lpSpec" type="_KjQ3rRKOEeajhbtskMXJfw" association="_KjQ3phKOEeajhbtskMXJfw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3qBKOEeajhbtskMXJfw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3qRKOEeajhbtskMXJfw" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_hv9NsNnYEeWIOYiRCk5bbQ" name="OtsiNepSpecHasMcPoolPac" memberEnd="_hv9Ns9nYEeWIOYiRCk5bbQ _hv9NtdnYEeWIOYiRCk5bbQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_hv9NsNnYEeWIOYiRCk5bbQ" name="McNepHasMcPoolPac" memberEnd="_hv9Ns9nYEeWIOYiRCk5bbQ _hv9NtdnYEeWIOYiRCk5bbQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hv9NsdnYEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hv9NstnYEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
@@ -33,7 +33,7 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedComment>
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Z6tlUBNAEeeQQtMBY9ly8w" name="OtsiNepSpecAugmentsNep" client="_VvSIYEUIEead1bezhJG4aw">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Z6tlUBNAEeeQQtMBY9ly8w" name="McNepSpecAugmentsNep" client="_VvSIYEUIEead1bezhJG4aw">
         <ownedComment xmi:type="uml:Comment" xmi:id="_GEOMUBiAEeeaw_DVk4Yi2w" annotatedElement="_Z6tlUBNAEeeQQtMBY9ly8w">
           <body>Augments the base LayerProtocol information in NodeEdgePoint with OCH-specific information</body>
         </ownedComment>
@@ -42,56 +42,146 @@ License: This module is distributed under the Apache License 2.0</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_7OKQUIfeEeet-8tHdGGp_w" name="OtsiRoutingSpecAugmentsRouteComputePolicy" client="_YS8DkIfeEeet-8tHdGGp_w">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_2YPCcI6dEeeyZasfnNSonw" name="OtsiCepSpecHasCtpPac" memberEnd="_2YQQkI6dEeeyZasfnNSonw _2YQ3oI6dEeeyZasfnNSonw">
+      <packagedElement xmi:type="uml:Association" xmi:id="_2YPCcI6dEeeyZasfnNSonw" name="OtsiCepHasCtpPac" memberEnd="_2YQQkI6dEeeyZasfnNSonw _2YQ3oI6dEeeyZasfnNSonw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2YPpgI6dEeeyZasfnNSonw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2YPpgY6dEeeyZasfnNSonw" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_2YQ3oI6dEeeyZasfnNSonw" name="otsiconnectionendpointspec" type="_KjQ3rRKOEeajhbtskMXJfw" association="_2YPCcI6dEeeyZasfnNSonw"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_2YQ3oI6dEeeyZasfnNSonw" name="otsiconnectionendpointspec" type="_KjQ3rRKOEeajhbtskMXJfw" association="_2YPCcI6dEeeyZasfnNSonw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_l-7SkJo3EeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_l_TtEJo3EeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_XCHpEHZpEeiPPoPDo3q5jA" name="OtsiACepSpecAugmentsCep" client="_mXvsEHZlEeiPPoPDo3q5jA">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_fhWN4HiHEeiPPoPDo3q5jA" name="OtsiSipSpecHasCapabilityPac" memberEnd="_fhbGYHiHEeiPPoPDo3q5jA _fhbtcHiHEeiPPoPDo3q5jA">
+      <packagedElement xmi:type="uml:Association" xmi:id="_fhWN4HiHEeiPPoPDo3q5jA" name="OtsiSipHasOtsiCapabilityPac" memberEnd="_fhbGYHiHEeiPPoPDo3q5jA _fhbtcHiHEeiPPoPDo3q5jA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fhZRMHiHEeiPPoPDo3q5jA" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fhZRMXiHEeiPPoPDo3q5jA" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_fhbtcHiHEeiPPoPDo3q5jA" name="otsiserviceinterfacepointspec" type="_EqncAHiHEeiPPoPDo3q5jA" association="_fhWN4HiHEeiPPoPDo3q5jA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Y9qecHiHEeiPPoPDo3q5jA" name="OtsiSipSpecAugmentsSip" client="_EqncAHiHEeiPPoPDo3q5jA">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Y9qecHiHEeiPPoPDo3q5jA" name="TpndSipSpecAugmentsSip" client="_EqncAHiHEeiPPoPDo3q5jA">
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_XqurIHkwEeiO-c_khjKlFQ" name="OtsiACsepSpecAugmentsCsep" client="_O0PLkHkwEeiO-c_khjKlFQ">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_A-T2MHkzEeiO-c_khjKlFQ" name="OtsiSipSpecHasMcPoolPac" memberEnd="_A-Z80HkzEeiO-c_khjKlFQ _A-Z803kzEeiO-c_khjKlFQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_A-T2MHkzEeiO-c_khjKlFQ" name="OtsiSipHasMcPoolPac" memberEnd="_A-Z80HkzEeiO-c_khjKlFQ _A-Z803kzEeiO-c_khjKlFQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_A-T2MXkzEeiO-c_khjKlFQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_A-T2MnkzEeiO-c_khjKlFQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_A-Z803kzEeiO-c_khjKlFQ" name="otsiaserviceinterfacepointspec" type="_EqncAHiHEeiPPoPDo3q5jA" association="_A-T2MHkzEeiO-c_khjKlFQ"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_A-Z803kzEeiO-c_khjKlFQ" name="otsiaserviceinterfacepointspec" type="_EqncAHiHEeiPPoPDo3q5jA" association="_A-T2MHkzEeiO-c_khjKlFQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LbfNMJmUEeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LblT0JmUEeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_aZjdUHk6EeiO-c_khjKlFQ" name="OtsiACsepSpecHasConfigPac" memberEnd="_aZkrcnk6EeiO-c_khjKlFQ _aZmgoHk6EeiO-c_khjKlFQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_aZjdUHk6EeiO-c_khjKlFQ" name="OtsiCsepHasConfigPac" memberEnd="_aZkrcnk6EeiO-c_khjKlFQ _aZmgoHk6EeiO-c_khjKlFQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aZkrcHk6EeiO-c_khjKlFQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aZkrcXk6EeiO-c_khjKlFQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_aZmgoHk6EeiO-c_khjKlFQ" name="otsiaconnectivityserviceendpointspec" type="_O0PLkHkwEeiO-c_khjKlFQ" association="_aZjdUHk6EeiO-c_khjKlFQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_AMK4gHk8EeiO-c_khjKlFQ" name="OtsiACepSpecHasFecPac" memberEnd="_AMLfknk8EeiO-c_khjKlFQ _AMMGonk8EeiO-c_khjKlFQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_AMK4gHk8EeiO-c_khjKlFQ" name="OtsiACepHasFecPac" memberEnd="_AMLfknk8EeiO-c_khjKlFQ _AMMGonk8EeiO-c_khjKlFQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AMLfkHk8EeiO-c_khjKlFQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AMLfkXk8EeiO-c_khjKlFQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_AMMGonk8EeiO-c_khjKlFQ" name="otsiaconnectionendpointspec" type="_mXvsEHZlEeiPPoPDo3q5jA" association="_AMK4gHk8EeiO-c_khjKlFQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_8cLHcIk7Eeil5oKL3Vgl-g" name="NmcCepSpecAugmentsCep" client="_BavtYIXSEeiYFOBVMQg1QQ">
-        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_JA0G4IXSEeiYFOBVMQg1QQ" name="NmcCepSpecHasCtpPac" memberEnd="_JA0t8oXSEeiYFOBVMQg1QQ _JA1VAYXSEeiYFOBVMQg1QQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JA0t8IXSEeiYFOBVMQg1QQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JA0t8YXSEeiYFOBVMQg1QQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_JA1VAYXSEeiYFOBVMQg1QQ" name="nmcconnectionendpointspec" type="_BavtYIXSEeiYFOBVMQg1QQ" association="_JA0G4IXSEeiYFOBVMQg1QQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_LhPS8IoJEeivCevppATXng" name="PhotonicAugmentsLayerProtocolQualifer" client="_ErlpwIoJEeivCevppATXng">
         <supplier xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_8Tky4JmTEeiOmuqNbykpsw" name="McSipHasMcPoolPac" memberEnd="_8Tky45mTEeiOmuqNbykpsw _8Tq5gZmTEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8Tky4ZmTEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8Tky4pmTEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_8Tq5gZmTEeiOmuqNbykpsw" name="smcserviceinterfacepoint" type="_syPL8JmTEeiOmuqNbykpsw" association="_8Tky4JmTEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MiYj0JmUEeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Miq3sJmUEeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_VE468JmVEeiOmuqNbykpsw" name="OlsSipSpecAugmentsSip" client="_syPL8JmTEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nWzrwJmYEeiOmuqNbykpsw" name="SmcCsepHasMcConfigPac" memberEnd="_nWzrw5mYEeiOmuqNbykpsw _nWzryJmYEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nWzrwZmYEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nWzrwpmYEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nWzryJmYEeiOmuqNbykpsw" name="olsconnectivityserviceendpoint" type="_Es15AJmWEeiOmuqNbykpsw" association="_nWzrwJmYEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uyEwMJmoEeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uzBycJmoEeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ObUMoJmaEeiOmuqNbykpsw" name="SmcCsepSpecAugmentsCsep" client="_Es15AJmWEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_djQTwJmoEeiOmuqNbykpsw" name="NmcCsepHasMcConfigPac" memberEnd="_djchApmoEeiOmuqNbykpsw _djchB5moEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_djchAJmoEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_djchAZmoEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_djchB5moEeiOmuqNbykpsw" name="nmcconnectivityserviceendpoint" type="_NCZwkJmoEeiOmuqNbykpsw" association="_djQTwJmoEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vqyg4JmoEeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vq-uIJmoEeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_w_nl0JmoEeiOmuqNbykpsw" name="OtsiCsepHasMcConfigPac" memberEnd="_w_nl05moEeiOmuqNbykpsw _w_tscJmoEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_w_nl0ZmoEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_w_nl0pmoEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_w_tscJmoEeiOmuqNbykpsw" name="otsinmcconnectivityserviceendpointspec" type="_O0PLkHkwEeiO-c_khjKlFQ" association="_w_nl0JmoEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_z1zv0JmoEeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_z1zv0ZmoEeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_7n9LkJmqEeiOmuqNbykpsw" name="NmcCsepSpecAugmentsCsep" client="_NCZwkJmoEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_c-z5wJozEeiOmuqNbykpsw" name="OmsCepSpecAugmentsCep" client="_aiExkJozEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_dbVdsJozEeiOmuqNbykpsw" name="OtsCepSpecAugmentsCep" client="_a2384JozEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_b_2-MJozEeiOmuqNbykpsw" name="NmcCepSpecAugmentsCep" client="_Xa-dwJozEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_cfC0kJozEeiOmuqNbykpsw" name="SmcCepSpecAugmentsCep" client="_aNMGsJozEeiOmuqNbykpsw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_pVuMEJozEeiOmuqNbykpsw" name="NmcCepHasMcCtpPac" memberEnd="_pVuME5ozEeiOmuqNbykpsw _pV0SspozEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_pVuMEZozEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pVuMEpozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_pV0SspozEeiOmuqNbykpsw" name="class1" type="_Xa-dwJozEeiOmuqNbykpsw" association="_pVuMEJozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_apqDcJo3EeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_apwKEJo3EeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_qOr0YJozEeiOmuqNbykpsw" name="OmsCepHasMcCtpPac" memberEnd="_qOx7ApozEeiOmuqNbykpsw _qOx7B5ozEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qOx7AJozEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qOx7AZozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_qOx7B5ozEeiOmuqNbykpsw" name="class3" type="_aiExkJozEeiOmuqNbykpsw" association="_qOr0YJozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b0p28Jo3EeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_b0v9kJo3EeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_qtbl4JozEeiOmuqNbykpsw" name="OtsCepHasMcCtpPac" memberEnd="_qtbl45ozEeiOmuqNbykpsw _qthsgpozEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qtbl4ZozEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qtbl4pozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_qthsgpozEeiOmuqNbykpsw" name="class4" type="_a2384JozEeiOmuqNbykpsw" association="_qtbl4JozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c--8EJo3EeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c_LJUJo3EeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_p0WBwJozEeiOmuqNbykpsw" name="SmcCepHasMcCtpPac" memberEnd="_p0WBw5ozEeiOmuqNbykpsw _p0WByJozEeiOmuqNbykpsw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_p0WBwZozEeiOmuqNbykpsw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_p0WBwpozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_p0WByJozEeiOmuqNbykpsw" name="class2" type="_aNMGsJozEeiOmuqNbykpsw" association="_p0WBwJozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZsTqYJo3EeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Zsf3oJo3EeiOmuqNbykpsw" value="1"/>
+        </ownedEnd>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams"/>
@@ -101,7 +191,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3rRKOEeajhbtskMXJfw" name="OtsiConnectionEndPointSpec">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3rRKOEeajhbtskMXJfw" name="OtsiNmcConnectionEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3sRKOEeajhbtskMXJfw" name="_otsiTermination" type="_KjQ3tBKOEeajhbtskMXJfw" isReadOnly="true" aggregation="composite" association="_KjQ3phKOEeajhbtskMXJfw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3shKOEeajhbtskMXJfw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sxKOEeajhbtskMXJfw" value="1"/>
@@ -134,14 +224,18 @@ License: This module is distributed under the Apache License 2.0</body>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_PKMDsEUIEead1bezhJG4aw" name="McPoolPac">
+      <packagedElement xmi:type="uml:Class" xmi:id="_PKMDsEUIEead1bezhJG4aw" name="MediaChannelPoolCapabilityPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MpIOQI51EeeyZasfnNSonw" name="availableSpectrum" type="_wB7jIHPYEeiPPoPDo3q5jA" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WlhUMI6cEeeyZasfnNSonw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WljwcI6cEeeyZasfnNSonw" value="*"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kt1T0JmXEeiOmuqNbykpsw" name="occupiedSpectrum" type="_wB7jIHPYEeiPPoPDo3q5jA" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qGyVgJmXEeiOmuqNbykpsw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qG-iwJmXEeiOmuqNbykpsw" value="*"/>
+        </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_VvSIYEUIEead1bezhJG4aw" name="OtsiNodeEdgePointSpec">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_otsiMcPool" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">
+      <packagedElement xmi:type="uml:Class" xmi:id="_VvSIYEUIEead1bezhJG4aw" name="MediaChannelNodeEdgePointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_mcPool" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ldi5wNnYEeWIOYiRCk5bbQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ldi5wdnYEeWIOYiRCk5bbQ" value="1"/>
         </ownedAttribute>
@@ -155,7 +249,7 @@ License: This module is distributed under the Apache License 2.0</body>
       <packagedElement xmi:type="uml:Class" xmi:id="_nBhMkI6cEeeyZasfnNSonw" name="MediaChannelCtpPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_J3v2UHZlEeiPPoPDo3q5jA" name="occupiedSpectrum" type="_wB7jIHPYEeiPPoPDo3q5jA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_mXvsEHZlEeiPPoPDo3q5jA" name="OtsiAConnectionEndPointSpec">
+      <packagedElement xmi:type="uml:Class" xmi:id="_mXvsEHZlEeiPPoPDo3q5jA" name="OtsiGConnectionEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3rhKOEeajhbtskMXJfw" name="_otsiAdapter" type="_KjQ3qhKOEeajhbtskMXJfw" isReadOnly="true" aggregation="composite" association="_KjQ3ohKOEeajhbtskMXJfw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3rxKOEeajhbtskMXJfw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sBKOEeajhbtskMXJfw" value="1"/>
@@ -175,12 +269,16 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Mf6h4M4xEeehIvzuBRCtZQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mf8-IM4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l6_TYJmrEeiOmuqNbykpsw" name="supportableModulation" type="__ZU_8HkzEeiO-c_khjKlFQ" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o3uKQJmrEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o30Q4JmrEeiOmuqNbykpsw" value="*"/>
+        </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_EqncAHiHEeiPPoPDo3q5jA" name="OtsiAServiceInterfacePointSpec">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_fhbGYHiHEeiPPoPDo3q5jA" name="_otsiCapability" type="_NhrjUHiHEeiPPoPDo3q5jA" aggregation="composite" association="_fhWN4HiHEeiPPoPDo3q5jA"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_A-Z80HkzEeiO-c_khjKlFQ" name="_otsiMcPool" type="_PKMDsEUIEead1bezhJG4aw" aggregation="composite" association="_A-T2MHkzEeiO-c_khjKlFQ">
+      <packagedElement xmi:type="uml:Class" xmi:id="_EqncAHiHEeiPPoPDo3q5jA" name="OtsiServiceInterfacePointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_fhbGYHiHEeiPPoPDo3q5jA" name="_otsiCapability" type="_NhrjUHiHEeiPPoPDo3q5jA" isReadOnly="true" aggregation="composite" association="_fhWN4HiHEeiPPoPDo3q5jA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_A-Z80HkzEeiO-c_khjKlFQ" name="_mcPool" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_A-T2MHkzEeiO-c_khjKlFQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JI07sHpTEei5LIrjJTgegQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JI07sXpTEei5LIrjJTgegQ" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JI07sXpTEei5LIrjJTgegQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_0mTzoHjCEeixydPRZ8lIKA" name="OtsiAMcPoolPac">
@@ -189,10 +287,14 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__vGtAHjCEeixydPRZ8lIKA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_O0PLkHkwEeiO-c_khjKlFQ" name="OtsiAConnectivityServiceEndPointSpec">
+      <packagedElement xmi:type="uml:Class" xmi:id="_O0PLkHkwEeiO-c_khjKlFQ" name="OtsiConnectivityServiceEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aZkrcnk6EeiO-c_khjKlFQ" name="_otsiConfig" type="_XVi5wHk6EeiO-c_khjKlFQ" aggregation="composite" association="_aZjdUHk6EeiO-c_khjKlFQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYaqMHk6EeiO-c_khjKlFQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYdtgHk6EeiO-c_khjKlFQ" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYdtgHk6EeiO-c_khjKlFQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_w_nl05moEeiOmuqNbykpsw" name="_nmcConfig" type="_awx_YJmYEeiOmuqNbykpsw" aggregation="composite" association="_w_nl0JmoEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_w_nl1pmoEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_w_nl15moEeiOmuqNbykpsw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_XVi5wHk6EeiO-c_khjKlFQ" name="OtsiConfigPac">
@@ -208,7 +310,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_F8Pronk6EeiO-c_khjKlFQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_F8Pro3k6EeiO-c_khjKlFQ" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_e2YfMHpREei5LIrjJTgegQ" name="transmitPower" visibility="public" type="_vzWvoHk-EeiW-bN1POS5zg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_e2YfMHpREei5LIrjJTgegQ" name="requestedTransmitPower" visibility="public" type="_vzWvoHk-EeiW-bN1POS5zg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_qzTdgHk7EeiO-c_khjKlFQ" name="FecParametersPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgXk7EeiO-c_khjKlFQ" name="preFecBer">
@@ -230,8 +332,50 @@ License: This module is distributed under the Apache License 2.0</body>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_BavtYIXSEeiYFOBVMQg1QQ" name="NmcConnectionEndPointSpec">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_JA0t8oXSEeiYFOBVMQg1QQ" name="_nmcCtp" type="_nBhMkI6cEeeyZasfnNSonw" aggregation="composite" association="_JA0G4IXSEeiYFOBVMQg1QQ"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_syPL8JmTEeiOmuqNbykpsw" name="McServiceInterfacePointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Tky45mTEeiOmuqNbykpsw" name="_mcPool" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_8Tky4JmTEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Tky5pmTEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Tq5gJmTEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_Es15AJmWEeiOmuqNbykpsw" name="SmcConnectivityServiceEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nWzrw5mYEeiOmuqNbykpsw" name="_smcConfig" type="_awx_YJmYEeiOmuqNbykpsw" aggregation="composite" association="_nWzrwJmYEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nWzrxpmYEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nWzrx5mYEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_awx_YJmYEeiOmuqNbykpsw" name="MediaChannelConfigPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_i18IoJmYEeiOmuqNbykpsw" name="requestedSpectrum" type="_wB7jIHPYEeiPPoPDo3q5jA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_NCZwkJmoEeiOmuqNbykpsw" name="NmcConnectivityServiceEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_djchApmoEeiOmuqNbykpsw" name="_nmcConfig" type="_awx_YJmYEeiOmuqNbykpsw" aggregation="composite" association="_djQTwJmoEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_djchBZmoEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_djchBpmoEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_Xa-dwJozEeiOmuqNbykpsw" name="NmcConnectionEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pVuME5ozEeiOmuqNbykpsw" name="_nmcCtp" type="_nBhMkI6cEeeyZasfnNSonw" aggregation="composite" association="_pVuMEJozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pV0SsJozEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pV0SsZozEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_aiExkJozEeiOmuqNbykpsw" name="OmsConnectionEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qOx7ApozEeiOmuqNbykpsw" name="_omsCtp" type="_nBhMkI6cEeeyZasfnNSonw" aggregation="composite" association="_qOr0YJozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qOx7BZozEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qOx7BpozEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_a2384JozEeiOmuqNbykpsw" name="OtsConnectionEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qtbl45ozEeiOmuqNbykpsw" name="_otsCtp" type="_nBhMkI6cEeeyZasfnNSonw" aggregation="composite" association="_qtbl4JozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qthsgJozEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qthsgZozEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_aNMGsJozEeiOmuqNbykpsw" name="SmcConnectionEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_p0WBw5ozEeiOmuqNbykpsw" name="_smcCtp" type="_nBhMkI6cEeeyZasfnNSonw" aggregation="composite" association="_p0WBwJozEeiOmuqNbykpsw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p0WBxpozEeiOmuqNbykpsw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p0WBx5ozEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_gyFqQBKOEeajhbtskMXJfw" name="TypeDefinitions">
@@ -641,17 +785,86 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_2KBpAHpKEei5LIrjJTgegQ" base_Element="_01yZ8HpKEei5LIrjJTgegQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_e2el0HpREei5LIrjJTgegQ" base_StructuralFeature="_e2YfMHpREei5LIrjJTgegQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_e2el0XpREei5LIrjJTgegQ" base_Property="_e2YfMHpREei5LIrjJTgegQ"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_BavtYYXSEeiYFOBVMQg1QQ" base_Class="_BavtYIXSEeiYFOBVMQg1QQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_BavtYoXSEeiYFOBVMQg1QQ" base_Class="_BavtYIXSEeiYFOBVMQg1QQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_JA0t84XSEeiYFOBVMQg1QQ" base_Property="_JA0t8oXSEeiYFOBVMQg1QQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_JA1VAIXSEeiYFOBVMQg1QQ" base_StructuralFeature="_JA0t8oXSEeiYFOBVMQg1QQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_JA1VAoXSEeiYFOBVMQg1QQ" base_Property="_JA1VAYXSEeiYFOBVMQg1QQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_JA1VA4XSEeiYFOBVMQg1QQ" base_StructuralFeature="_JA1VAYXSEeiYFOBVMQg1QQ"/>
-  <OpenModel_Profile:Specify xmi:id="_Aq-DIIk8Eeil5oKL3Vgl-g" base_Abstraction="_8cLHcIk7Eeil5oKL3Vgl-g"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_-rcl8Ik8Eeil5oKL3Vgl-g" base_Association="_JA0G4IXSEeiYFOBVMQg1QQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_qzUroHk7EeiO-c_khjKlFQ" base_Class="_qzTdgHk7EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_qzUEkHk7EeiO-c_khjKlFQ" base_Class="_qzTdgHk7EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:Experimental xmi:id="_FzBzUHk8EeiO-c_khjKlFQ" base_Element="_qzTdgHk7EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:Specify xmi:id="_V_v5MIoJEeivCevppATXng" base_Abstraction="_LhPS8IoJEeivCevppATXng"/>
   <OpenModel_Profile:Experimental xmi:id="_i4NZYIoJEeivCevppATXng" base_Element="_ErlpwIoJEeivCevppATXng"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_s21YEJmTEeiOmuqNbykpsw" base_Class="_syPL8JmTEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_s27esJmTEeiOmuqNbykpsw" base_Class="_syPL8JmTEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8Tky5JmTEeiOmuqNbykpsw" base_StructuralFeature="_8Tky45mTEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8Tky5ZmTEeiOmuqNbykpsw" base_Property="_8Tky45mTEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8Tq5gpmTEeiOmuqNbykpsw" base_StructuralFeature="_8Tq5gZmTEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8Tq5g5mTEeiOmuqNbykpsw" base_Property="_8Tq5gZmTEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_Kqk4MJmVEeiOmuqNbykpsw" base_Element="_syPL8JmTEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_O2NyMJmVEeiOmuqNbykpsw" base_Association="_8Tky4JmTEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="_XQeowJmVEeiOmuqNbykpsw" base_Abstraction="_VE468JmVEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_Es15AZmWEeiOmuqNbykpsw" base_Class="_Es15AJmWEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Es15ApmWEeiOmuqNbykpsw" base_Class="_Es15AJmWEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kt1T0ZmXEeiOmuqNbykpsw" base_StructuralFeature="_kt1T0JmXEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_kt1T0pmXEeiOmuqNbykpsw" base_Property="_kt1T0JmXEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_awx_YZmYEeiOmuqNbykpsw" base_Class="_awx_YJmYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_awx_YpmYEeiOmuqNbykpsw" base_Class="_awx_YJmYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_i18IoZmYEeiOmuqNbykpsw" base_StructuralFeature="_i18IoJmYEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_i18IopmYEeiOmuqNbykpsw" base_Property="_i18IoJmYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_ljpFAJmYEeiOmuqNbykpsw" base_Element="_awx_YJmYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nWzrxJmYEeiOmuqNbykpsw" base_StructuralFeature="_nWzrw5mYEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nWzrxZmYEeiOmuqNbykpsw" base_Property="_nWzrw5mYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nWzryZmYEeiOmuqNbykpsw" base_StructuralFeature="_nWzryJmYEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nWzrypmYEeiOmuqNbykpsw" base_Property="_nWzryJmYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_rS7w0JmdEeiOmuqNbykpsw" base_Element="_Es15AJmWEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_NCZwkZmoEeiOmuqNbykpsw" base_Class="_NCZwkJmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_NCZwkpmoEeiOmuqNbykpsw" base_Class="_NCZwkJmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_SoZvwJmoEeiOmuqNbykpsw" base_Element="_NCZwkJmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_djchA5moEeiOmuqNbykpsw" base_StructuralFeature="_djchApmoEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_djchBJmoEeiOmuqNbykpsw" base_Property="_djchApmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_djchCJmoEeiOmuqNbykpsw" base_StructuralFeature="_djchB5moEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_djchCZmoEeiOmuqNbykpsw" base_Property="_djchB5moEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_w_nl1JmoEeiOmuqNbykpsw" base_StructuralFeature="_w_nl05moEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w_nl1ZmoEeiOmuqNbykpsw" base_Property="_w_nl05moEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_w_tscZmoEeiOmuqNbykpsw" base_StructuralFeature="_w_tscJmoEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w_tscpmoEeiOmuqNbykpsw" base_Property="_w_tscJmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_85XbAJmoEeiOmuqNbykpsw" base_Association="_nWzrwJmYEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_-FugcJmoEeiOmuqNbykpsw" base_Association="_djQTwJmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_JBxXQJmpEeiOmuqNbykpsw" base_Association="_w_nl0JmoEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="_6wAP4JmqEeiOmuqNbykpsw" base_Abstraction="_ObUMoJmaEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="_E9YC0JmrEeiOmuqNbykpsw" base_Abstraction="_7n9LkJmqEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l6_TYZmrEeiOmuqNbykpsw" base_StructuralFeature="_l6_TYJmrEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_l6_TYpmrEeiOmuqNbykpsw" base_Property="_l6_TYJmrEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_XdQ8wJozEeiOmuqNbykpsw" base_Class="_Xa-dwJozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_XdXDYJozEeiOmuqNbykpsw" base_Class="_Xa-dwJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aNMGsZozEeiOmuqNbykpsw" base_Class="_aNMGsJozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_aNMGspozEeiOmuqNbykpsw" base_Class="_aNMGsJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aiExkZozEeiOmuqNbykpsw" base_Class="_aiExkJozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_aiExkpozEeiOmuqNbykpsw" base_Class="_aiExkJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_a2-DgJozEeiOmuqNbykpsw" base_Class="_a2384JozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_a2-DgZozEeiOmuqNbykpsw" base_Class="_a2384JozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pVuMFJozEeiOmuqNbykpsw" base_StructuralFeature="_pVuME5ozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_pVuMFZozEeiOmuqNbykpsw" base_Property="_pVuME5ozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pV0Ss5ozEeiOmuqNbykpsw" base_StructuralFeature="_pV0SspozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_pV0StJozEeiOmuqNbykpsw" base_Property="_pV0SspozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_p0WBxJozEeiOmuqNbykpsw" base_StructuralFeature="_p0WBw5ozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_p0WBxZozEeiOmuqNbykpsw" base_Property="_p0WBw5ozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_p0WByZozEeiOmuqNbykpsw" base_StructuralFeature="_p0WByJozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_p0WBypozEeiOmuqNbykpsw" base_Property="_p0WByJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qOx7A5ozEeiOmuqNbykpsw" base_StructuralFeature="_qOx7ApozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qOx7BJozEeiOmuqNbykpsw" base_Property="_qOx7ApozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qOx7CJozEeiOmuqNbykpsw" base_StructuralFeature="_qOx7B5ozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qOx7CZozEeiOmuqNbykpsw" base_Property="_qOx7B5ozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qtbl5JozEeiOmuqNbykpsw" base_StructuralFeature="_qtbl45ozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qtbl5ZozEeiOmuqNbykpsw" base_Property="_qtbl45ozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qthsg5ozEeiOmuqNbykpsw" base_StructuralFeature="_qthsgpozEeiOmuqNbykpsw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qthshJozEeiOmuqNbykpsw" base_Property="_qthsgpozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_T14UcJo1EeiOmuqNbykpsw" base_Element="_aNMGsJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_UryowJo1EeiOmuqNbykpsw" base_Element="_Xa-dwJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_VbmVEJo1EeiOmuqNbykpsw" base_Element="_aiExkJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Experimental xmi:id="_WIP_sJo1EeiOmuqNbykpsw" base_Element="_a2384JozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="_8S6ugJo2EeiOmuqNbykpsw" base_Abstraction="_cfC0kJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="_9Pg5oJo2EeiOmuqNbykpsw" base_Abstraction="_b_2-MJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="_-QGz8Jo2EeiOmuqNbykpsw" base_Abstraction="_c-z5wJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:Specify xmi:id="__ffYMJo2EeiOmuqNbykpsw" base_Abstraction="_dbVdsJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Av7FUJo3EeiOmuqNbykpsw" base_Association="_p0WBwJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_CQgHQJo3EeiOmuqNbykpsw" base_Association="_pVuMEJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_DOQI8Jo3EeiOmuqNbykpsw" base_Association="_qOr0YJozEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_EKZBEJo3EeiOmuqNbykpsw" base_Association="_qtbl4JozEeiOmuqNbykpsw"/>
 </xmi:XMI>


### PR DESCRIPTION
- renamed and updated Service constructs: OtsiSIPSpec, McSIPSpec,OtsiC SEPSpec, SmcCSEPSpec, NmcCSEPSpec
- added occupiedSpectrum attribute to McPoolCapabilityPac
- added MediaChannelConfigPac (requestedSpectrum attribute) to CSEPs
- renamed OtsiACEPSpec to OtsiGCEPSpec, OtsiCEPSpec to OtsiNmcCEPSpec
- added McCEPSpec classes: SmcCEPSpec, NmcCEPSpec, OmsCEPSpec, OtsCEPSpec with MediaChannelCtpPac.occupiedSpectrum attribute