### PR TITLE
 Partial Fixes to #351, #352 as per 09/25/2018 TAPI call agreements

### DIFF
--- a/OAS/tapi-photonic-media@2018-08-31.yaml
+++ b/OAS/tapi-photonic-media@2018-08-31.yaml
@@ -4429,6 +4429,9 @@ definitions:
       modulation:
         description: "The modulation techniqu selected at the source."
         $ref: "#/definitions/tapi.photonic.media.ModulationTechnique"
+      spectrum:
+        description: "none"
+        $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
       laser-control:
         description: "Laser control can be FORCED-ON, FORCED-OFF or LASER-SHUTDOWN"
         $ref: "#/definitions/tapi.photonic.media.LaserControlType"

--- a/OAS/tapi-photonic-media@2018-08-31.yaml
+++ b/OAS/tapi-photonic-media@2018-08-31.yaml
@@ -4184,7 +4184,7 @@ definitions:
     - "ITUT_G698_2"
     - "ITUT_G696_1"
     - "ITUT_G695"
-  tapi.photonic.media.CentralFrequencyOrWavelength:
+  tapi.photonic.media.CentralFrequency:
     type: "object"
     properties:
       central-frequency:
@@ -4192,23 +4192,9 @@ definitions:
         format: "int32"
         description: "The central frequency of the laser specified in MHz. It is the\
           \ oscillation frequency of the corresponding electromagnetic wave. "
-      channel-number:
-        type: "integer"
-        format: "int32"
-        description: "As per ITU-T G.694.1, this attribute is denoted as 'n' and is\
-          \ used to calculate the nominal central frequency (in THz) as follows:\r\
-          \n                    193.1 + <channelNumber> × <adjustmentGranularity>\
-          \ where channelNumber is a positive or negative integer including 0 and\
-          \ adjustment_granularity is the nominal central frequency granularity in\
-          \ THz"
-      grid-type:
-        description: "Specifies the frequency grid standard used to determine the\
-          \ nominal central frequency and frequency slot width"
-        $ref: "#/definitions/tapi.photonic.media.GridType"
-      adjustment-granularity:
-        description: "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it\
-          \ is used to calculate nominal central frequency (in THz)"
-        $ref: "#/definitions/tapi.photonic.media.AdjustmentGranularity"
+      frequency-constraint:
+        description: "none"
+        $ref: "#/definitions/tapi.photonic.media.FrequencyConstraint"
   tapi.photonic.media.ConnectionEndPointAugmentation2:
     type: "object"
     properties:
@@ -4256,9 +4242,6 @@ definitions:
   tapi.photonic.media.EndPointAugmentation1:
     type: "object"
     properties:
-      nmc-config:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.MediaChannelConfigPac"
       otsi-config:
         description: "none"
         $ref: "#/definitions/tapi.photonic.media.OtsiTerminationConfigPac"
@@ -4301,23 +4284,17 @@ definitions:
         type: "integer"
         format: "int32"
         description: "counter: bit error rate after correction by FEC"
-  tapi.photonic.media.FrequencySlot:
+  tapi.photonic.media.FrequencyConstraint:
     type: "object"
     properties:
-      central-frequency:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.CentralFrequencyOrWavelength"
-      spectral-width:
-        type: "integer"
-        format: "int32"
-        description: "Width of the media channel spectrum specified in MHz"
-      slot-width-number:
-        type: "integer"
-        format: "int32"
-        description: "As per ITU-T G.694.1, this attribute is denoted as 'm' and is\
-          \ used to calculate the slot width (in GHz) as follows:\r\n            \
-          \        12.5 × m where m is a positive integer and 12.5 is the slot width\
-          \ granularity in GHz."
+      adjustment-granularity:
+        description: "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it\
+          \ is used to calculate nominal central frequency (in THz)"
+        $ref: "#/definitions/tapi.photonic.media.AdjustmentGranularity"
+      grid-type:
+        description: "Specifies the frequency grid standard used to determine the\
+          \ nominal central frequency and frequency slot width"
+        $ref: "#/definitions/tapi.photonic.media.GridType"
   tapi.photonic.media.GridType:
     type: "string"
     enum:
@@ -4363,12 +4340,6 @@ definitions:
     - "PUMP"
     - "MODULATED"
     - "PULSE"
-  tapi.photonic.media.MediaChannelConfigPac:
-    type: "object"
-    properties:
-      spectrum:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.Spectrum"
   tapi.photonic.media.MediaChannelPoolCapabilityPac:
     type: "object"
     properties:
@@ -4376,23 +4347,23 @@ definitions:
         type: "array"
         description: "none"
         items:
-          $ref: "#/definitions/tapi.photonic.media.Spectrum"
+          $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
       supportable-spectrum:
         type: "array"
         description: "none"
         items:
-          $ref: "#/definitions/tapi.photonic.media.Spectrum"
+          $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
       occupied-spectrum:
         type: "array"
         description: "none"
         items:
-          $ref: "#/definitions/tapi.photonic.media.Spectrum"
+          $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
   tapi.photonic.media.MediaChannelPropertiesPac:
     type: "object"
     properties:
       occupied-spectrum:
         description: "none"
-        $ref: "#/definitions/tapi.photonic.media.Spectrum"
+        $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
       measured-power-egress:
         description: "none"
         $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
@@ -4409,6 +4380,8 @@ definitions:
     - "QPSK"
     - "8QAM"
     - "16QAM"
+    - "PAM4"
+    - "PAM8"
     - "UNDEFINED"
   tapi.photonic.media.OtsiCapabilityPac:
     type: "object"
@@ -4417,7 +4390,7 @@ definitions:
         type: "array"
         description: "The lower frequency of the channel spectrum"
         items:
-          $ref: "#/definitions/tapi.photonic.media.CentralFrequencyOrWavelength"
+          $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
       supportable-application-identifier:
         type: "array"
         description: "The list of supportable ApplicationIdentifiers."
@@ -4435,7 +4408,7 @@ definitions:
         type: "array"
         description: "The Upper frequency of the channel spectrum"
         items:
-          $ref: "#/definitions/tapi.photonic.media.CentralFrequencyOrWavelength"
+          $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
   tapi.photonic.media.OtsiGserverAdaptationPac:
     type: "object"
     properties:
@@ -4452,7 +4425,7 @@ definitions:
       central-frequency:
         description: "The central frequency of the laser. It is the oscillation frequency\
           \ of the corresponding electromagnetic wave"
-        $ref: "#/definitions/tapi.photonic.media.CentralFrequencyOrWavelength"
+        $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
       modulation:
         description: "The modulation techniqu selected at the source."
         $ref: "#/definitions/tapi.photonic.media.ModulationTechnique"
@@ -4461,11 +4434,14 @@ definitions:
         $ref: "#/definitions/tapi.photonic.media.LaserControlType"
       total-power-warn-threshold-lower:
         type: "string"
-        description: "Configure  Max, Default and Min values for lower power threshold."
+        description: "Allows to configure the Lowerpower threshold which is expected\
+          \ to be different from Default, but within the Min and Max values specified\
+          \ as OTSi SIP capability."
       total-power-warn-threshold-upper:
         type: "string"
-        description: "Configure the Max, Default and Min values for the Upper power\
-          \ threshold."
+        description: "Allows to configure the Upper power threshold which is expected\
+          \ to be different from Default, but within the Min and Max values specified\
+          \ as OTSi SIP capability."
       transmit-power:
         description: "Transmit power as requested."
         $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
@@ -4496,7 +4472,7 @@ definitions:
         $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
       selected-central-frequency:
         description: "none"
-        $ref: "#/definitions/tapi.photonic.media.CentralFrequencyOrWavelength"
+        $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
       transmited-power:
         description: "Measured power at the Transmitter."
         $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
@@ -4508,7 +4484,7 @@ definitions:
         $ref: "#/definitions/tapi.photonic.media.LaserPropertiesPac"
       selected-spectrum:
         description: "none"
-        $ref: "#/definitions/tapi.photonic.media.Spectrum"
+        $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
   tapi.photonic.media.OwnedNodeEdgePointAugmentation1:
     type: "object"
     properties:
@@ -4524,11 +4500,10 @@ definitions:
       power-spectral-density:
         type: "string"
         description: "This describes how power of a signal  is distributed over frequency\
-          \ specified in nW/MHz\r\n                    range of type : -2147483648..2147483648"
+          \ specified in nW/MHz"
       total-power:
         type: "string"
-        description: "The total power at any point in a channel specified in dBm.\r\
-          \n                    range of type : -99.000..99.000"
+        description: "The total power at any point in a channel specified in dBm."
   tapi.photonic.media.SelectedModulation:
     type: "string"
     enum:
@@ -4539,6 +4514,8 @@ definitions:
     - "QPSK"
     - "8QAM"
     - "16QAM"
+    - "PAM4"
+    - "PAM8"
     - "UNDEFINED"
   tapi.photonic.media.ServiceInterfacePointAugmentation1:
     type: "object"
@@ -4558,12 +4535,9 @@ definitions:
     x-augmentation:
       prefix: "tapi-photonic-media"
       namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.Spectrum:
+  tapi.photonic.media.SpectrumBand:
     type: "object"
     properties:
-      frequency-slot:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.FrequencySlot"
       lower-frequency:
         type: "integer"
         format: "int32"
@@ -4574,6 +4548,9 @@ definitions:
         format: "int32"
         description: "The upper frequency bound of the media channel spectrum specified\
           \ in MHz"
+      frequency-constraint:
+        description: "none"
+        $ref: "#/definitions/tapi.photonic.media.FrequencyConstraint"
   tapi.photonic.media.TotalPowerThresholdPac:
     type: "object"
     properties:

--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -1156,36 +1156,37 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_XVoZUnk6EeiO-c_khjKlFQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_XVoZU3k6EeiO-c_khjKlFQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_bR-xsMDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IWG6gMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IWG6gcG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
-          </eAnnotations>
+        <children xmi:type="notation:Shape" xmi:id="_TlcfcMMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_8MWlMMDSEeiXyMZOD9tv6w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR-xscDZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TlcfccMsEei3gLXE4_XcoA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bR_YwMDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TldGgMMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_9kM10MMrEei3gLXE4_XcoA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TldGgcMsEei3gLXE4_XcoA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TldGgsMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_F8ProHk6EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR_YwcDZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TldGg8MsEei3gLXE4_XcoA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bR__0MDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TldtkMMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_NK0yMHk6EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR__0cDZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TldtkcMsEei3gLXE4_XcoA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bR__0sDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TldtksMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_--VrgLXYEei8W-CGeBUOew"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR__08DZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Tldtk8MsEei3gLXE4_XcoA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bSAm4MDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TldtlMMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_N9lv45s8EeikSLSDi2qpXA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bSAm4cDZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TldtlcMsEei3gLXE4_XcoA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bSBN8MDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TleUoMMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_JfBWgLTdEeiF8sBzK2t1Sw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bSBN8cDZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TleUocMsEei3gLXE4_XcoA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bSBN8sDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_TleUosMsEei3gLXE4_XcoA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_JfEZ0LTdEeiF8sBzK2t1Sw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bSBN88DZEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TleUo8MsEei3gLXE4_XcoA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_XVoZVHk6EeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_XVoZVXk6EeiO-c_khjKlFQ"/>
@@ -1359,7 +1360,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GE5mYEeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GAZmYEeiOmuqNbykpsw" x="665" y="-144" width="308" height="78"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GAZmYEeiOmuqNbykpsw" x="665" y="-144" width="262" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_axWnOZmYEeiOmuqNbykpsw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_axWnOpmYEeiOmuqNbykpsw"/>
@@ -1714,9 +1715,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7cWEIYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-182, -235, -643984, -643984]$[-182, -39, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.5,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.37464788732394366,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-180, -235, -643984, -643984]$[-180, -39, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.5043859649122807,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.39644970414201186,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7cpmJIuWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_7cpmIIuWEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_7cpmJYuWEeiu6boZkiJHCA"/>
@@ -1894,7 +1895,7 @@
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nZkr4pmYEeiOmuqNbykpsw" points="[797, -226, -643984, -643984]$[797, -144, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoJmYEeiOmuqNbykpsw" id="(0.48214285714285715,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoZmYEeiOmuqNbykpsw" id="(0.4253246753246753,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoZmYEeiOmuqNbykpsw" id="(0.5,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ObaTQJmaEeiOmuqNbykpsw" type="Abstraction_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_7NoX0HjAEeixydPRZ8lIKA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_ObaTQ5maEeiOmuqNbykpsw" type="Abstraction_NameLabel">
@@ -2042,6 +2043,30 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__WU8lrudEeiljfl0umr-iQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__WU8l7udEeiljfl0umr-iQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__WU8mLudEeiljfl0umr-iQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zY6jAMMqEei3gLXE4_XcoA" type="Association_Edge" source="_7NoX0HjAEeixydPRZ8lIKA" target="_-8QyEHiGEeiPPoPDo3q5jA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_zY6jA8MqEei3gLXE4_XcoA" type="Association_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zY6jBMMqEei3gLXE4_XcoA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zY6jBcMqEei3gLXE4_XcoA" type="Association_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zY6jBsMqEei3gLXE4_XcoA" x="2" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zY6jB8MqEei3gLXE4_XcoA" type="Association_TargetRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zY6jCMMqEei3gLXE4_XcoA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zY6jCcMqEei3gLXE4_XcoA" type="Association_SourceRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zY6jCsMqEei3gLXE4_XcoA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zY6jC8MqEei3gLXE4_XcoA" type="Association_SourceMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zY6jDMMqEei3gLXE4_XcoA" x="-30" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zY6jDcMqEei3gLXE4_XcoA" type="Association_TargetMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zY6jDsMqEei3gLXE4_XcoA" x="31" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_zY6jAcMqEei3gLXE4_XcoA"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zY6jAsMqEei3gLXE4_XcoA" points="[430, -416, -643984, -643984]$[-207, -393, -643984, -643984]"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_07ESQMMqEei3gLXE4_XcoA" id="(1.0,0.46774193548387094)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="OtsiResourceSpec" measurementUnit="Pixel">
@@ -3542,7 +3567,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNVJo1EeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNfpo1EeiOmuqNbykpsw" x="3" y="-443" width="277" height="65"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNfpo1EeiOmuqNbykpsw" x="-83" y="-448" width="277" height="65"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F5JT0Jo1EeiOmuqNbykpsw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_F5JT0Zo1EeiOmuqNbykpsw" type="Class_NameLabel"/>
@@ -3572,7 +3597,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUDpo1EeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUQ5o1EeiOmuqNbykpsw" x="-5" y="-289" height="65"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUQ5o1EeiOmuqNbykpsw" x="-91" y="-294" height="65"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F5JUXpo1EeiOmuqNbykpsw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_F5JUX5o1EeiOmuqNbykpsw" type="Class_NameLabel"/>
@@ -3610,7 +3635,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUyJo1EeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JU_Zo1EeiOmuqNbykpsw" x="7" y="-141" width="246" height="98"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JU_Zo1EeiOmuqNbykpsw" x="-96" y="-146" width="283" height="98"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F5n08Jo1EeiOmuqNbykpsw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_F5n08Zo1EeiOmuqNbykpsw"/>
@@ -3936,7 +3961,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_F5DNN5o1EeiOmuqNbykpsw"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5DNO5o1EeiOmuqNbykpsw" points="[132, -289, -643984, -643984]$[132, -378, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5DNO5o1EeiOmuqNbykpsw" points="[46, -294, -643984, -643984]$[46, -383, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5DNPJo1EeiOmuqNbykpsw" id="(0.49458483754512633,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5DNPZo1EeiOmuqNbykpsw" id="(0.4657039711191336,1.0)"/>
     </edges>
@@ -3967,9 +3992,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_F5JUV5o1EeiOmuqNbykpsw"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5JUW5o1EeiOmuqNbykpsw" points="[112, -224, -643984, -643984]$[112, -141, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXJo1EeiOmuqNbykpsw" id="(0.4187725631768953,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXZo1EeiOmuqNbykpsw" id="(0.42276422764227645,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5JUW5o1EeiOmuqNbykpsw" points="[45, -229, -643984, -643984]$[45, -186, -643984, -643984]$[40, -186, -643984, -643984]$[40, -146, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXJo1EeiOmuqNbykpsw" id="(0.48014440433212996,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXZo1EeiOmuqNbykpsw" id="(0.4876325088339223,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_F5n09Jo1EeiOmuqNbykpsw" type="StereotypeCommentLink" source="_F5DNQpo1EeiOmuqNbykpsw" target="_F5n08Jo1EeiOmuqNbykpsw">
       <styles xmi:type="notation:FontStyle" xmi:id="_F5n09Zo1EeiOmuqNbykpsw"/>
@@ -4246,6 +4271,37 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1GymdrudEeiljfl0umr-iQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Gymd7udEeiljfl0umr-iQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1GymeLudEeiljfl0umr-iQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NDF3oMMqEei3gLXE4_XcoA" type="Association_Edge" source="_F5DNQpo1EeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3o8MqEei3gLXE4_XcoA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PJ82cMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3pMMqEei3gLXE4_XcoA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3pcMqEei3gLXE4_XcoA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PMo-EMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3psMqEei3gLXE4_XcoA" x="-2" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3p8MqEei3gLXE4_XcoA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PO7dEMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3qMMqEei3gLXE4_XcoA" x="15" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3qcMqEei3gLXE4_XcoA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PRmWkMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3qsMqEei3gLXE4_XcoA" x="-15" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3q8MqEei3gLXE4_XcoA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PVCFEMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3rMMqEei3gLXE4_XcoA" x="10" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3rcMqEei3gLXE4_XcoA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PYLfsMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3rsMqEei3gLXE4_XcoA" x="-7" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_NDF3ocMqEei3gLXE4_XcoA"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NDF3osMqEei3gLXE4_XcoA" points="[280, -410, -643984, -643984]$[382, -411, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PbcPEMMqEei3gLXE4_XcoA" id="(1.0,0.5846153846153846)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PbcPEcMqEei3gLXE4_XcoA" id="(0.0,0.49230769230769234)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
   <notation:Diagram xmi:id="_w3tFAI6QEeeyZasfnNSonw" type="PapyrusUMLClassDiagram" name="PhotonicTypes" measurementUnit="Pixel">
-    <children xmi:type="notation:Shape" xmi:id="_xnJk8I6QEeeyZasfnNSonw" type="DataType_Shape">
+    <children xmi:type="notation:Shape" xmi:id="_xnJk8I6QEeeyZasfnNSonw" type="DataType_Shape" fontColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_xnKMAI6QEeeyZasfnNSonw" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_xnKMAY6QEeeyZasfnNSonw" type="DataType_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xnKMAo6QEeeyZasfnNSonw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_xnKzEI6QEeeyZasfnNSonw" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_D3t3QHPYEeiPPoPDo3q5jA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_KjQ3xRKOEeajhbtskMXJfw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_D3t3QXPYEeiPPoPDo3q5jA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_D3t3QnPYEeiPPoPDo3q5jA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_87l7YI6VEeeyZasfnNSonw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_D3t3Q3PYEeiPPoPDo3q5jA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_D3t3RHPYEeiPPoPDo3q5jA" type="Property_DataTypeAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_6FebkMG_EeiAg83ctgK3eQ" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_TnDTYHPXEeiPPoPDo3q5jA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_D3t3RXPYEeiPPoPDo3q5jA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6FebkcG_EeiAg83ctgK3eQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_D3z94HPYEeiPPoPDo3q5jA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_KjQ3xhKOEeajhbtskMXJfw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_D3z94XPYEeiPPoPDo3q5jA"/>
+        <children xmi:type="notation:Shape" xmi:id="_6FkiMMG_EeiAg83ctgK3eQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_zkZ7QMG_EeiAg83ctgK3eQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6FkiMcG_EeiAg83ctgK3eQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_xnKzEY6QEeeyZasfnNSonw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_xnKzEo6QEeeyZasfnNSonw"/>
@@ -35,7 +27,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnKzGY6QEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnJk8Y6QEeeyZasfnNSonw" x="264" y="27" height="132"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnJk8Y6QEeeyZasfnNSonw" x="222" y="25" height="104"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xnY1g46QEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xnY1hI6QEeeyZasfnNSonw" showTitle="true"/>
@@ -77,7 +69,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsudOY6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsudMY6YEeeyZasfnNSonw" x="998" y="182"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsudMY6YEeeyZasfnNSonw" x="317" y="291"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bs3nI46YEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Bs3nJI6YEeeyZasfnNSonw" showTitle="true"/>
@@ -127,7 +119,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GaDH-Y6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GaDH8Y6YEeeyZasfnNSonw" x="831" y="184"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GaDH8Y6YEeeyZasfnNSonw" x="464" y="279"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GaMR446YEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_GaMR5I6YEeeyZasfnNSonw" showTitle="true"/>
@@ -173,7 +165,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_I9PddI6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_I9O2YY6YEeeyZasfnNSonw" x="638" y="178"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_I9O2YY6YEeeyZasfnNSonw" x="741" y="159"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_I9YnY46YEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_I9YnZI6YEeeyZasfnNSonw" showTitle="true"/>
@@ -209,7 +201,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lm8DlI6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lm61cY6YEeeyZasfnNSonw" x="203" y="184" width="378" height="113"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lm61cY6YEeeyZasfnNSonw" x="817" y="19" width="378" height="113"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LnEmc46YEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_LnEmdI6YEeeyZasfnNSonw" showTitle="true"/>
@@ -251,7 +243,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xvBJR48ZEeedErNofqJXiw"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xu7CoY8ZEeedErNofqJXiw" x="64" y="471"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xu7CoY8ZEeedErNofqJXiw" x="57" y="485"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xvTdII8ZEeedErNofqJXiw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xvTdIY8ZEeedErNofqJXiw" showTitle="true"/>
@@ -261,7 +253,7 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xvTdIo8ZEeedErNofqJXiw" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_wB7jIXPYEeiPPoPDo3q5jA" type="DataType_Shape">
+    <children xmi:type="notation:Shape" xmi:id="_wB7jIXPYEeiPPoPDo3q5jA" type="DataType_Shape" fontColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_wB7jI3PYEeiPPoPDo3q5jA" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_wB7jJHPYEeiPPoPDo3q5jA" type="DataType_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_wB7jJXPYEeiPPoPDo3q5jA" y="5"/>
@@ -275,9 +267,9 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_53PbYHPYEeiPPoPDo3q5jA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_6zXsc3PYEeiPPoPDo3q5jA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_l2BXQHlTEeiW-bN1POS5zg" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_kOwegHlTEeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l2BXQXlTEeiW-bN1POS5zg"/>
+        <children xmi:type="notation:Shape" xmi:id="_8O4_IMG_EeiAg83ctgK3eQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vsgcoMG_EeiAg83ctgK3eQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8O4_IcG_EeiAg83ctgK3eQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_wB7jJ3PYEeiPPoPDo3q5jA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_wB7jKHPYEeiPPoPDo3q5jA"/>
@@ -291,7 +283,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jL3PYEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jInPYEeiPPoPDo3q5jA" x="697" y="29" width="221" height="120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jInPYEeiPPoPDo3q5jA" x="507" y="21" width="290" height="106"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_vgmVsHZfEeiPPoPDo3q5jA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_vgmVsXZfEeiPPoPDo3q5jA" showTitle="true"/>
@@ -307,33 +299,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__ZU_9XkzEeiO-c_khjKlFQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__ZU_9nkzEeiO-c_khjKlFQ" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_C7nNoJ_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFiqsMDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_4CrVMJ_EEeiO_KvaRsULdw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7nNoZ_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFiqscDbEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C7obwJ_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFjRwMDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_40lTQJ_EEeiO_KvaRsULdw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7obwZ_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFjRwcDbEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C7obwp_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFj40MDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_6xqD8J_EEeiO_KvaRsULdw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7obw5_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFj40cDbEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C7pp4J_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFj40sDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_dLZaMHk3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7pp4Z_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFj408DbEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C7pp4p_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFkf4MDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_eMvicHk3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7pp45_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFkf4cDbEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C7pp5J_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFkf4sDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_rneCMHk3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7pp5Z_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFkf48DbEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C7qQ8J_FEeiO_KvaRsULdw" type="EnumerationLiteral_LiteralLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cFlG8MDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_s0U24Hk3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C7qQ8Z_FEeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFlG8cDbEeiXyMZOD9tv6w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cFlG8sDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel" fontColor="255">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_t-3WUMDTEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFlG88DbEeiXyMZOD9tv6w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cFlG9MDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel" fontColor="255">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_x6FOsMDTEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFlG9cDbEeiXyMZOD9tv6w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cFluAMDbEeiXyMZOD9tv6w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_wu-AkLDnEeiUZaG2JnNtGQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cFluAcDbEeiXyMZOD9tv6w"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__ZU_93kzEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__ZU_-HkzEeiO-c_khjKlFQ"/>
@@ -341,7 +345,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZU_-nkzEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZU_8nkzEeiO-c_khjKlFQ" x="1110" y="185" height="181"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZU_8nkzEeiO-c_khjKlFQ" x="956" y="163" height="222"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_fYd2F3k0EeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_fYd2GHk0EeiO-c_khjKlFQ" showTitle="true"/>
@@ -356,46 +360,6 @@
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2zBhZnlHEeiW-bN1POS5zg" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2zBhZXlHEeiW-bN1POS5zg" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_VP_ksHlJEeiW-bN1POS5zg" type="DataType_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_VP_ksnlJEeiW-bN1POS5zg" type="DataType_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VP_ks3lJEeiW-bN1POS5zg" type="DataType_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VP_ktHlJEeiW-bN1POS5zg" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_VP_ktXlJEeiW-bN1POS5zg" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_WSI-MHlJEeiW-bN1POS5zg" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_ILpCwnk3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WSI-MXlJEeiW-bN1POS5zg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_WSJlQHlJEeiW-bN1POS5zg" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_ILpCw3k3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WSJlQXlJEeiW-bN1POS5zg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_WSKMUHlJEeiW-bN1POS5zg" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_ILpCxHk3EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WSKMUXlJEeiW-bN1POS5zg"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_VP_ktnlJEeiW-bN1POS5zg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_VP_kt3lJEeiW-bN1POS5zg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_VP_kuHlJEeiW-bN1POS5zg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VP_kuXlJEeiW-bN1POS5zg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_VQALwHlJEeiW-bN1POS5zg" type="DataType_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_VQALwXlJEeiW-bN1POS5zg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_VQALwnlJEeiW-bN1POS5zg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_VQALw3lJEeiW-bN1POS5zg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQALxHlJEeiW-bN1POS5zg"/>
-      </children>
-      <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_ILpCwHk3EeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VP_ksXlJEeiW-bN1POS5zg" x="940" y="30" height="116"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_VQNAE3lJEeiW-bN1POS5zg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_VQNAFHlJEeiW-bN1POS5zg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VQNAFnlJEeiW-bN1POS5zg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_ILpCwHk3EeiO-c_khjKlFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQNAFXlJEeiW-bN1POS5zg" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_3YLeMHpKEei5LIrjJTgegQ" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_3YLeMnpKEei5LIrjJTgegQ" type="Enumeration_NameLabel"/>
@@ -421,7 +385,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YLeOXpKEei5LIrjJTgegQ"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YLeMXpKEei5LIrjJTgegQ" x="444" y="478"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YLeMXpKEei5LIrjJTgegQ" x="401" y="494"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_3YdyGnpKEei5LIrjJTgegQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_3YdyG3pKEei5LIrjJTgegQ" showTitle="true"/>
@@ -453,7 +417,7 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZQfPIoJEeivCevppATXng" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Er39oIoJEeivCevppATXng" type="Enumeration_Shape">
+    <children xmi:type="notation:Shape" xmi:id="_Er39oIoJEeivCevppATXng" type="Enumeration_Shape" fontColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_Er39oooJEeivCevppATXng" type="Enumeration_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_Er39o4oJEeivCevppATXng" type="Enumeration_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Er39pIoJEeivCevppATXng" y="5"/>
@@ -505,7 +469,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er39qYoJEeivCevppATXng"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er39oYoJEeivCevppATXng" x="67" y="209" height="219"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er39oYoJEeivCevppATXng" x="49" y="214" height="219"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_WAITsIoJEeivCevppATXng" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_WAITsYoJEeivCevppATXng" showTitle="true"/>
@@ -551,7 +515,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EMsiabqdEeimKvjOEffRIA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EMsiYbqdEeimKvjOEffRIA" x="215" y="311" width="224" height="125"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EMsiYbqdEeimKvjOEffRIA" x="527" y="494" width="224" height="125"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_lnxLALqdEeimKvjOEffRIA" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_lnxLArqdEeimKvjOEffRIA" type="Enumeration_NameLabel"/>
@@ -581,7 +545,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnxLCbqdEeimKvjOEffRIA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnxLAbqdEeimKvjOEffRIA" x="463" y="313"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnxLAbqdEeimKvjOEffRIA" x="768" y="492"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_-oQ0B7qdEeimKvjOEffRIA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_-oQ0CLqdEeimKvjOEffRIA"/>
@@ -598,6 +562,42 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AU8YSbqeEeimKvjOEffRIA" x="614" y="314"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nCyqQMG-EeiAg83ctgK3eQ" type="DataType_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nCyqQsG-EeiAg83ctgK3eQ" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nCyqQ8G-EeiAg83ctgK3eQ" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nCyqRMG-EeiAg83ctgK3eQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nCyqRcG-EeiAg83ctgK3eQ" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_od_ngMG_EeiAg83ctgK3eQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_87l7YI6VEeeyZasfnNSonw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_od_ngcG_EeiAg83ctgK3eQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_oeFuIMG_EeiAg83ctgK3eQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_KjQ3xRKOEeajhbtskMXJfw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_oeFuIcG_EeiAg83ctgK3eQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nCyqRsG-EeiAg83ctgK3eQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nCyqR8G-EeiAg83ctgK3eQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nCyqSMG-EeiAg83ctgK3eQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCyqScG-EeiAg83ctgK3eQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nCyqSsG-EeiAg83ctgK3eQ" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nCyqS8G-EeiAg83ctgK3eQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nCyqTMG-EeiAg83ctgK3eQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nCyqTcG-EeiAg83ctgK3eQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCyqTsG-EeiAg83ctgK3eQ"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCyqQcG-EeiAg83ctgK3eQ" x="279" y="145"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_sKC38MG-EeiAg83ctgK3eQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_sKC38cG-EeiAg83ctgK3eQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sKC388G-EeiAg83ctgK3eQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sKC38sG-EeiAg83ctgK3eQ" x="1220" y="63"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_w3tFAY6QEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_w3tFAo6QEeeyZasfnNSonw"/>
@@ -693,16 +693,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2zCIcHlHEeiW-bN1POS5zg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2zCIcXlHEeiW-bN1POS5zg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_VQNAF3lJEeiW-bN1POS5zg" type="StereotypeCommentLink" source="_VP_ksHlJEeiW-bN1POS5zg" target="_VQNAE3lJEeiW-bN1POS5zg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_VQNAGHlJEeiW-bN1POS5zg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VQNAHHlJEeiW-bN1POS5zg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_ILpCwHk3EeiO-c_khjKlFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VQNAGXlJEeiW-bN1POS5zg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VQNAGnlJEeiW-bN1POS5zg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VQNAG3lJEeiW-bN1POS5zg"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3YdyHnpKEei5LIrjJTgegQ" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_3YdyGnpKEei5LIrjJTgegQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_3YdyH3pKEei5LIrjJTgegQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3YdyI3pKEei5LIrjJTgegQ" name="BASE_ELEMENT">
@@ -735,7 +725,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_LhPS8ooJEeivCevppATXng"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LhPS84oJEeivCevppATXng" points="[0, -21, -3, 81]$[3, -94, 0, 8]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMIoJEeivCevppATXng" id="(0.5321100917431193,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMIoJEeivCevppATXng" id="(0.5294117647058824,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMYoJEeivCevppATXng" id="(0.4866666666666667,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WAITtIoJEeivCevppATXng" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_WAITsIoJEeivCevppATXng">
@@ -777,6 +767,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AU8YTbqeEeimKvjOEffRIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AU8YTrqeEeimKvjOEffRIA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AU8YT7qeEeimKvjOEffRIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sKC39MG-EeiAg83ctgK3eQ" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_sKC38MG-EeiAg83ctgK3eQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sKC39cG-EeiAg83ctgK3eQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sKC3-cG-EeiAg83ctgK3eQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sKC39sG-EeiAg83ctgK3eQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sKC398G-EeiAg83ctgK3eQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sKC3-MG-EeiAg83ctgK3eQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_gKM6AI6dEeeyZasfnNSonw" type="layersTree" name="Layers Tree Editor"/>
@@ -953,7 +953,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_l6_TYJmrEeiOmuqNbykpsw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_nIXsgZmrEeiOmuqNbykpsw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_7ZKFYLs6Eeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_7ZKFYLs6Eeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jg6iAMDZEeiXyMZOD9tv6w" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jg6iAcDZEeiXyMZOD9tv6w" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_eIOh8rs6Eeiljfl0umr-iQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_7ZKFYbs6Eeiljfl0umr-iQ"/>
         </children>
@@ -975,7 +978,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nhv0yXiHEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-347" y="-42" height="134"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-315" y="-39" height="134"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Nh1UVXiHEeiPPoPDo3q5jA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Nh1UVniHEeiPPoPDo3q5jA" showTitle="true"/>
@@ -1065,10 +1068,6 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_aZkrcnk6EeiO-c_khjKlFQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_lOxTYXk6EeiO-c_khjKlFQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_KydRwJmpEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_w_nl05moEeiOmuqNbykpsw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KydRwZmpEeiOmuqNbykpsw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_O0bY1HkwEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_O0bY1XkwEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_O0bY1nkwEeiO-c_khjKlFQ"/>
@@ -1157,33 +1156,36 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_XVoZUnk6EeiO-c_khjKlFQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_XVoZU3k6EeiO-c_khjKlFQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_943FYLtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_HSCZ4Hk6EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_943FYbtjEeiljfl0umr-iQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_bR-xsMDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IWG6gMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IWG6gcG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_8MWlMMDSEeiXyMZOD9tv6w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR-xscDZEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_943scLtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_bR_YwMDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_F8ProHk6EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_943scbtjEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR_YwcDZEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_943scrtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_bR__0MDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_NK0yMHk6EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_943sc7tjEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR__0cDZEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_944TgLtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_bR__0sDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_--VrgLXYEei8W-CGeBUOew"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_944TgbtjEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bR__08DZEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_944TgrtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_bSAm4MDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_N9lv45s8EeikSLSDi2qpXA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_944Tg7tjEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bSAm4cDZEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_944ThLtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_bSBN8MDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_JfBWgLTdEeiF8sBzK2t1Sw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_944ThbtjEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bSBN8cDZEeiXyMZOD9tv6w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_944ThrtjEeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_bSBN8sDZEeiXyMZOD9tv6w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_JfEZ0LTdEeiF8sBzK2t1Sw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_944Th7tjEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bSBN88DZEeiXyMZOD9tv6w"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_XVoZVHk6EeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_XVoZVXk6EeiO-c_khjKlFQ"/>
@@ -1203,7 +1205,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVoZYXk6EeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVnyQXk6EeiO-c_khjKlFQ" x="206" y="-33" width="373" height="176"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVnyQXk6EeiO-c_khjKlFQ" x="300" y="-129" width="304" height="176"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_XVyKYnk6EeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_XVyKY3k6EeiO-c_khjKlFQ" showTitle="true"/>
@@ -1375,14 +1377,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_88g1pZmoEeiOmuqNbykpsw" x="820" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_JEWKI5mpEeiOmuqNbykpsw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JEWKJJmpEeiOmuqNbykpsw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JEWKJpmpEeiOmuqNbykpsw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_w_nl0JmoEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JEWKJZmpEeiOmuqNbykpsw" x="523" y="-397"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_60fHQJmqEeiOmuqNbykpsw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_60fHQZmqEeiOmuqNbykpsw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_60fHQ5mqEeiOmuqNbykpsw" name="BASE_ELEMENT">
@@ -1423,7 +1417,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mlzdo5s8EeikSLSDi2qpXA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MlzdkZs8EeikSLSDi2qpXA" x="766" y="-46" height="112"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MlzdkZs8EeikSLSDi2qpXA" x="335" y="138" height="83"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_MmFxc5s8EeikSLSDi2qpXA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_MmFxdJs8EeikSLSDi2qpXA"/>
@@ -1433,7 +1427,10 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmFxdZs8EeikSLSDi2qpXA" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_gP2P0Lq4EeimKvjOEffRIA" type="Class_Shape" fontColor="255">
+    <children xmi:type="notation:Shape" xmi:id="_gP2P0Lq4EeimKvjOEffRIA" type="Class_Shape">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_it2GUMDZEeiXyMZOD9tv6w" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_it2GUcDZEeiXyMZOD9tv6w" key="fontColor" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_gP2P0rq4EeimKvjOEffRIA" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_gP2P07q4EeimKvjOEffRIA" type="Class_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_gP2P1Lq4EeimKvjOEffRIA" y="15"/>
@@ -1490,7 +1487,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P47q4EeimKvjOEffRIA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P0bq4EeimKvjOEffRIA" x="-249" y="186" height="142"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P0bq4EeimKvjOEffRIA" x="-310" y="177" height="142"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_gQIjs7q4EeimKvjOEffRIA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_gQIjtLq4EeimKvjOEffRIA"/>
@@ -1528,7 +1525,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NzU817tKEeiljfl0umr-iQ"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NzUVwbtKEeiljfl0umr-iQ" x="215" y="188"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NzUVwbtKEeiljfl0umr-iQ" x="663" y="-40"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_NzjmULtKEeiljfl0umr-iQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_NzjmUbtKEeiljfl0umr-iQ"/>
@@ -1717,9 +1714,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7cWEIYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-191, -235, -643984, -643984]$[-191, -42, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.4605263157894737,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.37681159420289856,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-182, -235, -643984, -643984]$[-182, -39, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.37464788732394366,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7cpmJIuWEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_7cpmIIuWEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_7cpmJYuWEeiu6boZkiJHCA"/>
@@ -1734,11 +1731,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_BDZzQIuXEeiu6boZkiJHCA" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_XVnyQHk6EeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzQ4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jikh8JmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRIuXEeiu6boZkiJHCA" x="-32" y="6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRIuXEeiu6boZkiJHCA" x="2" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzRYuXEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jlDOMJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRouXEeiu6boZkiJHCA" x="-49"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BDZzRouXEeiu6boZkiJHCA" x="-15" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzR4uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jnPmkJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1758,9 +1755,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BDZzQYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDZzQouXEeiu6boZkiJHCA" points="[365, -217, -643984, -643984]$[365, -33, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_541CMJmoEeiOmuqNbykpsw" id="(0.1583011583011583,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbbsIuXEeiu6boZkiJHCA" id="(0.42359249329758714,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDZzQouXEeiu6boZkiJHCA" points="[445, -217, -643984, -643984]$[445, -142, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_541CMJmoEeiOmuqNbykpsw" id="(0.4671814671814672,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbbsIuXEeiu6boZkiJHCA" id="(0.47368421052631576,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BEzhcIuXEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_BEy6Y4uXEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_BEzhcYuXEeiu6boZkiJHCA"/>
@@ -1914,37 +1911,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgJmaEeiOmuqNbykpsw" id="(0.48214285714285715,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgZmaEeiOmuqNbykpsw" id="(0.8571428571428571,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xCM_wJmoEeiOmuqNbykpsw" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_aw4GAJmYEeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_w5moEeiOmuqNbykpsw" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yfbywJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_xJmoEeiOmuqNbykpsw" x="-8" y="-42"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_xZmoEeiOmuqNbykpsw" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yiHTUJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_xpmoEeiOmuqNbykpsw" x="-3" y="-60"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_x5moEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yksGMJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_yJmoEeiOmuqNbykpsw" x="43" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_yZmoEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yoH0sJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_ypmoEeiOmuqNbykpsw" x="-43" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_y5moEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yrkxUJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_zJmoEeiOmuqNbykpsw" x="8" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xCM_zZmoEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yuDdkJmoEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xCM_zpmoEeiOmuqNbykpsw" x="-43" y="-20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_xCM_wZmoEeiOmuqNbykpsw"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_w_nl0JmoEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xCM_wpmoEeiOmuqNbykpsw" points="[531, -217, -643984, -643984]$[531, -122, -643984, -643984]$[665, -122, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xITnwJmoEeiOmuqNbykpsw" id="(0.7992277992277992,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xITnwZmoEeiOmuqNbykpsw" id="(0.0,0.28205128205128205)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_88g1p5moEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_88g1o5moEeiOmuqNbykpsw">
       <styles xmi:type="notation:FontStyle" xmi:id="_88g1qJmoEeiOmuqNbykpsw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_88g1rJmoEeiOmuqNbykpsw" name="BASE_ELEMENT">
@@ -1954,16 +1920,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_88g1qZmoEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_88g1qpmoEeiOmuqNbykpsw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_88g1q5moEeiOmuqNbykpsw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JEWKJ5mpEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_xCM_wJmoEeiOmuqNbykpsw" target="_JEWKI5mpEeiOmuqNbykpsw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JEWKKJmpEeiOmuqNbykpsw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JEWKLJmpEeiOmuqNbykpsw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_w_nl0JmoEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JEWKKZmpEeiOmuqNbykpsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JEWKKpmpEeiOmuqNbykpsw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JEWKK5mpEeiOmuqNbykpsw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_60fHRJmqEeiOmuqNbykpsw" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_60fHQJmqEeiOmuqNbykpsw">
       <styles xmi:type="notation:FontStyle" xmi:id="_60fHRZmqEeiOmuqNbykpsw"/>
@@ -1985,14 +1941,14 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MmFxeps8EeikSLSDi2qpXA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MmFxe5s8EeikSLSDi2qpXA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OBTyQJs8EeikSLSDi2qpXA" type="Association_Edge" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_MlzdkJs8EeikSLSDi2qpXA">
+    <edges xmi:type="notation:Connector" xmi:id="_OBTyQJs8EeikSLSDi2qpXA" type="Association_Edge" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_MlzdkJs8EeikSLSDi2qpXA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_OBTyQ5s8EeikSLSDi2qpXA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VVFh4Js8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyRJs8EeikSLSDi2qpXA" y="12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyRJs8EeikSLSDi2qpXA" x="4" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OBTyRZs8EeikSLSDi2qpXA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VYVDIJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyRps8EeikSLSDi2qpXA" x="2" y="-14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyRps8EeikSLSDi2qpXA" x="-15" y="-17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OBTyR5s8EeikSLSDi2qpXA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Va8SQJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2012,9 +1968,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_OBTyQZs8EeikSLSDi2qpXA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_N9lv4Js8EeikSLSDi2qpXA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OBTyQps8EeikSLSDi2qpXA" points="[519, 66, -643984, -643984]$[538, 137, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OIv3AJs8EeikSLSDi2qpXA" id="(1.0,0.23863636363636365)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OIv3AZs8EeikSLSDi2qpXA" id="(0.0,0.48214285714285715)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OBTyQps8EeikSLSDi2qpXA" points="[450, 34, -643984, -643984]$[450, 138, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OIv3AJs8EeikSLSDi2qpXA" id="(0.4934210526315789,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OIv3AZs8EeikSLSDi2qpXA" id="(0.558252427184466,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_gQIjt7q4EeimKvjOEffRIA" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_gQIjs7q4EeimKvjOEffRIA">
       <styles xmi:type="notation:FontStyle" xmi:id="_gQIjuLq4EeimKvjOEffRIA"/>
@@ -2053,9 +2009,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_eVdssbs6Eeiljfl0umr-iQ"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVdssrs6Eeiljfl0umr-iQ" points="[-133, 92, -643984, -643984]$[-133, 186, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQLs6Eeiljfl0umr-iQ" id="(0.5169082125603864,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQbs6Eeiljfl0umr-iQ" id="(0.4027777777777778,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVdssrs6Eeiljfl0umr-iQ" points="[-163, 95, -643984, -643984]$[-163, 177, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQLs6Eeiljfl0umr-iQ" id="(0.4494047619047619,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQbs6Eeiljfl0umr-iQ" id="(0.5069444444444444,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_NzjmVLtKEeiljfl0umr-iQ" type="StereotypeCommentLink" source="_NzUVwLtKEeiljfl0umr-iQ" target="_NzjmULtKEeiljfl0umr-iQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_NzjmVbtKEeiljfl0umr-iQ"/>
@@ -2163,7 +2119,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_w72iYHk2EeiO-c_khjKlFQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_51_V87ucEeiljfl0umr-iQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_51_V9LucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_51_V9LucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OBS7sMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OBS7scG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_QkC-sLtPEeiljfl0umr-iQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_51_V9bucEeiljfl0umr-iQ"/>
         </children>
@@ -2171,7 +2130,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_2EwdE5s8EeikSLSDi2qpXA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_51_V97ucEeiljfl0umr-iQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_51_V-LucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_51_V-LucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OhwkcMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OhwkccG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_Y0j8YrucEeiljfl0umr-iQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_51_V-bucEeiljfl0umr-iQ"/>
         </children>
@@ -2743,7 +2705,10 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_wHswJJs5EeikSLSDi2qpXA" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_wHswJZs5EeikSLSDi2qpXA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_w9RBwLucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_w9RBwLucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PBP80MG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PBP80cG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_UecwQLq2EeimKvjOEffRIA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_w9RBwbucEeiljfl0umr-iQ"/>
         </children>
@@ -3511,11 +3476,17 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_J3v2UHZlEeiPPoPDo3q5jA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_m-ufgZozEeiOmuqNbykpsw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_KCLYUJs-EeikSLSDi2qpXA" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_KCLYUJs-EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Thpl4MG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Thpl4cG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_GXqq45s9EeikSLSDi2qpXA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_KCLYUZs-EeikSLSDi2qpXA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_4CPq8LudEeiljfl0umr-iQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_4CPq8LudEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ub5AkMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ub5AkcG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_tRWUMrudEeiljfl0umr-iQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_4CPq8budEeiljfl0umr-iQ"/>
         </children>
@@ -4197,7 +4168,10 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QhXBoLtQEeiljfl0umr-iQ" id="(0.26475849731663686,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QhXosLtQEeiljfl0umr-iQ" id="(0.39892665474060823,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cumakLtQEeiljfl0umr-iQ" type="Association_Edge" source="_WDKY0JqMEeid4dfn4JFJZg" target="_aiK4MJozEeiOmuqNbykpsw" routing="Rectilinear" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_cumakLtQEeiljfl0umr-iQ" type="Association_Edge" source="_WDKY0JqMEeid4dfn4JFJZg" target="_aiK4MJozEeiOmuqNbykpsw" routing="Rectilinear" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QwSRgMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QwSRgcG-EeiAg83ctgK3eQ" key="lineColor" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_cunBoLtQEeiljfl0umr-iQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dPnc8LtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBobtQEeiljfl0umr-iQ" x="1" y="-18"/>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -74,7 +74,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8Tky4pmTEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_8Tq5gZmTEeiOmuqNbykpsw" name="smcserviceinterfacepoint" type="_syPL8JmTEeiOmuqNbykpsw" association="_8Tky4JmTEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MiYj0JmUEeiOmuqNbykpsw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MiYj0JmUEeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Miq3sJmUEeiOmuqNbykpsw" value="1"/>
         </ownedEnd>
       </packagedElement>
@@ -86,7 +86,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nWzrwpmYEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_nWzryJmYEeiOmuqNbykpsw" name="olsconnectivityserviceendpoint" type="_Es15AJmWEeiOmuqNbykpsw" association="_nWzrwJmYEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uyEwMJmoEeiOmuqNbykpsw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uyEwMJmoEeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uzBycJmoEeiOmuqNbykpsw" value="1"/>
         </ownedEnd>
       </packagedElement>
@@ -104,7 +104,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qOx7AZozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_qOx7B5ozEeiOmuqNbykpsw" name="class3" type="_aiExkJozEeiOmuqNbykpsw" association="_qOr0YJozEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b0p28Jo3EeiOmuqNbykpsw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b0p28Jo3EeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_b0v9kJo3EeiOmuqNbykpsw" value="1"/>
         </ownedEnd>
       </packagedElement>
@@ -113,7 +113,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qtbl4pozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_qthsgpozEeiOmuqNbykpsw" name="class4" type="_a2384JozEeiOmuqNbykpsw" association="_qtbl4JozEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c--8EJo3EeiOmuqNbykpsw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c--8EJo3EeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c_LJUJo3EeiOmuqNbykpsw" value="1"/>
         </ownedEnd>
       </packagedElement>
@@ -326,6 +326,7 @@ License: This module is distributed under the Apache License 2.0</body>
             <body>The central frequency of the laser. It is the oscillation frequency of the corresponding electromagnetic wave</body>
           </ownedComment>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9kM10MMrEei3gLXE4_XcoA" name="spectrum" type="_wB7jIHPYEeiPPoPDo3q5jA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_F8ProHk6EeiO-c_khjKlFQ" name="applicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw">
           <ownedComment xmi:type="uml:Comment" xmi:id="_F8ProXk6EeiO-c_khjKlFQ" annotatedElement="_F8ProHk6EeiO-c_khjKlFQ">
             <body>This attribute indicates the selected Application Identifier.</body>
@@ -421,7 +422,7 @@ License: This module is distributed under the Apache License 2.0</body>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_awx_YJmYEeiOmuqNbykpsw" name="MediaChannelConfigPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_i18IoJmYEeiOmuqNbykpsw" name="spectrum" type="_wB7jIHPYEeiPPoPDo3q5jA">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xeF8kJqPEeid4dfn4JFJZg"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xeF8kJqPEeid4dfn4JFJZg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xeMDMJqPEeid4dfn4JFJZg" value="1"/>
         </ownedAttribute>
       </packagedElement>
@@ -531,11 +532,7 @@ License: This module is distributed under the Apache License 2.0</body>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3xBKOEeajhbtskMXJfw" name="CentralFrequency" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_9pCiII6TEeeyZasfnNSonw" annotatedElement="_KjQ3xBKOEeajhbtskMXJfw">
-          <body>This data-type holds the central frequency information as well frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.&#xD;
-As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:&#xD;
-193.1 + &lt;channelNumber> × &lt;adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and &lt;adjustment_granularity> is the channel spacing in THz&#xD;
-For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz&#xD;
-For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz</body>
+          <body>This data-type holds the central frequency information as well frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.</body>
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_zkZ7QMG_EeiAg83ctgK3eQ" name="frequencyConstraint" type="_nCmdAMG-EeiAg83ctgK3eQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TnDTYHPXEeiPPoPDo3q5jA" name="centralFrequency">
@@ -689,11 +686,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_nCmdAMG-EeiAg83ctgK3eQ" name="FrequencyConstraint">
         <ownedComment xmi:type="uml:Comment" xmi:id="_nki3AMG_EeiAg83ctgK3eQ" annotatedElement="_nCmdAMG-EeiAg83ctgK3eQ">
-          <body>This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.&#xD;
-As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:&#xD;
-193.1 + &lt;channelNumber> × &lt;adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and &lt;adjustment_granularity> is the channel spacing in THz&#xD;
-For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz&#xD;
-For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz</body>
+          <body>This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.</body>
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_87l7YI6VEeeyZasfnNSonw" name="adjustmentGranularity" type="_htJmYI6QEeeyZasfnNSonw">
           <ownedComment xmi:type="uml:Comment" xmi:id="_XbMmsI6WEeeyZasfnNSonw" annotatedElement="_87l7YI6VEeeyZasfnNSonw">
@@ -1044,4 +1037,6 @@ For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width i
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vsgcosG_EeiAg83ctgK3eQ" base_Property="_vsgcoMG_EeiAg83ctgK3eQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zkZ7QcG_EeiAg83ctgK3eQ" base_StructuralFeature="_zkZ7QMG_EeiAg83ctgK3eQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zkZ7QsG_EeiAg83ctgK3eQ" base_Property="_zkZ7QMG_EeiAg83ctgK3eQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9kNc4MMrEei3gLXE4_XcoA" base_StructuralFeature="_9kM10MMrEei3gLXE4_XcoA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_9kP5IMMrEei3gLXE4_XcoA" base_Property="_9kM10MMrEei3gLXE4_XcoA"/>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -39,9 +39,6 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedComment>
         <supplier xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_7OKQUIfeEeet-8tHdGGp_w" name="OtsiRoutingSpecAugmentsRouteComputePolicy" client="_YS8DkIfeEeet-8tHdGGp_w">
-        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_XCHpEHZpEeiPPoPDo3q5jA" name="OtsiGCepSpecAugmentsCep" client="_mXvsEHZlEeiPPoPDo3q5jA">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
@@ -95,15 +92,6 @@ License: This module is distributed under the Apache License 2.0</body>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_ObUMoJmaEeiOmuqNbykpsw" name="McCsepSpecAugmentsCsep" client="_UyBxsBKOEeajhbtskMXJfw">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_w_nl0JmoEeiOmuqNbykpsw" name="OtsiCsepHasMcConfigPac" memberEnd="_w_nl05moEeiOmuqNbykpsw _w_tscJmoEeiOmuqNbykpsw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_w_nl0ZmoEeiOmuqNbykpsw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_w_nl0pmoEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_w_tscJmoEeiOmuqNbykpsw" name="otsinmcconnectivityserviceendpointspec" type="_O0PLkHkwEeiO-c_khjKlFQ" association="_w_nl0JmoEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_z1zv0JmoEeiOmuqNbykpsw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_z1zv0ZmoEeiOmuqNbykpsw" value="1"/>
-        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_c-z5wJozEeiOmuqNbykpsw" name="McCepSpecAugmentsCep" client="_aiExkJozEeiOmuqNbykpsw">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
@@ -175,21 +163,20 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cr1acbtQEeiljfl0umr-iQ" value="*"/>
         </ownedEnd>
       </packagedElement>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams">
-      <packagedElement xmi:type="uml:Association" xmi:id="_Y0iHMLucEeiljfl0umr-iQ" name="OtsiTtpHasReceivePower" memberEnd="_Y0j8YrucEeiljfl0umr-iQ _Y0lxkrucEeiljfl0umr-iQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Y0j8YLucEeiljfl0umr-iQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Y0j8YbucEeiljfl0umr-iQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_Y0lxkrucEeiljfl0umr-iQ" name="otsiterminationpac" type="_KjQ3tBKOEeajhbtskMXJfw" association="_Y0iHMLucEeiljfl0umr-iQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_tRVGELudEeiljfl0umr-iQ" name="McCtpHasEgressPower" memberEnd="_tRWUMrudEeiljfl0umr-iQ _tRYwcbudEeiljfl0umr-iQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tRWUMLudEeiljfl0umr-iQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tRWUMbudEeiljfl0umr-iQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_tRYwcbudEeiljfl0umr-iQ" name="mediachannelpropertiespac" type="_nBhMkI6cEeeyZasfnNSonw" association="_tRVGELudEeiljfl0umr-iQ"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_Y0iHMLucEeiljfl0umr-iQ" name="OtsiTtpHasReceivePower" memberEnd="_Y0j8YrucEeiljfl0umr-iQ _Y0lxkrucEeiljfl0umr-iQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Y0j8YLucEeiljfl0umr-iQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Y0j8YbucEeiljfl0umr-iQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Y0lxkrucEeiljfl0umr-iQ" name="otsiterminationpac" type="_KjQ3tBKOEeajhbtskMXJfw" association="_Y0iHMLucEeiljfl0umr-iQ"/>
+      </packagedElement>
     </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_bTHgIBKOEeajhbtskMXJfw" name="ObjectClasses">
       <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3qhKOEeajhbtskMXJfw" name="OtsiGServerAdaptationPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lIJUIHZfEeiPPoPDo3q5jA" name="numberOfOtsi" isReadOnly="true">
@@ -332,18 +319,12 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYaqMHk6EeiO-c_khjKlFQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYdtgHk6EeiO-c_khjKlFQ" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_w_nl05moEeiOmuqNbykpsw" name="_nmcConfig" type="_awx_YJmYEeiOmuqNbykpsw" aggregation="composite" association="_w_nl0JmoEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_w_nl1pmoEeiOmuqNbykpsw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_w_nl15moEeiOmuqNbykpsw" value="1"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_XVi5wHk6EeiO-c_khjKlFQ" name="OtsiTerminationConfigPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_HSCZ4Hk6EeiO-c_khjKlFQ" name="centralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw">
-          <ownedComment xmi:type="uml:Comment" xmi:id="__10uILDrEeiUZaG2JnNtGQ" annotatedElement="_HSCZ4Hk6EeiO-c_khjKlFQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8MWlMMDSEeiXyMZOD9tv6w" name="centralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_PV7o0MG9EeiAg83ctgK3eQ" annotatedElement="_8MWlMMDSEeiXyMZOD9tv6w">
             <body>The central frequency of the laser. It is the oscillation frequency of the corresponding electromagnetic wave</body>
           </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HSCZ4Xk6EeiO-c_khjKlFQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HSCZ4nk6EeiO-c_khjKlFQ" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_F8ProHk6EeiO-c_khjKlFQ" name="applicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw">
           <ownedComment xmi:type="uml:Comment" xmi:id="_F8ProXk6EeiO-c_khjKlFQ" annotatedElement="_F8ProHk6EeiO-c_khjKlFQ">
@@ -371,13 +352,13 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_JfBWgLTdEeiF8sBzK2t1Sw" name="totalPowerWarnThresholdUpper">
           <ownedComment xmi:type="uml:Comment" xmi:id="_JfBWgbTdEeiF8sBzK2t1Sw" annotatedElement="_JfBWgLTdEeiF8sBzK2t1Sw">
-            <body>Configure the Max, Default and Min values for the Upper power threshold.</body>
+            <body>Allows to configure the Upper power threshold which is expected to be different from Default, but within the Min and Max values specified as OTSi SIP capability.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_JfEZ0LTdEeiF8sBzK2t1Sw" name="totalPowerWarnThresholdLower">
           <ownedComment xmi:type="uml:Comment" xmi:id="_JfEZ0bTdEeiF8sBzK2t1Sw" annotatedElement="_JfEZ0LTdEeiF8sBzK2t1Sw">
-            <body>Configure  Max, Default and Min values for lower power threshold.</body>
+            <body>Allows to configure the Lowerpower threshold which is expected to be different from Default, but within the Min and Max values specified as OTSi SIP capability.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
         </ownedAttribute>
@@ -548,40 +529,20 @@ License: This module is distributed under the Apache License 2.0</body>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3xBKOEeajhbtskMXJfw" name="CentralFrequencyOrWavelength" isLeaf="true">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3xBKOEeajhbtskMXJfw" name="CentralFrequency" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_9pCiII6TEeeyZasfnNSonw" annotatedElement="_KjQ3xBKOEeajhbtskMXJfw">
-          <body>This data-type holds the central frequency directly or optionally the information to determine the nominal central frequency of a FIXED grid (DWDM or CWDM) and FLEX grid type systems.&#xD;
+          <body>This data-type holds the central frequency information as well frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.&#xD;
 As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:&#xD;
-193.1 + &lt;channelNumber> × &lt;adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and &lt;adjustment_granularity> is the nominal central frequency granularity in THz&#xD;
+193.1 + &lt;channelNumber> × &lt;adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and &lt;adjustment_granularity> is the channel spacing in THz&#xD;
 For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz&#xD;
 For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3xRKOEeajhbtskMXJfw" name="gridType" visibility="public" type="_iHIbYI6KEeeyZasfnNSonw">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_QuSUsI6UEeeyZasfnNSonw" annotatedElement="_KjQ3xRKOEeajhbtskMXJfw">
-            <body>Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_nJd3wHk1EeiO-c_khjKlFQ" type="_iHIbYI6KEeeyZasfnNSonw" instance="_G--TMHPEEeiPPoPDo3q5jA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_87l7YI6VEeeyZasfnNSonw" name="adjustmentGranularity" type="_htJmYI6QEeeyZasfnNSonw">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_XbMmsI6WEeeyZasfnNSonw" annotatedElement="_87l7YI6VEeeyZasfnNSonw">
-            <body>Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_rJ2kAHk1EeiO-c_khjKlFQ" type="_htJmYI6QEeeyZasfnNSonw" instance="_BtiOwHPEEeiPPoPDo3q5jA"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zkZ7QMG_EeiAg83ctgK3eQ" name="frequencyConstraint" type="_nCmdAMG-EeiAg83ctgK3eQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TnDTYHPXEeiPPoPDo3q5jA" name="centralFrequency">
           <ownedComment xmi:type="uml:Comment" xmi:id="_kx5nELDmEeiUZaG2JnNtGQ" annotatedElement="_TnDTYHPXEeiPPoPDo3q5jA">
             <body>The central frequency of the laser specified in MHz. It is the oscillation frequency of the corresponding electromagnetic wave. </body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3xhKOEeajhbtskMXJfw" name="channelNumber" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_N0Dm8I6OEeeyZasfnNSonw" annotatedElement="_KjQ3xhKOEeajhbtskMXJfw">
-            <body>As per ITU-T G.694.1, this attribute is denoted as &quot;n&quot; and is used to calculate the nominal central frequency (in THz) as follows:&#xD;
-193.1 + &lt;channelNumber> × &lt;adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and adjustment_granularity is the nominal central frequency granularity in THz</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_EmfBwHPYEeiPPoPDo3q5jA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_EmfBwXPYEeiPPoPDo3q5jA" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_ujOyoC_2EeeAJ6VQzZ2ulw" name="OpticalRoutingStrategy" isLeaf="true">
@@ -667,7 +628,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
         </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_BtiOwHPEEeiPPoPDo3q5jA" name="UNCONSTRAINED"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_wB7jIHPYEeiPPoPDo3q5jA" name="Spectrum">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_wB7jIHPYEeiPPoPDo3q5jA" name="SpectrumBand">
         <ownedComment xmi:type="uml:Comment" xmi:id="_j8kaEHpKEei5LIrjJTgegQ" annotatedElement="_wB7jIHPYEeiPPoPDo3q5jA">
           <body>This data-type holds the spectrum information in termsof upper/lower frequency directly or optionally the information to determin this in terms of the nominal central frequency and spectral width for a FIXED grid (DWDM or CWDM) and FLEX grid type systems.</body>
         </ownedComment>
@@ -683,10 +644,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_kOwegHlTEeiW-bN1POS5zg" name="frequencySlot" type="_ILpCwHk3EeiO-c_khjKlFQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p5HZQHlTEeiW-bN1POS5zg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p5J1gHlTEeiW-bN1POS5zg" value="1"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vsgcoMG_EeiAg83ctgK3eQ" name="frequencyConstraint" type="_nCmdAMG-EeiAg83ctgK3eQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="__ZU_8HkzEeiO-c_khjKlFQ" name="ModulationTechnique" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4CrVMJ_EEeiO_KvaRsULdw" name="RZ"/>
@@ -696,36 +654,16 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eMvicHk3EeiO-c_khjKlFQ" name="QPSK"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_rneCMHk3EeiO-c_khjKlFQ" name="8QAM"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_s0U24Hk3EeiO-c_khjKlFQ" name="16QAM"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_t-3WUMDTEeiXyMZOD9tv6w" name="PAM4"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_x6FOsMDTEeiXyMZOD9tv6w" name="PAM8"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wu-AkLDnEeiUZaG2JnNtGQ" name="UNDEFINED"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_ILpCwHk3EeiO-c_khjKlFQ" name="FrequencySlot" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_ILpCwXk3EeiO-c_khjKlFQ" annotatedElement="_ILpCwHk3EeiO-c_khjKlFQ">
-          <body>The frequency range allocated to a slot and unavailable to other slots within a flexible grid. A frequency slot is defined by its nominal central frequency. As per ITU-T G.694.1  the slot width is calculated as follows:&#xD;
-12.5 × &lt;slotWidthNumber> where slotWidthNumber is a positive integer and 12.5 is the slot width granularity in GHz</body>
-        </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ILpCwnk3EeiO-c_khjKlFQ" name="centralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ILpCw3k3EeiO-c_khjKlFQ" name="spectralWidth">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_PU0oMLqvEeimKvjOEffRIA" annotatedElement="_ILpCw3k3EeiO-c_khjKlFQ">
-            <body>Width of the media channel spectrum specified in MHz</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ILpCxHk3EeiO-c_khjKlFQ" name="slotWidthNumber">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_ILpCxXk3EeiO-c_khjKlFQ" annotatedElement="_ILpCxHk3EeiO-c_khjKlFQ">
-            <body>As per ITU-T G.694.1, this attribute is denoted as &quot;m&quot; and is used to calculate the slot width (in GHz) as follows:&#xD;
-12.5 × m where m is a positive integer and 12.5 is the slot width granularity in GHz.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ILpCxnk3EeiO-c_khjKlFQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ILpCx3k3EeiO-c_khjKlFQ" value="1"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_01yZ8HpKEei5LIrjJTgegQ" name="LaserType" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_01yZ8XpKEei5LIrjJTgegQ" name="PUMP"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_01yZ8npKEei5LIrjJTgegQ" name="MODULATED"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_01yZ83pKEei5LIrjJTgegQ" name="PULSE"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_ErlpwIoJEeivCevppATXng" name="SpectrumType">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_ErlpwIoJEeivCevppATXng" name="PhotonicLayerQualifier">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_a9CSkIoJEeivCevppATXng" name="OTSi"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_byLK0IoJEeivCevppATXng" name="OTSiA"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dSypAIoJEeivCevppATXng" name="OTSiG"/>
@@ -748,6 +686,27 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wbE8kLqdEeimKvjOEffRIA" name="OFF"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yPxNULqdEeimKvjOEffRIA" name="PULSING"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_z39TILqdEeimKvjOEffRIA" name="UNDEFINED"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_nCmdAMG-EeiAg83ctgK3eQ" name="FrequencyConstraint">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_nki3AMG_EeiAg83ctgK3eQ" annotatedElement="_nCmdAMG-EeiAg83ctgK3eQ">
+          <body>This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.&#xD;
+As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:&#xD;
+193.1 + &lt;channelNumber> × &lt;adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and &lt;adjustment_granularity> is the channel spacing in THz&#xD;
+For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz&#xD;
+For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_87l7YI6VEeeyZasfnNSonw" name="adjustmentGranularity" type="_htJmYI6QEeeyZasfnNSonw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_XbMmsI6WEeeyZasfnNSonw" annotatedElement="_87l7YI6VEeeyZasfnNSonw">
+            <body>Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_rJ2kAHk1EeiO-c_khjKlFQ" type="_htJmYI6QEeeyZasfnNSonw" instance="_BtiOwHPEEeiPPoPDo3q5jA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3xRKOEeajhbtskMXJfw" name="gridType" visibility="public" type="_iHIbYI6KEeeyZasfnNSonw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_QuSUsI6UEeeyZasfnNSonw" annotatedElement="_KjQ3xRKOEeajhbtskMXJfw">
+            <body>Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_nJd3wHk1EeiO-c_khjKlFQ" type="_iHIbYI6KEeeyZasfnNSonw" instance="_G--TMHPEEeiPPoPDo3q5jA"/>
+        </ownedAttribute>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_MSvNkBMEEeaOevPmmmHXcA" name="Imports">
@@ -796,7 +755,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KjUiABKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3uRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJEBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3vhKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJEhKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xRKOEeajhbtskMXJfw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVwIBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xhKOEeajhbtskMXJfw" valueRange=""/>
   <OpenModel_Profile:Experimental xmi:id="_1G8qkBKOEeajhbtskMXJfw" base_Element="_KjQ3vRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_3eqI0BKOEeajhbtskMXJfw" base_Element="_KjQ3xBKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ouzcsdK-Eeau-fGWj88_Vg" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
@@ -816,12 +774,10 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXBhsEeewCs0lkpWskw" base_Property="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXRhsEeewCs0lkpWskw" base_Property="_KjQ3vhKOEeajhbtskMXJfw" attributeValueChangeNotification="YES"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncXxhsEeewCs0lkpWskw" base_Property="_KjQ3xRKOEeajhbtskMXJfw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncYBhsEeewCs0lkpWskw" base_Property="_KjQ3xhKOEeajhbtskMXJfw" attributeValueChangeNotification="NO" bitLength="LENGTH_8_BIT"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YKbQAFqoEeexvMtO2oNM9g" base_Class="_KjQ3qhKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_jtfbUYfeEeet-8tHdGGp_w" base_StructuralFeature="_jtfbUIfeEeet-8tHdGGp_w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jtfbUofeEeet-8tHdGGp_w" base_Property="_jtfbUIfeEeet-8tHdGGp_w"/>
   <OpenModel_Profile:Experimental xmi:id="_uCdrEIfeEeet-8tHdGGp_w" base_Element="_ujOyoC_2EeeAJ6VQzZ2ulw"/>
-  <OpenModel_Profile:Specify xmi:id="_CjXjUIffEeet-8tHdGGp_w" base_Abstraction="_7OKQUIfeEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_YS9RsIfeEeet-8tHdGGp_w" base_Class="_YS8DkIfeEeet-8tHdGGp_w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YS8qoIfeEeet-8tHdGGp_w" base_Class="_YS8DkIfeEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KjTT4BKOEeajhbtskMXJfw" base_Class="_KjQ3rRKOEeajhbtskMXJfw" support="CONDITIONAL_MANDATORY" condition="OTSiA"/>
@@ -857,8 +813,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_Lv2GAHNoEeiPPoPDo3q5jA" base_Element="_KjQ3rRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_NG-4EHNoEeiPPoPDo3q5jA" base_Element="_YS8DkIfeEeet-8tHdGGp_w"/>
   <OpenModel_Profile:Experimental xmi:id="_OQvVcHNoEeiPPoPDo3q5jA" base_Element="_VvSIYEUIEead1bezhJG4aw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TnDTYXPXEeiPPoPDo3q5jA" base_Property="_TnDTYHPXEeiPPoPDo3q5jA" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_TnDTYnPXEeiPPoPDo3q5jA" base_StructuralFeature="_TnDTYHPXEeiPPoPDo3q5jA" valueRange="" unit="MHz"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_16WvEXPYEeiPPoPDo3q5jA" base_Property="_16WvEHPYEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_16WvEnPYEeiPPoPDo3q5jA" base_StructuralFeature="_16WvEHPYEeiPPoPDo3q5jA" unit="MHz"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_53PbYXPYEeiPPoPDo3q5jA" base_Property="_53PbYHPYEeiPPoPDo3q5jA"/>
@@ -900,16 +854,8 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_4yodwI6cEeeyZasfnNSonw" base_Element="_nBhMkI6cEeeyZasfnNSonw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w72iYXk2EeiO-c_khjKlFQ" base_Property="_w72iYHk2EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_w72iYnk2EeiO-c_khjKlFQ" base_StructuralFeature="_w72iYHk2EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ILpCyXk3EeiO-c_khjKlFQ" base_Property="_ILpCwnk3EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ILvJYHk3EeiO-c_khjKlFQ" base_StructuralFeature="_ILpCwnk3EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ILvJYXk3EeiO-c_khjKlFQ" base_Property="_ILpCw3k3EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ILvJYnk3EeiO-c_khjKlFQ" base_StructuralFeature="_ILpCw3k3EeiO-c_khjKlFQ" unit="MHz"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ILvJY3k3EeiO-c_khjKlFQ" base_Property="_ILpCxHk3EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ILvJZHk3EeiO-c_khjKlFQ" base_StructuralFeature="_ILpCxHk3EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F8QSsHk6EeiO-c_khjKlFQ" base_Property="_F8ProHk6EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_F8SH4Hk6EeiO-c_khjKlFQ" base_StructuralFeature="_F8ProHk6EeiO-c_khjKlFQ" valueRange="null"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HSDA8Hk6EeiO-c_khjKlFQ" base_Property="_HSCZ4Hk6EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_HSE2IHk6EeiO-c_khjKlFQ" base_StructuralFeature="_HSCZ4Hk6EeiO-c_khjKlFQ" valueRange="null" unit="null"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NK1ZQHk6EeiO-c_khjKlFQ" base_Property="_NK0yMHk6EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_NK31gHk6EeiO-c_khjKlFQ" base_StructuralFeature="_NK0yMHk6EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_aZlSgHk6EeiO-c_khjKlFQ" base_Property="_aZkrcnk6EeiO-c_khjKlFQ"/>
@@ -917,7 +863,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_aZnHsHk6EeiO-c_khjKlFQ" base_Property="_aZmgoHk6EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_aZnHsXk6EeiO-c_khjKlFQ" base_StructuralFeature="_aZmgoHk6EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_hspQcHk6EeiO-c_khjKlFQ" base_Association="_aZjdUHk6EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:Experimental xmi:id="_J2lk0Hk7EeiO-c_khjKlFQ" base_Element="_ILpCwHk3EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_XVkH4Hk6EeiO-c_khjKlFQ" base_Class="_XVi5wHk6EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_XVjg0Hk6EeiO-c_khjKlFQ" base_Class="_XVi5wHk6EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:Experimental xmi:id="_qXjyIHk6EeiO-c_khjKlFQ" base_Element="_XVi5wHk6EeiO-c_khjKlFQ"/>
@@ -948,8 +893,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_vzX9wHk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsHk-EeiW-bN1POS5zg" valueRange="" unit="dBm"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzYk0Hk-EeiW-bN1POS5zg" base_Property="_vzXWsXk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_32_BIT"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_vzYk0Xk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsXk-EeiW-bN1POS5zg" valueRange="" unit="nW/MHz"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_kOxFkHlTEeiW-bN1POS5zg" base_Property="_kOwegHlTEeiW-bN1POS5zg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_kOxsoHlTEeiW-bN1POS5zg" base_StructuralFeature="_kOwegHlTEeiW-bN1POS5zg"/>
   <OpenModel_Profile:Experimental xmi:id="_2KBpAHpKEei5LIrjJTgegQ" base_Element="_01yZ8HpKEei5LIrjJTgegQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_qzUroHk7EeiO-c_khjKlFQ" base_Class="_qzTdgHk7EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_qzUEkHk7EeiO-c_khjKlFQ" base_Class="_qzTdgHk7EeiO-c_khjKlFQ"/>
@@ -972,12 +915,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nWzrxZmYEeiOmuqNbykpsw" base_Property="_nWzrw5mYEeiOmuqNbykpsw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nWzryZmYEeiOmuqNbykpsw" base_StructuralFeature="_nWzryJmYEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nWzrypmYEeiOmuqNbykpsw" base_Property="_nWzryJmYEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_w_nl1JmoEeiOmuqNbykpsw" base_StructuralFeature="_w_nl05moEeiOmuqNbykpsw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w_nl1ZmoEeiOmuqNbykpsw" base_Property="_w_nl05moEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_w_tscZmoEeiOmuqNbykpsw" base_StructuralFeature="_w_tscJmoEeiOmuqNbykpsw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w_tscpmoEeiOmuqNbykpsw" base_Property="_w_tscJmoEeiOmuqNbykpsw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_85XbAJmoEeiOmuqNbykpsw" base_Association="_nWzrwJmYEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_JBxXQJmpEeiOmuqNbykpsw" base_Association="_w_nl0JmoEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Specify xmi:id="_6wAP4JmqEeiOmuqNbykpsw" base_Abstraction="_ObUMoJmaEeiOmuqNbykpsw">
     <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
   </OpenModel_Profile:Specify>
@@ -1096,4 +1034,14 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_tRYwc7udEeiljfl0umr-iQ" base_StructuralFeature="_tRYwcbudEeiljfl0umr-iQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_1EaA0LudEeiljfl0umr-iQ" base_Association="_tRVGELudEeiljfl0umr-iQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="__Rzo8LudEeiljfl0umr-iQ" base_Association="_eDYeMLs6Eeiljfl0umr-iQ"/>
+  <OpenModel_Profile:Cond xmi:id="_l0rdwMDAEeiXyMZOD9tv6w" condition="WHEN layer-protocol-name=PHOTONIC_MEDIA" base_Relationship="_Y9qecHiHEeiPPoPDo3q5jA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8MWlMcDSEeiXyMZOD9tv6w" base_Property="_8MWlMMDSEeiXyMZOD9tv6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8Md58MDSEeiXyMZOD9tv6w" base_StructuralFeature="_8MWlMMDSEeiXyMZOD9tv6w"/>
+  <OpenModel_Profile:Experimental xmi:id="_sIIzcMG-EeiAg83ctgK3eQ" base_Element="_nCmdAMG-EeiAg83ctgK3eQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IYC-wMG_EeiAg83ctgK3eQ" base_StructuralFeature="_TnDTYHPXEeiPPoPDo3q5jA" unit="MHz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IbAMIMG_EeiAg83ctgK3eQ" base_Property="_TnDTYHPXEeiPPoPDo3q5jA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vsgcocG_EeiAg83ctgK3eQ" base_StructuralFeature="_vsgcoMG_EeiAg83ctgK3eQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vsgcosG_EeiAg83ctgK3eQ" base_Property="_vsgcoMG_EeiAg83ctgK3eQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zkZ7QcG_EeiAg83ctgK3eQ" base_StructuralFeature="_zkZ7QMG_EeiAg83ctgK3eQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zkZ7QsG_EeiAg83ctgK3eQ" base_Property="_zkZ7QMG_EeiAg83ctgK3eQ"/>
 </xmi:XMI>

--- a/YANG/tapi-photonic-media@2018-08-31.tree
+++ b/YANG/tapi-photonic-media@2018-08-31.tree
@@ -88,6 +88,12 @@ module: tapi-photonic-media
        |  |  +--rw adjustment-granularity?   adjustment-granularity
        |  |  +--rw grid-type?                grid-type
        |  +--rw central-frequency?      uint64
+       +--rw spectrum
+       |  +--rw upper-frequency?        uint64
+       |  +--rw lower-frequency?        uint64
+       |  +--rw frequency-constraint
+       |     +--rw adjustment-granularity?   adjustment-granularity
+       |     +--rw grid-type?                grid-type
        +--rw application-identifier
        |  +--rw application-identifier-type?   application-identifier-type
        |  +--rw application-code?              string

--- a/YANG/tapi-photonic-media@2018-08-31.tree
+++ b/YANG/tapi-photonic-media@2018-08-31.tree
@@ -3,25 +3,20 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
     +--ro otsi-termination
        +--ro selected-central-frequency
-       |  +--ro grid-type?                grid-type
-       |  +--ro adjustment-granularity?   adjustment-granularity
-       |  +--ro central-frequency?        uint64
-       |  +--ro channel-number?           uint64
+       |  +--ro frequency-constraint
+       |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  +--ro grid-type?                grid-type
+       |  +--ro central-frequency?      uint64
        +--ro selected-application-identifier
        |  +--ro application-identifier-type?   application-identifier-type
        |  +--ro application-code?              string
        +--ro selected-modulation?               modulation-technique
        +--ro selected-spectrum
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro transmited-power
        |  +--ro total-power?              decimal64
        |  +--ro power-spectral-density?   decimal64
@@ -36,38 +31,23 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
     +--ro mc-pool
        +--ro supportable-spectrum* []
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro available-spectrum* []
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro occupied-spectrum* []
-          +--ro upper-frequency?   uint64
-          +--ro lower-frequency?   uint64
-          +--ro frequency-slot
-             +--ro central-frequency
-             |  +--ro grid-type?                grid-type
-             |  +--ro adjustment-granularity?   adjustment-granularity
-             |  +--ro central-frequency?        uint64
-             |  +--ro channel-number?           uint64
-             +--ro spectral-width?      uint64
-             +--ro slot-width-number?   uint64
+          +--ro upper-frequency?        uint64
+          +--ro lower-frequency?        uint64
+          +--ro frequency-constraint
+             +--ro adjustment-granularity?   adjustment-granularity
+             +--ro grid-type?                grid-type
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
     +--ro otsi-adapter
     |  +--ro number-of-otsi?   uint64
@@ -81,15 +61,15 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-common:service-interface-point:
     +--ro otsi-capability
        +--ro supportable-lower-central-frequency* []
-       |  +--ro grid-type?                grid-type
-       |  +--ro adjustment-granularity?   adjustment-granularity
-       |  +--ro central-frequency?        uint64
-       |  +--ro channel-number?           uint64
+       |  +--ro frequency-constraint
+       |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  +--ro grid-type?                grid-type
+       |  +--ro central-frequency?      uint64
        +--ro supportable-upper-central-frequency* []
-       |  +--ro grid-type?                grid-type
-       |  +--ro adjustment-granularity?   adjustment-granularity
-       |  +--ro central-frequency?        uint64
-       |  +--ro channel-number?           uint64
+       |  +--ro frequency-constraint
+       |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  +--ro grid-type?                grid-type
+       |  +--ro central-frequency?      uint64
        +--ro supportable-application-identifier* []
        |  +--ro application-identifier-type?   application-identifier-type
        |  +--ro application-code?              string
@@ -103,116 +83,69 @@ module: tapi-photonic-media
           +--ro total-power-lower-warn-threshold-min?       decimal64
   augment /tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
     +--rw otsi-config
-    |  +--rw central-frequency
-    |  |  +--rw grid-type?                grid-type
-    |  |  +--rw adjustment-granularity?   adjustment-granularity
-    |  |  +--rw central-frequency?        uint64
-    |  |  +--rw channel-number?           uint64
-    |  +--rw application-identifier
-    |  |  +--rw application-identifier-type?   application-identifier-type
-    |  |  +--rw application-code?              string
-    |  +--rw modulation?                         modulation-technique
-    |  +--rw laser-control?                      laser-control-type
-    |  +--rw transmit-power
-    |  |  +--rw total-power?              decimal64
-    |  |  +--ro power-spectral-density?   decimal64
-    |  +--rw total-power-warn-threshold-upper?   decimal64
-    |  +--rw total-power-warn-threshold-lower?   decimal64
-    +--rw nmc-config
-       +--rw spectrum
-          +--rw upper-frequency?   uint64
-          +--rw lower-frequency?   uint64
-          +--rw frequency-slot
-             +--rw central-frequency
-             |  +--rw grid-type?                grid-type
-             |  +--rw adjustment-granularity?   adjustment-granularity
-             |  +--rw central-frequency?        uint64
-             |  +--rw channel-number?           uint64
-             +--rw spectral-width?      uint64
-             +--rw slot-width-number?   uint64
+       +--rw central-frequency
+       |  +--rw frequency-constraint
+       |  |  +--rw adjustment-granularity?   adjustment-granularity
+       |  |  +--rw grid-type?                grid-type
+       |  +--rw central-frequency?      uint64
+       +--rw application-identifier
+       |  +--rw application-identifier-type?   application-identifier-type
+       |  +--rw application-code?              string
+       +--rw modulation?                         modulation-technique
+       +--rw laser-control?                      laser-control-type
+       +--rw transmit-power
+       |  +--rw total-power?              decimal64
+       |  +--ro power-spectral-density?   decimal64
+       +--rw total-power-warn-threshold-upper?   decimal64
+       +--rw total-power-warn-threshold-lower?   decimal64
   augment /tapi-common:context/tapi-common:service-interface-point:
     +--ro mc-pool
        +--ro supportable-spectrum* []
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro available-spectrum* []
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro occupied-spectrum* []
-          +--ro upper-frequency?   uint64
-          +--ro lower-frequency?   uint64
-          +--ro frequency-slot
-             +--ro central-frequency
-             |  +--ro grid-type?                grid-type
-             |  +--ro adjustment-granularity?   adjustment-granularity
-             |  +--ro central-frequency?        uint64
-             |  +--ro channel-number?           uint64
-             +--ro spectral-width?      uint64
-             +--ro slot-width-number?   uint64
+          +--ro upper-frequency?        uint64
+          +--ro lower-frequency?        uint64
+          +--ro frequency-constraint
+             +--ro adjustment-granularity?   adjustment-granularity
+             +--ro grid-type?                grid-type
   augment /tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
     +--ro mc-pool
        +--ro supportable-spectrum* []
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro available-spectrum* []
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro occupied-spectrum* []
-          +--ro upper-frequency?   uint64
-          +--ro lower-frequency?   uint64
-          +--ro frequency-slot
-             +--ro central-frequency
-             |  +--ro grid-type?                grid-type
-             |  +--ro adjustment-granularity?   adjustment-granularity
-             |  +--ro central-frequency?        uint64
-             |  +--ro channel-number?           uint64
-             +--ro spectral-width?      uint64
-             +--ro slot-width-number?   uint64
+          +--ro upper-frequency?        uint64
+          +--ro lower-frequency?        uint64
+          +--ro frequency-constraint
+             +--ro adjustment-granularity?   adjustment-granularity
+             +--ro grid-type?                grid-type
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
     +--ro media-channel
        +--ro occupied-spectrum
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro measured-power-ingress
        |  +--ro total-power?              decimal64
        |  +--ro power-spectral-density?   decimal64
@@ -222,16 +155,11 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
     +--ro ots-media-channel
        +--ro occupied-spectrum
-       |  +--ro upper-frequency?   uint64
-       |  +--ro lower-frequency?   uint64
-       |  +--ro frequency-slot
-       |     +--ro central-frequency
-       |     |  +--ro grid-type?                grid-type
-       |     |  +--ro adjustment-granularity?   adjustment-granularity
-       |     |  +--ro central-frequency?        uint64
-       |     |  +--ro channel-number?           uint64
-       |     +--ro spectral-width?      uint64
-       |     +--ro slot-width-number?   uint64
+       |  +--ro upper-frequency?        uint64
+       |  +--ro lower-frequency?        uint64
+       |  +--ro frequency-constraint
+       |     +--ro adjustment-granularity?   adjustment-granularity
+       |     +--ro grid-type?                grid-type
        +--ro measured-power-ingress
        |  +--ro total-power?              decimal64
        |  +--ro power-spectral-density?   decimal64

--- a/YANG/tapi-photonic-media@2018-08-31.yang
+++ b/YANG/tapi-photonic-media@2018-08-31.yang
@@ -111,7 +111,7 @@ module tapi-photonic-media {
         grouping otsi-termination-pac {
             container selected-central-frequency {
                 config false;
-                uses central-frequency-or-wavelength;
+                uses central-frequency;
                 description "none";
             }
             container selected-application-identifier {
@@ -127,7 +127,7 @@ module tapi-photonic-media {
             }
             container selected-spectrum {
                 config false;
-                uses spectrum;
+                uses spectrum-band;
                 description "none";
             }
             container transmited-power {
@@ -149,17 +149,17 @@ module tapi-photonic-media {
         grouping media-channel-pool-capability-pac {
             list supportable-spectrum {
                 config false;
-                uses spectrum;
+                uses spectrum-band;
                 description "none";
             }
             list available-spectrum {
                 config false;
-                uses spectrum;
+                uses spectrum-band;
                 description "none";
             }
             list occupied-spectrum {
                 config false;
-                uses spectrum;
+                uses spectrum-band;
                 description "none";
             }
             description "none";
@@ -182,7 +182,7 @@ module tapi-photonic-media {
         grouping media-channel-properties-pac {
             container occupied-spectrum {
                 config false;
-                uses spectrum;
+                uses spectrum-band;
                 description "none";
             }
             container measured-power-ingress {
@@ -212,12 +212,12 @@ module tapi-photonic-media {
         grouping otsi-capability-pac {
             list supportable-lower-central-frequency {
                 config false;
-                uses central-frequency-or-wavelength;
+                uses central-frequency;
                 description "The lower frequency of the channel spectrum";
             }
             list supportable-upper-central-frequency {
                 config false;
-                uses central-frequency-or-wavelength;
+                uses central-frequency;
                 description "The Upper frequency of the channel spectrum";
             }
             list supportable-application-identifier {
@@ -250,15 +250,11 @@ module tapi-photonic-media {
                 uses otsi-termination-config-pac;
                 description "none";
             }
-            container nmc-config {
-                uses media-channel-config-pac;
-                description "none";
-            }
             description "none";
         }
         grouping otsi-termination-config-pac {
             container central-frequency {
-                uses central-frequency-or-wavelength;
+                uses central-frequency;
                 description "The central frequency of the laser. It is the oscillation frequency of the corresponding electromagnetic wave";
             }
             container application-identifier {
@@ -281,13 +277,13 @@ module tapi-photonic-media {
             	type decimal64 {
                 	fraction-digits 7;
                 }
-                description "Configure the Max, Default and Min values for the Upper power threshold.";
+                description "Allows to configure the Upper power threshold which is expected to be different from Default, but within the Min and Max values specified as OTSi SIP capability.";
             }
             leaf total-power-warn-threshold-lower {
             	type decimal64 {
                 	fraction-digits 7;
                 }
-                description "Configure  Max, Default and Min values for lower power threshold.";
+                description "Allows to configure the Lowerpower threshold which is expected to be different from Default, but within the Min and Max values specified as OTSi SIP capability.";
             }
             description "none";
         }
@@ -341,7 +337,7 @@ module tapi-photonic-media {
         }
         grouping media-channel-config-pac {
             container spectrum {
-                uses spectrum;
+                uses spectrum-band;
                 description "none";
             }
             description "none";
@@ -397,16 +393,14 @@ module tapi-photonic-media {
             	type decimal64 {
                 	fraction-digits 7;
                 }
-                description "The total power at any point in a channel specified in dBm.
-                    range of type : -99.000..99.000";
+                description "The total power at any point in a channel specified in dBm.";
             }
             leaf power-spectral-density {
             	type decimal64 {
                 	fraction-digits 7;
                 }
                 config false;
-                description "This describes how power of a signal  is distributed over frequency specified in nW/MHz
-                    range of type : -2147483648..2147483648";
+                description "This describes how power of a signal  is distributed over frequency specified in nW/MHz";
             }
             description "Indication with severity warning raised when a total power value measured is above the threshold.";
         }
@@ -453,48 +447,48 @@ module tapi-photonic-media {
     /***********************
     * package type-definitions
     **********************/ 
-        identity SPECTRUM_TYPE {
+        identity PHOTONIC_LAYER_QUALIFIER {
         	base tapi-common:LAYER_PROTOCOL_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_OTSi {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_OTSi {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_OTSiA {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_OTSiA {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_OTSiG {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_OTSiG {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_NMC {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_NMC {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_NMCA {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_NMCA {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_SMC {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_SMC {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_SMCA {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_SMCA {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_OCH {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_OCH {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_OMS {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_OMS {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
-        identity SPECTRUM_TYPE_OTS {
-            base SPECTRUM_TYPE;
+        identity PHOTONIC_LAYER_QUALIFIER_OTS {
+            base PHOTONIC_LAYER_QUALIFIER;
             description "none";
         }
         grouping application-identifier {
@@ -508,27 +502,18 @@ module tapi-photonic-media {
             }
             description "The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.";
         }
-        grouping central-frequency-or-wavelength {
-            leaf grid-type {
-                type grid-type;
-                description "Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width";
-            }
-            leaf adjustment-granularity {
-                type adjustment-granularity;
-                description "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)";
+        grouping central-frequency {
+            container frequency-constraint {
+                uses frequency-constraint;
+                description "none";
             }
             leaf central-frequency {
                 type uint64;
                 description "The central frequency of the laser specified in MHz. It is the oscillation frequency of the corresponding electromagnetic wave. ";
             }
-            leaf channel-number {
-                type uint64;
-                description "As per ITU-T G.694.1, this attribute is denoted as 'n' and is used to calculate the nominal central frequency (in THz) as follows:
-                    193.1 + <channelNumber> × <adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and adjustment_granularity is the nominal central frequency granularity in THz";
-            }
-            description "This data-type holds the central frequency directly or optionally the information to determine the nominal central frequency of a FIXED grid (DWDM or CWDM) and FLEX grid type systems.
+            description "This data-type holds the central frequency information as well frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.
                 As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:
-                193.1 + <channelNumber> × <adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and <adjustment_granularity> is the nominal central frequency granularity in THz
+                193.1 + <channelNumber> × <adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and <adjustment_granularity> is the channel spacing in THz
                 For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz
                 For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz";
         }
@@ -627,7 +612,7 @@ module tapi-photonic-media {
             }
             description "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency";
         }
-        grouping spectrum {
+        grouping spectrum-band {
             leaf upper-frequency {
                 type uint64;
                 description "The upper frequency bound of the media channel spectrum specified in MHz";
@@ -636,8 +621,8 @@ module tapi-photonic-media {
                 type uint64;
                 description "The lower frequency bound of the media channel spectrum specified in MHz";
             }
-            container frequency-slot {
-                uses frequency-slot;
+            container frequency-constraint {
+                uses frequency-constraint;
                 description "none";
             }
             description "This data-type holds the spectrum information in termsof upper/lower frequency directly or optionally the information to determin this in terms of the nominal central frequency and spectral width for a FIXED grid (DWDM or CWDM) and FLEX grid type systems.";
@@ -665,28 +650,17 @@ module tapi-photonic-media {
                 enum 16QAM {
                     description "none";
                 }
+                enum PAM4 {
+                    description "none";
+                }
+                enum PAM8 {
+                    description "none";
+                }
                 enum UNDEFINED {
                     description "none";
                 }
             }
             description "none";
-        }
-        grouping frequency-slot {
-            container central-frequency {
-                uses central-frequency-or-wavelength;
-                description "none";
-            }
-            leaf spectral-width {
-                type uint64;
-                description "Width of the media channel spectrum specified in MHz";
-            }
-            leaf slot-width-number {
-                type uint64;
-                description "As per ITU-T G.694.1, this attribute is denoted as 'm' and is used to calculate the slot width (in GHz) as follows:
-                    12.5 × m where m is a positive integer and 12.5 is the slot width granularity in GHz.";
-            }
-            description "The frequency range allocated to a slot and unavailable to other slots within a flexible grid. A frequency slot is defined by its nominal central frequency. As per ITU-T G.694.1  the slot width is calculated as follows:
-                12.5 × <slotWidthNumber> where slotWidthNumber is a positive integer and 12.5 is the slot width granularity in GHz";
         }
         typedef laser-type {
             type enumeration {
@@ -702,9 +676,9 @@ module tapi-photonic-media {
             }
             description "none";
         }
-        typedef spectrum-type {
+        typedef photonic-layer-qualifier {
             type identityref {
-                base SPECTRUM_TYPE;
+                base PHOTONIC_LAYER_QUALIFIER;
             }
             description "none";
         }
@@ -741,6 +715,21 @@ module tapi-photonic-media {
                 }
             }
             description "none";
+        }
+        grouping frequency-constraint {
+            leaf adjustment-granularity {
+                type adjustment-granularity;
+                description "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)";
+            }
+            leaf grid-type {
+                type grid-type;
+                description "Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width";
+            }
+            description "This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.
+                As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:
+                193.1 + <channelNumber> × <adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and <adjustment_granularity> is the channel spacing in THz
+                For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz
+                For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz";
         }
 
 }

--- a/YANG/tapi-photonic-media@2018-08-31.yang
+++ b/YANG/tapi-photonic-media@2018-08-31.yang
@@ -257,6 +257,10 @@ module tapi-photonic-media {
                 uses central-frequency;
                 description "The central frequency of the laser. It is the oscillation frequency of the corresponding electromagnetic wave";
             }
+            container spectrum {
+                uses spectrum-band;
+                description "none";
+            }
             container application-identifier {
                 uses application-identifier;
                 description "This attribute indicates the selected Application Identifier.";
@@ -511,11 +515,7 @@ module tapi-photonic-media {
                 type uint64;
                 description "The central frequency of the laser specified in MHz. It is the oscillation frequency of the corresponding electromagnetic wave. ";
             }
-            description "This data-type holds the central frequency information as well frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.
-                As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:
-                193.1 + <channelNumber> × <adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and <adjustment_granularity> is the channel spacing in THz
-                For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz
-                For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz";
+            description "This data-type holds the central frequency information as well frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.";
         }
         typedef optical-routing-strategy {
             type enumeration {
@@ -725,11 +725,7 @@ module tapi-photonic-media {
                 type grid-type;
                 description "Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width";
             }
-            description "This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.
-                As per ITU-T G.694.1, the nominal central frequency (in THz) is calculated as follows:
-                193.1 + <channelNumber> × <adjustmentGranularity> where channelNumber is a positive or negative integer including 0 and <adjustment_granularity> is the channel spacing in THz
-                For FIXED grid types, the adjustmentGranularity is one of (0.1/0.05/0.025/0.0125) THz corresponding to channel spacing of one of (100/50/25/12.5) GHz
-                For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width is variable in increments of 12.5 GHz";
+            description "This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.";
         }
 
 }


### PR DESCRIPTION
- Renamed CentralFrequencyOrWavelength data-type to CentralFrequency
- Renamed Spectrum data-type to SpectrumBand
- Removed support for legacy definitions (m,n) of channel-number and
frequency-slot to compute CentralFrequency & SpectrumBand
- Refactored the frequency constraints properties of CentralFrequency
(grid-type and adjustment-granularity) into a separate (new) data-type
FrequencyConstraint.
- Added FrequencyConstraint property to CentralFrequency and
SpectrumBand data-types
- Renamed SpectrumType enumeration to PhotonicLayerQualifier
- Added 2 additional ModulationTechniques: PAM4 & PAM8
- Clarified comments/descriptions for threshold/power configuration
attributes