### PR TITLE
PhtoniceMedia missing parameters added by Telefonica

### DIFF
--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -535,11 +535,8 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i4ZmqYoJEeivCevppATXng" x="242" y="207"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_w3tFAY6QEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_w3tFAY6QEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.2.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_w3tFAo6QEeeyZasfnNSonw"/>
-    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_4hhRwIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
-      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    </styles>
     <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
     <edges xmi:type="notation:Connector" xmi:id="_xnY1h46QEeeyZasfnNSonw" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_xnY1g46QEeeyZasfnNSonw">
       <styles xmi:type="notation:FontStyle" xmi:id="_xnY1iI6QEeeyZasfnNSonw"/>
@@ -692,6 +689,9 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i4ZmrooJEeivCevppATXng"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i4Zmr4oJEeivCevppATXng"/>
     </edges>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_4hhRwIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
+    </styles>
   </notation:Diagram>
   <notation:Diagram xmi:id="_gKM6AI6dEeeyZasfnNSonw" type="layersTree" name="Layers Tree Editor"/>
   <notation:Diagram xmi:id="_gqHJII6dEeeyZasfnNSonw" type="layersTree" name="Layers Tree Editor"/>
@@ -1345,11 +1345,8 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YnbcZZs8EeikSLSDi2qpXA" x="476" y="-150"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.2.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
-    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_41c6YIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
-      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    </styles>
     <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
     <edges xmi:type="notation:Connector" xmi:id="_Eq6W9HiHEeiPPoPDo3q5jA" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_Eq6W8HiHEeiPPoPDo3q5jA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Eq6W9XiHEeiPPoPDo3q5jA"/>
@@ -1817,6 +1814,9 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ynbcaps8EeikSLSDi2qpXA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ynbca5s8EeikSLSDi2qpXA"/>
     </edges>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_41c6YIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
+    </styles>
   </notation:Diagram>
   <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="OtsiResourceSpec" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_xbRtvnkvEeiO-c_khjKlFQ" type="Class_Shape">
@@ -2709,11 +2709,32 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bc5qwqSqEeiKJbr6a5Jjpg" x="781" y="-133"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_xbR3JHkvEeiO-c_khjKlFQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <children xmi:type="notation:Shape" xmi:id="_FeMycKnGEeiJ3vVqCdpzlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FeMycanGEeiJ3vVqCdpzlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FeNZgKnGEeiJ3vVqCdpzlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FeMycqnGEeiJ3vVqCdpzlA" x="781" y="-133"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yuZMkLDlEeiUZaG2JnNtGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yuZMkbDlEeiUZaG2JnNtGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yuZzoLDlEeiUZaG2JnNtGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yuZMkrDlEeiUZaG2JnNtGQ" x="781" y="-133"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VEhuULKeEei69qzpcujF2A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_VEhuUbKeEei69qzpcujF2A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VEiVYLKeEei69qzpcujF2A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VEhuUrKeEei69qzpcujF2A" x="781" y="-133"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_xbR3JHkvEeiO-c_khjKlFQ" name="diagram_compatibility_version" stringValue="1.2.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_xbR3JXkvEeiO-c_khjKlFQ"/>
-    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_5yYcsIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
-      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    </styles>
     <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
     <edges xmi:type="notation:Connector" xmi:id="_xbR3SXkvEeiO-c_khjKlFQ" type="Abstraction_Edge" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_xbRupnkvEeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbR3SnkvEeiO-c_khjKlFQ" type="Abstraction_NameLabel">
@@ -3484,6 +3505,39 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bc5qx6SqEeiKJbr6a5Jjpg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bc5qyKSqEeiKJbr6a5Jjpg"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FeNZganGEeiJ3vVqCdpzlA" type="StereotypeCommentLink" source="_xbRwI3kvEeiO-c_khjKlFQ" target="_FeMycKnGEeiJ3vVqCdpzlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FeNZgqnGEeiJ3vVqCdpzlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FeOAkanGEeiJ3vVqCdpzlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FeNZg6nGEeiJ3vVqCdpzlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FeNZhKnGEeiJ3vVqCdpzlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FeOAkKnGEeiJ3vVqCdpzlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yuZzobDlEeiUZaG2JnNtGQ" type="StereotypeCommentLink" source="_xbRwI3kvEeiO-c_khjKlFQ" target="_yuZMkLDlEeiUZaG2JnNtGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yuZzorDlEeiUZaG2JnNtGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yuaasrDlEeiUZaG2JnNtGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yuZzo7DlEeiUZaG2JnNtGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yuaasLDlEeiUZaG2JnNtGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yuaasbDlEeiUZaG2JnNtGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VEi8cLKeEei69qzpcujF2A" type="StereotypeCommentLink" source="_xbRwI3kvEeiO-c_khjKlFQ" target="_VEhuULKeEei69qzpcujF2A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VEi8cbKeEei69qzpcujF2A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VEi8dbKeEei69qzpcujF2A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VEi8crKeEei69qzpcujF2A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VEi8c7KeEei69qzpcujF2A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VEi8dLKeEei69qzpcujF2A"/>
+    </edges>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_5yYcsIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
+    </styles>
   </notation:Diagram>
   <notation:Diagram xmi:id="_3bpg4IoMEeivCevppATXng" type="PapyrusUMLClassDiagram" name="McResourceSpec" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_SvF9cJozEeiOmuqNbykpsw" type="Class_Shape">
@@ -3908,11 +3962,8 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_avylJZs-EeikSLSDi2qpXA" x="608" y="-184"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_3bpg4YoMEeivCevppATXng" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_3bpg4YoMEeivCevppATXng" name="diagram_compatibility_version" stringValue="1.2.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_3bpg4ooMEeivCevppATXng"/>
-    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_6ePdIIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
-      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    </styles>
     <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
     <edges xmi:type="notation:Connector" xmi:id="_SvSKt5ozEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_SvF9cJozEeiOmuqNbykpsw" target="_SvSKs5ozEeiOmuqNbykpsw">
       <styles xmi:type="notation:FontStyle" xmi:id="_SvSKuJozEeiOmuqNbykpsw"/>
@@ -4312,5 +4363,8 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_avylKps-EeikSLSDi2qpXA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_avylK5s-EeikSLSDi2qpXA"/>
     </edges>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_6ePdIIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
+    </styles>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -193,23 +193,35 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3tBKOEeajhbtskMXJfw" name="OtsiTerminationPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jVAoEJROEee0N_ppE1lIiw" name="selectedCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_9cw2ALKhEei69qzpcujF2A" annotatedElement="_KjQ3tBKOEeajhbtskMXJfw">
+          <body>Provides status information only.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jVAoEJROEee0N_ppE1lIiw" name="selectedCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ojmz4JROEee0N_ppE1lIiw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ojs6gJROEee0N_ppE1lIiw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_i_zYsKnSEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uRKOEeajhbtskMXJfw" name="selectedApplicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uRKOEeajhbtskMXJfw" name="selectedApplicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3uhKOEeajhbtskMXJfw" annotatedElement="_KjQ3uRKOEeajhbtskMXJfw">
             <body>This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LuHRgM4xEeehIvzuBRCtZQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LuIfoM4xEeehIvzuBRCtZQ" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_w72iYHk2EeiO-c_khjKlFQ" name="selectedModulation" type="__ZU_8HkzEeiO-c_khjKlFQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_2EwdE5s8EeikSLSDi2qpXA" name="_transmitedPower" type="_-2cKkJs7EeikSLSDi2qpXA" aggregation="composite" association="_2EwdEJs8EeikSLSDi2qpXA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_w72iYHk2EeiO-c_khjKlFQ" name="selectedModulation" type="__ZU_8HkzEeiO-c_khjKlFQ" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_599fsLDnEeiUZaG2JnNtGQ" annotatedElement="_w72iYHk2EeiO-c_khjKlFQ">
+            <body>This parameter defines the modulation used at the source</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_yxi8ULDnEeiUZaG2JnNtGQ" value="UNDEFINED"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2EwdE5s8EeikSLSDi2qpXA" name="_transmitedPower" type="_-2cKkJs7EeikSLSDi2qpXA" isReadOnly="true" aggregation="composite" association="_2EwdEJs8EeikSLSDi2qpXA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2EwdFps8EeikSLSDi2qpXA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2EwdF5s8EeikSLSDi2qpXA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_zJdQ8ps5EeikSLSDi2qpXA" name="_laserProperties" type="_wHacQJs5EeikSLSDi2qpXA" aggregation="composite" association="_zJXKUJs5EeikSLSDi2qpXA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zJdQ8ps5EeikSLSDi2qpXA" name="_laserProperties" type="_wHacQJs5EeikSLSDi2qpXA" isReadOnly="true" aggregation="composite" association="_zJXKUJs5EeikSLSDi2qpXA">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5EaLILKgEei69qzpcujF2A" annotatedElement="_zJdQ8ps5EeikSLSDi2qpXA">
+            <body>Laser properties.</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zJdQ9Zs5EeikSLSDi2qpXA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zJdQ9ps5EeikSLSDi2qpXA" value="1"/>
         </ownedAttribute>
@@ -255,21 +267,71 @@ License: This module is distributed under the Apache License 2.0</body>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_AMLfknk8EeiO-c_khjKlFQ" name="_fecParameters" type="_qzTdgHk7EeiO-c_khjKlFQ" isReadOnly="true" aggregation="composite" association="_AMK4gHk8EeiO-c_khjKlFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_NhrjUHiHEeiPPoPDo3q5jA" name="OtsiCapabilityPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9XaUJJmEee26o4qs2D5Ig" name="supportableLowerCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_CosS4LKjEei69qzpcujF2A" annotatedElement="_NhrjUHiHEeiPPoPDo3q5jA">
+          <body>Can read the status of the warning for the upper value that the power can reach.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9XaUJJmEee26o4qs2D5Ig" name="supportableLowerCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pXy3ULDqEeiUZaG2JnNtGQ" annotatedElement="_x9XaUJJmEee26o4qs2D5Ig">
+            <body>The lower frequency of the channel spectrum</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KgckgM4xEeehIvzuBRCtZQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KgdyoM4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_t2oxcI50EeeyZasfnNSonw" name="supportableUpperCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_t2oxcI50EeeyZasfnNSonw" name="supportableUpperCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qWfUMLDqEeiUZaG2JnNtGQ" annotatedElement="_t2oxcI50EeeyZasfnNSonw">
+            <body>The Upper frequency of the channel spectrum</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LI65wM4xEeehIvzuBRCtZQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LI8H4M4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_7gkK0I50EeeyZasfnNSonw" name="supportableApplicationIdentifier" type="_KjQ3vRKOEeajhbtskMXJfw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7gkK0I50EeeyZasfnNSonw" name="supportableApplicationIdentifier" type="_KjQ3vRKOEeajhbtskMXJfw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Jh7cgLDrEeiUZaG2JnNtGQ" annotatedElement="_7gkK0I50EeeyZasfnNSonw">
+            <body>The identifier of the Application. Size 255</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Mf6h4M4xEeehIvzuBRCtZQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mf8-IM4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_l6_TYJmrEeiOmuqNbykpsw" name="supportableModulation" type="__ZU_8HkzEeiO-c_khjKlFQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l6_TYJmrEeiOmuqNbykpsw" name="supportableModulation" type="__ZU_8HkzEeiO-c_khjKlFQ" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_RrT-cLDrEeiUZaG2JnNtGQ" annotatedElement="_l6_TYJmrEeiOmuqNbykpsw">
+            <body>This parameter defines the modulation used at the source</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o3uKQJmrEeiOmuqNbykpsw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o30Q4JmrEeiOmuqNbykpsw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-IYJYLKiEei69qzpcujF2A" name="totalPowerUpperWarn" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EeqWALKjEei69qzpcujF2A" annotatedElement="_-IYJYLKiEei69qzpcujF2A">
+            <body>Can read the status of the warning for the upper value that the power can reach.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_-IYJYbKiEei69qzpcujF2A"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YXTUYLKjEei69qzpcujF2A" name="totalPowerLowerWarn">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_j0CdcLKjEei69qzpcujF2A" annotatedElement="_YXTUYLKjEei69qzpcujF2A">
+            <body>Can be read the status of the warning for the lower value that the power can reach.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_YXTUYbKjEei69qzpcujF2A"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__SYo8LKjEei69qzpcujF2A" name="totalPowerUpperWarnThresholdMin">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_CVP9ALKkEei69qzpcujF2A" annotatedElement="__SYo8LKjEei69qzpcujF2A">
+            <body>Can be read the value of the lower threshold that was set</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="__SYo8bKjEei69qzpcujF2A"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_DkHj4LKkEei69qzpcujF2A" name="totalPowerUpperWarnThresholdDefault">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_DkHj4bKkEei69qzpcujF2A" annotatedElement="_DkHj4LKkEei69qzpcujF2A">
+            <body>Can be read the value of the default  threshold that was set</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_DkHj4rKkEei69qzpcujF2A"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hoAOQLKkEei69qzpcujF2A" name="totalPowerUpperWarnThresholdMax">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hoAOQbKkEei69qzpcujF2A" annotatedElement="_hoAOQLKkEei69qzpcujF2A">
+            <body>Can be read the value of the upper threshold that was set</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_hoAOQrKkEei69qzpcujF2A"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_EqncAHiHEeiPPoPDo3q5jA" name="OtsiServiceInterfacePointSpec">
@@ -287,8 +349,12 @@ License: This module is distributed under the Apache License 2.0</body>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_XVi5wHk6EeiO-c_khjKlFQ" name="OtsiTerminationConfigPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_HSCZ4Hk6EeiO-c_khjKlFQ" name="selectedCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__10uILDrEeiUZaG2JnNtGQ" annotatedElement="_HSCZ4Hk6EeiO-c_khjKlFQ">
+            <body>The central frequency of the laser. It is the oscillation frequency of the corresponding electromagnetic wave</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HSCZ4Xk6EeiO-c_khjKlFQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HSCZ4nk6EeiO-c_khjKlFQ" value="1"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_MrpxELDsEeiUZaG2JnNtGQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_F8ProHk6EeiO-c_khjKlFQ" name="selectedApplicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw">
           <ownedComment xmi:type="uml:Comment" xmi:id="_F8ProXk6EeiO-c_khjKlFQ" annotatedElement="_F8ProHk6EeiO-c_khjKlFQ">
@@ -296,31 +362,68 @@ License: This module is distributed under the Apache License 2.0</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_F8Pronk6EeiO-c_khjKlFQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_F8Pro3k6EeiO-c_khjKlFQ" value="1"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_dkFGwLDsEeiUZaG2JnNtGQ" value="Not initialized."/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_NK0yMHk6EeiO-c_khjKlFQ" name="selectedModulation" type="__ZU_8HkzEeiO-c_khjKlFQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NK0yMHk6EeiO-c_khjKlFQ" name="selectedModulation" type="__ZU_8HkzEeiO-c_khjKlFQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rb7nYLDsEeiUZaG2JnNtGQ" annotatedElement="_NK0yMHk6EeiO-c_khjKlFQ">
+            <body>The modulation techniqu selected at the source.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_w8V78LDsEeiUZaG2JnNtGQ" value="UNDEFINED"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_N9lv45s8EeikSLSDi2qpXA" name="_requestedTransmitPower" type="_-2cKkJs7EeikSLSDi2qpXA" aggregation="composite" association="_N9lv4Js8EeikSLSDi2qpXA">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8K--oLDsEeiUZaG2JnNtGQ" annotatedElement="_N9lv45s8EeikSLSDi2qpXA">
+            <body>Transmit power as requested.</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_N9lv5ps8EeikSLSDi2qpXA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_N9lv55s8EeikSLSDi2qpXA" value="1"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_m_gbQLKgEei69qzpcujF2A" name="_laserProperties" type="_wHacQJs5EeikSLSDi2qpXA" aggregation="composite">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_m_gbQbKgEei69qzpcujF2A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_m_gbQrKgEei69qzpcujF2A" value="1"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_qzTdgHk7EeiO-c_khjKlFQ" name="FecPropertiesPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgXk7EeiO-c_khjKlFQ" name="preFecBer">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgnk7EeiO-c_khjKlFQ" name="postFecBer">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhHk7EeiO-c_khjKlFQ" name="correctedBytes" visibility="public">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgXk7EeiO-c_khjKlFQ" name="preFecBer" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EFRWAKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdgXk7EeiO-c_khjKlFQ">
+            <body>counter: bit error rate before correction by FEC</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_1KmGcKnYEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhXk7EeiO-c_khjKlFQ" name="correctedBits" visibility="public">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgnk7EeiO-c_khjKlFQ" name="postFecBer" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AqG2sKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdgnk7EeiO-c_khjKlFQ">
+            <body>counter: bit error rate after correction by FEC</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_2HRKEKnYEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdg3k7EeiO-c_khjKlFQ" name="uncorrectableBytes">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhHk7EeiO-c_khjKlFQ" name="correctedBytes" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_88brEKnYEeiJ3vVqCdpzlA" annotatedElement="_qzTdhHk7EeiO-c_khjKlFQ">
+            <body>Bytes corrected between those that were received corrupted</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_r6GygKnYEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_65vVkHk7EeiO-c_khjKlFQ" name="uncorrectableBits">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhXk7EeiO-c_khjKlFQ" name="correctedBits" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7RtOoKnYEeiJ3vVqCdpzlA" annotatedElement="_qzTdhXk7EeiO-c_khjKlFQ">
+            <body>Bits corrected between those that were received corrupted</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3RzqkKnYEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdg3k7EeiO-c_khjKlFQ" name="uncorrectableBytes" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_e8-_UKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdg3k7EeiO-c_khjKlFQ">
+            <body>Bytes that could not be corrected by FEC</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_W2PhsKnZEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_65vVkHk7EeiO-c_khjKlFQ" name="uncorrectableBits" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_eSBWwKnZEeiJ3vVqCdpzlA" annotatedElement="_65vVkHk7EeiO-c_khjKlFQ">
+            <body>Bits that could not be corrected by FEC</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_YHDCQKnZEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_syPL8JmTEeiOmuqNbykpsw" name="MediaChannelServiceInterfacePointSpec">
@@ -360,29 +463,78 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_wHacQJs5EeikSLSDi2qpXA" name="LaserPropertiesPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEXk7EeiO-c_khjKlFQ" name="laserApplicationType" visibility="public" type="_01yZ8HpKEei5LIrjJTgegQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEXk7EeiO-c_khjKlFQ" name="laserApplicationType" visibility="public" type="_01yZ8HpKEei5LIrjJTgegQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Gpgv0LDpEeiUZaG2JnNtGQ" annotatedElement="_jwVxEXk7EeiO-c_khjKlFQ">
+            <body>The type of laser, its operational wavelengths, and its applications. String size 255.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_4SE8IKnVEeiJ3vVqCdpzlA" value="NOT INITIALIZED"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEnk7EeiO-c_khjKlFQ" name="laserBiasCurrent" visibility="public">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_d-ddALDpEeiUZaG2JnNtGQ" annotatedElement="_jwVxEnk7EeiO-c_khjKlFQ">
+            <body>The Bias current of the laser that is the medium polarization current of the laser.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_m19CILDpEeiUZaG2JnNtGQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxE3k7EeiO-c_khjKlFQ" name="laserTemperature" visibility="public">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7LkTkLDtEeiUZaG2JnNtGQ" annotatedElement="_jwVxE3k7EeiO-c_khjKlFQ">
+            <body>The temperature of the laser</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_KJkiIKnWEeiJ3vVqCdpzlA" value="-99"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lG_acLKgEei69qzpcujF2A" name="laserControl" type="_4qTT8LKeEei69qzpcujF2A">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lG_acbKgEei69qzpcujF2A" annotatedElement="_lG_acLKgEei69qzpcujF2A">
+            <body>The laser can be configured in this three status: froced-on ,forced-off or automatic laser shutdown</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_lG_acrKgEei69qzpcujF2A" value="UNDEFINED"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_-2cKkJs7EeikSLSDi2qpXA" name="PowerPropertiesPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Of5m4LKiEei69qzpcujF2A" annotatedElement="_-2cKkJs7EeikSLSDi2qpXA">
+          <body>Indication with severity warning raised when a total power value measured is above the threshold.</body>
+        </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsHk-EeiW-bN1POS5zg" name="totalPower">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_NX2skLDoEeiUZaG2JnNtGQ" annotatedElement="_vzXWsHk-EeiW-bN1POS5zg">
+            <body>The total power at any point in a channel including TX and RX.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_JxaKULDoEeiUZaG2JnNtGQ"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsXk-EeiW-bN1POS5zg" name="spectralPowerDensity" visibility="public">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsXk-EeiW-bN1POS5zg" name="spectralPowerDensity" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_srl1QLDoEeiUZaG2JnNtGQ" annotatedElement="_vzXWsXk-EeiW-bN1POS5zg">
+            <body>This describes how power of a signal  is distributed over frequency</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vzXWsnk-EeiW-bN1POS5zg"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_cIyKQLDoEeiUZaG2JnNtGQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MxtmwLKiEei69qzpcujF2A" name="totalPowerLowerWarnThreshold">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_SsdG4LKiEei69qzpcujF2A" annotatedElement="_MxtmwLKiEei69qzpcujF2A">
+            <body>Indication with severity warning raised when a total power value measured is Lower the threshold.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_MxtmwbKiEei69qzpcujF2A"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_c2QBYLKiEei69qzpcujF2A" name="totalPowerUpperWarnThreshold">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_c2QBYbKiEei69qzpcujF2A" annotatedElement="_c2QBYLKiEei69qzpcujF2A">
+            <body>Indication with severity warning raised when a total power value measured is above the threshold.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_c2QBYrKiEei69qzpcujF2A"/>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_gyFqQBKOEeajhbtskMXJfw" name="TypeDefinitions">
       <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3vRKOEeajhbtskMXJfw" name="ApplicationIdentifier" isLeaf="true">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3vhKOEeajhbtskMXJfw" name="applicationIdentifierType" visibility="public" type="_E7uYgI6HEeeyZasfnNSonw"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3vxKOEeajhbtskMXJfw" name="applicationIdentifierValue" visibility="public">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3vhKOEeajhbtskMXJfw" name="applicationIdentifierType" visibility="public" type="_E7uYgI6HEeeyZasfnNSonw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_eulkULDnEeiUZaG2JnNtGQ" annotatedElement="_KjQ3vhKOEeajhbtskMXJfw">
+            <body>The identifier of the application</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_kOPD4LDnEeiUZaG2JnNtGQ" value="Not Initialized."/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3vxKOEeajhbtskMXJfw" name="applicationIdentifierValue" visibility="public" type="_Hgr7sKnTEeiJ3vVqCdpzlA" isUnique="false">
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_l6CeYLDnEeiUZaG2JnNtGQ" value="Not Initialized."/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3xBKOEeajhbtskMXJfw" name="CentralFrequencyOrWavelength" isLeaf="true">
@@ -406,7 +558,11 @@ For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width i
           <defaultValue xmi:type="uml:InstanceValue" xmi:id="_rJ2kAHk1EeiO-c_khjKlFQ" instance="_BtiOwHPEEeiPPoPDo3q5jA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TnDTYHPXEeiPPoPDo3q5jA" name="centralFrequency">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_kx5nELDmEeiUZaG2JnNtGQ" annotatedElement="_TnDTYHPXEeiPPoPDo3q5jA">
+            <body>The central frequency of the laser. It is the oscillation frequency of the corresponding electromagnetic wave</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_oJWy0KnaEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3xhKOEeajhbtskMXJfw" name="channelNumber" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_N0Dm8I6OEeeyZasfnNSonw" annotatedElement="_KjQ3xhKOEeajhbtskMXJfw">
@@ -416,6 +572,7 @@ For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width i
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_EmfBwHPYEeiPPoPDo3q5jA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_EmfBwXPYEeiPPoPDo3q5jA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_zUfOgKnaEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_ujOyoC_2EeeAJ6VQzZ2ulw" name="OpticalRoutingStrategy" isLeaf="true">
@@ -506,9 +663,11 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_16WvEHPYEeiPPoPDo3q5jA" name="upperFrequency">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_07as4KnWEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_53PbYHPYEeiPPoPDo3q5jA" name="lowerFrequency">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_7joXAKnWEeiJ3vVqCdpzlA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_kOwegHlTEeiW-bN1POS5zg" name="frequencySlot" type="_ILpCwHk3EeiO-c_khjKlFQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p5HZQHlTEeiW-bN1POS5zg"/>
@@ -523,6 +682,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eMvicHk3EeiO-c_khjKlFQ" name="QPSK"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_rneCMHk3EeiO-c_khjKlFQ" name="8QAM"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_s0U24Hk3EeiO-c_khjKlFQ" name="16QAM"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wu-AkLDnEeiUZaG2JnNtGQ" name="UNDEFINED"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_ILpCwHk3EeiO-c_khjKlFQ" name="FrequencySlot" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_ILpCwXk3EeiO-c_khjKlFQ" annotatedElement="_ILpCwHk3EeiO-c_khjKlFQ">
@@ -559,6 +719,22 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_IFVFYIoMEeivCevppATXng" name="OCH"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Fug_AIoMEeivCevppATXng" name="OMS"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_GbrnAIoMEeivCevppATXng" name="OTS"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_Hgr7sKnTEeiJ3vVqCdpzlA" name="ApplicationIndentifierValueType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ROxJMLDnEeiUZaG2JnNtGQ" annotatedElement="_Hgr7sKnTEeiJ3vVqCdpzlA">
+          <body>The type of the application that runs at the receiver.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_J38uAKnTEeiJ3vVqCdpzlA" name="MEASURING"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_K1etQKnTEeiJ3vVqCdpzlA" name="TERMINATION"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_4qTT8LKeEei69qzpcujF2A" name="LaseControlType">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_75ksULKeEei69qzpcujF2A" name="FORCED-ON"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8j738LKeEei69qzpcujF2A" name="FORCED-OFF"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_-E0b4LKeEei69qzpcujF2A" name="AUTOMATIC-LASER-SHUTDOWN"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__ErWYLKeEei69qzpcujF2A" name="UNDEFINED"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_imunsLKhEei69qzpcujF2A" name="ON"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jLdscLKhEei69qzpcujF2A" name="OFF"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mK88YLKhEei69qzpcujF2A" name="PULSING-STATE"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_MSvNkBMEEeaOevPmmmHXcA" name="Imports">
@@ -608,7 +784,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJEBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3vhKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJERKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3vxKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJEhKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xRKOEeajhbtskMXJfw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVwIBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVwIBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xhKOEeajhbtskMXJfw" valueRange="0..100"/>
   <OpenModel_Profile:Experimental xmi:id="_1G8qkBKOEeajhbtskMXJfw" base_Element="_KjQ3vRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_3eqI0BKOEeajhbtskMXJfw" base_Element="_KjQ3xBKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ouzcsdK-Eeau-fGWj88_Vg" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
@@ -626,10 +802,10 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncVhhsEeewCs0lkpWskw" base_Property="_KjQ3sRKOEeajhbtskMXJfw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncVxhsEeewCs0lkpWskw" base_Property="_KjQ3uRKOEeajhbtskMXJfw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXBhsEeewCs0lkpWskw" base_Property="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXRhsEeewCs0lkpWskw" base_Property="_KjQ3vhKOEeajhbtskMXJfw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXhhsEeewCs0lkpWskw" base_Property="_KjQ3vxKOEeajhbtskMXJfw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXRhsEeewCs0lkpWskw" base_Property="_KjQ3vhKOEeajhbtskMXJfw" attributeValueChangeNotification="YES"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXhhsEeewCs0lkpWskw" base_Property="_KjQ3vxKOEeajhbtskMXJfw" attributeValueChangeNotification="YES"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXxhsEeewCs0lkpWskw" base_Property="_KjQ3xRKOEeajhbtskMXJfw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncYBhsEeewCs0lkpWskw" base_Property="_KjQ3xhKOEeajhbtskMXJfw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncYBhsEeewCs0lkpWskw" base_Property="_KjQ3xhKOEeajhbtskMXJfw" attributeValueChangeNotification="NO" bitLength="LENGTH_8_BIT"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YKbQAFqoEeexvMtO2oNM9g" base_Class="_KjQ3qhKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_jtfbUYfeEeet-8tHdGGp_w" base_StructuralFeature="_jtfbUIfeEeet-8tHdGGp_w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jtfbUofeEeet-8tHdGGp_w" base_Property="_jtfbUIfeEeet-8tHdGGp_w"/>
@@ -645,10 +821,10 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YKbQA1qoEeexvMtO2oNM9g" base_Class="_PKMDsEUIEead1bezhJG4aw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KjT68BKOEeajhbtskMXJfw" base_Class="_KjQ3tBKOEeajhbtskMXJfw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YKbQAlqoEeexvMtO2oNM9g" base_Class="_KjQ3tBKOEeajhbtskMXJfw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_t2pYgI50EeeyZasfnNSonw" base_Property="_t2oxcI50EeeyZasfnNSonw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_t2p_kI50EeeyZasfnNSonw" base_StructuralFeature="_t2oxcI50EeeyZasfnNSonw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7gkx4I50EeeyZasfnNSonw" base_Property="_7gkK0I50EeeyZasfnNSonw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_7gkx4Y50EeeyZasfnNSonw" base_StructuralFeature="_7gkK0I50EeeyZasfnNSonw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_t2pYgI50EeeyZasfnNSonw" base_Property="_t2oxcI50EeeyZasfnNSonw" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_t2p_kI50EeeyZasfnNSonw" base_StructuralFeature="_t2oxcI50EeeyZasfnNSonw" valueRange="195.88500..196.00000" unit="THz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7gkx4I50EeeyZasfnNSonw" base_Property="_7gkK0I50EeeyZasfnNSonw" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7gkx4Y50EeeyZasfnNSonw" base_StructuralFeature="_7gkK0I50EeeyZasfnNSonw" valueRange="255"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MpI1UI51EeeyZasfnNSonw" base_Property="_MpIOQI51EeeyZasfnNSonw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MpJcYI51EeeyZasfnNSonw" base_StructuralFeature="_MpIOQI51EeeyZasfnNSonw"/>
   <OpenModel_Profile:Experimental xmi:id="_9YJc4I6HEeeyZasfnNSonw" base_Element="_E7uYgI6HEeeyZasfnNSonw"/>
@@ -660,10 +836,10 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_2YQQko6dEeeyZasfnNSonw" base_StructuralFeature="_2YQQkI6dEeeyZasfnNSonw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2YQ3oY6dEeeyZasfnNSonw" base_Property="_2YQ3oI6dEeeyZasfnNSonw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_2YQ3oo6dEeeyZasfnNSonw" base_StructuralFeature="_2YQ3oI6dEeeyZasfnNSonw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_x9XaUZJmEee26o4qs2D5Ig" base_StructuralFeature="_x9XaUJJmEee26o4qs2D5Ig"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_x9YBYJJmEee26o4qs2D5Ig" base_Property="_x9XaUJJmEee26o4qs2D5Ig"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jXpsYJROEee0N_ppE1lIiw" base_Property="_jVAoEJROEee0N_ppE1lIiw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jXrhkJROEee0N_ppE1lIiw" base_StructuralFeature="_jVAoEJROEee0N_ppE1lIiw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_x9XaUZJmEee26o4qs2D5Ig" base_StructuralFeature="_x9XaUJJmEee26o4qs2D5Ig" valueRange="193.00000..193.02500" unit="THz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_x9YBYJJmEee26o4qs2D5Ig" base_Property="_x9XaUJJmEee26o4qs2D5Ig" bitLength="LENGTH_64_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jXpsYJROEee0N_ppE1lIiw" base_Property="_jVAoEJROEee0N_ppE1lIiw" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jXrhkJROEee0N_ppE1lIiw" base_StructuralFeature="_jVAoEJROEee0N_ppE1lIiw" unit="THz"/>
   <OpenModel_Profile:StrictComposite xmi:id="_odjvEBNqEeiod932A6hg3A" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_q2ZOsBNqEeiod932A6hg3A" base_Association="_KjQ3ohKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_sl9H0BNqEeiod932A6hg3A" base_Association="_2YPCcI6dEeeyZasfnNSonw"/>
@@ -675,12 +851,12 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_Lv2GAHNoEeiPPoPDo3q5jA" base_Element="_KjQ3rRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_NG-4EHNoEeiPPoPDo3q5jA" base_Element="_YS8DkIfeEeet-8tHdGGp_w"/>
   <OpenModel_Profile:Experimental xmi:id="_OQvVcHNoEeiPPoPDo3q5jA" base_Element="_VvSIYEUIEead1bezhJG4aw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TnDTYXPXEeiPPoPDo3q5jA" base_Property="_TnDTYHPXEeiPPoPDo3q5jA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_TnDTYnPXEeiPPoPDo3q5jA" base_StructuralFeature="_TnDTYHPXEeiPPoPDo3q5jA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TnDTYXPXEeiPPoPDo3q5jA" base_Property="_TnDTYHPXEeiPPoPDo3q5jA" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TnDTYnPXEeiPPoPDo3q5jA" base_StructuralFeature="_TnDTYHPXEeiPPoPDo3q5jA" valueRange="193.00013..195.99988" unit="THz"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_16WvEXPYEeiPPoPDo3q5jA" base_Property="_16WvEHPYEeiPPoPDo3q5jA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_16WvEnPYEeiPPoPDo3q5jA" base_StructuralFeature="_16WvEHPYEeiPPoPDo3q5jA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_16WvEnPYEeiPPoPDo3q5jA" base_StructuralFeature="_16WvEHPYEeiPPoPDo3q5jA" unit="THz"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_53PbYXPYEeiPPoPDo3q5jA" base_Property="_53PbYHPYEeiPPoPDo3q5jA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_53PbYnPYEeiPPoPDo3q5jA" base_StructuralFeature="_53PbYHPYEeiPPoPDo3q5jA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_53PbYnPYEeiPPoPDo3q5jA" base_StructuralFeature="_53PbYHPYEeiPPoPDo3q5jA" unit="THz"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_lIJUIXZfEeiPPoPDo3q5jA" base_Property="_lIJUIHZfEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_lIJUInZfEeiPPoPDo3q5jA" base_StructuralFeature="_lIJUIHZfEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:Experimental xmi:id="_vgaIcHZfEeiPPoPDo3q5jA" base_Element="_wB7jIHPYEeiPPoPDo3q5jA"/>
@@ -716,7 +892,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelClass xmi:id="_nBhzoI6cEeeyZasfnNSonw" base_Class="_nBhMkI6cEeeyZasfnNSonw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_nBhMkY6cEeeyZasfnNSonw" base_Class="_nBhMkI6cEeeyZasfnNSonw"/>
   <OpenModel_Profile:Experimental xmi:id="_4yodwI6cEeeyZasfnNSonw" base_Element="_nBhMkI6cEeeyZasfnNSonw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w72iYXk2EeiO-c_khjKlFQ" base_Property="_w72iYHk2EeiO-c_khjKlFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w72iYXk2EeiO-c_khjKlFQ" base_Property="_w72iYHk2EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_w72iYnk2EeiO-c_khjKlFQ" base_StructuralFeature="_w72iYHk2EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ILpCyXk3EeiO-c_khjKlFQ" base_Property="_ILpCwnk3EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ILvJYHk3EeiO-c_khjKlFQ" base_StructuralFeature="_ILpCwnk3EeiO-c_khjKlFQ"/>
@@ -724,11 +900,11 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ILvJYnk3EeiO-c_khjKlFQ" base_StructuralFeature="_ILpCw3k3EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ILvJY3k3EeiO-c_khjKlFQ" base_Property="_ILpCxHk3EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ILvJZHk3EeiO-c_khjKlFQ" base_StructuralFeature="_ILpCxHk3EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F8QSsHk6EeiO-c_khjKlFQ" base_Property="_F8ProHk6EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_F8SH4Hk6EeiO-c_khjKlFQ" base_StructuralFeature="_F8ProHk6EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HSDA8Hk6EeiO-c_khjKlFQ" base_Property="_HSCZ4Hk6EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_HSE2IHk6EeiO-c_khjKlFQ" base_StructuralFeature="_HSCZ4Hk6EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NK1ZQHk6EeiO-c_khjKlFQ" base_Property="_NK0yMHk6EeiO-c_khjKlFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F8QSsHk6EeiO-c_khjKlFQ" base_Property="_F8ProHk6EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_F8SH4Hk6EeiO-c_khjKlFQ" base_StructuralFeature="_F8ProHk6EeiO-c_khjKlFQ" valueRange="255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HSDA8Hk6EeiO-c_khjKlFQ" base_Property="_HSCZ4Hk6EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HSE2IHk6EeiO-c_khjKlFQ" base_StructuralFeature="_HSCZ4Hk6EeiO-c_khjKlFQ" valueRange="193.00000..195.99988" unit="THz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NK1ZQHk6EeiO-c_khjKlFQ" base_Property="_NK0yMHk6EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_NK31gHk6EeiO-c_khjKlFQ" base_StructuralFeature="_NK0yMHk6EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_aZlSgHk6EeiO-c_khjKlFQ" base_Property="_aZkrcnk6EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_aZl5kHk6EeiO-c_khjKlFQ" base_StructuralFeature="_aZkrcnk6EeiO-c_khjKlFQ"/>
@@ -739,33 +915,33 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelClass xmi:id="_XVkH4Hk6EeiO-c_khjKlFQ" base_Class="_XVi5wHk6EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_XVjg0Hk6EeiO-c_khjKlFQ" base_Class="_XVi5wHk6EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:Experimental xmi:id="_qXjyIHk6EeiO-c_khjKlFQ" base_Element="_XVi5wHk6EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYInk7EeiO-c_khjKlFQ" base_Property="_jwVxEXk7EeiO-c_khjKlFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYInk7EeiO-c_khjKlFQ" base_Property="_jwVxEXk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYI3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEXk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJHk7EeiO-c_khjKlFQ" base_Property="_jwVxEnk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJXk7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEnk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJnk7EeiO-c_khjKlFQ" base_Property="_jwVxE3k7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJ3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxE3k7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzUroXk7EeiO-c_khjKlFQ" base_Property="_qzTdgXk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzUronk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdgXk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzVSsHk7EeiO-c_khjKlFQ" base_Property="_qzTdgnk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzVSsXk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdgnk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzVSsnk7EeiO-c_khjKlFQ" base_Property="_qzTdg3k7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzVSs3k7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdg3k7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzV5wHk7EeiO-c_khjKlFQ" base_Property="_qzTdhHk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzV5wXk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdhHk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzV5wnk7EeiO-c_khjKlFQ" base_Property="_qzTdhXk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzV5w3k7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdhXk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_65vVkXk7EeiO-c_khjKlFQ" base_Property="_65vVkHk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_65vVknk7EeiO-c_khjKlFQ" base_StructuralFeature="_65vVkHk7EeiO-c_khjKlFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJHk7EeiO-c_khjKlFQ" base_Property="_jwVxEnk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJXk7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEnk7EeiO-c_khjKlFQ" valueRange="0.5..10.0" unit="mA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJnk7EeiO-c_khjKlFQ" base_Property="_jwVxE3k7EeiO-c_khjKlFQ" attributeValueChangeNotification="NO" bitLength="LENGTH_8_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJ3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxE3k7EeiO-c_khjKlFQ" unit="Celsius"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzUroXk7EeiO-c_khjKlFQ" base_Property="_qzTdgXk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_16_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzUronk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdgXk7EeiO-c_khjKlFQ" counter="ZERO_COUNTER" unit="ms"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzVSsHk7EeiO-c_khjKlFQ" base_Property="_qzTdgnk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_16_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzVSsXk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdgnk7EeiO-c_khjKlFQ" counter="ZERO_COUNTER" unit="ms"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzVSsnk7EeiO-c_khjKlFQ" base_Property="_qzTdg3k7EeiO-c_khjKlFQ" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzVSs3k7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdg3k7EeiO-c_khjKlFQ" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzV5wHk7EeiO-c_khjKlFQ" base_Property="_qzTdhHk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzV5wXk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdhHk7EeiO-c_khjKlFQ" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzV5wnk7EeiO-c_khjKlFQ" base_Property="_qzTdhXk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qzV5w3k7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdhXk7EeiO-c_khjKlFQ" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_65vVkXk7EeiO-c_khjKlFQ" base_Property="_65vVkHk7EeiO-c_khjKlFQ" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_65vVknk7EeiO-c_khjKlFQ" base_StructuralFeature="_65vVkHk7EeiO-c_khjKlFQ" counter="ZERO_COUNTER"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AMMGoHk8EeiO-c_khjKlFQ" base_Property="_AMLfknk8EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_AMMGoXk8EeiO-c_khjKlFQ" base_StructuralFeature="_AMLfknk8EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AMMtsHk8EeiO-c_khjKlFQ" base_Property="_AMMGonk8EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_AMMtsXk8EeiO-c_khjKlFQ" base_StructuralFeature="_AMMGonk8EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_IwNWIHk8EeiO-c_khjKlFQ" base_Association="_AMK4gHk8EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzXWs3k-EeiW-bN1POS5zg" base_Property="_vzXWsHk-EeiW-bN1POS5zg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzX9wHk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsHk-EeiW-bN1POS5zg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzYk0Hk-EeiW-bN1POS5zg" base_Property="_vzXWsXk-EeiW-bN1POS5zg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzYk0Xk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsXk-EeiW-bN1POS5zg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzXWs3k-EeiW-bN1POS5zg" base_Property="_vzXWsHk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzX9wHk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsHk-EeiW-bN1POS5zg" valueRange="-99.000..99.000" unit="dBm"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzYk0Hk-EeiW-bN1POS5zg" base_Property="_vzXWsXk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzYk0Xk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsXk-EeiW-bN1POS5zg" valueRange="-2147483648..2147483648" unit="dBm"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_kOxFkHlTEeiW-bN1POS5zg" base_Property="_kOwegHlTEeiW-bN1POS5zg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_kOxsoHlTEeiW-bN1POS5zg" base_StructuralFeature="_kOwegHlTEeiW-bN1POS5zg"/>
   <OpenModel_Profile:Experimental xmi:id="_2KBpAHpKEei5LIrjJTgegQ" base_Element="_01yZ8HpKEei5LIrjJTgegQ"/>
@@ -799,8 +975,8 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Specify xmi:id="_6wAP4JmqEeiOmuqNbykpsw" base_Abstraction="_ObUMoJmaEeiOmuqNbykpsw">
     <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
   </OpenModel_Profile:Specify>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_l6_TYZmrEeiOmuqNbykpsw" base_StructuralFeature="_l6_TYJmrEeiOmuqNbykpsw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_l6_TYpmrEeiOmuqNbykpsw" base_Property="_l6_TYJmrEeiOmuqNbykpsw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l6_TYZmrEeiOmuqNbykpsw" base_StructuralFeature="_l6_TYJmrEeiOmuqNbykpsw" valueRange="255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_l6_TYpmrEeiOmuqNbykpsw" base_Property="_l6_TYJmrEeiOmuqNbykpsw" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_aiExkZozEeiOmuqNbykpsw" base_Class="_aiExkJozEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_aiExkpozEeiOmuqNbykpsw" base_Class="_aiExkJozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_a2-DgJozEeiOmuqNbykpsw" base_Class="_a2384JozEeiOmuqNbykpsw"/>
@@ -856,8 +1032,8 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelClass xmi:id="_-2cKkZs7EeikSLSDi2qpXA" base_Class="_-2cKkJs7EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_-2cKkps7EeikSLSDi2qpXA" base_Class="_-2cKkJs7EeikSLSDi2qpXA"/>
   <OpenModel_Profile:Experimental xmi:id="_C2W8wJs8EeikSLSDi2qpXA" base_Element="_-2cKkJs7EeikSLSDi2qpXA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_N9lv5Js8EeikSLSDi2qpXA" base_StructuralFeature="_N9lv45s8EeikSLSDi2qpXA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_N9lv5Zs8EeikSLSDi2qpXA" base_Property="_N9lv45s8EeikSLSDi2qpXA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_N9lv5Js8EeikSLSDi2qpXA" base_StructuralFeature="_N9lv45s8EeikSLSDi2qpXA" unit="dBm"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_N9lv5Zs8EeikSLSDi2qpXA" base_Property="_N9lv45s8EeikSLSDi2qpXA" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_N9lv6Zs8EeikSLSDi2qpXA" base_StructuralFeature="_N9lv6Js8EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_N9lv6ps8EeikSLSDi2qpXA" base_Property="_N9lv6Js8EeikSLSDi2qpXA"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_Yj_t4Js8EeikSLSDi2qpXA" base_Association="_N9lv4Js8EeikSLSDi2qpXA"/>
@@ -871,4 +1047,22 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GXqq6Zs9EeikSLSDi2qpXA" base_StructuralFeature="_GXqq6Js9EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_GXqq6ps9EeikSLSDi2qpXA" base_Property="_GXqq6Js9EeikSLSDi2qpXA"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_NQ2JMJs9EeikSLSDi2qpXA" base_Association="_GXqq4Js9EeikSLSDi2qpXA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_lG_ac7KgEei69qzpcujF2A" base_Property="_lG_acLKgEei69qzpcujF2A" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lHABgLKgEei69qzpcujF2A" base_StructuralFeature="_lG_acLKgEei69qzpcujF2A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_m_gbQ7KgEei69qzpcujF2A" base_Property="_m_gbQLKgEei69qzpcujF2A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_m_hCULKgEei69qzpcujF2A" base_StructuralFeature="_m_gbQLKgEei69qzpcujF2A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MxtmwrKiEei69qzpcujF2A" base_Property="_MxtmwLKiEei69qzpcujF2A" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MxuN0LKiEei69qzpcujF2A" base_StructuralFeature="_MxtmwLKiEei69qzpcujF2A" unit="dBm"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_c2QBY7KiEei69qzpcujF2A" base_Property="_c2QBYLKiEei69qzpcujF2A" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_c2R2kLKiEei69qzpcujF2A" base_StructuralFeature="_c2QBYLKiEei69qzpcujF2A" unit="dBm"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_-IYJYrKiEei69qzpcujF2A" base_Property="_-IYJYLKiEei69qzpcujF2A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-IYwcLKiEei69qzpcujF2A" base_StructuralFeature="_-IYJYLKiEei69qzpcujF2A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_YXTUYrKjEei69qzpcujF2A" base_Property="_YXTUYLKjEei69qzpcujF2A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YXT7cLKjEei69qzpcujF2A" base_StructuralFeature="_YXTUYLKjEei69qzpcujF2A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__SYo8rKjEei69qzpcujF2A" base_Property="__SYo8LKjEei69qzpcujF2A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__SZQALKjEei69qzpcujF2A" base_StructuralFeature="__SYo8LKjEei69qzpcujF2A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DkHj47KkEei69qzpcujF2A" base_Property="_DkHj4LKkEei69qzpcujF2A" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DkIK8LKkEei69qzpcujF2A" base_StructuralFeature="_DkHj4LKkEei69qzpcujF2A" unit="dBm"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hoAOQ7KkEei69qzpcujF2A" base_Property="_hoAOQLKkEei69qzpcujF2A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hoA1ULKkEei69qzpcujF2A" base_StructuralFeature="_hoAOQLKkEei69qzpcujF2A"/>
 </xmi:XMI>


### PR DESCRIPTION
Hello Team,

The pull request contains modifications made to TAPI PhotonicMedia UML.
Telefonica  Germany has added a few missing parameters besides defining units for certain parameters, setting stereotypes and modifying the access type of attributes as either RW or RO.

Regards,
Shrikanth