### PR TITLE
Fix #333: Aligned RoutingConstraints for Connectivity & PathComputation

### DIFF
--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -7,45 +7,41 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0G9yijBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0G9yizBFEeam35bpdXJzEw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_cyxRgNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygt4EK1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4Es8M2kIEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyxRgdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygt4Ea1eEeiIjuV0HZnJAQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyx4kNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygt4Eq1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4EtL4EUcEeWEwNCluy4jrw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyx4kdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygt4E61eEeiIjuV0HZnJAQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyx4ktoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-sK1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_WFu44u_qEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyx4k9oHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-sa1eEeiIjuV0HZnJAQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyyfoNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-sq1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Wuyu0q1bEeiIjuV0HZnJAQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-s61eEeiIjuV0HZnJAQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-tK1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TyD6Qv4yEea_VPdGG2-szQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfodoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-ta1eEeiIjuV0HZnJAQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyyfotoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nfDxo-_pEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfo9oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyyfpNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_caIFkNnlEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfpdoHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyyfptoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_kuDzQ0HaEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfp9oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyyfqNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-tq1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MKK0kIfWEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfqdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-t61eEeiIjuV0HZnJAQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyzGsNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-uK1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nfDxo-_pEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-ua1eEeiIjuV0HZnJAQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-vK1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyzGsdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-va1eEeiIjuV0HZnJAQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_cyzGstoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ygz-vq1eEeiIjuV0HZnJAQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyzGs9oHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygz-v61eEeiIjuV0HZnJAQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0G9zbDBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0G9zbTBFEeam35bpdXJzEw"/>
@@ -65,7 +61,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G9zeTBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G9zpzBFEeam35bpdXJzEw" x="222" y="23" height="219"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G9zpzBFEeam35bpdXJzEw" x="222" y="56" width="298" height="186"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0G91jDBFEeam35bpdXJzEw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G91jTBFEeam35bpdXJzEw" type="Class_NameLabel"/>
@@ -73,49 +69,37 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0G91jzBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0G91kDBFEeam35bpdXJzEw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_et9XwIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TfFtEK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Hk2vsK1lEeiqCPid09Hqfw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtEa1lEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TfFtEq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_lY2XULvZEeWYrqoqXLgguw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9XwYoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtE61lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_et9XwooPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TfFtFK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3bhE4L2BEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9Xw4oPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtFa1lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_et9-0IoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_1dtjYIfYEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9-0YoPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_et9-0ooPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TfFtFq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_-YtW8L11EeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9-04oPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtF61lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_et9-1IoPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TfFtGK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_caIFkNnlEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtGa1lEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TfFtGq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ru76gGNFEee0bPnI-Gt-mQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9-1YoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtG61lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_et9-1ooPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_RhdgwL2HEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9-14oPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_et9-2IoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_GqeeML2JEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et9-2YoPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_et-l4IoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YQtngIoPEeivCevppATXng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et-l4YoPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_et-l4ooPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_7Zr48IfgEeet-8tHdGGp_w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et-l44oPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_et-l5IoPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TfFtHK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_l8TgscF3EeaALJQAf08uAg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et-l5YoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtHa1lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_et-l5ooPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TfFtHq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_wt-RckXOEeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_et-l54oPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfFtH61lEeiqCPid09Hqfw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0G928TBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0G928jBFEeam35bpdXJzEw"/>
@@ -135,7 +119,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G92_jBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G93LDBFEeam35bpdXJzEw" x="208" y="-295" width="303" height="237"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G93LDBFEeam35bpdXJzEw" x="208" y="-216" width="303" height="158"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HHioDBFEeam35bpdXJzEw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHioTBFEeam35bpdXJzEw" type="Class_NameLabel"/>
@@ -309,7 +293,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHl6TBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="87" y="313" width="303" height="209"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="147" y="315" width="303" height="209"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HtYijBFEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0HtYizBFEeam35bpdXJzEw" showTitle="true"/>
@@ -810,39 +794,39 @@
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_BDPgJf4xEea_VPdGG2-szQ" type="Class_AttributeCompartment">
         <children xmi:type="notation:Shape" xmi:id="_n4dMgNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dMgdoHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4dzkNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzkdoHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4dzktoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_wGVAhMF-EeaALJQAf08uAg"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_wGVAhMF-EeaALJQAf08uAg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzk9oHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4dzlNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_xyluAsF-EeaALJQAf08uAg"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_xyluAsF-EeaALJQAf08uAg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzldoHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4dzltoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzl9oHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4dzmNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzmdoHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4dzmtoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzm9oHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4eaoNoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4eaodoHEeeYx-v40uoW_Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_n4eaotoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_SWwL11EeWdore3Cxez9g"/>
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_3_SWwL11EeWdore3Cxez9g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n4eao9oHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_BDPgJv4xEea_VPdGG2-szQ"/>
@@ -862,13 +846,13 @@
         <styles xmi:type="notation:FilteringStyle" xmi:id="_BDPgMv4xEea_VPdGG2-szQ"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPgM_4xEea_VPdGG2-szQ"/>
       </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_-fei4P4wEea_VPdGG2-szQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPgIf4xEea_VPdGG2-szQ" x="-258" y="202" width="302" height="222"/>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPgIf4xEea_VPdGG2-szQ" x="-283" y="185" width="302" height="174"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BDVm2_4xEea_VPdGG2-szQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BDVm3P4xEea_VPdGG2-szQ" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BDVm3v4xEea_VPdGG2-szQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDVm3f4xEea_VPdGG2-szQ" x="200"/>
@@ -941,7 +925,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_oMIfVEeeirpBaj87qAw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_BEYfVEeeirpBaj87qAw" x="-279" y="-85" height="255"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_BEYfVEeeirpBaj87qAw" x="-281" y="-28" height="205"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__ZO4sIfVEeeirpBaj87qAw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__ZO4sYfVEeeirpBaj87qAw"/>
@@ -950,48 +934,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZO4sofVEeeirpBaj87qAw" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_n02ZoIfbEeeirpBaj87qAw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_n02ZoofbEeeirpBaj87qAw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_n03AsIfbEeeirpBaj87qAw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_n03AsYfbEeeirpBaj87qAw" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_n03AsofbEeeirpBaj87qAw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_KxFdkIfdEeet-8tHdGGp_w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_6ZZS4IfbEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KxFdkYfdEeet-8tHdGGp_w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_KxIg4IfdEeet-8tHdGGp_w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_-XrtYIfbEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KxIg4YfdEeet-8tHdGGp_w"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_n03As4fbEeeirpBaj87qAw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_n03AtIfbEeeirpBaj87qAw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_n03AtYfbEeeirpBaj87qAw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n03AtofbEeeirpBaj87qAw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_n03At4fbEeeirpBaj87qAw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_n03AuIfbEeeirpBaj87qAw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_n03AuYfbEeeirpBaj87qAw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_n03AuofbEeeirpBaj87qAw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n03Au4fbEeeirpBaj87qAw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_n03AvIfbEeeirpBaj87qAw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_n03AvYfbEeeirpBaj87qAw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_n03AvofbEeeirpBaj87qAw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_n03Av4fbEeeirpBaj87qAw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n03AwIfbEeeirpBaj87qAw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n02ZoYfbEeeirpBaj87qAw" x="-290" y="-223" height="82"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_n1D1A4fbEeeirpBaj87qAw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_n1D1BIfbEeeirpBaj87qAw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1D1BofbEeeirpBaj87qAw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1D1BYfbEeeirpBaj87qAw" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SCXpgIhDEeeOl5P_FBJSmA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_SCY3oIhDEeeOl5P_FBJSmA" type="Class_NameLabel"/>
@@ -1071,14 +1013,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCrLgohDEeeOl5P_FBJSmA" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_eeIQE4uQEeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_eeIQFIuQEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eeIQFouQEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eeIQFYuQEeiu6boZkiJHCA" x="408" y="-395"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_lUBw4IuQEeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_lUBw4YuQEeiu6boZkiJHCA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lUBw44uQEeiu6boZkiJHCA" name="BASE_ELEMENT">
@@ -1134,6 +1068,76 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZGrNxYuREeiu6boZkiJHCA" x="919" y="130"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__j-OAK1aEeiIjuV0HZnJAQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="__j-OAq1aEeiIjuV0HZnJAQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="__j-OA61aEeiIjuV0HZnJAQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__j-OBK1aEeiIjuV0HZnJAQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__j-OBa1aEeiIjuV0HZnJAQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_QFABQK1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_AwfVYK1kEeiqCPid09Hqfw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABQa1kEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QFABQq1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_RhdgwL2HEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABQ61kEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QFABRK1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_GqeeML2JEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABRa1kEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QFABRq1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_YQtngIoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABR61kEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QFABSK1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_-XrtYIfbEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABSa1kEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QFABSq1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_6ZZS4IfbEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABS61kEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QFABTK1kEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_1dtjYIfYEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QFABTa1kEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="__j-OBq1aEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__j-OB61aEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__j-OCK1aEeiIjuV0HZnJAQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OCa1aEeiIjuV0HZnJAQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__j-OCq1aEeiIjuV0HZnJAQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__j-OC61aEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__j-ODK1aEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__j-ODa1aEeiIjuV0HZnJAQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-ODq1aEeiIjuV0HZnJAQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__j-OD61aEeiIjuV0HZnJAQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__j-OEK1aEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__j-OEa1aEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__j-OEq1aEeiIjuV0HZnJAQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OE61aEeiIjuV0HZnJAQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-282" y="-183" height="141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__kQh461aEeiIjuV0HZnJAQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__kQh5K1aEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__kQh5q1aEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__kQh5a1aEeiIjuV0HZnJAQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5re7M61bEeiIjuV0HZnJAQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5re7NK1bEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5re7Nq1bEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5re7Na1bEeiIjuV0HZnJAQ" x="422" y="-77"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmgeMTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmgeMjBFEeam35bpdXJzEw"/>
@@ -1222,7 +1226,7 @@
     <edges xmi:type="notation:Connector" xmi:id="_BDVm3_4xEea_VPdGG2-szQ" type="StereotypeCommentLink" source="_BDPgIP4xEea_VPdGG2-szQ" target="_BDVm2_4xEea_VPdGG2-szQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_BDVm4P4xEea_VPdGG2-szQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BDVm5P4xEea_VPdGG2-szQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDVm4f4xEea_VPdGG2-szQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
@@ -1239,16 +1243,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ZPfw4fVEeeirpBaj87qAw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ZQG0IfVEeeirpBaj87qAw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_n1D1B4fbEeeirpBaj87qAw" type="StereotypeCommentLink" source="_n02ZoIfbEeeirpBaj87qAw" target="_n1D1A4fbEeeirpBaj87qAw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_n1D1CIfbEeeirpBaj87qAw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1EcEofbEeeirpBaj87qAw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n1D1CYfbEeeirpBaj87qAw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n1EcEIfbEeeirpBaj87qAw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n1EcEYfbEeeirpBaj87qAw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_SCrykIhDEeeOl5P_FBJSmA" type="StereotypeCommentLink" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_SCrLgIhDEeeOl5P_FBJSmA">
       <styles xmi:type="notation:FontStyle" xmi:id="_SCrykYhDEeeOl5P_FBJSmA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SCrylYhDEeeOl5P_FBJSmA" name="BASE_ELEMENT">
@@ -1258,41 +1252,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SCrykohDEeeOl5P_FBJSmA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SCryk4hDEeeOl5P_FBJSmA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SCrylIhDEeeOl5P_FBJSmA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_edc6oIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G91jDBFEeam35bpdXJzEw" target="_n02ZoIfbEeeirpBaj87qAw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_eddhsIuQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eddhsYuQEeiu6boZkiJHCA" x="-1" y="-8"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_eddhsouQEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eddhs4uQEeiu6boZkiJHCA" x="15" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_eddhtIuQEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eddhtYuQEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_eddhtouQEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eddht4uQEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_eddhuIuQEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eddhuYuQEeiu6boZkiJHCA" x="-15" y="-15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_eddhuouQEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eddhu4uQEeiu6boZkiJHCA" x="15" y="-15"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_edc6oYuQEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_edc6oouQEeiu6boZkiJHCA" points="[208, -182, -643984, -643984]$[33, -177, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jm0BIIuQEeiu6boZkiJHCA" id="(0.0,0.34177215189873417)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ixe7oIuQEeiu6boZkiJHCA" id="(1.0,0.10975609756097561)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_eeIQF4uQEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_edc6oIuQEeiu6boZkiJHCA" target="_eeIQE4uQEeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_eeIQGIuQEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eeIQHIuQEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eeIQGYuQEeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eeIQGouQEeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eeIQG4uQEeiu6boZkiJHCA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lT2KsIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="__Y_BEIfVEeeirpBaj87qAw">
       <children xmi:type="notation:DecorationNode" xmi:id="_lT2xwIuQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1322,8 +1281,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_lT2KsYuQEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lT2KsouQEeiu6boZkiJHCA" points="[222, 102, -643984, -643984]$[49, 65, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nlKtEIuQEeiu6boZkiJHCA" id="(0.0,0.2420091324200913)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oo4M0IuQEeiu6boZkiJHCA" id="(1.0,0.6313725490196078)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nlKtEIuQEeiu6boZkiJHCA" id="(0.0,0.40860215053763443)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oo4M0IuQEeiu6boZkiJHCA" id="(1.0,0.7804878048780488)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lUBw5IuQEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_lT2KsIuQEeiu6boZkiJHCA" target="_lUBw4IuQEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_lUBw5YuQEeiu6boZkiJHCA"/>
@@ -1349,7 +1308,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xDb-V4uQEeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_xDb-WIuQEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xDb-WYuQEeiu6boZkiJHCA" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xDb-WYuQEeiu6boZkiJHCA" x="-3" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_xDb-WouQEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xDb-W4uQEeiu6boZkiJHCA" y="-20"/>
@@ -1358,7 +1317,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_l8BM0MF3EeaALJQAf08uAg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xDbXQouQEeiu6boZkiJHCA" points="[365, -58, -643984, -643984]$[359, 23, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRejMIuQEeiu6boZkiJHCA" id="(0.11221122112211221,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y-LMsIuQEeiu6boZkiJHCA" id="(0.06993006993006994,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y-LMsIuQEeiu6boZkiJHCA" id="(0.06711409395973154,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_z_dqkIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G91jDBFEeam35bpdXJzEw" target="_0G9yhzBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_z_dqk4uQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1374,7 +1333,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_z_dqmouQEeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_z_dqm4uQEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_z_dqnIuQEeiu6boZkiJHCA" y="-17"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z_dqnIuQEeiu6boZkiJHCA" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_z_dqnYuQEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_z_dqnouQEeiu6boZkiJHCA" x="2" y="18"/>
@@ -1383,7 +1342,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_wt9DUEXOEeaB8vMnkFQLXQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z_dqkouQEeiu6boZkiJHCA" points="[365, -58, -643984, -643984]$[359, 23, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1udjAIuQEeiu6boZkiJHCA" id="(0.8778877887788779,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Weg0IuQEeiu6boZkiJHCA" id="(0.8811188811188811,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Weg0IuQEeiu6boZkiJHCA" id="(0.8456375838926175,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3JCDkIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="_0G91jDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_3JCqoIuQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1402,11 +1361,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3JDRsIuQEeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3JDRsYuQEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3JDRsouQEeiu6boZkiJHCA" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3JDRsouQEeiu6boZkiJHCA" x="5" y="16"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_3JCDkYuQEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3JCDkouQEeiu6boZkiJHCA" points="[359, 23, -643984, -643984]$[365, -58, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iXm6IK1dEeiIjuV0HZnJAQ" id="(0.4597315436241611,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bhqvUK1YEeiIjuV0HZnJAQ" id="(0.49834983498349833,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3JQGB4uQEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_3JCDkIuQEeiu6boZkiJHCA" target="_3JQGA4uQEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_3JQGCIuQEeiu6boZkiJHCA"/>
@@ -1418,30 +1379,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3JQtEIuQEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3JQtEYuQEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_8oadYIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="_BDPgIP4xEea_VPdGG2-szQ">
+    <edges xmi:type="notation:Connector" xmi:id="_8oadYIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="_BDPgIP4xEea_VPdGG2-szQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_8obEcIuQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obEcYuQEeiu6boZkiJHCA" x="-1" y="-14"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IKD6EK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obEcYuQEeiu6boZkiJHCA" x="16" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8obEcouQEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obEc4uQEeiu6boZkiJHCA" x="5" y="26"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IRySsK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obEc4uQEeiu6boZkiJHCA" y="-4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8obEdIuQEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obEdYuQEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IaHvUK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obEdYuQEeiu6boZkiJHCA" x="27" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8obEdouQEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obrgIuQEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IizxQK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obrgIuQEeiu6boZkiJHCA" x="-27" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8obrgYuQEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obrgouQEeiu6boZkiJHCA" x="-18" y="-16"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ip3bgK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obrgouQEeiu6boZkiJHCA" x="9" y="-16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8obrg4uQEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obrhIuQEeiu6boZkiJHCA" x="12" y="-12"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IzCloK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8obrhIuQEeiu6boZkiJHCA" x="-15" y="-12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_8oadYYuQEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8oadYouQEeiu6boZkiJHCA" points="[222, 187, -643984, -643984]$[44, 255, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__GDkgIuQEeiu6boZkiJHCA" id="(0.0,0.8904109589041096)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Mcb8IuQEeiu6boZkiJHCA" id="(1.0,0.07207207207207207)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8oadYouQEeiu6boZkiJHCA" points="[222, 218, -643984, -643984]$[120, 218, -643984, -643984]$[120, 292, -643984, -643984]$[19, 292, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__GDkgIuQEeiu6boZkiJHCA" id="(0.0,0.8709677419354839)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Mcb8IuQEeiu6boZkiJHCA" id="(1.0,0.6149425287356322)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_8onRtIuQEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_8oadYIuQEeiu6boZkiJHCA" target="_8onRsIuQEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_8onRtYuQEeiu6boZkiJHCA"/>
@@ -1455,28 +1422,34 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DM_ksIuREeiu6boZkiJHCA" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="_0HHlMDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_DM_ks4uREeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALwIuREeiu6boZkiJHCA" x="3" y="6"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XRyRsK1cEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALwIuREeiu6boZkiJHCA" x="8" y="4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_DNALwYuREeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALwouREeiu6boZkiJHCA" x="-8" y="-1"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XdXPkK1cEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALwouREeiu6boZkiJHCA" x="-6" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_DNALw4uREeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALxIuREeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XlwWkK1cEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALxIuREeiu6boZkiJHCA" x="12" y="-19"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_DNALxYuREeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALxouREeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XujGMK1cEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALxouREeiu6boZkiJHCA" x="-10" y="18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_DNALx4uREeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALyIuREeiu6boZkiJHCA" x="-1" y="-15"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_X3uQUK1cEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALyIuREeiu6boZkiJHCA" x="10" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_DNALyYuREeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALyouREeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YAsmIK1cEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DNALyouREeiu6boZkiJHCA" x="-11" y="-19"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_DM_ksYuREeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DM_ksouREeiu6boZkiJHCA" points="[311, 242, -643984, -643984]$[277, 313, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EXtEUIuREeiu6boZkiJHCA" id="(0.08391608391608392,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EvkxwIuREeiu6boZkiJHCA" id="(0.5247524752475248,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EXtEUIuREeiu6boZkiJHCA" id="(0.2080536912751678,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EvkxwIuREeiu6boZkiJHCA" id="(0.4521452145214521,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DNKj0IuREeiu6boZkiJHCA" type="StereotypeCommentLink" source="_DM_ksIuREeiu6boZkiJHCA" target="_DNJ8w4uREeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_DNKj0YuREeiu6boZkiJHCA"/>
@@ -1516,7 +1489,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_G3oqcYuREeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G3oqcouREeiu6boZkiJHCA" points="[436, 242, -643984, -643984]$[461, 308, -643984, -643984]$[719, 308, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IAcFkIuREeiu6boZkiJHCA" id="(0.8356643356643356,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IAcFkIuREeiu6boZkiJHCA" id="(0.802013422818792,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IAcFkYuREeiu6boZkiJHCA" id="(0.0,0.3979591836734694)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_G30QpIuREeiu6boZkiJHCA" type="StereotypeCommentLink" source="_G3oqcIuREeiu6boZkiJHCA" target="_G30QoIuREeiu6boZkiJHCA">
@@ -1689,6 +1662,57 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iiLsYqSfEeiKJbr6a5Jjpg" points="[1101, -176, -643984, -643984]$[1179, -176, -643984, -643984]$[1179, -251, -643984, -643984]$[1101, -251, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lFunMKSfEeiKJbr6a5Jjpg" id="(1.0,0.502092050209205)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lFunMaSfEeiKJbr6a5Jjpg" id="(1.0,0.18828451882845187)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__kQh561aEeiIjuV0HZnJAQ" type="StereotypeCommentLink" source="__j-OAK1aEeiIjuV0HZnJAQ" target="__kQh461aEeiIjuV0HZnJAQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="__kQh6K1aEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__kQh7K1aEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__kQh6a1aEeiIjuV0HZnJAQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__kQh6q1aEeiIjuV0HZnJAQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__kQh661aEeiIjuV0HZnJAQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_W6DjoK1bEeiIjuV0HZnJAQ" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="__j-OAK1aEeiIjuV0HZnJAQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_W6Djo61bEeiIjuV0HZnJAQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zzraUK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6DjpK1bEeiIjuV0HZnJAQ" x="13" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_W6Djpa1bEeiIjuV0HZnJAQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_z7zbkK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Djpq1bEeiIjuV0HZnJAQ" x="29" y="-1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_W6Djp61bEeiIjuV0HZnJAQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0EMikK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6DjqK1bEeiIjuV0HZnJAQ" x="45" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_W6Djqa1bEeiIjuV0HZnJAQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0M-rIK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Djqq1bEeiIjuV0HZnJAQ" x="-45" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_W6Djq61bEeiIjuV0HZnJAQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0V26UK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6DjrK1bEeiIjuV0HZnJAQ" x="17" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_W6Djra1bEeiIjuV0HZnJAQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0eX9IK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Djrq1bEeiIjuV0HZnJAQ" x="-16" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_W6Djoa1bEeiIjuV0HZnJAQ"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W6Djoq1bEeiIjuV0HZnJAQ" points="[222, 51, -643984, -643984]$[132, 51, -643984, -643984]$[132, -100, -643984, -643984]$[16, -100, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAK1bEeiIjuV0HZnJAQ" id="(0.0,0.1324200913242009)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAa1bEeiIjuV0HZnJAQ" id="(1.0,0.5886524822695035)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5re7N61bEeiIjuV0HZnJAQ" type="StereotypeCommentLink" source="_W6DjoK1bEeiIjuV0HZnJAQ" target="_5re7M61bEeiIjuV0HZnJAQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5re7OK1bEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5re7PK1bEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5re7Oa1bEeiIjuV0HZnJAQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5re7Oq1bEeiIjuV0HZnJAQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5re7O61bEeiIjuV0HZnJAQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityServiceSkeleton" measurementUnit="Pixel">
@@ -5342,40 +5366,6 @@
       <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_KtcbYCmxEeeA7tvtQmACtQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CY6TQYhBEeeOl5P_FBJSmA" x="348" y="211"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Dkf8oIhBEeeOl5P_FBJSmA" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Dkf8oohBEeeOl5P_FBJSmA" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Dkf8o4hBEeeOl5P_FBJSmA" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Dkf8pIhBEeeOl5P_FBJSmA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Dkf8pYhBEeeOl5P_FBJSmA" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_gDmagIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_LLdOwUXZEeeeyqnd6Cxkjw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gDmagYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_gDoPsIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_LLdOwkXZEeeeyqnd6Cxkjw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gDoPsYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_gDoPsohBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_LLdOw0XZEeeeyqnd6Cxkjw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gDoPs4hBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_gDo2wIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_srl4wGhjEeeWO9Idc2UXkw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gDo2wYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_gDo2wohBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_tZ4iIGhjEeeWO9Idc2UXkw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gDo2w4hBEeeOl5P_FBJSmA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Dkf8pohBEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Dkf8p4hBEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Dkf8qIhBEeeOl5P_FBJSmA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Dkf8qYhBEeeOl5P_FBJSmA"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_LLdOwEXZEeeeyqnd6Cxkjw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Dkf8oYhBEeeOl5P_FBJSmA" x="703" y="206"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_IDDyoIhBEeeOl5P_FBJSmA" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_IDEZsIhBEeeOl5P_FBJSmA" type="Enumeration_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_IDEZsYhBEeeOl5P_FBJSmA" type="Enumeration_FloatingNameLabel">
@@ -5400,49 +5390,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IDEZt4hBEeeOl5P_FBJSmA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#__jPYUCmmEeeA7tvtQmACtQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IDDyoYhBEeeOl5P_FBJSmA" x="505" y="208"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_lAXPcIhBEeeOl5P_FBJSmA" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_lAX2gIhBEeeOl5P_FBJSmA" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lAoVMIhBEeeOl5P_FBJSmA" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lAoVMYhBEeeOl5P_FBJSmA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_lAoVMohBEeeOl5P_FBJSmA" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_l66MIIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_2HQV0Cr1EeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l66MIYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l66zMIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_6TLjsCr1EeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l66zMYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l66zMohBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_lfHloCtHEeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l66zM4hBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l67aQIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_mY3RECtHEeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l67aQYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l67aQohBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_nRsWgCtHEeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l67aQ4hBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l67aRIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_osHGECtHEeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l67aRYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l68BUIhBEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_p6IYYCtHEeeA7tvtQmACtQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l68BUYhBEeeOl5P_FBJSmA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_lAoVM4hBEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_lAoVNIhBEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_lAoVNYhBEeeOl5P_FBJSmA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lAoVNohBEeeOl5P_FBJSmA"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_P377ECr1EeeA7tvtQmACtQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lAXPcYhBEeeOl5P_FBJSmA" x="353" y="27"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IDDyoYhBEeeOl5P_FBJSmA" x="340" y="59"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_W_wkgfItEea79czpMf3AVQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_W_wkgvItEea79czpMf3AVQ"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -96,17 +96,25 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x430YEUfEeWEwNCluy4jrw" value="*"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_c8MLwDLEEeaULOmJRJKM0Q" name="ConstrHasAvoidTopology" memberEnd="_c8MLxDLEEeaULOmJRJKM0Q _c8MLxzLEEeaULOmJRJKM0Q">
+      <packagedElement xmi:type="uml:Association" xmi:id="_c8MLwDLEEeaULOmJRJKM0Q" name="ConstrHasAvoidTopology">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_c8MLwjLEEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_c8MLwzLEEeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_c8MLxzLEEeaULOmJRJKM0Q" name="_connectivityConstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_c8MLwDLEEeaULOmJRJKM0Q"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
+        <memberEnd xmi:type="uml:Property" href="#_c8MLxzLEEeaULOmJRJKM0Q"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_c8MLxzLEEeaULOmJRJKM0Q" name="_connectivityConstraint" association="_c8MLwDLEEeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_nxS_ADLCEeaULOmJRJKM0Q" name="ConstrHasIncludeTopology" memberEnd="_nxcI8jLCEeaULOmJRJKM0Q _nxl58DLCEeaULOmJRJKM0Q">
+      <packagedElement xmi:type="uml:Association" xmi:id="_nxS_ADLCEeaULOmJRJKM0Q" name="ConstrHasIncludeTopology">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nxcI8DLCEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nxcI8TLCEeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_nxl58DLCEeaULOmJRJKM0Q" name="_connectivityConstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_nxS_ADLCEeaULOmJRJKM0Q"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
+        <memberEnd xmi:type="uml:Property" href="#_nxl58DLCEeaULOmJRJKM0Q"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nxl58DLCEeaULOmJRJKM0Q" name="_connectivityConstraint" association="_nxS_ADLCEeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_wt9DUEXOEeaB8vMnkFQLXQ" name="ConstrHasDiversityExcl" memberEnd="_wt-RckXOEeaB8vMnkFQLXQ _wuAGoEXOEeaB8vMnkFQLXQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_wt-RcEXOEeaB8vMnkFQLXQ" source="org.eclipse.papyrus">
@@ -120,17 +128,25 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_l8TgtMF3EeaALJQAf08uAg" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_l8BM0MF3EeaALJQAf08uAg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_xyfnYMF-EeaALJQAf08uAg" name="ConstrHasExcludePath" memberEnd="_xyluAsF-EeaALJQAf08uAg _xyluBcF-EeaALJQAf08uAg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_xyfnYMF-EeaALJQAf08uAg" name="ConstrHasExcludePath">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_xyluAMF-EeaALJQAf08uAg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_xyluAcF-EeaALJQAf08uAg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_xyluBcF-EeaALJQAf08uAg" name="_connectivityConstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_xyfnYMF-EeaALJQAf08uAg"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_xyluAsF-EeaALJQAf08uAg"/>
+        <memberEnd xmi:type="uml:Property" href="#_xyluBcF-EeaALJQAf08uAg"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_xyluBcF-EeaALJQAf08uAg" name="_connectivityConstraint" association="_xyfnYMF-EeaALJQAf08uAg">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_wGVAgMF-EeaALJQAf08uAg" name="ConstrHasIncludePath" memberEnd="_wGVAhMF-EeaALJQAf08uAg _wGVAh8F-EeaALJQAf08uAg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_wGVAgMF-EeaALJQAf08uAg" name="ConstrHasIncludePath">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_wGVAgsF-EeaALJQAf08uAg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_wGVAg8F-EeaALJQAf08uAg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_wGVAh8F-EeaALJQAf08uAg" name="_connectivityConstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_wGVAgMF-EeaALJQAf08uAg"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_wGVAhMF-EeaALJQAf08uAg"/>
+        <memberEnd xmi:type="uml:Property" href="#_wGVAh8F-EeaALJQAf08uAg"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_wGVAh8F-EeaALJQAf08uAg" name="_connectivityConstraint" association="_wGVAgMF-EeaALJQAf08uAg">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_mvBt0MhsEeaVlemTikmRHw" name="ContextHasConnections" memberEnd="_mvBt1MhsEeaVlemTikmRHw _mvBt18hsEeaVlemTikmRHw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_mvBt0shsEeaVlemTikmRHw" source="org.eclipse.papyrus">
@@ -192,17 +208,25 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_TyD6Rf4yEea_VPdGG2-szQ" name="connectivityservice" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_Tx9zoP4yEea_VPdGG2-szQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_MjEHgP4zEea_VPdGG2-szQ" name="ConstrHasExcludeLink" memberEnd="_MjEHhP4zEea_VPdGG2-szQ _MjEHh_4zEea_VPdGG2-szQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_MjEHgP4zEea_VPdGG2-szQ" name="ConstrHasExcludeLink">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MjEHgv4zEea_VPdGG2-szQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MjEHg_4zEea_VPdGG2-szQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_MjEHh_4zEea_VPdGG2-szQ" name="topologyconstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_MjEHgP4zEea_VPdGG2-szQ"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
+        <memberEnd xmi:type="uml:Property" href="#_MjEHh_4zEea_VPdGG2-szQ"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MjEHh_4zEea_VPdGG2-szQ" name="topologyconstraint" association="_MjEHgP4zEea_VPdGG2-szQ">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_Ca3vgP4zEea_VPdGG2-szQ" name="ConstrHasIncludeLink" memberEnd="_Ca3vhP4zEea_VPdGG2-szQ _Ca3vh_4zEea_VPdGG2-szQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_Ca3vgP4zEea_VPdGG2-szQ" name="ConstrHasIncludeLink">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ca3vgv4zEea_VPdGG2-szQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ca3vg_4zEea_VPdGG2-szQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_Ca3vh_4zEea_VPdGG2-szQ" name="topologyconstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_Ca3vgP4zEea_VPdGG2-szQ"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
+        <memberEnd xmi:type="uml:Property" href="#_Ca3vh_4zEea_VPdGG2-szQ"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Ca3vh_4zEea_VPdGG2-szQ" name="topologyconstraint" association="_Ca3vgP4zEea_VPdGG2-szQ">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_Ju5pkBM2Eee0L_IMWjydgQ" name="AugmentsRootContext" client="_e4FmwMhsEeaVlemTikmRHw">
         <ownedComment xmi:type="uml:Comment" xmi:id="_kTvHoBhvEeewCs0lkpWskw" annotatedElement="_Ju5pkBM2Eee0L_IMWjydgQ">
@@ -225,17 +249,25 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6fX0AEwPEeewALXL7BvPYw" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_5TB-sE5qEeeicu4cm-7qRg" name="ConstrHasExcludeNode" memberEnd="_5TDM0U5qEeeicu4cm-7qRg _5TDz4k5qEeeicu4cm-7qRg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_5TB-sE5qEeeicu4cm-7qRg" name="ConstrHasExcludeNode">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5TClwE5qEeeicu4cm-7qRg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5TDM0E5qEeeicu4cm-7qRg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_5TDz4k5qEeeicu4cm-7qRg" name="topologyconstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_5TB-sE5qEeeicu4cm-7qRg"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
+        <memberEnd xmi:type="uml:Property" href="#_5TDz4k5qEeeicu4cm-7qRg"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_5TDz4k5qEeeicu4cm-7qRg" name="topologyconstraint" association="_5TB-sE5qEeeicu4cm-7qRg">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_tATBwE5qEeeicu4cm-7qRg" name="ConstrHasIncludeNode" memberEnd="_tAVeAE5qEeeicu4cm-7qRg _tAkHgE5qEeeicu4cm-7qRg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_tATBwE5qEeeicu4cm-7qRg" name="ConstrHasIncludeNode">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tAUP4E5qEeeicu4cm-7qRg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tAU28E5qEeeicu4cm-7qRg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_tAkHgE5qEeeicu4cm-7qRg" name="topologyconstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_tATBwE5qEeeicu4cm-7qRg"/>
+        <memberEnd xmi:type="uml:Property" href="TapiPathComputation.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
+        <memberEnd xmi:type="uml:Property" href="#_tAkHgE5qEeeicu4cm-7qRg"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_tAkHgE5qEeeicu4cm-7qRg" name="topologyconstraint" association="_tATBwE5qEeeicu4cm-7qRg">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_EN290GJREeek3OrhDuslYQ" name="CSEPHasStatePac" memberEnd="_EN4L8WJREeek3OrhDuslYQ _EN5aEGJREeek3OrhDuslYQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_EN3k4GJREeek3OrhDuslYQ" source="org.eclipse.papyrus">
@@ -252,7 +284,7 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="__jkCIHIYEeeSiaQ95-6r9w" name="cepholder" type="_1ZroEHIYEeeSiaQ95-6r9w" association="__jfwsHIYEeeSiaQ95-6r9w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_MKHxQIfWEeeirpBaj87qAw" name="ConnServiceHasResiConstraints" memberEnd="_MKK0kIfWEeeirpBaj87qAw _MKLboYfWEeeirpBaj87qAw">
+      <packagedElement xmi:type="uml:Association" xmi:id="_MKHxQIfWEeeirpBaj87qAw" name="ConnServiceHasResilienceConstr" memberEnd="_MKK0kIfWEeeirpBaj87qAw _MKLboYfWEeeirpBaj87qAw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MKJmcIfWEeeirpBaj87qAw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MKJmcYfWEeeirpBaj87qAw" key="nature" value="UML_Nature"/>
         </eAnnotations>
@@ -269,12 +301,6 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s7y5EHMFEeeSiaQ95-6r9w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s71VUHMFEeeSiaQ95-6r9w" value="1"/>
         </ownedEnd>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_7ZpcsIfgEeet-8tHdGGp_w" name="ConnConstraintHasRouteComputePolicy" memberEnd="_7Zr48IfgEeet-8tHdGGp_w _7ZsgAofgEeet-8tHdGGp_w">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7ZrR4IfgEeet-8tHdGGp_w" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7ZrR4YfgEeet-8tHdGGp_w" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_7ZsgAofgEeet-8tHdGGp_w" name="connectivityconstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_7ZpcsIfgEeet-8tHdGGp_w"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_sGvKoMZaEeeAD9H5zOiMUQ" name="CEPHasTerminationPac" memberEnd="_sGvxssZaEeeAD9H5zOiMUQ _sGwYwMZaEeeAD9H5zOiMUQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_sGvxsMZaEeeAD9H5zOiMUQ" source="org.eclipse.papyrus">
@@ -299,6 +325,12 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_K_kkYJ_CEeiO_KvaRsULdw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_K_0cAJ_CEeiO_KvaRsULdw" value="*"/>
         </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_WumhkK1bEeiIjuV0HZnJAQ" name="ConnServiceHasRoutingConstr" memberEnd="_Wuyu0q1bEeiIjuV0HZnJAQ _Wuyu161bEeiIjuV0HZnJAQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Wuyu0K1bEeiIjuV0HZnJAQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Wuyu0a1bEeiIjuV0HZnJAQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Wuyu161bEeiIjuV0HZnJAQ" name="connectivityservice" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_WumhkK1bEeiIjuV0HZnJAQ"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
@@ -341,8 +373,14 @@ License: This module is distributed under the Apache License 2.0</body>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hoAc0KU5EeWkWNPM1BHzGA" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hoJmwKU5EeWkWNPM1BHzGA" value="*"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SK70ML2KEeWdore3Cxez9g" name="connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="create"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WWvDMP5CEea_VPdGG2-szQ" name="topoConstraint" type="_-fei4P4wEea_VPdGG2-szQ" isUnique="false" effect="create">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SK70ML2KEeWdore3Cxez9g" name="connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="create"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_lCUXcK1eEeiIjuV0HZnJAQ" name="routingConstraint">
+            <type xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wvS78K1eEeiIjuV0HZnJAQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wvrWcK1eEeiIjuV0HZnJAQ" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WWvDMP5CEea_VPdGG2-szQ" name="topologyConstraint" isUnique="false" effect="create">
+            <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Y4JQAP5CEea_VPdGG2-szQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Y4bj4P5CEea_VPdGG2-szQ" value="1"/>
           </ownedParameter>
@@ -360,11 +398,17 @@ License: This module is distributed under the Apache License 2.0</body>
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_n_cMYP6cEea_VPdGG2-szQ" name="endPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="update"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YRJ1cL2TEeWdore3Cxez9g" name="connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="update">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YRJ1cL2TEeWdore3Cxez9g" name="connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="update">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HkOeQP6cEea_VPdGG2-szQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HllJIP6cEea_VPdGG2-szQ" value="1"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_LFBEcP6cEea_VPdGG2-szQ" name="topoConstraint" type="_-fei4P4wEea_VPdGG2-szQ" isUnique="false" effect="update">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_3xRw8K1eEeiIjuV0HZnJAQ" name="routingConstraint" effect="update">
+            <type xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4iUzYK1eEeiIjuV0HZnJAQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4izUgK1eEeiIjuV0HZnJAQ" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_LFBEcP6cEea_VPdGG2-szQ" name="topologyConstraint" isUnique="false" effect="update">
+            <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LydZQP6cEea_VPdGG2-szQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LydZQv6cEea_VPdGG2-szQ" value="1"/>
           </ownedParameter>
@@ -381,7 +425,6 @@ License: This module is distributed under the Apache License 2.0</body>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_zDaPoL2WEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Y9jZsL2ZEeWdore3Cxez9g" name="service" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="delete"/>
         </ownedOperation>
       </packagedElement>
     </packagedElement>
@@ -486,6 +529,9 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Hk2vsK1lEeiqCPid09Hqfw" name="serviceLayer">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel">
           <ownedComment xmi:type="uml:Comment" xmi:id="_8GC6UL2BEeWdore3Cxez9g">
@@ -495,45 +541,16 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cE7T8L2REeWdore3Cxez9g"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cE7T8b2REeWdore3Cxez9g" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_1dtjYIfYEeeirpBaj87qAw" name="isExclusive">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_buMbwIfZEeeirpBaj87qAw" annotatedElement="_1dtjYIfYEeeirpBaj87qAw">
-            <body>To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_-iMboIfYEeeirpBaj87qAw" value="true"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_-YtW8L11EeWdore3Cxez9g" name="requestedCapacity">
           <type xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_caIFkNnlEeWIOYiRCk5bbQ" name="connectivityDirection">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ru76gGNFEee0bPnI-Gt-mQ" name="schedule">
           <type xmi:type="uml:DataType" href="TapiCommon.uml#_-ijf4FtVEeexvMtO2oNM9g"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MrlDoIhGEeeOl5P_FBJSmA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mrm40IhGEeeOl5P_FBJSmA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
-            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
-          </ownedComment>
-          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rhdgwr2HEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rhdgw72HEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_GqeeMb2JEeWdore3Cxez9g" annotatedElement="_GqeeML2JEeWdore3Cxez9g">
-            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
-          </ownedComment>
-          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GqeeMr2JEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GqeeM72JEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_YQtngIoPEeivCevppATXng" name="sharedRiskCharacteristic">
-          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqz9v-EeWowYqZXEhn3A"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cMJiUIoPEeivCevppATXng"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cMLXgIoPEeivCevppATXng" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_7Zr48IfgEeet-8tHdGGp_w" name="_routeComputePolicy" type="_k96BsIfbEeeirpBaj87qAw" aggregation="composite" association="_7ZpcsIfgEeet-8tHdGGp_w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BTPtUIfhEeet-8tHdGGp_w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BTRigIfhEeet-8tHdGGp_w" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_l8TgscF3EeaALJQAf08uAg" name="_corouteInclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_l8BM0MF3EeaALJQAf08uAg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zv3oIMGAEeaALJQAf08uAg"/>
@@ -561,25 +578,23 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YteN0EUdEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YtgqEEUdEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_WFu44u_qEeWLlrwIF3w0vA" name="_connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" aggregation="composite" association="_WFlH4O_qEeWLlrwIF3w0vA"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_TyD6Qv4yEea_VPdGG2-szQ" name="_topoConstraint" type="_-fei4P4wEea_VPdGG2-szQ" aggregation="composite" association="_Tx9zoP4yEea_VPdGG2-szQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WFu44u_qEeWLlrwIF3w0vA" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" aggregation="composite" association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Wuyu0q1bEeiIjuV0HZnJAQ" name="_routingConstraint" aggregation="composite" association="_WumhkK1bEeiIjuV0HZnJAQ">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Wuyu1a1bEeiIjuV0HZnJAQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Wuyu1q1bEeiIjuV0HZnJAQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TyD6Qv4yEea_VPdGG2-szQ" name="_topologyConstraint" aggregation="composite" association="_Tx9zoP4yEea_VPdGG2-szQ">
+          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ckc88P4yEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ckc88v4yEea_VPdGG2-szQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_nfDxo-_pEeWLlrwIF3w0vA" name="_state" aggregation="composite" association="_nfDxoO_pEeWLlrwIF3w0vA">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_caIFkNnlEeWIOYiRCk5bbQ" name="direction">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_kuDzQ0HaEeWqPKyD1j6LMg" name="layerProtocolName" visibility="public">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kuDzREHaEeWqPKyD1j6LMg" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kuDzRUHaEeWqPKyD1j6LMg" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MKK0kIfWEeeirpBaj87qAw" name="_resilienceConstraint" type="_MBqV4OrzEeaeHOJw3lCT8A" aggregation="composite" association="_MKHxQIfWEeeirpBaj87qAw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bTT98IfWEeeirpBaj87qAw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bTXoUIfWEeeirpBaj87qAw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nfDxo-_pEeWLlrwIF3w0vA" name="_state" aggregation="composite" association="_nfDxoO_pEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_MIWTIGh5EeWZEqTYAF8eqA" name="ConnectivityServiceEndPoint" isLeaf="true">
@@ -810,76 +825,10 @@ All administrative controls of any aspect of protection are rejected.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oHONMIoPEeivCevppATXng" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_-fei4P4wEea_VPdGG2-szQ" name="TopologyConstraint">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_nxcI8jLCEeaULOmJRJKM0Q" name="_includeTopology" isReadOnly="true" association="_nxS_ADLCEeaULOmJRJKM0Q">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YQFpADLEEeaULOmJRJKM0Q"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YQFpAjLEEeaULOmJRJKM0Q" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_c8MLxDLEEeaULOmJRJKM0Q" name="_avoidTopology" isReadOnly="true" association="_c8MLwDLEEeaULOmJRJKM0Q">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hUfowDLEEeaULOmJRJKM0Q"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hUfowjLEEeaULOmJRJKM0Q" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_wGVAhMF-EeaALJQAf08uAg" name="_includePath" isReadOnly="true" association="_wGVAgMF-EeaALJQAf08uAg">
-          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ON4p8MF_EeaALJQAf08uAg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ON-wkMF_EeaALJQAf08uAg" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_xyluAsF-EeaALJQAf08uAg" name="_excludePath" isReadOnly="true" association="_xyfnYMF-EeaALJQAf08uAg">
-          <type xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e8ofMMF_EeaALJQAf08uAg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e8ofMsF_EeaALJQAf08uAg" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ca3vhP4zEea_VPdGG2-szQ" name="_includeLink" isReadOnly="true" association="_Ca3vgP4zEea_VPdGG2-szQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_xdX0kE5rEeeicu4cm-7qRg" annotatedElement="_Ca3vhP4zEea_VPdGG2-szQ">
-            <body>This is a loose constraint - that is it is unordered and could be a partial list </body>
-          </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_I_odAP4zEea_VPdGG2-szQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_I_prIP4zEea_VPdGG2-szQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_MjEHhP4zEea_VPdGG2-szQ" name="_excludeLink" isReadOnly="true" association="_MjEHgP4zEea_VPdGG2-szQ">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OG3ckP4zEea_VPdGG2-szQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OG3ckv4zEea_VPdGG2-szQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_tAVeAE5qEeeicu4cm-7qRg" name="_includeNode" isReadOnly="true" association="_tATBwE5qEeeicu4cm-7qRg">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_zUMzUE5rEeeicu4cm-7qRg" annotatedElement="_tAVeAE5qEeeicu4cm-7qRg">
-            <body>This is a loose constraint - that is it is unordered and could be a partial list</body>
-          </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1OubwE5qEeeicu4cm-7qRg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1OxfEE5qEeeicu4cm-7qRg" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_5TDM0U5qEeeicu4cm-7qRg" name="_excludeNode" isReadOnly="true" association="_5TB-sE5qEeeicu4cm-7qRg">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-ZosIE5qEeeicu4cm-7qRg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-ZqhUE5qEeeicu4cm-7qRg" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_SWwL11EeWdore3Cxez9g" name="preferredTransportLayer" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_f3CoEMF2EeaALJQAf08uAg" annotatedElement="_3_SWwL11EeWdore3Cxez9g">
-            <body>soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers</body>
-          </ownedComment>
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p_hKEL2SEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p_q7EL2SEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-      </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_1ZroEHIYEeeSiaQ95-6r9w" name="CepList">
         <ownedAttribute xmi:type="uml:Property" xmi:id="__jiM8XIYEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" aggregation="composite" association="__jfwsHIYEeeSiaQ95-6r9w">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HRcT0HIZEeeSiaQ95-6r9w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HRhzYHIZEeeSiaQ95-6r9w" value="*"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_k96BsIfbEeeirpBaj87qAw" name="RouteComputePolicy">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_6ZZS4IfbEeeirpBaj87qAw" name="routeObjectiveFunction" type="_P377ECr1EeeA7tvtQmACtQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dc41YIfdEeet-8tHdGGp_w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dc7RoIfdEeet-8tHdGGp_w" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-XrtYIfbEeeirpBaj87qAw" name="diversityPolicy" type="_LLdOwEXZEeeeyqnd6Cxkjw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eexwMIfdEeet-8tHdGGp_w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eey-UIfdEeet-8tHdGGp_w" value="1"/>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
@@ -943,22 +892,6 @@ Note: Only relevant when part of a protection scheme.</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_N9G5gCmqEeeA7tvtQmACtQ" name="HOLD_OFF_TIME"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Pr8Z4CmqEeeA7tvtQmACtQ" name="WAIT_FOR_NOTIFICATION"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_P377ECr1EeeA7tvtQmACtQ" name="RouteObjectiveFunction" isLeaf="true">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2HQV0Cr1EeeA7tvtQmACtQ" name="MIN_WORK_ROUTE_HOP"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_6TLjsCr1EeeA7tvtQmACtQ" name="MIN_WORK_ROUTE_COST"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_lfHloCtHEeeA7tvtQmACtQ" name="MIN_WORK_ROUTE_LATENCY"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mY3RECtHEeeA7tvtQmACtQ" name="MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nRsWgCtHEeeA7tvtQmACtQ" name="MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_osHGECtHEeeA7tvtQmACtQ" name="MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_p6IYYCtHEeeA7tvtQmACtQ" name="LOAD_BALANCE_MAX_UNUSED_CAPACITY"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_LLdOwEXZEeeeyqnd6Cxkjw" name="DiversityPolicy" isLeaf="true">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LLdOwUXZEeeeyqnd6Cxkjw" name="SRLG"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LLdOwkXZEeeeyqnd6Cxkjw" name="SRNG"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LLdOw0XZEeeeyqnd6Cxkjw" name="SNG"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_srl4wGhjEeeWO9Idc2UXkw" name="NODE"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_tZ4iIGhjEeeWO9Idc2UXkw" name="LINK"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_KtcbYCmxEeeA7tvtQmACtQ" name="ProtectionRole" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_QqOi4CmxEeeA7tvtQmACtQ" name="WORK"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VVyKYCsiEeeA7tvtQmACtQ" name="PROTECT"/>
@@ -996,7 +929,6 @@ Note: Only relevant when part of a protection scheme.</body>
     </profileApplication>
   </uml:Model>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_B3Ln4UHCEeWqPKyD1j6LMg" base_StructuralFeature="_B3Ln4EHCEeWqPKyD1j6LMg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_kuEaUEHaEeWqPKyD1j6LMg" base_StructuralFeature="_kuDzQ0HaEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_IZ49kEHbEeWqPKyD1j6LMg" base_StructuralFeature="_IZ3vc0HbEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ZiYSAUUcEeWEwNCluy4jrw" base_StructuralFeature="_ZiYSAEUcEeWEwNCluy4jrw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ZiZgIUUcEeWEwNCluy4jrw" base_StructuralFeature="_ZiZgIEUcEeWEwNCluy4jrw"/>
@@ -1023,18 +955,17 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelParameter xmi:id="_T9ChoaU5EeWkWNPM1BHzGA" base_Parameter="_T9ChoKU5EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_7BwFUbvMEeWYrqoqXLgguw" base_Parameter="_7BwFULvMEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_lY2XUbvZEeWYrqoqXLgguw" base_StructuralFeature="_lY2XULvZEeWYrqoqXLgguw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_3_SWwb11EeWdore3Cxez9g" base_StructuralFeature="_3_SWwL11EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3_SWwb11EeWdore3Cxez9g">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_3_SWwL11EeWdore3Cxez9g"/>
+  </OpenModel_Profile:OpenModelAttribute>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_-YtW8b11EeWdore3Cxez9g" base_StructuralFeature="_-YtW8L11EeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_3bhE4b2BEeWdore3Cxez9g" base_StructuralFeature="_3bhE4L2BEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_RhdgxL2HEeWdore3Cxez9g" base_StructuralFeature="_RhdgwL2HEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_GqeeNL2JEeWdore3Cxez9g" base_StructuralFeature="_GqeeML2JEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_SK70Mb2KEeWdore3Cxez9g" base_Parameter="_SK70ML2KEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_JqtJcb2TEeWdore3Cxez9g" base_Parameter="_JqtJcL2TEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_YRJ1cb2TEeWdore3Cxez9g" base_Parameter="_YRJ1cL2TEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_zDaPob2WEeWdore3Cxez9g" base_Parameter="_zDaPoL2WEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_zEZcMb2YEeWdore3Cxez9g" base_Parameter="_zEZcML2YEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_L70owb2ZEeWdore3Cxez9g" base_Parameter="_L70owL2ZEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_Y9jZsb2ZEeWdore3Cxez9g" base_Parameter="_Y9jZsL2ZEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_V2I0IdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_V2I0INnlEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_caIFkdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_caIFkNnlEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpO_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxo-_pEeWLlrwIF3w0vA"/>
@@ -1059,8 +990,12 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk10FJvEeWcs7ZjyujtOg" base_Operation="_WHPN81JvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1x1JvEeWcs7ZjyujtOg" base_Operation="_WHPN6FJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_qH8fkb2NEeWdore3Cxez9g" base_Operation="_qH8fkL2NEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_nxcI8zLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxcI8jLCEeaULOmJRJKM0Q"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLxTLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nxcI8zLCEeaULOmJRJKM0Q">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
+  </OpenModel_Profile:OpenModelAttribute>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLxTLEEeaULOmJRJKM0Q">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
+  </OpenModel_Profile:OpenModelAttribute>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yA-gBhrEeewCs0lkpWskw" base_Property="_B3Ln4EHCEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nxl58TLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxl58DLCEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLyDLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxzLEEeaULOmJRJKM0Q"/>
@@ -1070,8 +1005,12 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_YyoyA2kJEeWZEqTYAF8eqA" base_StructuralFeature="_YyoyAmkJEeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_l8Tgs8F3EeaALJQAf08uAg" base_StructuralFeature="_l8TgscF3EeaALJQAf08uAg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_l8TgtsF3EeaALJQAf08uAg" base_StructuralFeature="_l8TgtMF3EeaALJQAf08uAg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_wGVAhsF-EeaALJQAf08uAg" base_StructuralFeature="_wGVAhMF-EeaALJQAf08uAg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_xyluBMF-EeaALJQAf08uAg" base_StructuralFeature="_xyluAsF-EeaALJQAf08uAg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wGVAhsF-EeaALJQAf08uAg">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_wGVAhMF-EeaALJQAf08uAg"/>
+  </OpenModel_Profile:OpenModelAttribute>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xyluBMF-EeaALJQAf08uAg">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_xyluAsF-EeaALJQAf08uAg"/>
+  </OpenModel_Profile:OpenModelAttribute>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wb19gMF-EeaALJQAf08uAg" base_StructuralFeature="_wGVAh8F-EeaALJQAf08uAg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_xyluB8F-EeaALJQAf08uAg" base_StructuralFeature="_xyluBcF-EeaALJQAf08uAg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_e4FmwchsEeaVlemTikmRHw" base_Class="_e4FmwMhsEeaVlemTikmRHw"/>
@@ -1105,11 +1044,14 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:ExtendedComposite xmi:id="_GL8T8PIrEea79czpMf3AVQ" base_Association="_CpflcOsbEealN7CdLT_GPw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_MIZrUPIrEea79czpMf3AVQ" base_Association="__LyaYOsYEealN7CdLT_GPw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_kKvJ4fKiEeaAIfPpmDwI5Q" base_StructuralFeature="_kKvJ4PKiEeaAIfPpmDwI5Q"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_-fei4f4wEea_VPdGG2-szQ" base_Class="_-fei4P4wEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TyD6RP4yEea_VPdGG2-szQ" base_StructuralFeature="_TyD6Qv4yEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TyD6R_4yEea_VPdGG2-szQ" base_StructuralFeature="_TyD6Rf4yEea_VPdGG2-szQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ca3vhv4zEea_VPdGG2-szQ" base_StructuralFeature="_Ca3vhP4zEea_VPdGG2-szQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_MjEHhv4zEea_VPdGG2-szQ" base_StructuralFeature="_MjEHhP4zEea_VPdGG2-szQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ca3vhv4zEea_VPdGG2-szQ">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
+  </OpenModel_Profile:OpenModelAttribute>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MjEHhv4zEea_VPdGG2-szQ">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
+  </OpenModel_Profile:OpenModelAttribute>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_DYrbkP4zEea_VPdGG2-szQ" base_StructuralFeature="_Ca3vh_4zEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MjEHif4zEea_VPdGG2-szQ" base_StructuralFeature="_MjEHh_4zEea_VPdGG2-szQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_UUBlkP43Eea_VPdGG2-szQ" base_Association="_ZiXD4EUcEeWEwNCluy4jrw"/>
@@ -1162,8 +1104,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBllRhrEeewCs0lkpWskw" base_Property="_lY2XULvZEeWYrqoqXLgguw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCMoBhrEeewCs0lkpWskw" base_Property="_3bhE4L2BEeWdore3Cxez9g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCMoRhrEeewCs0lkpWskw" base_Property="_-YtW8L11EeWdore3Cxez9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCMohhrEeewCs0lkpWskw" base_Property="_RhdgwL2HEeWdore3Cxez9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCzsBhrEeewCs0lkpWskw" base_Property="_GqeeML2JEeWdore3Cxez9g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCzsRhrEeewCs0lkpWskw" base_Property="_l8TgscF3EeaALJQAf08uAg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yDawBhrEeewCs0lkpWskw" base_Property="_wt-RckXOEeaB8vMnkFQLXQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yEB0BhrEeewCs0lkpWskw" base_Property="_4EtL4EUcEeWEwNCluy4jrw"/>
@@ -1172,7 +1112,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPEhhrEeewCs0lkpWskw" base_Property="_TyD6Qv4yEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPFBhrEeewCs0lkpWskw" base_Property="_nfDxo-_pEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPFRhrEeewCs0lkpWskw" base_Property="_caIFkNnlEeWIOYiRCk5bbQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPFhhrEeewCs0lkpWskw" base_Property="_kuDzQ0HaEeWqPKyD1j6LMg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPFxhrEeewCs0lkpWskw" base_Property="_YyoyAmkJEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPGBhrEeewCs0lkpWskw" base_Property="_MIWTJ2h5EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPGRhrEeewCs0lkpWskw" base_Property="_MIWTK2h5EeWZEqTYAF8eqA"/>
@@ -1193,13 +1132,27 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPKhhrEeewCs0lkpWskw" base_Property="_kKvJ4PKiEeaAIfPpmDwI5Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPKxhrEeewCs0lkpWskw" base_Property="_zpUU8O4GEeaRONVEJOGI1g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLBhrEeewCs0lkpWskw" base_Property="_nuZ_TOryEeaeHOJw3lCT8A"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLRhrEeewCs0lkpWskw" base_Property="_nxcI8jLCEeaULOmJRJKM0Q"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLhhrEeewCs0lkpWskw" base_Property="_c8MLxDLEEeaULOmJRJKM0Q"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLxhrEeewCs0lkpWskw" base_Property="_wGVAhMF-EeaALJQAf08uAg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMBhrEeewCs0lkpWskw" base_Property="_xyluAsF-EeaALJQAf08uAg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMRhrEeewCs0lkpWskw" base_Property="_Ca3vhP4zEea_VPdGG2-szQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMhhrEeewCs0lkpWskw" base_Property="_MjEHhP4zEea_VPdGG2-szQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMxhrEeewCs0lkpWskw" base_Property="_3_SWwL11EeWdore3Cxez9g"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLRhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLhhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPLxhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_wGVAhMF-EeaALJQAf08uAg"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMBhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_xyluAsF-EeaALJQAf08uAg"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMRhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMhhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMxhrEeewCs0lkpWskw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_3_SWwL11EeWdore3Cxez9g"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqIEkwFEeewALXL7BvPYw" base_Property="_nJqIEUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nJqvIEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqIEUwFEeewALXL7BvPYw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqvIkwFEeewALXL7BvPYw" base_Property="_nJqvIUwFEeewALXL7BvPYw"/>
@@ -1211,10 +1164,18 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ihqds0wPEeewALXL7BvPYw" base_StructuralFeature="_ihqdsUwPEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_COm-UEwVEeewALXL7BvPYw" base_Association="_l5X4MMhsEeaVlemTikmRHw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_Durp8EwVEeewALXL7BvPYw" base_Association="_mvBt0MhsEeaVlemTikmRHw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tAVeAU5qEeeicu4cm-7qRg" base_Property="_tAVeAE5qEeeicu4cm-7qRg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_tAWFEE5qEeeicu4cm-7qRg" base_StructuralFeature="_tAVeAE5qEeeicu4cm-7qRg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5TDz4E5qEeeicu4cm-7qRg" base_Property="_5TDM0U5qEeeicu4cm-7qRg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_5TDz4U5qEeeicu4cm-7qRg" base_StructuralFeature="_5TDM0U5qEeeicu4cm-7qRg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tAVeAU5qEeeicu4cm-7qRg">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tAWFEE5qEeeicu4cm-7qRg">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
+  </OpenModel_Profile:OpenModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5TDz4E5qEeeicu4cm-7qRg">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5TDz4U5qEeeicu4cm-7qRg">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
+  </OpenModel_Profile:OpenModelAttribute>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tAkHgU5qEeeicu4cm-7qRg" base_Property="_tAkHgE5qEeeicu4cm-7qRg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_tS-GIE5qEeeicu4cm-7qRg" base_StructuralFeature="_tAkHgE5qEeeicu4cm-7qRg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5TEa8E5qEeeicu4cm-7qRg" base_Property="_5TDz4k5qEeeicu4cm-7qRg"/>
@@ -1230,7 +1191,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6BGE8FqnEeexvMtO2oNM9g" base_Class="_jwuBoOryEeaeHOJw3lCT8A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6BGE8VqnEeexvMtO2oNM9g" base_Class="_nuZ_MOryEeaeHOJw3lCT8A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6BGE8lqnEeexvMtO2oNM9g" base_Class="_MBqV4OrzEeaeHOJw3lCT8A"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6BGE81qnEeexvMtO2oNM9g" base_Class="_-fei4P4wEea_VPdGG2-szQ"/>
   <OpenModel_Profile:LifecycleAggregate xmi:id="_hlAgAFroEeexvMtO2oNM9g" base_Association="_4ErWsEUcEeWEwNCluy4jrw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_EN4zAGJREeek3OrhDuslYQ" base_StructuralFeature="_EN4L8WJREeek3OrhDuslYQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_EN4zAWJREeek3OrhDuslYQ" base_Property="_EN4L8WJREeek3OrhDuslYQ"/>
@@ -1270,18 +1230,18 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MKLboIfWEeeirpBaj87qAw" base_Property="_MKK0kIfWEeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MKLboofWEeeirpBaj87qAw" base_StructuralFeature="_MKLboYfWEeeirpBaj87qAw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MKLbo4fWEeeirpBaj87qAw" base_Property="_MKLboYfWEeeirpBaj87qAw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_1duKcIfYEeeirpBaj87qAw" base_StructuralFeature="_1dtjYIfYEeeirpBaj87qAw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1duKcYfYEeeirpBaj87qAw" base_Property="_1dtjYIfYEeeirpBaj87qAw"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_k96BsYfbEeeirpBaj87qAw" base_Class="_k96BsIfbEeeirpBaj87qAw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_k96BsofbEeeirpBaj87qAw" base_Class="_k96BsIfbEeeirpBaj87qAw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_6ZZS4YfbEeeirpBaj87qAw" base_StructuralFeature="_6ZZS4IfbEeeirpBaj87qAw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6ZZ58IfbEeeirpBaj87qAw" base_Property="_6ZZS4IfbEeeirpBaj87qAw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_-XrtYYfbEeeirpBaj87qAw" base_StructuralFeature="_-XrtYIfbEeeirpBaj87qAw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_-XrtYofbEeeirpBaj87qAw" base_Property="_-XrtYIfbEeeirpBaj87qAw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_7ZsgAIfgEeet-8tHdGGp_w" base_StructuralFeature="_7Zr48IfgEeet-8tHdGGp_w"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7ZsgAYfgEeet-8tHdGGp_w" base_Property="_7Zr48IfgEeet-8tHdGGp_w"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_7ZtHEIfgEeet-8tHdGGp_w" base_StructuralFeature="_7ZsgAofgEeet-8tHdGGp_w"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7ZtHEYfgEeet-8tHdGGp_w" base_Property="_7ZsgAofgEeet-8tHdGGp_w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6ZZS4YfbEeeirpBaj87qAw">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_6ZZS4IfbEeeirpBaj87qAw"/>
+  </OpenModel_Profile:OpenModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6ZZ58IfbEeeirpBaj87qAw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_6ZZS4IfbEeeirpBaj87qAw"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-XrtYYfbEeeirpBaj87qAw">
+    <base_StructuralFeature xmi:type="uml:Property" href="TapiPathComputation.uml#_-XrtYIfbEeeirpBaj87qAw"/>
+  </OpenModel_Profile:OpenModelAttribute>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_-XrtYofbEeeirpBaj87qAw">
+    <base_Property xmi:type="uml:Property" href="TapiPathComputation.uml#_-XrtYIfbEeeirpBaj87qAw"/>
+  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
   <OpenModel_Profile:OpenModelParameter xmi:id="_CHjpsYfiEeet-8tHdGGp_w" base_Parameter="_CHjpsIfiEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_KCNMEYfiEeet-8tHdGGp_w" base_Parameter="_KCNMEIfiEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_207M8YfjEeet-8tHdGGp_w" base_StructuralFeature="_207M8IfjEeet-8tHdGGp_w"/>
@@ -1296,7 +1256,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_sGwYwsZaEeeAD9H5zOiMUQ" base_StructuralFeature="_sGwYwMZaEeeAD9H5zOiMUQ"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_zltdoMZaEeeAD9H5zOiMUQ" base_Association="_sGvKoMZaEeeAD9H5zOiMUQ"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_1Ys_cM4UEeehIvzuBRCtZQ" base_Association="_WFlH4O_qEeWLlrwIF3w0vA"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_4ak1AM4UEeehIvzuBRCtZQ" base_Association="_7ZpcsIfgEeet-8tHdGGp_w"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_51xAoM4UEeehIvzuBRCtZQ" base_Association="_MKHxQIfWEeeirpBaj87qAw"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_7MbRkM4UEeehIvzuBRCtZQ" base_Association="_Tx9zoP4yEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_XLHewNoCEeeYx-v40uoW_Q" base_StructuralFeature="_B3KZwUHCEeWqPKyD1j6LMg"/>
@@ -1306,8 +1265,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ypGtAIoOEeivCevppATXng" base_StructuralFeature="_ypGF8IoOEeivCevppATXng"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6zHhEYoOEeivCevppATXng" base_Property="_6zHhEIoOEeivCevppATXng"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6zHhEooOEeivCevppATXng" base_StructuralFeature="_6zHhEIoOEeivCevppATXng"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_YQtngYoPEeivCevppATXng" base_Property="_YQtngIoPEeivCevppATXng"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_YQuOkIoPEeivCevppATXng" base_StructuralFeature="_YQtngIoPEeivCevppATXng"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_4c2XcJ--EeiO_KvaRsULdw" base_StructuralFeature="_4c1JUJ--EeiO_KvaRsULdw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_4c4MoJ--EeiO_KvaRsULdw" base_Property="_4c1JUJ--EeiO_KvaRsULdw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_4c7P8Z--EeiO_KvaRsULdw" base_StructuralFeature="_4c7P8J--EeiO_KvaRsULdw"/>
@@ -1316,4 +1273,13 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_sWosMJ_BEeiO_KvaRsULdw" base_Property="_sWmP8J_BEeiO_KvaRsULdw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_sWqhYJ_BEeiO_KvaRsULdw" base_StructuralFeature="_sWp6UZ_BEeiO_KvaRsULdw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_sWqhYZ_BEeiO_KvaRsULdw" base_Property="_sWp6UZ_BEeiO_KvaRsULdw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Wuyu061bEeiIjuV0HZnJAQ" base_Property="_Wuyu0q1bEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Wuyu1K1bEeiIjuV0HZnJAQ" base_StructuralFeature="_Wuyu0q1bEeiIjuV0HZnJAQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Wuyu2K1bEeiIjuV0HZnJAQ" base_Property="_Wuyu161bEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Wuyu2a1bEeiIjuV0HZnJAQ" base_StructuralFeature="_Wuyu161bEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_5jkVUK1bEeiIjuV0HZnJAQ" base_Association="_WumhkK1bEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_lCUXca1eEeiIjuV0HZnJAQ" base_Parameter="_lCUXcK1eEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_3xRw8a1eEeiIjuV0HZnJAQ" base_Parameter="_3xRw8K1eEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Hk2vsa1lEeiqCPid09Hqfw" base_StructuralFeature="_Hk2vsK1lEeiqCPid09Hqfw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Hk2vsq1lEeiqCPid09Hqfw" base_Property="_Hk2vsK1lEeiqCPid09Hqfw"/>
 </xmi:XMI>

--- a/UML/TapiPathComputation.notation
+++ b/UML/TapiPathComputation.notation
@@ -25,7 +25,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__7bo0jBGEeam35bpdXJzEw" y="5"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7bpADBGEeam35bpdXJzEw" x="453" y="432" width="126" height="72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7bpADBGEeam35bpdXJzEw" x="420" y="430" width="126" height="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__7bpATBGEeam35bpdXJzEw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="__7bpAjBGEeam35bpdXJzEw" type="Class_NameLabel"/>
@@ -51,7 +51,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7bpEzBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7bpQTBGEeam35bpdXJzEw" x="399" y="577" width="155" height="71"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7bpQTBGEeam35bpdXJzEw" x="366" y="575" width="155" height="71"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__7bqJjBGEeam35bpdXJzEw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="__7bqJzBGEeam35bpdXJzEw" type="Class_NameLabel"/>
@@ -211,7 +211,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7k0WDBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7k0hjBGEeam35bpdXJzEw" x="380" y="103" width="125" height="92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__7k0hjBGEeam35bpdXJzEw" x="341" y="192" width="125" height="71"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__73tqjBGEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__73tqzBGEeam35bpdXJzEw" showTitle="true"/>
@@ -317,7 +317,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jCJFkzJEEeamvfKYyWmELQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jCJFgTJEEeamvfKYyWmELQ" x="747" y="106" width="177"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jCJFgTJEEeamvfKYyWmELQ" x="728" y="164" width="177"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_jCS2mzJEEeamvfKYyWmELQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_jCS2nDJEEeamvfKYyWmELQ" showTitle="true"/>
@@ -351,7 +351,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jm3rkzM1EeaULOmJRJKM0Q"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jm3rgTM1EeaULOmJRJKM0Q" x="795" y="424" width="131" height="76"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jm3rgTM1EeaULOmJRJKM0Q" x="762" y="422" width="131" height="76"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_JnA1izM1EeaULOmJRJKM0Q" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_JnA1jDM1EeaULOmJRJKM0Q" showTitle="true"/>
@@ -363,17 +363,13 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_MowIIzM1EeaULOmJRJKM0Q" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_MowIJDM1EeaULOmJRJKM0Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mo55IDM1EeaULOmJRJKM0Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_MnHJYDM1EeaULOmJRJKM0Q"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mo55IDM1EeaULOmJRJKM0Q" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MowIJTM1EeaULOmJRJKM0Q" x="947" y="6"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_OdKsEzM1EeaULOmJRJKM0Q" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_OdKsFDM1EeaULOmJRJKM0Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OdKsFjM1EeaULOmJRJKM0Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_ObYjYDM1EeaULOmJRJKM0Q"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OdKsFjM1EeaULOmJRJKM0Q" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OdKsFTM1EeaULOmJRJKM0Q" x="947" y="6"/>
     </children>
@@ -432,7 +428,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_hxP6U8huEeaVlemTikmRHw" type="Class_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hxP6VMhuEeaVlemTikmRHw" y="5"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_hxP6VchuEeaVlemTikmRHw" type="Class_AttributeCompartment">
+      <children xmi:type="notation:BasicCompartment" xmi:id="_hxP6VchuEeaVlemTikmRHw" visible="false" type="Class_AttributeCompartment">
         <children xmi:type="notation:Shape" xmi:id="_hQs8kshvEeaVlemTikmRHw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPathComputation.uml#_JEyyNMhvEeaVlemTikmRHw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_hQs8k8hvEeaVlemTikmRHw"/>
@@ -459,7 +455,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hxP6Y8huEeaVlemTikmRHw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hxP6UchuEeaVlemTikmRHw" x="-15" y="-157" height="87"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hxP6UchuEeaVlemTikmRHw" x="-10" y="-157" width="220" height="69"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_hxP6f8huEeaVlemTikmRHw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_hxP6gMhuEeaVlemTikmRHw" showTitle="true"/>
@@ -493,7 +489,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RFbuQf4tEea_VPdGG2-szQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RFVnkf4tEea_VPdGG2-szQ" x="376" y="276" width="135" height="72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RFVnkf4tEea_VPdGG2-szQ" x="345" y="325" width="135" height="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_RFn7i_4tEea_VPdGG2-szQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_RFn7jP4tEea_VPdGG2-szQ" showTitle="true"/>
@@ -825,6 +821,72 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mcg0NYuWEeiu6boZkiJHCA" x="995" y="324"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_DtO1UK1OEeiIjuV0HZnJAQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DtO1Ua1OEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DtRRkK1OEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DtO1Uq1OEeiIjuV0HZnJAQ" x="653" y="432"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pBdREK1fEeiIjuV0HZnJAQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pBdREq1fEeiIjuV0HZnJAQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pBdRE61fEeiIjuV0HZnJAQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pBdRFK1fEeiIjuV0HZnJAQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pBdRFa1fEeiIjuV0HZnJAQ" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pBdRFq1fEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pBdRF61fEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pBdRGK1fEeiIjuV0HZnJAQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pBdRGa1fEeiIjuV0HZnJAQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pBdRGq1fEeiIjuV0HZnJAQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pBdRG61fEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pBdRHK1fEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pBdRHa1fEeiIjuV0HZnJAQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pBdRHq1fEeiIjuV0HZnJAQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pBdRH61fEeiIjuV0HZnJAQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pBdRIK1fEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pBdRIa1fEeiIjuV0HZnJAQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pBdRIq1fEeiIjuV0HZnJAQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pBdRI61fEeiIjuV0HZnJAQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pBdREa1fEeiIjuV0HZnJAQ" x="730" y="66" width="174" height="80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pBpeU61fEeiIjuV0HZnJAQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_pBpeVK1fEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pBpeVq1fEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pBpeVa1fEeiIjuV0HZnJAQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MtvuY61gEeiIjuV0HZnJAQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MtvuZK1gEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MtvuZq1gEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MtvuZa1gEeiIjuV0HZnJAQ" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SjC4YK1hEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SjC4Ya1hEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SjC4Y61hEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SjC4Yq1hEeiqCPid09Hqfw" x="620" y="430"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_T74MMK1kEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T74MMa1kEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T74MM61kEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T74MMq1kEeiqCPid09Hqfw" x="620" y="430"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_8OGbYTBGEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_8OGbYjBGEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_PBN5UIuUEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -833,30 +895,36 @@
     <element xmi:type="uml:Package" href="TapiPathComputation.uml#_rZmYoC5zEea0_JngOlSKcA"/>
     <edges xmi:type="notation:Connector" xmi:id="__7bq1TBGEeam35bpdXJzEw" type="Association_Edge" source="__7k0RDBGEeam35bpdXJzEw" target="_jCJFgDJEEeamvfKYyWmELQ">
       <children xmi:type="notation:DecorationNode" xmi:id="__7bq1jBGEeam35bpdXJzEw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rARuMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq1zBGEeam35bpdXJzEw" x="1" y="13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__7bq2DBGEeam35bpdXJzEw" type="Association_NameLabel">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__7bq2TBGEeam35bpdXJzEw" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__7bq2jBGEeam35bpdXJzEw" key="visible" value="true"/>
         </eAnnotations>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rBzYMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq2zBGEeam35bpdXJzEw" x="-4" y="-11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__7bq3DBGEeam35bpdXJzEw" visible="false" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq3TBGEeam35bpdXJzEw" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rDVCMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq3TBGEeam35bpdXJzEw" x="36" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__7bq3jBGEeam35bpdXJzEw" visible="false" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq3zBGEeam35bpdXJzEw" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rFC5cK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq3zBGEeam35bpdXJzEw" x="-36" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__7bq4DBGEeam35bpdXJzEw" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq4TBGEeam35bpdXJzEw" x="-27" y="14"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rG898K1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq4TBGEeam35bpdXJzEw" x="9" y="14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__7bq4jBGEeam35bpdXJzEw" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq4zBGEeam35bpdXJzEw" x="26" y="17"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rIen8K1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__7bq4zBGEeam35bpdXJzEw" x="-10" y="17"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__7bq5DBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__7bq6zBGEeam35bpdXJzEw" points="[0, 0, -253, 97]$[224, -95, -29, 2]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__7bq7DBGEeam35bpdXJzEw" id="(1.0,0.8913043478260869)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__7bq7DBGEeam35bpdXJzEw" id="(1.0,0.7323943661971831)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__7bq7TBGEeam35bpdXJzEw" id="(0.0,0.79)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__9zndDBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="__7bq1TBGEeam35bpdXJzEw" target="__9zncDBGEeam35bpdXJzEw">
@@ -981,22 +1049,28 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_sC9uIE0REeaqn4OIuRCwEg" type="Association_Edge" source="_sBVWcE0REeaqn4OIuRCwEg" target="__7bpATBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_sC9uI00REeaqn4OIuRCwEg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5uQlkK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_sC9uJE0REeaqn4OIuRCwEg" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_sC9uJU0REeaqn4OIuRCwEg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5vyPkK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_sC9uJk0REeaqn4OIuRCwEg" x="2" y="-15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_sC9uJ00REeaqn4OIuRCwEg" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_sC9uKE0REeaqn4OIuRCwEg" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5xT5kK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sC9uKE0REeaqn4OIuRCwEg" x="25" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_sC9uKU0REeaqn4OIuRCwEg" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_sC9uKk0REeaqn4OIuRCwEg" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5y1jkK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sC9uKk0REeaqn4OIuRCwEg" x="-25" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_sDHfIE0REeaqn4OIuRCwEg" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_sDHfIU0REeaqn4OIuRCwEg" x="9" y="17"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_50phcK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sDHfIU0REeaqn4OIuRCwEg" x="34" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_sDHfIk0REeaqn4OIuRCwEg" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_sDHfI00REeaqn4OIuRCwEg" x="-12" y="15"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_53O7YK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sDHfI00REeaqn4OIuRCwEg" x="-37" y="15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_sC9uIU0REeaqn4OIuRCwEg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_MM4s4EHBEeWqPKyD1j6LMg"/>
@@ -1096,15 +1170,17 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EAOn0BM8Eee0L_IMWjydgQ" type="Abstraction_Edge" source="_hxP6UMhuEeaVlemTikmRHw" target="_Ax_xQBM8Eee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_EAOn0xM8Eee0L_IMWjydgQ" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mp2IMK1ZEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_EAOn1BM8Eee0L_IMWjydgQ" x="-7" y="-12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_EAOn1RM8Eee0L_IMWjydgQ" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mrwMsK1ZEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_EAOn1hM8Eee0L_IMWjydgQ" x="-5" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_EAOn0RM8Eee0L_IMWjydgQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EAOn0hM8Eee0L_IMWjydgQ" points="[36, -2, -160, 4]$[184, -9, -12, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EBRwsBM8Eee0L_IMWjydgQ" id="(1.0,0.367816091954023)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EBRwsBM8Eee0L_IMWjydgQ" id="(1.0,0.463768115942029)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EBRwsRM8Eee0L_IMWjydgQ" id="(0.0,0.4470588235294118)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_F3E0txM8Eee0L_IMWjydgQ" type="StereotypeCommentLink" source="_EAOn0BM8Eee0L_IMWjydgQ" target="_F3E0sxM8Eee0L_IMWjydgQ">
@@ -1219,16 +1295,18 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_vKhv8FrnEeexvMtO2oNM9g" type="InterfaceRealization_Edge" source="_hxP6UMhuEeaVlemTikmRHw" target="__7kyxDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_vKhv81rnEeexvMtO2oNM9g" type="InterfaceRealization_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_vKhv9FrnEeexvMtO2oNM9g" y="40"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mtkxoK1ZEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vKhv9FrnEeexvMtO2oNM9g" x="-1" y="38"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_vKiXAFrnEeexvMtO2oNM9g" type="InterfaceRealization_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_vKiXAVrnEeexvMtO2oNM9g" y="60"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mvMiQK1ZEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vKiXAVrnEeexvMtO2oNM9g" x="-1" y="58"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_vKhv8VrnEeexvMtO2oNM9g"/>
       <element xmi:type="uml:InterfaceRealization" href="TapiPathComputation.uml#_vItyEFrnEeexvMtO2oNM9g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vKhv8lrnEeexvMtO2oNM9g" points="[29, -1, -526, 1]$[547, 0, -8, 2]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vMh7EFrnEeexvMtO2oNM9g" id="(0.14583333333333334,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vMh7EVrnEeexvMtO2oNM9g" id="(0.45454545454545453,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vMh7EFrnEeexvMtO2oNM9g" id="(0.1409090909090909,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vMh7EVrnEeexvMtO2oNM9g" id="(0.3902439024390244,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mevKhM1kEeeFHsPqdArtwA" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_mevKgM1kEeeFHsPqdArtwA">
       <styles xmi:type="notation:FontStyle" xmi:id="_mevKhc1kEeeFHsPqdArtwA"/>
@@ -1293,11 +1371,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_0f9WQIuVEeiu6boZkiJHCA" type="Association_Edge" source="_hxP6UMhuEeaVlemTikmRHw" target="__7k0RDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0f99UIuVEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2NyKAIuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0f99UYuVEeiu6boZkiJHCA" x="-23" y="-174"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0f99UYuVEeiu6boZkiJHCA" x="-14" y="-6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0f99UouVEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2PgoUIuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0f99U4uVEeiu6boZkiJHCA" x="-32" y="-191"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0f99U4uVEeiu6boZkiJHCA" x="-29" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0f99VIuVEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2RhagIuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1313,13 +1391,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0f99WouVEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2VLLcIuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0f-kYIuVEeiu6boZkiJHCA" x="-70" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0f-kYIuVEeiu6boZkiJHCA" x="-15" y="-14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_0f9WQYuVEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0f9WQouVEeiu6boZkiJHCA" points="[129, -70, -643984, -643984]$[129, 149, -643984, -643984]$[380, 149, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2MCdkIuVEeiu6boZkiJHCA" id="(0.5,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2MCdkYuVEeiu6boZkiJHCA" id="(0.0,0.5)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0f9WQouVEeiu6boZkiJHCA" points="[126, -88, -643984, -643984]$[126, 219, -643984, -643984]$[341, 219, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2MCdkIuVEeiu6boZkiJHCA" id="(0.6181818181818182,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2MCdkYuVEeiu6boZkiJHCA" id="(0.0,0.38028169014084506)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0hBGN4uVEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_0f9WQIuVEeiu6boZkiJHCA" target="_0hBGM4uVEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_0hBGOIuVEeiu6boZkiJHCA"/>
@@ -1338,7 +1416,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_37fB8ouVEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_42-Z0IuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_37fB84uVEeiu6boZkiJHCA" x="13" y="-9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_37fB84uVEeiu6boZkiJHCA" x="13" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_37fB9IuVEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_44QMMIuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1354,13 +1432,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_37fB-ouVEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_479AcIuVEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_37fB-4uVEeiu6boZkiJHCA" x="-18" y="-21"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_37fB-4uVEeiu6boZkiJHCA" x="-12" y="-17"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_37ea4YuVEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_37ea4ouVEeiu6boZkiJHCA" points="[194, -70, -643984, -643984]$[171, -33, -643984, -643984]$[343, -33, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40On0IuVEeiu6boZkiJHCA" id="(0.6458333333333334,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40On0YuVEeiu6boZkiJHCA" id="(0.0,0.4111111111111111)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_37ea4ouVEeiu6boZkiJHCA" points="[168, -88, -643984, -643984]$[157, -43, -643984, -643984]$[343, -43, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40On0IuVEeiu6boZkiJHCA" id="(0.759090909090909,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40On0YuVEeiu6boZkiJHCA" id="(0.0,0.3)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_38mcRIuVEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_37ea4IuVEeiu6boZkiJHCA" target="_38mcQIuVEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_38mcRYuVEeiu6boZkiJHCA"/>
@@ -1509,11 +1587,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_O44KwIuWEeiu6boZkiJHCA" type="Association_Edge" source="__7kz7zBGEeam35bpdXJzEw" target="_jCJFgDJEEeamvfKYyWmELQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_O44Kw4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PuzGIIuWEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O44KxIuWEeiu6boZkiJHCA" x="30" y="12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O44KxIuWEeiu6boZkiJHCA" x="66" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O44KxYuWEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PwB1MIuWEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O44KxouWEeiu6boZkiJHCA" x="47" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O44KxouWEeiu6boZkiJHCA" x="71" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O44Kx4uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PxPWIIuWEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1525,7 +1603,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O44x0ouWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PztbUIuWEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O44x04uWEeiu6boZkiJHCA" x="14" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O44x04uWEeiu6boZkiJHCA" x="11" y="12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O44x1IuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P1QTcIuWEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1533,8 +1611,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_O44KwYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O44KwouWEeiu6boZkiJHCA" points="[536, 20, -643984, -643984]$[529, 128, -643984, -643984]$[747, 128, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PtNxwIuWEeiu6boZkiJHCA" id="(0.8815165876777251,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O44KwouWEeiu6boZkiJHCA" points="[490, 20, -643984, -643984]$[490, 186, -643984, -643984]$[728, 186, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PtNxwIuWEeiu6boZkiJHCA" id="(0.6966824644549763,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PtNxwYuWEeiu6boZkiJHCA" id="(0.0,0.22)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_O5xioIuWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_O44KwIuWEeiu6boZkiJHCA" target="_O5w7k4uWEeiu6boZkiJHCA">
@@ -1549,26 +1627,34 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YF9lYIuWEeiu6boZkiJHCA" type="Association_Edge" source="__7kz7zBGEeam35bpdXJzEw" target="__7k0RDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_YF9lY4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tT9oEK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YF9lZIuWEeiu6boZkiJHCA" x="5" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YF9lZYuWEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tVrfUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YF9lZouWEeiu6boZkiJHCA" x="-13" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YF9lZ4uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-McIuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tXNJUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-McIuWEeiu6boZkiJHCA" x="12" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YF-McYuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-McouWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tYuzUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-McouWEeiu6boZkiJHCA" x="-12" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YF-Mc4uWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-MdIuWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_taQdUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-MdIuWEeiu6boZkiJHCA" x="12" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YF-MdYuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-MdouWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tbyHUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YF-MdouWEeiu6boZkiJHCA" x="-12" y="20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_YF9lYYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YF9lYouWEeiu6boZkiJHCA" points="[442, 20, -643984, -643984]$[448, 103, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_teL7EK1fEeiIjuV0HZnJAQ" id="(0.2843601895734597,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_teL7Ea1fEeiIjuV0HZnJAQ" id="(0.496,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YGWm94uWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_YF9lYIuWEeiu6boZkiJHCA" target="_YGWm84uWEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_YGWm-IuWEeiu6boZkiJHCA"/>
@@ -1582,98 +1668,124 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_czGp8IuWEeiu6boZkiJHCA" type="Association_Edge" source="__7k0RDBGEeam35bpdXJzEw" target="_RFVnkP4tEea_VPdGG2-szQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_czGp84uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tJwjMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_czGp9IuWEeiu6boZkiJHCA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_czGp9YuWEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tLqnsK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_czGp9ouWEeiu6boZkiJHCA" x="1" y="-4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_czGp94uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRAIuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tNSYUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRAIuWEeiu6boZkiJHCA" x="12" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_czHRAYuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRAouWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tPAPkK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRAouWEeiu6boZkiJHCA" x="-12" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_czHRA4uWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRBIuWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tQoAMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRBIuWEeiu6boZkiJHCA" x="12" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_czHRBYuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRBouWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tSV3cK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_czHRBouWEeiu6boZkiJHCA" x="-12" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_czGp8YuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_eMpiAN6ZEeWd9KDn6x5Skg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_czGp8ouWEeiu6boZkiJHCA" points="[443, 195, -643984, -643984]$[442, 276, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_czGp8ouWEeiu6boZkiJHCA" points="[412, 250, -643984, -643984]$[411, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uBZ84K1fEeiIjuV0HZnJAQ" id="(0.568,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uBZ84a1fEeiIjuV0HZnJAQ" id="(0.4962962962962963,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_e3LagIuWEeiu6boZkiJHCA" type="Association_Edge" source="_RFVnkP4tEea_VPdGG2-szQ" target="__7bpATBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_e3Lag4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tgMGMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LahIuWEeiu6boZkiJHCA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_e3LahYuWEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tiYekK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LahouWEeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_e3Lah4uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LaiIuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tkySUK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LaiIuWEeiu6boZkiJHCA" x="34" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_e3LaiYuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LaiouWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tmgJkK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LaiouWEeiu6boZkiJHCA" x="-34" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_e3Lai4uWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LajIuWEeiu6boZkiJHCA" x="-22" y="-16"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_toH6MK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LajIuWEeiu6boZkiJHCA" x="12" y="-16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_e3LajYuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LajouWEeiu6boZkiJHCA" x="24" y="-22"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tpvq0K1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e3LajouWEeiu6boZkiJHCA" x="-10" y="-22"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_e3LagYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e3LagouWEeiu6boZkiJHCA" points="[447, 348, -643984, -643984]$[472, 577, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e3LagouWEeiu6boZkiJHCA" points="[414, 346, -643984, -643984]$[439, 575, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f39iEIuWEeiu6boZkiJHCA" id="(0.25925925925925924,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gNefEIuWEeiu6boZkiJHCA" id="(0.07741935483870968,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_h31IEIuWEeiu6boZkiJHCA" type="Association_Edge" source="__7bowDBGEeam35bpdXJzEw" target="__7bpATBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_h31IE4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5W840K1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IFIuWEeiu6boZkiJHCA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_h31IFYuWEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5Yei0K1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IFouWEeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_h31IF4uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IGIuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5aAM0K1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IGIuWEeiu6boZkiJHCA" x="11" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_h31IGYuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IGouWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5bn9cK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IGouWEeiu6boZkiJHCA" x="-11" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_h31IG4uWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IHIuWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5duPMK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IHIuWEeiu6boZkiJHCA" x="11" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_h31IHYuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IHouWEeiu6boZkiJHCA" x="2" y="14"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5foTsK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_h31IHouWEeiu6boZkiJHCA" x="-9" y="14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_h31IEYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_h31IEouWEeiu6boZkiJHCA" points="[506, 504, -643984, -643984]$[486, 577, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_h31IEouWEeiu6boZkiJHCA" points="[473, 502, -643984, -643984]$[453, 575, -643984, -643984]"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jIBkoIuWEeiu6boZkiJHCA" id="(0.7419354838709677,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_kEvrkIuWEeiu6boZkiJHCA" type="Association_Edge" source="_Jm3rgDM1EeaULOmJRJKM0Q" target="__7bowDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_kEwSoIuWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5h0sEK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSoYuWEeiu6boZkiJHCA" x="1" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_kEwSoouWEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5kuPEK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSo4uWEeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_kEwSpIuWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSpYuWEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5m6ncK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSpYuWEeiu6boZkiJHCA" x="32" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_kEwSpouWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSp4uWEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5o6ykK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSp4uWEeiu6boZkiJHCA" x="-32" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_kEwSqIuWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSqYuWEeiu6boZkiJHCA" x="-22" y="-10"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5q03EK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSqYuWEeiu6boZkiJHCA" x="10" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_kEwSqouWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSq4uWEeiu6boZkiJHCA" x="22" y="-15"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5sWhEK1fEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kEwSq4uWEeiu6boZkiJHCA" x="-10" y="-15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_kEvrkYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kEvrkouWEeiu6boZkiJHCA" points="[795, 468, -643984, -643984]$[579, 462, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kEvrkouWEeiu6boZkiJHCA" points="[762, 466, -643984, -643984]$[546, 460, -643984, -643984]"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_kFjj4IuWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_kEvrkIuWEeiu6boZkiJHCA" target="_kFi804uWEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_kFjj4YuWEeiu6boZkiJHCA"/>
@@ -1712,8 +1824,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_mb5JIYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mb5JIouWEeiu6boZkiJHCA" points="[805, 424, -643984, -643984]$[805, 321, -643984, -643984]$[511, 323, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nZpK0IuWEeiu6boZkiJHCA" id="(0.07633587786259542,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mb5JIouWEeiu6boZkiJHCA" points="[800, 422, -643984, -643984]$[800, 372, -643984, -643984]$[480, 372, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nZpK0IuWEeiu6boZkiJHCA" id="(0.2900763358778626,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nZpK0YuWEeiu6boZkiJHCA" id="(1.0,0.6527777777777778)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mchbQYuWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_mb5JIIuWEeiu6boZkiJHCA" target="_mcg0M4uWEeiu6boZkiJHCA">
@@ -1726,98 +1838,116 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mchbRIuWEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mchbRYuWEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_rKatwIuWEeiu6boZkiJHCA" type="Association_Edge" source="_jCJFgDJEEeamvfKYyWmELQ" target="_Jm3rgDM1EeaULOmJRJKM0Q">
-      <children xmi:type="notation:DecorationNode" xmi:id="_rKatw4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rKatxIuWEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_rKatxYuWEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rKatxouWEeiu6boZkiJHCA" x="-59" y="52"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_rKatx4uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rKatyIuWEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_rKatyYuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rKatyouWEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_rKaty4uWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rKatzIuWEeiu6boZkiJHCA" x="-20" y="-10"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_rKatzYuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rKatzouWEeiu6boZkiJHCA" x="26" y="-16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_rKatwYuWEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_MnHJYDM1EeaULOmJRJKM0Q"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rKatwouWEeiu6boZkiJHCA" points="[839, 206, -643984, -643984]$[857, 424, -643984, -643984]"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_smqCQIuWEeiu6boZkiJHCA" id="(0.35877862595419846,0.0)"/>
+    <edges xmi:type="notation:Connector" xmi:id="_DtRRka1OEeiIjuV0HZnJAQ" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_DtO1UK1OEeiIjuV0HZnJAQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DtRRkq1OEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DtRRlq1OEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DtRRk61OEeiIjuV0HZnJAQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DtRRlK1OEeiIjuV0HZnJAQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DtRRla1OEeiIjuV0HZnJAQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_t1ZGQIuWEeiu6boZkiJHCA" type="Association_Edge" source="_jCJFgDJEEeamvfKYyWmELQ" target="_Jm3rgDM1EeaULOmJRJKM0Q">
-      <children xmi:type="notation:DecorationNode" xmi:id="_t1ZGQ4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ZGRIuWEeiu6boZkiJHCA" y="-20"/>
+    <edges xmi:type="notation:Connector" xmi:id="_pBpeV61fEeiIjuV0HZnJAQ" type="StereotypeCommentLink" source="_pBdREK1fEeiIjuV0HZnJAQ" target="_pBpeU61fEeiIjuV0HZnJAQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_pBpeWK1fEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pBpeXK1fEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pBpeWa1fEeiIjuV0HZnJAQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pBpeWq1fEeiIjuV0HZnJAQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pBpeW61fEeiIjuV0HZnJAQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BZo84K1gEeiIjuV0HZnJAQ" type="Association_Edge" source="__7kz7zBGEeam35bpdXJzEw" target="_pBdREK1fEeiIjuV0HZnJAQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BZo8461gEeiIjuV0HZnJAQ" type="Association_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZo85K1gEeiIjuV0HZnJAQ" x="14" y="10"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_t1ZGRYuWEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ZGRouWEeiu6boZkiJHCA" x="-41" y="-32"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BZo85a1gEeiIjuV0HZnJAQ" type="Association_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZo85q1gEeiIjuV0HZnJAQ" x="44" y="-10"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_t1ZGR4uWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ZGSIuWEeiu6boZkiJHCA" y="-20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BZo8561gEeiIjuV0HZnJAQ" type="Association_TargetRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZo86K1gEeiIjuV0HZnJAQ" y="-20"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_t1ZGSYuWEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ZGSouWEeiu6boZkiJHCA" y="20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BZo86a1gEeiIjuV0HZnJAQ" type="Association_SourceRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZo86q1gEeiIjuV0HZnJAQ" y="20"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_t1ZGS4uWEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ZGTIuWEeiu6boZkiJHCA" x="-22" y="12"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BZo8661gEeiIjuV0HZnJAQ" type="Association_SourceMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZo87K1gEeiIjuV0HZnJAQ" x="-33" y="16"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_t1ZGTYuWEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ZGTouWEeiu6boZkiJHCA" x="26" y="17"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BZo87a1gEeiIjuV0HZnJAQ" type="Association_TargetMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZo87q1gEeiIjuV0HZnJAQ" x="27" y="15"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_t1ZGQYuWEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_ObYjYDM1EeaULOmJRJKM0Q"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_t1ZGQouWEeiu6boZkiJHCA" points="[839, 206, -643984, -643984]$[857, 424, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vKKg0IuWEeiu6boZkiJHCA" id="(0.8983050847457628,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_utd9wIuWEeiu6boZkiJHCA" id="(0.8473282442748091,0.0)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BZo84a1gEeiIjuV0HZnJAQ"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZo84q1gEeiIjuV0HZnJAQ" points="[543, 20, -643984, -643984]$[730, 117, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bc4eIK1gEeiIjuV0HZnJAQ" id="(0.9478672985781991,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bc4eIa1gEeiIjuV0HZnJAQ" id="(0.0,0.6375)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MtvuZ61gEeiIjuV0HZnJAQ" type="StereotypeCommentLink" source="_BZo84K1gEeiIjuV0HZnJAQ" target="_MtvuY61gEeiIjuV0HZnJAQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MtvuaK1gEeiIjuV0HZnJAQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MtvubK1gEeiIjuV0HZnJAQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mtvuaa1gEeiIjuV0HZnJAQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mtvuaq1gEeiIjuV0HZnJAQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mtvua61gEeiIjuV0HZnJAQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SjC4ZK1hEeiqCPid09Hqfw" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_SjC4YK1hEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SjC4Za1hEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SjC4aa1hEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SjC4Zq1hEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SjC4Z61hEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SjC4aK1hEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_T74MNK1kEeiqCPid09Hqfw" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_T74MMK1kEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T74MNa1kEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T74MOa1kEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T74MNq1kEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T74MN61kEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T74MOK1kEeiqCPid09Hqfw"/>
     </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="_SwLpIEQ7EeaktYCiiVTurg" type="PapyrusUMLClassDiagram" name="PathConstraints" measurementUnit="Pixel">
+  <notation:Diagram xmi:id="_SwLpIEQ7EeaktYCiiVTurg" type="PapyrusUMLClassDiagram" name="PathComputationServiceDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_Tx0sUEQ7EeaktYCiiVTurg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_Tx0sUkQ7EeaktYCiiVTurg" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_Tx0sU0Q7EeaktYCiiVTurg" type="Class_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Tx0sVEQ7EeaktYCiiVTurg" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_Tx0sVUQ7EeaktYCiiVTurg" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_V9q40EQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_qXAPuTJDEeamvfKYyWmELQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q40UQ7EeaktYCiiVTurg"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_YK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_RhdgwL2HEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_Ya1lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q40kQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_qXAPsjJDEeamvfKYyWmELQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q400Q7EeaktYCiiVTurg"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_Yq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_GqeeML2JEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_Y61lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q41EQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_qXAPtjJDEeamvfKYyWmELQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q41UQ7EeaktYCiiVTurg"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_ZK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_YQtngIoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_Za1lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q41kQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_qXAPujJDEeamvfKYyWmELQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q410Q7EeaktYCiiVTurg"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_Zq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_-XrtYIfbEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_Z61lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q42kQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_qXAPwjJDEeamvfKYyWmELQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q420Q7EeaktYCiiVTurg"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_aK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_6ZZS4IfbEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_aa1lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q43EQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_MnHJZDM1EeaULOmJRJKM0Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q43UQ7EeaktYCiiVTurg"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_aq1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_AwfVYK1kEeiqCPid09Hqfw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_a61lEeiqCPid09Hqfw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q43kQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_ObiUYjM1EeaULOmJRJKM0Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q430Q7EeaktYCiiVTurg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_V9q45EQ7EeaktYCiiVTurg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_V9q45UQ7EeaktYCiiVTurg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_g5bJEBMuEee0L_IMWjydgQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_g5bJERMuEee0L_IMWjydgQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_-g4_bK1lEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_1dtjYIfYEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-g4_ba1lEeiqCPid09Hqfw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Tx0sVkQ7EeaktYCiiVTurg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Tx0sV0Q7EeaktYCiiVTurg"/>
@@ -1837,7 +1967,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx0sY0Q7EeaktYCiiVTurg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx0sUUQ7EeaktYCiiVTurg" x="75" y="64" height="192"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx0sUUQ7EeaktYCiiVTurg" x="620" y="-72" height="139"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Tx0sf0Q7EeaktYCiiVTurg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Tx0sgEQ7EeaktYCiiVTurg" showTitle="true"/>
@@ -1899,7 +2029,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UdQ2E0Q7EeaktYCiiVTurg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UdQ2AUQ7EeaktYCiiVTurg" x="379" y="62" height="157"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UdQ2AUQ7EeaktYCiiVTurg" x="621" y="381" height="140"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_UdanG0Q7EeaktYCiiVTurg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_UdanHEQ7EeaktYCiiVTurg" showTitle="true"/>
@@ -1945,7 +2075,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U9Gzw0Q7EeaktYCiiVTurg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U9GzsUQ7EeaktYCiiVTurg" x="392" y="236" height="88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U9GzsUQ7EeaktYCiiVTurg" x="617" y="280" height="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_U9P9o0Q7EeaktYCiiVTurg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_U9P9pEQ7EeaktYCiiVTurg" showTitle="true"/>
@@ -1954,6 +2084,398 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U9P9pUQ7EeaktYCiiVTurg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_x_hQ4K1iEeiqCPid09Hqfw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_x_hQ4q1iEeiqCPid09Hqfw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_x_hQ461iEeiqCPid09Hqfw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_x_hQ5K1iEeiqCPid09Hqfw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_x_hQ5a1iEeiqCPid09Hqfw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_y2NBQK1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_1EaBNC2bEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2NBQa1iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH4K1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_f8XbBC2cEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH4a1iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH4q1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_7tFa0i2aEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH461iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH5K1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_BX7Foq1gEeiIjuV0HZnJAQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH5a1iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH5q1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_jUIIo-_xEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH561iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH6K1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_jyVHk-_xEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH6a1iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH7K1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH7a1iEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_y2TH7q1iEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_y2TH761iEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_x_hQ5q1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_x_hQ561iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_x_hQ6K1iEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_hQ6a1iEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_x_hQ6q1iEeiqCPid09Hqfw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_x_hQ661iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_x_hQ7K1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_x_hQ7a1iEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_hQ7q1iEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_x_hQ761iEeiqCPid09Hqfw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_x_hQ8K1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_x_hQ8a1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_x_hQ8q1iEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_hQ861iEeiqCPid09Hqfw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_hQ4a1iEeiqCPid09Hqfw" x="60" y="59" height="163"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_x_zkw61iEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_x_zkxK1iEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x_zkxq1iEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_zkxa1iEeiqCPid09Hqfw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6HtgAK1iEeiqCPid09Hqfw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6HtgAq1iEeiqCPid09Hqfw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6HtgA61iEeiqCPid09Hqfw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6HtgBK1iEeiqCPid09Hqfw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_6HtgBa1iEeiqCPid09Hqfw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_LN_rgK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_eMyr8t6ZEeWd9KDn6x5Skg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LN_rga1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LN_rgq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_iuK74-_xEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LN_rg61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LN_rhK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_EN4ewK1jEeiqCPid09Hqfw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LN_rha1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LN_rhq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_5r3gQK1cEeiIjuV0HZnJAQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LN_rh61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LN_riK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LN_ria1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LN_riq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LN_ri61jEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_6HtgBq1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_6HtgB61iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_6HtgCK1iEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6HtgCa1iEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_6HtgCq1iEeiqCPid09Hqfw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_6HtgC61iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_6HtgDK1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_6HtgDa1iEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6HtgDq1iEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_6HzmoK1iEeiqCPid09Hqfw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_6Hzmoa1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_6Hzmoq1iEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_6Hzmo61iEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6HzmpK1iEeiqCPid09Hqfw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6HtgAa1iEeiqCPid09Hqfw" x="249" y="492" height="119"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6IF6g61iEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6IF6hK1iEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6IF6hq1iEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6IF6ha1iEeiqCPid09Hqfw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MzH2QK1jEeiqCPid09Hqfw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MzH2Qq1jEeiqCPid09Hqfw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MzH2Q61jEeiqCPid09Hqfw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MzH2RK1jEeiqCPid09Hqfw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MzH2Ra1jEeiqCPid09Hqfw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Tnno4K1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_YEuIVC2nEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tnno4a1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TntvgK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_yYDuvC2mEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvga1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Tntvgq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_KekBYK1dEeiIjuV0HZnJAQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvg61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TntvhK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_WptIkK1dEeiIjuV0HZnJAQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvha1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Tntvhq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_yYDutC2mEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvh61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TntviK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_yYDuuC2mEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvia1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Tntviq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvi61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TntvjK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tntvja1jEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MzH2Rq1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MzH2R61jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MzH2SK1jEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MzH2Sa1jEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MzH2Sq1jEeiqCPid09Hqfw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MzH2S61jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MzH2TK1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MzH2Ta1jEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MzH2Tq1jEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MzH2T61jEeiqCPid09Hqfw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MzH2UK1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MzH2Ua1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MzH2Uq1jEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MzH2U61jEeiqCPid09Hqfw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MzH2Qa1jEeiqCPid09Hqfw" x="31" y="320" height="164"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MzUDg61jEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MzUDhK1jEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MzUDhq1jEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MzUDha1jEeiqCPid09Hqfw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YifAYK1jEeiqCPid09Hqfw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_YifAYq1jEeiqCPid09Hqfw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_YifAY61jEeiqCPid09Hqfw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YifAZK1jEeiqCPid09Hqfw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_YilHAK1jEeiqCPid09Hqfw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_c9U0AK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0Aa1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0Aq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0A61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0BK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_wGVAhMF-EeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0Ba1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0Bq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_xyluAsF-EeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0B61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0CK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0Ca1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0Cq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0C61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0DK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0Da1jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0Dq1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0D61jEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c9U0EK1jEeiqCPid09Hqfw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPathComputation.uml#_3_SWwL11EeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c9U0Ea1jEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_YilHAa1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_YilHAq1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_YilHA61jEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YilHBK1jEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_YilHBa1jEeiqCPid09Hqfw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_YilHBq1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_YilHB61jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_YilHCK1jEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YilHCa1jEeiqCPid09Hqfw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_YilHCq1jEeiqCPid09Hqfw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_YilHC61jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_YilHDK1jEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_YilHDa1jEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YilHDq1jEeiqCPid09Hqfw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YifAYa1jEeiqCPid09Hqfw" x="619" y="91" height="174"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YixUQ61jEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YixURK1jEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YixURq1jEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YixURa1jEeiqCPid09Hqfw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Eal9s61mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Eal9tK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eal9tq1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eal9ta1mEeiqCPid09Hqfw" x="304" y="-41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_GuUT061mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_GuUT1K1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GuUT1q1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GuUT1a1mEeiqCPid09Hqfw" x="533" y="330"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Tj-Xo61mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Tj-XpK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tj-Xpq1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tj-Xpa1mEeiqCPid09Hqfw" x="304" y="-41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_V4W1E61mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_V4W1FK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_V4W1Fq1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V4W1Fa1mEeiqCPid09Hqfw" x="304" y="-41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZEwfo61mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ZEwfpK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZEwfpq1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZEwfpa1mEeiqCPid09Hqfw" x="304" y="-41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZdwOc61mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ZdwOdK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZdwOdq1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZdwOda1mEeiqCPid09Hqfw" x="304" y="-41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZvHrQ61mEeiqCPid09Hqfw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ZvHrRK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZvHrRq1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZvHrRa1mEeiqCPid09Hqfw" x="304" y="-41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q4NEYK1sEeiqCPid09Hqfw" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_q4NrcK1sEeiqCPid09Hqfw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_q4Nrca1sEeiqCPid09Hqfw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_q4Nrcq1sEeiqCPid09Hqfw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q4Nrc61sEeiqCPid09Hqfw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_v6FC0K1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_LLdOwUXZEeeeyqnd6Cxkjw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_v6FC0a1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_v6Fp4K1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_LLdOwkXZEeeeyqnd6Cxkjw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_v6Fp4a1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_v6Fp4q1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_LLdOw0XZEeeeyqnd6Cxkjw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_v6Fp461sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_v6GQ8K1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_srl4wGhjEeeWO9Idc2UXkw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_v6GQ8a1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_v6GQ8q1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_tZ4iIGhjEeeWO9Idc2UXkw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_v6GQ861sEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q4NrdK1sEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q4Nrda1sEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q4Nrdq1sEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q4Nrd61sEeiqCPid09Hqfw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiPathComputation.uml#_LLdOwEXZEeeeyqnd6Cxkjw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q4NEYa1sEeiqCPid09Hqfw" x="428" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rRypEK1sEeiqCPid09Hqfw" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rRzQIK1sEeiqCPid09Hqfw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rRzQIa1sEeiqCPid09Hqfw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rRzQIq1sEeiqCPid09Hqfw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rRzQI61sEeiqCPid09Hqfw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_wxjdYK1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_2HQV0Cr1EeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxjdYa1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wxkEcK1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_6TLjsCr1EeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxkEca1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wxkEcq1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_lfHloCtHEeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxkEc61sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wxkEdK1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_mY3RECtHEeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxkEda1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wxkEdq1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_nRsWgCtHEeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxkEd61sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wxkEeK1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_osHGECtHEeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxkEea1sEeiqCPid09Hqfw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wxkrgK1sEeiqCPid09Hqfw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPathComputation.uml#_p6IYYCtHEeeA7tvtQmACtQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxkrga1sEeiqCPid09Hqfw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rRzQJK1sEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rRzQJa1sEeiqCPid09Hqfw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rRzQJq1sEeiqCPid09Hqfw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rRzQJ61sEeiqCPid09Hqfw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiPathComputation.uml#_P377ECr1EeeA7tvtQmACtQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rRypEa1sEeiqCPid09Hqfw" x="63" y="-123"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_SwLpIUQ7EeaktYCiiVTurg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_SwLpIkQ7EeaktYCiiVTurg"/>
@@ -1990,6 +2512,333 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U9P9qUQ7EeaktYCiiVTurg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U9P9qkQ7EeaktYCiiVTurg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U9P9q0Q7EeaktYCiiVTurg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_x_zkx61iEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_x_zkw61iEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_x_zkyK1iEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x_zkzK1iEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_x_zkya1iEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x_zkyq1iEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x_zky61iEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6IF6h61iEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_6IF6g61iEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6IF6iK1iEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6IF6jK1iEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6IF6ia1iEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6IF6iq1iEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6IF6i61iEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MzUDh61jEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_MzUDg61jEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MzUDiK1jEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MzUDjK1jEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MzUDia1jEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MzUDiq1jEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MzUDi61jEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YixUR61jEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_YixUQ61jEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YixUSK1jEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YixUTK1jEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YixUSa1jEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YixUSq1jEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YixUS61jEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EZQg8K1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_6HtgAK1iEeiqCPid09Hqfw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EZQg861mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PqdvcK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EZQg9K1mEeiqCPid09Hqfw" x="-53" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EZQg9a1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Pt6FAK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EZQg9q1mEeiqCPid09Hqfw" x="-72" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EZQg961mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PxJmQK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EZQg-K1mEeiqCPid09Hqfw" x="31" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EZQg-a1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P09vQK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EZQg-q1mEeiqCPid09Hqfw" x="-31" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EZQg-61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P5QZYK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EZQg_K1mEeiqCPid09Hqfw" x="14" y="22"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EZQg_a1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P-HrQK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EZQg_q1mEeiqCPid09Hqfw" x="-12" y="-23"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_EZQg8a1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EZQg8q1mEeiqCPid09Hqfw" points="[316, 222, -643984, -643984]$[432, 430, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E5ybIK1mEeiqCPid09Hqfw" id="(0.9069069069069069,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJ6h0K1mEeiqCPid09Hqfw" id="(0.42641509433962266,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Eal9t61mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_Eal9s61mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Eal9uK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eal9vK1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Eal9ua1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eal9uq1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eal9u61mEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GsUIsK1mEeiqCPid09Hqfw" type="Association_Edge" source="_6HtgAK1iEeiqCPid09Hqfw" target="_Tx0sUEQ7EeaktYCiiVTurg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_GsUIs61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H0jjIK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GsUItK1mEeiqCPid09Hqfw" x="-69" y="-203"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GsUIta1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H4FYQK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GsUItq1mEeiqCPid09Hqfw" x="-44" y="-196"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GsUIt61mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H7hGwK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GsUIuK1mEeiqCPid09Hqfw" x="115" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GsUIua1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H_0X8K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GsUIuq1mEeiqCPid09Hqfw" x="-116" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GsUIu61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IENIsK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GsUIvK1mEeiqCPid09Hqfw" x="13" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GsUIva1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IIZsMK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GsUIvq1mEeiqCPid09Hqfw" x="-15" y="17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_GsUIsa1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GsUIsq1mEeiqCPid09Hqfw" points="[514, 572, -643984, -643984]$[917, 572, -643984, -643984]$[917, 67, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwvaIK1mEeiqCPid09Hqfw" id="(1.0,0.6638655462184874)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwvaIa1mEeiqCPid09Hqfw" id="(0.9195046439628483,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GuUT161mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_GuUT061mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_GuUT2K1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GuUT3K1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GuUT2a1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GuUT2q1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GuUT261mEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Th-MgK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_U9GzsEQ7EeaktYCiiVTurg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mg61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oQPLUK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Th-MhK1mEeiqCPid09Hqfw" x="6" y="89"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mha1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oUc88K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Th-Mhq1mEeiqCPid09Hqfw" x="-18" y="71"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mh61mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oZUO0K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Th-MiK1mEeiqCPid09Hqfw" x="50" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mia1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oej7MK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Th-Miq1mEeiqCPid09Hqfw" x="-49" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mi61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oiYEMK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Th-MjK1mEeiqCPid09Hqfw" x="6" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mja1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ol__8K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Th-Mjq1mEeiqCPid09Hqfw" x="-12" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Th-Mga1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Th-Mgq1mEeiqCPid09Hqfw" points="[393, 169, -643984, -643984]$[575, 169, -643984, -643984]$[575, 343, -643984, -643984]$[623, 343, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VTU1YK1mEeiqCPid09Hqfw" id="(1.0,0.6687116564417178)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMcF0K1mEeiqCPid09Hqfw" id="(0.0,0.5277777777777778)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Tj-Xp61mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_Tj-Xo61mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Tj-XqK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tj-XrK1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tj-Xqa1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tj-Xqq1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tj-Xq61mEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_V21LEK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_UdQ2AEQ7EeaktYCiiVTurg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_V21LE61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_opbucK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_V21LFK1mEeiqCPid09Hqfw" x="-40" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_V21LFa1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_otP3cK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_V21LFq1mEeiqCPid09Hqfw" x="-57" y="54"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_V21LF61mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_owrl8K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_V21LGK1mEeiqCPid09Hqfw" x="57" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_V21LGa1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_o0H7gK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_V21LGq1mEeiqCPid09Hqfw" x="-57" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_V21LG61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_o4OYYK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_V21LHK1mEeiqCPid09Hqfw" x="9" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_V21LHa1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_o8zWYK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_V21LHq1mEeiqCPid09Hqfw" x="-17" y="-14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_V21LEa1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_V21LEq1mEeiqCPid09Hqfw" points="[393, 208, -643984, -643984]$[529, 208, -643984, -643984]$[529, 418, -643984, -643984]$[621, 418, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WfqssK1mEeiqCPid09Hqfw" id="(1.0,0.9079754601226994)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XB0-kK1mEeiqCPid09Hqfw" id="(0.0,0.2642857142857143)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_V4W1F61mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_V4W1E61mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_V4W1GK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_V4W1HK1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_V4W1Ga1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V4W1Gq1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V4W1G61mEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZDO1oK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_Tx0sUEQ7EeaktYCiiVTurg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZDO1o61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jkOIIK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZDO1pK1mEeiqCPid09Hqfw" x="-2" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZDO1pa1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jnv9QK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZDO1pq1mEeiqCPid09Hqfw" x="21" y="6"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZDO1p61mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jsCnYK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZDO1qK1mEeiqCPid09Hqfw" x="33" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZDO1qa1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jvrKMK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZDO1qq1mEeiqCPid09Hqfw" x="-33" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZDO1q61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jzM_UK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZDO1rK1mEeiqCPid09Hqfw" x="8" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZDO1ra1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_j3Zi0K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZDO1rq1mEeiqCPid09Hqfw" x="-13" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZDO1oa1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZDO1oq1mEeiqCPid09Hqfw" points="[393, 78, -643984, -643984]$[517, 78, -643984, -643984]$[517, 31, -643984, -643984]$[620, 31, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jgZ_IK1mEeiqCPid09Hqfw" id="(1.0,0.1165644171779141)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jgZ_Ia1mEeiqCPid09Hqfw" id="(0.0,0.7482014388489209)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZEwfp61mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_ZEwfo61mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZEwfqK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZEwfrK1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZEwfqa1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZEwfqq1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZEwfq61mEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZcUrEK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_YifAYK1jEeiqCPid09Hqfw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrE61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l5QF0K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZcUrFK1mEeiqCPid09Hqfw" x="-11" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrFa1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l97KcK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZcUrFq1mEeiqCPid09Hqfw" x="-2" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrF61mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mCmPEK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZcUrGK1mEeiqCPid09Hqfw" x="28" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrGa1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mGa_IK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZcUrGq1mEeiqCPid09Hqfw" x="-28" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrG61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mKC64K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZcUrHK1mEeiqCPid09Hqfw" x="6" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrHa1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mNkwAK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZcUrHq1mEeiqCPid09Hqfw" x="-17" y="12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZcUrEa1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZcUrEq1mEeiqCPid09Hqfw" points="[393, 113, -643984, -643984]$[619, 113, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l0e6kK1mEeiqCPid09Hqfw" id="(1.0,0.3312883435582822)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l0e6ka1mEeiqCPid09Hqfw" id="(0.0,0.12643678160919541)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZdwOd61mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_ZdwOc61mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZdwOeK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZdwOfK1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZdwOea1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZdwOeq1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZdwOe61mEeiqCPid09Hqfw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZtTtYK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_MzH2QK1jEeiqCPid09Hqfw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZtTtY61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pCDCwK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZtTtZK1mEeiqCPid09Hqfw" x="1" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZtTtZa1mEeiqCPid09Hqfw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pF95cK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZtTtZq1mEeiqCPid09Hqfw" x="-11" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZtTtZ61mEeiqCPid09Hqfw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pJfukK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZtTtaK1mEeiqCPid09Hqfw" x="26" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZtTtaa1mEeiqCPid09Hqfw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pNBjsK1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZtTtaq1mEeiqCPid09Hqfw" x="-25" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZtTta61mEeiqCPid09Hqfw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pRUN0K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZtTtbK1mEeiqCPid09Hqfw" x="9" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZtTtba1mEeiqCPid09Hqfw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pU2C8K1mEeiqCPid09Hqfw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZtTtbq1mEeiqCPid09Hqfw" x="-25" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZtTtYa1mEeiqCPid09Hqfw"/>
+      <element xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZtTtYq1mEeiqCPid09Hqfw" points="[246, 222, -643984, -643984]$[196, 392, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_acJwYK1mEeiqCPid09Hqfw" id="(0.3303303303303303,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pYqzAK1mEeiqCPid09Hqfw" id="(0.47766323024054985,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZvHrR61mEeiqCPid09Hqfw" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_ZvHrQ61mEeiqCPid09Hqfw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZvHrSK1mEeiqCPid09Hqfw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZvHrTK1mEeiqCPid09Hqfw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZvHrSa1mEeiqCPid09Hqfw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZvHrSq1mEeiqCPid09Hqfw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZvHrS61mEeiqCPid09Hqfw"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -60,18 +60,6 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uxroci2nEeair-8ZDvf8jw" value="*"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_ObYjYDM1EeaULOmJRJKM0Q" name="RouteConstrHasAvoidTopology" memberEnd="_ObiUYjM1EeaULOmJRJKM0Q _ObiUZTM1EeaULOmJRJKM0Q">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ObiUYDM1EeaULOmJRJKM0Q" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ObiUYTM1EeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_ObiUZTM1EeaULOmJRJKM0Q" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" association="_ObYjYDM1EeaULOmJRJKM0Q"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_MnHJYDM1EeaULOmJRJKM0Q" name="RouteConstrHasIncludeTopology" memberEnd="_MnHJZDM1EeaULOmJRJKM0Q _MnHJZzM1EeaULOmJRJKM0Q">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MnHJYjM1EeaULOmJRJKM0Q" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MnHJYzM1EeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_MnHJZzM1EeaULOmJRJKM0Q" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" association="_MnHJYDM1EeaULOmJRJKM0Q"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_JEyyMMhvEeaVlemTikmRHw" name="ContextHasPathCompService" memberEnd="_JEyyNMhvEeaVlemTikmRHw _JEyyN8hvEeaVlemTikmRHw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JEyyMshvEeaVlemTikmRHw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JEyyM8hvEeaVlemTikmRHw" key="nature" value="UML_Nature"/>
@@ -89,6 +77,12 @@ License: This module is distributed under the Apache License 2.0</body>
           <body>Augments the base TAPI Context with PathComputationService information</body>
         </ownedComment>
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_BX0_AK1gEeiIjuV0HZnJAQ" name="PathServiceHasTopologyConstraints" memberEnd="_BX7Foq1gEeiIjuV0HZnJAQ _BX7Fp61gEeiIjuV0HZnJAQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_BX7FoK1gEeiIjuV0HZnJAQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_BX7Foa1gEeiIjuV0HZnJAQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_BX7Fp61gEeiIjuV0HZnJAQ" name="pathcomputationservice" type="_IUF7cC2XEeair-8ZDvf8jw" association="_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_rZmYoC5zEea0_JngOlSKcA" name="Diagrams"/>
@@ -108,6 +102,10 @@ License: This module is distributed under the Apache License 2.0</body>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NKeg8i2qEeair-8ZDvf8jw" value="2"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPn96MEeWd9KDn6x5Skg" name="routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_jQBd8K1fEeiIjuV0HZnJAQ" name="topologyConstraint" type="_-fei4P4wEea_VPdGG2-szQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lB8ukK1fEeiIjuV0HZnJAQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lCbPsK1fEeiIjuV0HZnJAQ" value="1"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_8XQOgN6QEeWd9KDn6x5Skg" name="objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_zhR6MC2eEeair-8ZDvf8jw" name="service" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out"/>
         </ownedOperation>
@@ -138,6 +136,12 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNMnMd6ZEeWd9KDn6x5Skg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_iuK74-_xEeWLlrwIF3w0vA" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" isReadOnly="true" aggregation="composite" association="_iuK74O_xEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EN4ewK1jEeiqCPid09Hqfw" name="direction">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5r3gQK1cEeiIjuV0HZnJAQ" name="layerProtocolName" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_yYDusC2mEeair-8ZDvf8jw" name="PathServiceEndPoint" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_yYDusS2mEeair-8ZDvf8jw" annotatedElement="_yYDusC2mEeair-8ZDvf8jw">
@@ -155,6 +159,17 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <ownedAttribute xmi:type="uml:Property" xmi:id="_YEuIVC2nEeair-8ZDvf8jw" name="_serviceInterfacePoint" isReadOnly="true" association="_YEuIUC2nEeair-8ZDvf8jw">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yYDuvC2mEeair-8ZDvf8jw" name="layerProtocolName" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYDuvS2mEeair-8ZDvf8jw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYDuvi2mEeair-8ZDvf8jw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KekBYK1dEeiIjuV0HZnJAQ" name="layerProtocolQualifier">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WptIkK1dEeiIjuV0HZnJAQ" name="capacity">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_yYDutC2mEeair-8ZDvf8jw" name="role" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_yYDutS2mEeair-8ZDvf8jw" annotatedElement="_yYDutC2mEeair-8ZDvf8jw">
             <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
@@ -171,11 +186,6 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYDuui2mEeair-8ZDvf8jw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYDuuy2mEeair-8ZDvf8jw" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_yYDuvC2mEeair-8ZDvf8jw" name="serviceLayer" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYDuvS2mEeair-8ZDvf8jw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYDuvi2mEeair-8ZDvf8jw" value="1"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_IUF7cC2XEeair-8ZDvf8jw" name="PathComputationService">
         <generalization xmi:type="uml:Generalization" xmi:id="_IUF7cS2XEeair-8ZDvf8jw">
@@ -190,6 +200,10 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nArLQi2cEeair-8ZDvf8jw" value="2"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7tFa0i2aEeair-8ZDvf8jw" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" aggregation="composite" association="_7s7p0C2aEeair-8ZDvf8jw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BX7Foq1gEeiIjuV0HZnJAQ" name="_topologyConstraint" type="_-fei4P4wEea_VPdGG2-szQ" aggregation="composite" association="_BX0_AK1gEeiIjuV0HZnJAQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BX7Fpa1gEeiIjuV0HZnJAQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BX7Fpq1gEeiIjuV0HZnJAQ" value="1"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jUIIo-_xEeWLlrwIF3w0vA" name="_objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" aggregation="composite" association="_jUIIoO_xEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jyVHk-_xEeWLlrwIF3w0vA" name="_optimizationConstraint" type="_PK97QO-fEeWLlrwIF3w0vA" aggregation="composite" association="_jyVHkO_xEeWLlrwIF3w0vA"/>
       </packagedElement>
@@ -222,50 +236,44 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_qXAPsDJDEeamvfKYyWmELQ" name="RoutingConstraint">
-        <generalization xmi:type="uml:Generalization" xmi:id="_gvfwQD4zEea-1_BGg-qcjQ">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-        </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPuTJDEeamvfKYyWmELQ" name="requestedCapacity" isReadOnly="true">
-          <type xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPsjJDEeamvfKYyWmELQ" name="serviceLevel" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_qXAPszJDEeamvfKYyWmELQ">
-            <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPtDJDEeamvfKYyWmELQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPtTJDEeamvfKYyWmELQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPtjJDEeamvfKYyWmELQ" name="pathLayer" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPtzJDEeamvfKYyWmELQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPuDJDEeamvfKYyWmELQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPujJDEeamvfKYyWmELQ" name="costCharacteristic" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_qXAPuzJDEeamvfKYyWmELQ" annotatedElement="_qXAPujJDEeamvfKYyWmELQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
             <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
           </ownedComment>
           <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPvDJDEeamvfKYyWmELQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPvTJDEeamvfKYyWmELQ" value="*"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rhdgwr2HEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rhdgw72HEeWdore3Cxez9g" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPwjJDEeamvfKYyWmELQ" name="latencyCharacteristic" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_qXAPwzJDEeamvfKYyWmELQ" annotatedElement="_qXAPwjJDEeamvfKYyWmELQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GqeeMb2JEeWdore3Cxez9g" annotatedElement="_GqeeML2JEeWdore3Cxez9g">
             <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
           </ownedComment>
           <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPxDJDEeamvfKYyWmELQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPxTJDEeamvfKYyWmELQ" value="*"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GqeeMr2JEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GqeeM72JEeWdore3Cxez9g" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_MnHJZDM1EeaULOmJRJKM0Q" name="_includeTopology" isReadOnly="true" association="_MnHJYDM1EeaULOmJRJKM0Q">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_leUTgDM1EeaULOmJRJKM0Q"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_leUTgjM1EeaULOmJRJKM0Q" value="*"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YQtngIoPEeivCevppATXng" name="riskDiversityCharacteristic">
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqz9v-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cMJiUIoPEeivCevppATXng"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cMLXgIoPEeivCevppATXng" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ObiUYjM1EeaULOmJRJKM0Q" name="_avoidTopology" isReadOnly="true" association="_ObYjYDM1EeaULOmJRJKM0Q">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s0hsEDM1EeaULOmJRJKM0Q"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s0hsEjM1EeaULOmJRJKM0Q" value="*"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-XrtYIfbEeeirpBaj87qAw" name="diversityPolicy" type="_LLdOwEXZEeeeyqnd6Cxkjw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eexwMIfdEeet-8tHdGGp_w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eey-UIfdEeet-8tHdGGp_w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6ZZS4IfbEeeirpBaj87qAw" name="routeObjectiveFunction" type="_P377ECr1EeeA7tvtQmACtQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dc41YIfdEeet-8tHdGGp_w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dc7RoIfdEeet-8tHdGGp_w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AwfVYK1kEeiqCPid09Hqfw" name="routeDirection">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1dtjYIfYEeeirpBaj87qAw" name="isExclusive">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_buMbwIfZEeeirpBaj87qAw" annotatedElement="_1dtjYIfYEeeirpBaj87qAw">
+            <body>To distinguish if the resources are to be exclusive to the service</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_-iMboIfYEeeirpBaj87qAw" value="true"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_hv0W8MhuEeaVlemTikmRHw" name="PathComputationContext" isLeaf="true">
@@ -278,6 +286,86 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_boQGUshvEeaVlemTikmRHw" value="*"/>
         </ownedAttribute>
         <interfaceRealization xmi:type="uml:InterfaceRealization" xmi:id="_vItyEFrnEeexvMtO2oNM9g" client="_hv0W8MhuEeaVlemTikmRHw" supplier="_5ASPgN6MEeWd9KDn6x5Skg" contract="_5ASPgN6MEeWd9KDn6x5Skg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_-fei4P4wEea_VPdGG2-szQ" name="TopologyConstraint">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nxcI8jLCEeaULOmJRJKM0Q" name="_includeTopology" isReadOnly="true">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YQFpADLEEeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YQFpAjLEEeaULOmJRJKM0Q" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_nxS_ADLCEeaULOmJRJKM0Q"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_c8MLxDLEEeaULOmJRJKM0Q" name="_avoidTopology" isReadOnly="true">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hUfowDLEEeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hUfowjLEEeaULOmJRJKM0Q" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_c8MLwDLEEeaULOmJRJKM0Q"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wGVAhMF-EeaALJQAf08uAg" name="_includePath" type="_aMQ88N5xEeWd9KDn6x5Skg" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ON4p8MF_EeaALJQAf08uAg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ON-wkMF_EeaALJQAf08uAg" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_wGVAgMF-EeaALJQAf08uAg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xyluAsF-EeaALJQAf08uAg" name="_excludePath" type="_aMQ88N5xEeWd9KDn6x5Skg" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e8ofMMF_EeaALJQAf08uAg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e8ofMsF_EeaALJQAf08uAg" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_xyfnYMF-EeaALJQAf08uAg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ca3vhP4zEea_VPdGG2-szQ" name="_includeLink" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xdX0kE5rEeeicu4cm-7qRg" annotatedElement="_Ca3vhP4zEea_VPdGG2-szQ">
+            <body>This is a loose constraint - that is it is unordered and could be a partial list </body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_I_odAP4zEea_VPdGG2-szQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_I_prIP4zEea_VPdGG2-szQ" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_Ca3vgP4zEea_VPdGG2-szQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MjEHhP4zEea_VPdGG2-szQ" name="_excludeLink" isReadOnly="true">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OG3ckP4zEea_VPdGG2-szQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OG3ckv4zEea_VPdGG2-szQ" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_MjEHgP4zEea_VPdGG2-szQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tAVeAE5qEeeicu4cm-7qRg" name="_includeNode" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_zUMzUE5rEeeicu4cm-7qRg" annotatedElement="_tAVeAE5qEeeicu4cm-7qRg">
+            <body>This is a loose constraint - that is it is unordered and could be a partial list</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1OubwE5qEeeicu4cm-7qRg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1OxfEE5qEeeicu4cm-7qRg" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_tATBwE5qEeeicu4cm-7qRg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5TDM0U5qEeeicu4cm-7qRg" name="_excludeNode" isReadOnly="true">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-ZosIE5qEeeicu4cm-7qRg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-ZqhUE5qEeeicu4cm-7qRg" value="*"/>
+          <association xmi:type="uml:Association" href="TapiConnectivity.uml#_5TB-sE5qEeeicu4cm-7qRg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_SWwL11EeWdore3Cxez9g" name="preferredTransportLayer" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_f3CoEMF2EeaALJQAf08uAg" annotatedElement="_3_SWwL11EeWdore3Cxez9g">
+            <body>soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p_hKEL2SEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p_q7EL2SEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_hy1bUK1sEeiqCPid09Hqfw" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_P377ECr1EeeA7tvtQmACtQ" name="RouteObjectiveFunction" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2HQV0Cr1EeeA7tvtQmACtQ" name="MIN_WORK_ROUTE_HOP"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_6TLjsCr1EeeA7tvtQmACtQ" name="MIN_WORK_ROUTE_COST"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_lfHloCtHEeeA7tvtQmACtQ" name="MIN_WORK_ROUTE_LATENCY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mY3RECtHEeeA7tvtQmACtQ" name="MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nRsWgCtHEeeA7tvtQmACtQ" name="MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_osHGECtHEeeA7tvtQmACtQ" name="MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_p6IYYCtHEeeA7tvtQmACtQ" name="LOAD_BALANCE_MAX_UNUSED_CAPACITY"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_LLdOwEXZEeeeyqnd6Cxkjw" name="DiversityPolicy" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LLdOwUXZEeeeyqnd6Cxkjw" name="SRLG"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LLdOwkXZEeeeyqnd6Cxkjw" name="SRNG"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LLdOw0XZEeeeyqnd6Cxkjw" name="SNG"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_srl4wGhjEeeWO9Idc2UXkw" name="NODE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_tZ4iIGhjEeeWO9Idc2UXkw" name="LINK"/>
       </packagedElement>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_WrKlUBMuEee0L_IMWjydgQ">
@@ -358,21 +446,11 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
   <OpenModel_Profile:OpenModelOperation xmi:id="_5AcAht6MEeWd9KDn6x5Skg" base_Operation="_5ASPmt6MEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_5AcAkt6MEeWd9KDn6x5Skg" base_Operation="_5ASPqN6MEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_qXAPxjJDEeamvfKYyWmELQ" base_Class="_qXAPsDJDEeamvfKYyWmELQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAPyjJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPsjJDEeamvfKYyWmELQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAPzzJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPtjJDEeamvfKYyWmELQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAP0zJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPuTJDEeamvfKYyWmELQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAP1TJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPujJDEeamvfKYyWmELQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAP3zJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPwjJDEeamvfKYyWmELQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_MnHJZTM1EeaULOmJRJKM0Q" base_StructuralFeature="_MnHJZDM1EeaULOmJRJKM0Q"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ObiUYzM1EeaULOmJRJKM0Q" base_StructuralFeature="_ObiUYjM1EeaULOmJRJKM0Q"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_MnHJaDM1EeaULOmJRJKM0Q" base_StructuralFeature="_MnHJZzM1EeaULOmJRJKM0Q"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ObiUZjM1EeaULOmJRJKM0Q" base_StructuralFeature="_ObiUZTM1EeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_hxJzsMhuEeaVlemTikmRHw" base_Class="_hv0W8MhuEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_JEyyNchvEeaVlemTikmRHw" base_StructuralFeature="_JEyyNMhvEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_JEyyOMhvEeaVlemTikmRHw" base_StructuralFeature="_JEyyN8hvEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_UdrWBchvEeaVlemTikmRHw" base_StructuralFeature="_UdrWBMhvEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_UdrWCMhvEeaVlemTikmRHw" base_StructuralFeature="_UdrWB8hvEeaVlemTikmRHw"/>
-  <OpenModel_Profile:PassedByReference xmi:id="_ClolABMvEee0L_IMWjydgQ" base_Property="_1EaBNC2bEeair-8ZDvf8jw"/>
   <OpenModel_Profile:Specify xmi:id="_F2-uEBM8Eee0L_IMWjydgQ" base_Abstraction="_D_ExQBM8Eee0L_IMWjydgQ">
     <target>/TapiCommon:Context:_context</target>
   </OpenModel_Profile:Specify>
@@ -384,8 +462,6 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuphhsEeewCs0lkpWskw" base_Property="_1EjyMC2bEeair-8ZDvf8jw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPupxhsEeewCs0lkpWskw" base_Property="_eMyr9N6ZEeWd9KDn6x5Skg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuqBhsEeewCs0lkpWskw" base_Property="_YEuIVy2nEeair-8ZDvf8jw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuqRhsEeewCs0lkpWskw" base_Property="_ObiUZTM1EeaULOmJRJKM0Q"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuqhhsEeewCs0lkpWskw" base_Property="_MnHJZzM1EeaULOmJRJKM0Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuqxhsEeewCs0lkpWskw" base_Property="_JEyyN8hvEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPurBhsEeewCs0lkpWskw" base_Property="_UdrWB8hvEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPurRhsEeewCs0lkpWskw" base_Property="_eMyr8t6ZEeWd9KDn6x5Skg"/>
@@ -405,13 +481,6 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuuxhsEeewCs0lkpWskw" base_Property="_YQ35MN5vEeWd9KDn6x5Skg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuvBhsEeewCs0lkpWskw" base_Property="_BS_lAN5rEeWd9KDn6x5Skg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuvRhsEeewCs0lkpWskw" base_Property="_H7MS8N5pEeWd9KDn6x5Skg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuvhhsEeewCs0lkpWskw" base_Property="_qXAPuTJDEeamvfKYyWmELQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuvxhsEeewCs0lkpWskw" base_Property="_qXAPsjJDEeamvfKYyWmELQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuwBhsEeewCs0lkpWskw" base_Property="_qXAPtjJDEeamvfKYyWmELQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuwRhsEeewCs0lkpWskw" base_Property="_qXAPujJDEeamvfKYyWmELQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuwhhsEeewCs0lkpWskw" base_Property="_qXAPwjJDEeamvfKYyWmELQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuwxhsEeewCs0lkpWskw" base_Property="_MnHJZDM1EeaULOmJRJKM0Q"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuxBhsEeewCs0lkpWskw" base_Property="_ObiUYjM1EeaULOmJRJKM0Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuxRhsEeewCs0lkpWskw" base_Property="_JEyyNMhvEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NhPuxhhsEeewCs0lkpWskw" base_Property="_UdrWBMhvEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_1fJuUFqoEeexvMtO2oNM9g" base_Class="_aMQ88N5xEeWd9KDn6x5Skg"/>
@@ -425,4 +494,30 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
   <OpenModel_Profile:LifecycleAggregate xmi:id="_VPacUFroEeexvMtO2oNM9g" base_Association="_1EaBMC2bEeair-8ZDvf8jw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_pDTZAM1kEeeFHsPqdArtwA" base_Association="_JEyyMMhvEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelStatement xmi:id="_hBI0S2m2EeiLh_06MH5Rjg" base_Model="_Fk3e0DA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_-fei4f4wEea_VPdGG2-szQ" base_Class="_-fei4P4wEea_VPdGG2-szQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6BGE81qnEeexvMtO2oNM9g" base_Class="_-fei4P4wEea_VPdGG2-szQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RhdgxL2HEeWdore3Cxez9g" base_StructuralFeature="_RhdgwL2HEeWdore3Cxez9g"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCMohhrEeewCs0lkpWskw" base_Property="_RhdgwL2HEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GqeeNL2JEeWdore3Cxez9g" base_StructuralFeature="_GqeeML2JEeWdore3Cxez9g"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yCzsBhrEeewCs0lkpWskw" base_Property="_GqeeML2JEeWdore3Cxez9g"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_YQtngYoPEeivCevppATXng" base_Property="_YQtngIoPEeivCevppATXng"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YQuOkIoPEeivCevppATXng" base_StructuralFeature="_YQtngIoPEeivCevppATXng"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1duKcIfYEeeirpBaj87qAw" base_StructuralFeature="_1dtjYIfYEeeirpBaj87qAw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1duKcYfYEeeirpBaj87qAw" base_Property="_1dtjYIfYEeeirpBaj87qAw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5r3gQa1cEeiIjuV0HZnJAQ" base_Property="_5r3gQK1cEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5r3gQq1cEeiIjuV0HZnJAQ" base_StructuralFeature="_5r3gQK1cEeiIjuV0HZnJAQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_KekBYa1dEeiIjuV0HZnJAQ" base_Property="_KekBYK1dEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KekBYq1dEeiIjuV0HZnJAQ" base_StructuralFeature="_KekBYK1dEeiIjuV0HZnJAQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_WptIka1dEeiIjuV0HZnJAQ" base_Property="_WptIkK1dEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WptIkq1dEeiIjuV0HZnJAQ" base_StructuralFeature="_WptIkK1dEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_jQBd8a1fEeiIjuV0HZnJAQ" base_Parameter="_jQBd8K1fEeiIjuV0HZnJAQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BX7Fo61gEeiIjuV0HZnJAQ" base_Property="_BX7Foq1gEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BX7FpK1gEeiIjuV0HZnJAQ" base_StructuralFeature="_BX7Foq1gEeiIjuV0HZnJAQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BX7FqK1gEeiIjuV0HZnJAQ" base_Property="_BX7Fp61gEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BX7Fqa1gEeiIjuV0HZnJAQ" base_StructuralFeature="_BX7Fp61gEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Mr1p4K1gEeiIjuV0HZnJAQ" base_Association="_BX0_AK1gEeiIjuV0HZnJAQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_EN4ewa1jEeiqCPid09Hqfw" base_StructuralFeature="_EN4ewK1jEeiqCPid09Hqfw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_EN4ewq1jEeiqCPid09Hqfw" base_Property="_EN4ewK1jEeiqCPid09Hqfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_AwfVYa1kEeiqCPid09Hqfw" base_StructuralFeature="_AwfVYK1kEeiqCPid09Hqfw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AwfVYq1kEeiqCPid09Hqfw" base_Property="_AwfVYK1kEeiqCPid09Hqfw"/>
 </xmi:XMI>

--- a/YANG/tapi-connectivity@2018-08-31.yang
+++ b/YANG/tapi-connectivity@2018-08-31.yang
@@ -222,6 +222,10 @@ module tapi-connectivity {
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
         grouping connectivity-constraint {
+            leaf service-layer {
+                type tapi-common:layer-protocol-name;
+                description "none";
+            }
             leaf service-type {
                 type service-type;
                 description "none";
@@ -230,32 +234,16 @@ module tapi-connectivity {
                 type string;
                 description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
             }
-            leaf is-exclusive {
-                type boolean;
-                default "true";
-                description "To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)";
-            }
             container requested-capacity {
                 uses tapi-common:capacity;
                 description "none";
             }
-            container schedule {
-                uses tapi-common:time-range;
+            leaf connectivity-direction {
+                type tapi-common:forwarding-direction;
                 description "none";
             }
-            list cost-characteristic {
-                key 'cost-name';
-                uses tapi-topology:cost-characteristic;
-                description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
-            }
-            list latency-characteristic {
-                key 'traffic-property-name';
-                uses tapi-topology:latency-characteristic;
-                description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
-            }
-            list shared-risk-characteristic {
-                key 'risk-characteristic-name';
-                uses tapi-topology:risk-characteristic;
+            container schedule {
+                uses tapi-common:time-range;
                 description "none";
             }
             container coroute-inclusion {
@@ -267,7 +255,6 @@ module tapi-connectivity {
                 key 'connectivity-service-uuid';
                 description "none";
             }
-            uses route-compute-policy;
             description "none";
         }
         grouping connectivity-service {
@@ -283,19 +270,12 @@ module tapi-connectivity {
                 config false;
                 description "none";
             }
-            leaf direction {
-                type tapi-common:forwarding-direction;
-                description "none";
-            }
-            leaf layer-protocol-name {
-                type tapi-common:layer-protocol-name;
-                description "none";
-            }
             uses tapi-common:service-spec;
             uses connectivity-constraint;
-            uses topology-constraint;
-            uses tapi-common:admin-state-pac;
+            uses tapi-path-computation:routing-constraint;
+            uses tapi-path-computation:topology-constraint;
             uses resilience-constraint;
+            uses tapi-common:admin-state-pac;
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
@@ -479,77 +459,10 @@ module tapi-connectivity {
             }
             description "A list of control parameters to apply to a switch.";
         }
-        grouping topology-constraint {
-            list include-topology {
-                uses tapi-topology:topology-ref;
-                key 'topology-uuid';
-                config false;
-                description "none";
-            }
-            list avoid-topology {
-                uses tapi-topology:topology-ref;
-                key 'topology-uuid';
-                config false;
-                description "none";
-            }
-            list include-path {
-                uses tapi-path-computation:path-ref;
-                key 'path-uuid';
-                config false;
-                description "none";
-            }
-            list exclude-path {
-                uses tapi-path-computation:path-ref;
-                key 'path-uuid';
-                config false;
-                description "none";
-            }
-            list include-link {
-                uses tapi-topology:link-ref;
-                key 'topology-uuid link-uuid';
-                config false;
-                description "This is a loose constraint - that is it is unordered and could be a partial list ";
-            }
-            list exclude-link {
-                uses tapi-topology:link-ref;
-                key 'topology-uuid link-uuid';
-                config false;
-                description "none";
-            }
-            list include-node {
-                uses tapi-topology:node-ref;
-                key 'topology-uuid node-uuid';
-                config false;
-                description "This is a loose constraint - that is it is unordered and could be a partial list";
-            }
-            list exclude-node {
-                uses tapi-topology:node-ref;
-                key 'topology-uuid node-uuid';
-                config false;
-                description "none";
-            }
-            leaf-list preferred-transport-layer {
-                type tapi-common:layer-protocol-name;
-                config false;
-                description "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers";
-            }
-            description "none";
-        }
         grouping cep-list {
             list connection-end-point {
                 key 'uuid';
                 uses connection-end-point;
-                description "none";
-            }
-            description "none";
-        }
-        grouping route-compute-policy {
-            leaf route-objective-function {
-                type route-objective-function;
-                description "none";
-            }
-            leaf diversity-policy {
-                type diversity-policy;
                 description "none";
             }
             description "none";
@@ -646,52 +559,6 @@ module tapi-connectivity {
             }
             description "none";
         }
-        typedef route-objective-function {
-            type enumeration {
-                enum MIN_WORK_ROUTE_HOP {
-                    description "none";
-                }
-                enum MIN_WORK_ROUTE_COST {
-                    description "none";
-                }
-                enum MIN_WORK_ROUTE_LATENCY {
-                    description "none";
-                }
-                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP {
-                    description "none";
-                }
-                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST {
-                    description "none";
-                }
-                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY {
-                    description "none";
-                }
-                enum LOAD_BALANCE_MAX_UNUSED_CAPACITY {
-                    description "none";
-                }
-            }
-            description "none";
-        }
-        typedef diversity-policy {
-            type enumeration {
-                enum SRLG {
-                    description "none";
-                }
-                enum SRNG {
-                    description "none";
-                }
-                enum SNG {
-                    description "none";
-                }
-                enum NODE {
-                    description "none";
-                }
-                enum LINK {
-                    description "none";
-                }
-            }
-            description "none";
-        }
         typedef protection-role {
             type enumeration {
                 enum WORK {
@@ -771,12 +638,16 @@ module tapi-connectivity {
                     uses connectivity-service-end-point;
                     description "none";
                 }
-                container conn-constraint {
+                container connectivity-constraint {
                     uses connectivity-constraint;
                     description "none";
                 }
-                container topo-constraint {
-                    uses topology-constraint;
+                container routing-constraint {
+                    uses tapi-path-computation:routing-constraint;
+                    description "none";
+                }
+                container topology-constraint {
+                    uses tapi-path-computation:topology-constraint;
                     description "none";
                 }
                 list resilience-constraint {
@@ -806,12 +677,16 @@ module tapi-connectivity {
                     uses connectivity-service-end-point;
                     description "none";
                 }
-                container conn-constraint {
+                container connectivity-constraint {
                     uses connectivity-constraint;
                     description "none";
                 }
-                container topo-constraint {
-                    uses topology-constraint;
+                container routing-constraint {
+                    uses tapi-path-computation:routing-constraint;
+                    description "none";
+                }
+                container topology-constraint {
+                    uses tapi-path-computation:topology-constraint;
                     description "none";
                 }
                 list resilience-constraint {
@@ -835,12 +710,6 @@ module tapi-connectivity {
             input {
                 leaf service-id-or-name {
                     type string;
-                    description "none";
-                }
-            }
-            output {
-                container service {
-                    uses connectivity-service;
                     description "none";
                 }
             }

--- a/YANG/tapi-path-computation@2018-08-31.yang
+++ b/YANG/tapi-path-computation@2018-08-31.yang
@@ -80,6 +80,15 @@ module tapi-path-computation {
                 uses routing-constraint;
                 description "none";
             }
+            leaf direction {
+                type tapi-common:forwarding-direction;
+                description "none";
+            }
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
+                config false;
+                description "none";
+            }
             uses tapi-common:resource-spec;
             description "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes";
         }
@@ -87,6 +96,19 @@ module tapi-path-computation {
             container service-interface-point {
             	uses tapi-common:service-interface-point-ref;
                 config false;
+                description "none";
+            }
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            leaf layer-protocol-qualifier {
+                type tapi-common:layer-protocol-qualifier;
+                description "none";
+            }
+            container capacity {
+                uses tapi-common:capacity;
                 description "none";
             }
             leaf role {
@@ -98,11 +120,6 @@ module tapi-path-computation {
                 type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the EndPoint.";
-            }
-            leaf service-layer {
-                type tapi-common:layer-protocol-name;
-                config false;
-                description "none";
             }
             uses tapi-common:local-class;
             description "The association of the FC to LTPs is made via EndPoints.
@@ -130,6 +147,10 @@ module tapi-path-computation {
             }
             container routing-constraint {
                 uses routing-constraint;
+                description "none";
+            }
+            container topology-constraint {
+                uses topology-constraint;
                 description "none";
             }
             container objective-function {
@@ -182,46 +203,38 @@ module tapi-path-computation {
             description "none";
         }
         grouping routing-constraint {
-            container requested-capacity {
-                config false;
-                uses tapi-common:capacity;
-                description "none";
-            }
-            leaf service-level {
-                type string;
-                config false;
-                description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
-            }
-            leaf-list path-layer {
-                type tapi-common:layer-protocol-name;
-                config false;
-                description "none";
-            }
             list cost-characteristic {
                 key 'cost-name';
-                config false;
                 uses tapi-topology:cost-characteristic;
                 description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
             }
             list latency-characteristic {
                 key 'traffic-property-name';
-                config false;
                 uses tapi-topology:latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
-            list include-topology {
-                uses tapi-topology:topology-ref;
-                key 'topology-uuid';
-                config false;
+            list risk-diversity-characteristic {
+                key 'risk-characteristic-name';
+                uses tapi-topology:risk-characteristic;
                 description "none";
             }
-            list avoid-topology {
-                uses tapi-topology:topology-ref;
-                key 'topology-uuid';
-                config false;
+            leaf diversity-policy {
+                type diversity-policy;
                 description "none";
             }
-            uses tapi-common:local-class;
+            leaf route-objective-function {
+                type route-objective-function;
+                description "none";
+            }
+            leaf route-direction {
+                type tapi-common:forwarding-direction;
+                description "none";
+            }
+            leaf is-exclusive {
+                type boolean;
+                default "true";
+                description "To distinguish if the resources are to be exclusive to the service";
+            }
             description "none";
         }
         grouping path-computation-context {
@@ -235,6 +248,112 @@ module tapi-path-computation {
                 config false;
                 uses path;
                 description "none";
+            }
+            description "none";
+        }
+        grouping topology-constraint {
+            list include-topology {
+                uses tapi-topology:topology-ref;
+                key 'topology-uuid';
+                config false;
+                description "none";
+            }
+            list avoid-topology {
+                uses tapi-topology:topology-ref;
+                key 'topology-uuid';
+                config false;
+                description "none";
+            }
+            list include-path {
+                uses tapi-path-computation:path-ref;
+                key 'path-uuid';
+                config false;
+                description "none";
+            }
+            list exclude-path {
+                uses tapi-path-computation:path-ref;
+                key 'path-uuid';
+                config false;
+                description "none";
+            }
+            list include-link {
+                uses tapi-topology:link-ref;
+                key 'topology-uuid link-uuid';
+                config false;
+                description "This is a loose constraint - that is it is unordered and could be a partial list ";
+            }
+            list exclude-link {
+                uses tapi-topology:link-ref;
+                key 'topology-uuid link-uuid';
+                config false;
+                description "none";
+            }
+            list include-node {
+                uses tapi-topology:node-ref;
+                key 'topology-uuid node-uuid';
+                config false;
+                description "This is a loose constraint - that is it is unordered and could be a partial list";
+            }
+            list exclude-node {
+                uses tapi-topology:node-ref;
+                key 'topology-uuid node-uuid';
+                config false;
+                description "none";
+            }
+            leaf-list preferred-transport-layer {
+                type tapi-common:layer-protocol-name;
+                config false;
+                description "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers";
+            }
+            description "none";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        typedef route-objective-function {
+            type enumeration {
+                enum MIN_WORK_ROUTE_HOP {
+                    description "none";
+                }
+                enum MIN_WORK_ROUTE_COST {
+                    description "none";
+                }
+                enum MIN_WORK_ROUTE_LATENCY {
+                    description "none";
+                }
+                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP {
+                    description "none";
+                }
+                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST {
+                    description "none";
+                }
+                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY {
+                    description "none";
+                }
+                enum LOAD_BALANCE_MAX_UNUSED_CAPACITY {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef diversity-policy {
+            type enumeration {
+                enum SRLG {
+                    description "none";
+                }
+                enum SRNG {
+                    description "none";
+                }
+                enum SNG {
+                    description "none";
+                }
+                enum NODE {
+                    description "none";
+                }
+                enum LINK {
+                    description "none";
+                }
             }
             description "none";
         }
@@ -253,6 +372,10 @@ module tapi-path-computation {
                 }
                 container routing-constraint {
                     uses routing-constraint;
+                    description "none";
+                }
+                container topology-constraint {
+                    uses topology-constraint;
                     description "none";
                 }
                 container objective-function {


### PR DESCRIPTION
- Added RoutingConstraint attribute into ConnectivityService
- Added TopologyConstraint attribute into PathComputationService
- Deleted duplicate attributes (CostCharacteristics,
LatencyCharacteristics, RiskCharacterstics) from ConnectivityConstraint
class since these are also present in RoutingConstraint class
- Added the RouteComputePolicy class/attributes into
TapiPathComputation:RoutingConstraint and removed from
ConnectivityConstraint
- Moved the TopologyConstraints class from TapiConnectivity into
TapiPathComputation model/module
- Also updated PathServiceEndPoint to be consistent with
ConnectivityServiceEndPoint by adding layerProtocol and capacity
attributes
- updated Path class with layerProtocolName and direction attributes