### PR TITLE
Fix #356 - wrap "uses grouping" statement with a container for augments

### DIFF
--- a/OAS/tapi-connectivity@2018-08-31.yaml
+++ b/OAS/tapi-connectivity@2018-08-31.yaml
@@ -71,419 +71,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/connection={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.Connection"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.Connection"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.Connection"
-        400:
-          description: "Internal error"
-  /data/context/connection={uuid}/switch-control={switch-control-uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.SwitchControl"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      - name: "switch-control-uuid"
-        in: "path"
-        description: "Id of switch-control"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.SwitchControl"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.SwitchControl"
-        400:
-          description: "Internal error"
-  /data/context/connectivity-service/:
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/connectivity-service={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ConnectivityService"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-connectivity"
-      description: "creates or updates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-connectivity"
-      description: "removes tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -582,192 +169,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.node.OwnedNodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.node.OwnedNodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        400:
-          description: "Internal error"
-  ? /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/connection-end-point={connection-end-point-uuid}/
-  : get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ConnectionEndPoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      - name: "connection-end-point-uuid"
-        in: "path"
-        description: "Id of connection-end-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ConnectionEndPoint"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -1598,44 +999,6 @@ definitions:
         \ protocol including all circuit and packet forms.\r\n                At the\
         \ lowest level of recursion, a FC represents a cross-connection within an\
         \ NE."
-  tapi.connectivity.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - $ref: "#/definitions/tapi.common.TerminationPac"
-    - type: "object"
-      properties:
-        client-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        connection-port-role:
-          description: "Each EP of the FC has a role (e.g., working, protection, protected,\
-            \ symmetric, hub, spoke, leaf, root)  in the context of the FC with respect\
-            \ to the FC function. "
-          $ref: "#/definitions/tapi.common.PortRole"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        layer-protocol-qualifier:
-          type: "string"
-          description: "none"
-        parent-node-edge-point:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        aggregated-connection-end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPointRef"
-        connection-port-direction:
-          description: "The orientation of defined flow at the EndPoint."
-          $ref: "#/definitions/tapi.common.PortDirection"
-      description: "The LogicalTerminationPoint (LTP) object class encapsulates the\
-        \ termination and adaptation functions of one or more transport layers. \r\
-        \n                The structure of LTP supports all transport protocols including\
-        \ circuit and packet forms."
   tapi.connectivity.ConnectionEndPointRef:
     allOf:
     - $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
@@ -1644,7 +1007,7 @@ definitions:
         connection-end-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.ConnectionRef:
     type: "object"
@@ -1652,7 +1015,7 @@ definitions:
       connection-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid"
   tapi.connectivity.ConnectivityConstraint:
     type: "object"
     properties:
@@ -1684,6 +1047,19 @@ definitions:
       coroute-inclusion:
         description: "none"
         $ref: "#/definitions/tapi.connectivity.ConnectivityServiceRef"
+  tapi.connectivity.ConnectivityContext:
+    type: "object"
+    properties:
+      connectivity-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
+      connection:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.Connection"
   tapi.connectivity.ConnectivityService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -1761,20 +1137,13 @@ definitions:
       connectivity-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
   tapi.connectivity.ContextAugmentation3:
     type: "object"
     properties:
-      connectivity-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      connection:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.Connection"
+      connectivity-context:
+        description: "Augments the base TAPI Context with ConnectivityService information"
+        $ref: "#/definitions/tapi.connectivity.ConnectivityContext"
     x-augmentation:
       prefix: "tapi-connectivity"
       namespace: "urn:onf:otcc:yang:tapi-connectivity"
@@ -1804,17 +1173,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.getconnectivityservicelist.Output"
-  tapi.connectivity.OwnedNodeEdgePointAugmentation1:
-    type: "object"
-    properties:
-      connection-end-point:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-    x-augmentation:
-      prefix: "tapi-connectivity"
-      namespace: "urn:onf:otcc:yang:tapi-connectivity"
   tapi.connectivity.ProtectionRole:
     type: "string"
     enum:
@@ -1914,7 +1272,7 @@ definitions:
         route-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.SelectionControl:
     type: "string"
@@ -2020,7 +1378,7 @@ definitions:
         switch-control-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.UpdateConnectivityService:
     type: "object"
@@ -2150,16 +1508,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -2277,6 +1628,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2543,16 +1907,9 @@ definitions:
   tapi.path.computation.ContextAugmentation2:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -2597,6 +1954,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2661,7 +2031,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -2852,14 +2222,9 @@ definitions:
   tapi.topology.ContextAugmentation4:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -3007,7 +2372,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -3107,7 +2472,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -3117,7 +2482,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -3157,7 +2522,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -3264,13 +2629,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -3413,41 +2789,3 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.topology.Topology"
-  tapi.topology.node.OwnedNodeEdgePoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.OwnedNodeEdgePointAugmentation1"
-    - $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-  tapi.topology.topology.Node:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.CapacityPac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.topology.TransferCostPac"
-    - $ref: "#/definitions/tapi.topology.TransferIntegrityPac"
-    - $ref: "#/definitions/tapi.topology.TransferTimingPac"
-    - type: "object"
-      properties:
-        layer-protocol-name:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.common.LayerProtocolName"
-        encap-topology:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.TopologyRef"
-        owned-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        node-rule-group:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        aggregated-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-      description: "none"

--- a/OAS/tapi-dsr@2018-08-31.yaml
+++ b/OAS/tapi-dsr@2018-08-31.yaml
@@ -71,731 +71,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/connection={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.Connection"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.Connection"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.Connection"
-        400:
-          description: "Internal error"
-  /data/context/connection={uuid}/switch-control={switch-control-uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.SwitchControl"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      - name: "switch-control-uuid"
-        in: "path"
-        description: "Id of switch-control"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.SwitchControl"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.SwitchControl"
-        400:
-          description: "Internal error"
-  /data/context/connectivity-service/:
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/connectivity-service={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ConnectivityService"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-connectivity"
-      description: "creates or updates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-connectivity"
-      description: "removes tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/meg={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.Meg"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of meg"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.Meg"
-          schema:
-            $ref: "#/definitions/tapi.oam.Meg"
-        400:
-          description: "Internal error"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/oam-job/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-job={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamJob"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamJob"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-profile/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-profile={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamProfile"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamProfile"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-service/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-service={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamService"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -894,192 +169,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.node.OwnedNodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.node.OwnedNodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        400:
-          description: "Internal error"
-  ? /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/connection-end-point={connection-end-point-uuid}/
-  : get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ceplist.ConnectionEndPoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      - name: "connection-end-point-uuid"
-        in: "path"
-        description: "Id of connection-end-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ceplist.ConnectionEndPoint"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -2217,44 +1306,6 @@ definitions:
         \ protocol including all circuit and packet forms.\r\n                At the\
         \ lowest level of recursion, a FC represents a cross-connection within an\
         \ NE."
-  tapi.connectivity.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - $ref: "#/definitions/tapi.common.TerminationPac"
-    - type: "object"
-      properties:
-        client-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        connection-port-role:
-          description: "Each EP of the FC has a role (e.g., working, protection, protected,\
-            \ symmetric, hub, spoke, leaf, root)  in the context of the FC with respect\
-            \ to the FC function. "
-          $ref: "#/definitions/tapi.common.PortRole"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        layer-protocol-qualifier:
-          type: "string"
-          description: "none"
-        parent-node-edge-point:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        aggregated-connection-end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPointRef"
-        connection-port-direction:
-          description: "The orientation of defined flow at the EndPoint."
-          $ref: "#/definitions/tapi.common.PortDirection"
-      description: "The LogicalTerminationPoint (LTP) object class encapsulates the\
-        \ termination and adaptation functions of one or more transport layers. \r\
-        \n                The structure of LTP supports all transport protocols including\
-        \ circuit and packet forms."
   tapi.connectivity.ConnectionEndPointRef:
     allOf:
     - $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
@@ -2263,7 +1314,7 @@ definitions:
         connection-end-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.ConnectionRef:
     type: "object"
@@ -2271,7 +1322,7 @@ definitions:
       connection-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid"
   tapi.connectivity.ConnectivityConstraint:
     type: "object"
     properties:
@@ -2303,6 +1354,19 @@ definitions:
       coroute-inclusion:
         description: "none"
         $ref: "#/definitions/tapi.connectivity.ConnectivityServiceRef"
+  tapi.connectivity.ConnectivityContext:
+    type: "object"
+    properties:
+      connectivity-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
+      connection:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.Connection"
   tapi.connectivity.ConnectivityService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -2382,7 +1446,7 @@ definitions:
         connectivity-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.ConnectivityServiceRef:
     type: "object"
@@ -2390,20 +1454,13 @@ definitions:
       connectivity-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
   tapi.connectivity.ContextAugmentation4:
     type: "object"
     properties:
-      connectivity-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      connection:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.Connection"
+      connectivity-context:
+        description: "Augments the base TAPI Context with ConnectivityService information"
+        $ref: "#/definitions/tapi.connectivity.ConnectivityContext"
     x-augmentation:
       prefix: "tapi-connectivity"
       namespace: "urn:onf:otcc:yang:tapi-connectivity"
@@ -2433,17 +1490,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.getconnectivityservicelist.Output"
-  tapi.connectivity.OwnedNodeEdgePointAugmentation1:
-    type: "object"
-    properties:
-      connection-end-point:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-    x-augmentation:
-      prefix: "tapi-connectivity"
-      namespace: "urn:onf:otcc:yang:tapi-connectivity"
   tapi.connectivity.ProtectionRole:
     type: "string"
     enum:
@@ -2543,7 +1589,7 @@ definitions:
         route-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.SelectionControl:
     type: "string"
@@ -2649,17 +1695,13 @@ definitions:
         switch-control-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.UpdateConnectivityService:
     type: "object"
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.updateconnectivityservice.Output"
-  tapi.connectivity.ceplist.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-    - $ref: "#/definitions/tapi.oam.ConnectionEndPointAugmentation1"
   tapi.connectivity.createconnectivityservice.Input:
     type: "object"
     properties:
@@ -2783,16 +1825,9 @@ definitions:
   tapi.notification.ContextAugmentation2:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -2910,6 +1945,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3168,45 +2216,12 @@ definitions:
       subscription-service:
         description: "none"
         $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-  tapi.oam.ConnectionEndPointAugmentation1:
-    type: "object"
-    properties:
-      mip:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MipRef"
-      mep:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MepRef"
-    x-augmentation:
-      prefix: "tapi-oam"
-      namespace: "urn:onf:otcc:yang:tapi-oam"
   tapi.oam.ContextAugmentation1:
     type: "object"
     properties:
-      oam-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamService"
-      oam-profile:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      oam-job:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      meg:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.Meg"
+      oam-context:
+        description: "Augments the base TAPI Context with OamService information"
+        $ref: "#/definitions/tapi.oam.OamContext"
     x-augmentation:
       prefix: "tapi-oam"
       namespace: "urn:onf:otcc:yang:tapi-oam"
@@ -3313,7 +2328,7 @@ definitions:
       meg-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:uuid"
   tapi.oam.Mep:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3346,7 +2361,7 @@ definitions:
         mep-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
       description: "none"
   tapi.oam.Mip:
     allOf:
@@ -3368,7 +2383,7 @@ definitions:
         mip-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamConstraint:
     type: "object"
@@ -3383,6 +2398,29 @@ definitions:
       direction:
         description: "none"
         $ref: "#/definitions/tapi.common.ForwardingDirection"
+  tapi.oam.OamContext:
+    type: "object"
+    properties:
+      oam-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamService"
+      oam-profile:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamProfile"
+      oam-job:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamJob"
+      meg:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.Meg"
   tapi.oam.OamJob:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3438,7 +2476,7 @@ definitions:
       oam-profile-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:uuid"
   tapi.oam.OamService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3491,7 +2529,7 @@ definitions:
         oam-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamServiceRef:
     type: "object"
@@ -3499,7 +2537,7 @@ definitions:
       oam-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:uuid"
   tapi.oam.PmBinData:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3816,16 +2854,9 @@ definitions:
   tapi.path.computation.ContextAugmentation3:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -3870,6 +2901,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3934,7 +2978,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -4125,14 +3169,9 @@ definitions:
   tapi.topology.ContextAugmentation5:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -4280,7 +3319,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -4380,7 +3419,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -4390,7 +3429,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -4430,7 +3469,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -4537,13 +3576,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -4686,41 +3736,3 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.topology.Topology"
-  tapi.topology.node.OwnedNodeEdgePoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.OwnedNodeEdgePointAugmentation1"
-    - $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-  tapi.topology.topology.Node:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.CapacityPac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.topology.TransferCostPac"
-    - $ref: "#/definitions/tapi.topology.TransferIntegrityPac"
-    - $ref: "#/definitions/tapi.topology.TransferTimingPac"
-    - type: "object"
-      properties:
-        layer-protocol-name:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.common.LayerProtocolName"
-        encap-topology:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.TopologyRef"
-        owned-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        node-rule-group:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        aggregated-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-      description: "none"

--- a/OAS/tapi-eth@2018-08-31.yaml
+++ b/OAS/tapi-eth@2018-08-31.yaml
@@ -71,731 +71,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/connection={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.Connection"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.Connection"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.Connection"
-        400:
-          description: "Internal error"
-  /data/context/connection={uuid}/switch-control={switch-control-uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.SwitchControl"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      - name: "switch-control-uuid"
-        in: "path"
-        description: "Id of switch-control"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.SwitchControl"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.SwitchControl"
-        400:
-          description: "Internal error"
-  /data/context/connectivity-service/:
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/connectivity-service={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ConnectivityService"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-connectivity"
-      description: "creates or updates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-connectivity"
-      description: "removes tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/meg={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.oamcontext.Meg"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of meg"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.oamcontext.Meg"
-          schema:
-            $ref: "#/definitions/tapi.oam.oamcontext.Meg"
-        400:
-          description: "Internal error"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/oam-job/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.oamcontext.OamJob"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.oamcontext.OamJob.body-param"
-        description: "tapi.oam.oamcontext.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-job={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.oamcontext.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.oamcontext.OamJob"
-          schema:
-            $ref: "#/definitions/tapi.oam.oamcontext.OamJob"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.oamcontext.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.oamcontext.OamJob.body-param"
-        description: "tapi.oam.oamcontext.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.oamcontext.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.oamcontext.OamJob.body-param"
-        description: "tapi.oam.oamcontext.OamJob to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.oamcontext.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-profile/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.oamcontext.OamProfile"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.oamcontext.OamProfile.body-param"
-        description: "tapi.oam.oamcontext.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-profile={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.oamcontext.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.oamcontext.OamProfile"
-          schema:
-            $ref: "#/definitions/tapi.oam.oamcontext.OamProfile"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.oamcontext.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.oamcontext.OamProfile.body-param"
-        description: "tapi.oam.oamcontext.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.oamcontext.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.oamcontext.OamProfile.body-param"
-        description: "tapi.oam.oamcontext.OamProfile to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.oamcontext.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-service/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-service={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamService"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -894,192 +169,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.node.OwnedNodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.node.OwnedNodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        400:
-          description: "Internal error"
-  ? /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/connection-end-point={connection-end-point-uuid}/
-  : get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ceplist.ConnectionEndPoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      - name: "connection-end-point-uuid"
-        in: "path"
-        description: "Id of connection-end-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ceplist.ConnectionEndPoint"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -2217,44 +1306,6 @@ definitions:
         \ protocol including all circuit and packet forms.\r\n                At the\
         \ lowest level of recursion, a FC represents a cross-connection within an\
         \ NE."
-  tapi.connectivity.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - $ref: "#/definitions/tapi.common.TerminationPac"
-    - type: "object"
-      properties:
-        client-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        connection-port-role:
-          description: "Each EP of the FC has a role (e.g., working, protection, protected,\
-            \ symmetric, hub, spoke, leaf, root)  in the context of the FC with respect\
-            \ to the FC function. "
-          $ref: "#/definitions/tapi.common.PortRole"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        layer-protocol-qualifier:
-          type: "string"
-          description: "none"
-        parent-node-edge-point:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        aggregated-connection-end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPointRef"
-        connection-port-direction:
-          description: "The orientation of defined flow at the EndPoint."
-          $ref: "#/definitions/tapi.common.PortDirection"
-      description: "The LogicalTerminationPoint (LTP) object class encapsulates the\
-        \ termination and adaptation functions of one or more transport layers. \r\
-        \n                The structure of LTP supports all transport protocols including\
-        \ circuit and packet forms."
   tapi.connectivity.ConnectionEndPointRef:
     allOf:
     - $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
@@ -2263,7 +1314,7 @@ definitions:
         connection-end-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.ConnectionRef:
     type: "object"
@@ -2271,7 +1322,7 @@ definitions:
       connection-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid"
   tapi.connectivity.ConnectivityConstraint:
     type: "object"
     properties:
@@ -2303,6 +1354,19 @@ definitions:
       coroute-inclusion:
         description: "none"
         $ref: "#/definitions/tapi.connectivity.ConnectivityServiceRef"
+  tapi.connectivity.ConnectivityContext:
+    type: "object"
+    properties:
+      connectivity-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
+      connection:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.Connection"
   tapi.connectivity.ConnectivityService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -2382,7 +1446,7 @@ definitions:
         connectivity-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.ConnectivityServiceRef:
     type: "object"
@@ -2390,20 +1454,13 @@ definitions:
       connectivity-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
   tapi.connectivity.ContextAugmentation4:
     type: "object"
     properties:
-      connectivity-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      connection:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.Connection"
+      connectivity-context:
+        description: "Augments the base TAPI Context with ConnectivityService information"
+        $ref: "#/definitions/tapi.connectivity.ConnectivityContext"
     x-augmentation:
       prefix: "tapi-connectivity"
       namespace: "urn:onf:otcc:yang:tapi-connectivity"
@@ -2433,17 +1490,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.getconnectivityservicelist.Output"
-  tapi.connectivity.OwnedNodeEdgePointAugmentation1:
-    type: "object"
-    properties:
-      connection-end-point:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-    x-augmentation:
-      prefix: "tapi-connectivity"
-      namespace: "urn:onf:otcc:yang:tapi-connectivity"
   tapi.connectivity.ProtectionRole:
     type: "string"
     enum:
@@ -2543,7 +1589,7 @@ definitions:
         route-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.SelectionControl:
     type: "string"
@@ -2649,18 +1695,13 @@ definitions:
         switch-control-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.UpdateConnectivityService:
     type: "object"
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.updateconnectivityservice.Output"
-  tapi.connectivity.ceplist.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-    - $ref: "#/definitions/tapi.eth.ConnectionEndPointAugmentation1"
-    - $ref: "#/definitions/tapi.oam.ConnectionEndPointAugmentation2"
   tapi.connectivity.createconnectivityservice.Input:
     type: "object"
     properties:
@@ -2783,169 +1824,6 @@ definitions:
         type: "integer"
         format: "int32"
         description: "This attribute returns the configured bandwidth"
-  tapi.eth.ColourMode:
-    type: "string"
-    enum:
-    - "COLOUR_BLIND"
-    - "COLOUR_AWARE"
-  tapi.eth.ConnectionEndPointAugmentation1:
-    type: "object"
-    properties:
-      eth-term:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EthTerminationPac"
-      ety-term:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EtyTerminationPac"
-      eth-ctp:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EthCtpPac"
-    x-augmentation:
-      prefix: "tapi-eth"
-      namespace: "urn:onf:otcc:yang:tapi-eth"
-  tapi.eth.ControlFrameFilter:
-    type: "object"
-    properties:
-      c-2-00-00-2-a:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-0-c:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-0-b:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-2-c:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-0-e:
-        type: "boolean"
-        description: "This attribute identifies the Individual LAN Scope group address,\
-          \ Nearest Bridge group address (LLDP protocol)."
-        default: false
-      c-2-00-00-2-b:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-0-d:
-        type: "boolean"
-        description: "This attribute identifies the Provider Bridge MVRP address."
-        default: false
-      c-2-00-00-2-e:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-2-d:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-0-f:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-2-f:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-10:
-        type: "boolean"
-        description: "This attribute identifies the 'All LANs Bridge Management Group\
-          \ Address'."
-        default: false
-      c-2-00-00-09:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-29:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-07:
-        type: "boolean"
-        description: "This attribute identifies the Metro Ethernet Forum E-LMI protocol\
-          \ group address."
-        default: false
-      c-2-00-00-08:
-        type: "boolean"
-        description: "This attribute identifies the Provider Bridge Group address."
-        default: false
-      c-2-00-00-27:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-05:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-28:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-06:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-25:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-03:
-        type: "boolean"
-        description: "This attribute identifies the Nearest non-TPMR Bridge group\
-          \ address (Port Authentication protocol)."
-        default: false
-      c-2-00-00-26:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-04:
-        type: "boolean"
-        description: "This attribute identifies the IEEE MAC-specific Control Protocols\
-          \ group address."
-        default: false
-      c-2-00-00-23:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-01:
-        type: "boolean"
-        description: "This attribute identifies the IEEE MAC-specific Control Protocols\
-          \ group address (PAUSE protocol)."
-        default: false
-      c-2-00-00-24:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-02:
-        type: "boolean"
-        description: "This attribute identifies the IEEE 802.3 Slow_Protocols_Multicast\
-          \ address (LACP/LAMP or Link OAM protocols)."
-        default: false
-      c-2-00-00-21:
-        type: "boolean"
-        description: "This attribute identifies the Customer Bridge MVRP address."
-        default: false
-      c-2-00-00-22:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
-      c-2-00-00-00:
-        type: "boolean"
-        description: "This attribute identifies the STP/RSTP/MSTP protocol address."
-        default: false
-      c-2-00-00-20:
-        type: "boolean"
-        description: "This attribute identifies the Customer and Provider Bridge MMRP\
-          \ address."
-        default: false
-      c-2-00-00-0-a:
-        type: "boolean"
-        description: "Reserved for future standardization."
-        default: false
   tapi.eth.CsfConfig:
     type: "string"
     enum:
@@ -2954,145 +1832,169 @@ definitions:
     - "ENABLED_WITH_RDI_FDI"
     - "ENABLED_WITH_RDI_FDI_DCI"
     - "ENABLED_WITH_DCI"
-  tapi.eth.EthCtpPac:
+  tapi.eth.Eth1DmThresholdData:
     type: "object"
     properties:
-      csf-rdi-fdi-enable:
-        type: "boolean"
-        description: "This attribute models the MI_CSFrdifdiEnable information defined\
-          \ in G.8021."
-        default: false
-      vlan-config:
+      near-end-1-dm-cross-threshold:
+        description: "This attribute contains the near end cross threshold values\
+          \ of the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      near-end-1-dm-clear-threshold:
+        description: "This attribute contains the near end clear threshold values\
+          \ of the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+  tapi.eth.Eth1LmThresholdData:
+    type: "object"
+    properties:
+      near-end-1-lm-cross-threshold:
+        description: "This attribute contains the near end cross threshold values\
+          \ of the loss measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      near-end-1-lm-clear-threshold:
+        description: "This attribute is only valid for frame loss ratio parameters\
+          \ and counter type parameters working in the 'standing condition method'\
+          \ (see G.7710, section 10.1.7.2: Threshold reporting) and contains the near\
+          \ end clear threshold values of the loss measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+  tapi.eth.EthDmThresholdData:
+    type: "object"
+    properties:
+      bi-dir-dm-clear-threshold:
+        description: "This attribute contains the bidirectional clear threshold values\
+          \ of the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      near-end-dm-cross-threshold:
+        description: "This attribute contains the near end cross threshold values\
+          \ of the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      far-end-dm-clear-threshold:
+        description: "This attribute contains the far end clear threshold values of\
+          \ the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      far-end-dm-cross-threshold:
+        description: "This attribute contains the far end cross threshold values of\
+          \ the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      bi-dir-dm-cross-threshold:
+        description: "This attribute contains the bidirectional cross threshold values\
+          \ of the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      near-end-dm-clear-threshold:
+        description: "This attribute contains the near end clear threshold values\
+          \ of the delay measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+  tapi.eth.EthLinkTraceJob:
+    type: "object"
+    properties:
+      time-to-live:
         type: "integer"
         format: "int32"
-        description: "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information\
-          \ defined in G.8021.\r\n                    range of type : -1, 0, 1..4094"
-      filter-config:
-        description: "This attribute models the FilterConfig MI defined in section\
-          \ 8.3/G.8021. It indicates the configured filter action for each of the\
-          \ 33 group MAC addresses for control frames. The 33 MAC addresses are:\r\
-          \n                    - All bridges address: 01-80-C2-00-00-10,\r\n    \
-          \                - Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\r\
-          \n                    - GARP Application addresses: 01-80-C2-00-00-20 to\
-          \ 01-80-C2-00-00-2F.\r\n                    The filter action is Pass or\
-          \ Block. \r\n                    If the destination address of the incoming\
-          \ ETH_CI_D matches one of the above addresses, the filter process shall\
-          \ perform the corresponding configured filter action. \r\n             \
-          \       If none of the above addresses match, the ETH_CI_D is passed."
-        $ref: "#/definitions/tapi.eth.ControlFrameFilter"
-      mac-length:
-        type: "integer"
-        format: "int32"
-        description: "This attribute models the MAC_Lenght MI defined in 8.6/G.8021\
-          \ for the MAC Length Check process. It indicates the allowed maximum frame\
-          \ length in bytes.\r\n                    range of type : 1518, 1522, 2000"
-        default: 2000
-      csf-report:
-        type: "boolean"
-        description: "This attribute models the MI_CSF_Reported information defined\
-          \ in G.8021.\r\n                    range of type : true, false"
-        default: false
-      filter-config-snk:
+        description: "G.8052: This parameter provides the Time To Live (TTL) parameter\
+          \ of the Link Track protocol.\r\n                    The TTL parameter allows\
+          \ the receiver (MIP or MEP) of the LTM frame to determine if the frame can\
+          \ be terminated. TTL is decremented every time the LTM frame is relayed.\
+          \ LTM frame with TTL<=1 is terminated and not relayed."
+      eth-lt-msg:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOamOperationCommonPac"
+  tapi.eth.EthLinkTraceResultData:
+    type: "object"
+    properties:
+      result-list:
         type: "array"
-        description: "This attribute models the FilteConfig MI defined in 8.3/G.8021.\
-          \ It indicates the configured filter action for each of the 33 group MAC\
-          \ addresses for control frames. The 33 MAC addresses are:\r\n          \
-          \          01-80-C2-00-00-10, \r\n                    01-80-C2-00-00-00\
-          \ to 01-80-C2-00-00-0F, and \r\n                    01-80-C2-00-00-20 to\
-          \ 01-80-C2-00-00-2F.\r\n                    The filter action is Pass or\
-          \ Block. \r\n                    If the destination address of the incoming\
-          \ ETH_CI_D matches one of the above addresses, the filter process shall\
-          \ perform the corresponding configured filter action. \r\n             \
-          \       If none of the above addresses match, the ETH_CI_D is passed."
+        description: "G.8052: This parameter returns the results of the LT process.\
+          \ It contains a list of the result received from the individual LTR frames.\r\
+          \n                    The result from the individual LTR frame include the\
+          \ Source Mac Address, the TTL, and TLV."
+        items:
+          $ref: "#/definitions/tapi.eth.LinkTraceResult"
+  tapi.eth.EthLmThresholdData:
+    type: "object"
+    properties:
+      far-end-lm-clear-threshold:
+        description: "This attribute is only valid for frame loss ratio parameters\
+          \ and counter type parameters working in the 'standing condition method'\
+          \ (see G.7710, section 10.1.7.2: Threshold reporting) and contains the far\
+          \ end clear threshold values of the loss measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      far-end-lm-cross-threshold:
+        description: "This attribute contains the far end cross threshold values of\
+          \ the loss measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      near-end-lm-clear-threshold:
+        description: "This attribute is only valid for frame loss ratio parameters\
+          \ and counter type parameters working in the 'standing condition method'\
+          \ (see G.7710, section 10.1.7.2: Threshold reporting) and contains the near\
+          \ end clear threshold values of the loss measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      bi-dir-lm-uas-cross-threshold:
+        type: "integer"
+        format: "int32"
+        description: "This attribute contains the bidirectional cross threshold value\
+          \ of the UAS loss measurement."
+      bi-dir-lm-uas-clear-threshold:
+        type: "integer"
+        format: "int32"
+        description: "This attribute is only valid for the UAS parameter working in\
+          \ the 'standing condition method' (see G.7710, section 10.1.7.2: Threshold\
+          \ reporting) and contains the bidirectional clear threshold value of the\
+          \ UAS loss measurement."
+      near-end-lm-cross-threshold:
+        description: "This attribute contains the near end cross threshold values\
+          \ of the loss measurements."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+  tapi.eth.EthLoopbackJob:
+    type: "object"
+    properties:
+      number:
+        type: "integer"
+        format: "int32"
+        description: "G.8052: This parameter specifies how many LB messages to be\
+          \ sent for the LB_Series process."
+      eth-lb-msg:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOamMsgCommonPac"
+  tapi.eth.EthLoopbackResultData:
+    type: "object"
+    properties:
+      ber-lbr-frames:
+        type: "integer"
+        format: "int32"
+        description: "G.8052: This parameter returns the number of LBR frames where\
+          \ there was a bit error in the pattern."
+      crc-lbr-frames:
+        type: "integer"
+        format: "int32"
+        description: "G.8052: This parameter returns the number of LBR frames where\
+          \ the CRC in the pattern failed."
+      detected-peer-mep:
+        type: "array"
+        description: "G.8052: This parameter returns the MAC addresses of the discovered\
+          \ peer MEPs of the subject MEP."
         items:
           type: "string"
-      pll-thr:
+      sent-lbm-frames:
         type: "integer"
         format: "int32"
-        description: "This attribute provisions the threshold for the number of active\
-          \ ports. If the number of active ports is more than zero but less than the\
-          \ provisioned threshold, a cPLL (Partial Link Loss) is raised. See section\
-          \ 9.7.1.2 of G.8021.\r\n                    range of type : 0..number of\
-          \ ports"
-      csf-config:
-        description: "This attribute models the combination of all CSF related MI\
-          \ signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined\
-          \ in G.8021.\r\n                    range of type : true, false"
-        $ref: "#/definitions/tapi.eth.CsfConfig"
-      partner-system-id:
-        type: "string"
-        description: "See 802.1AX:\r\n                    A MAC address consisting\
-          \ of the unique identifier for the current protocol Partner of this Aggregator.\
-          \ A value of zero indicates that there is no known Partner. If the aggregation\
-          \ is manually configured, this System ID value will be a value assigned\
-          \ by the local System."
-      partner-system-priority:
+        description: "G.8052: This parameter returns the total number of sent LBM\
+          \ frames."
+      out-of-order-lbr-frames:
         type: "integer"
         format: "int32"
-        description: "See 802.1AX:\r\n                    Indicates the priority associated\
-          \ with the Partner’s System ID. If the aggregation is manually configured,\
-          \ this System Priority value will be a value assigned by the local System.\r\
-          \n                    range of type : 2-octet"
-      partner-oper-key:
+        description: "G.8052: This parameter returns the number of LBR traffic unites\
+          \ (messages) that were received out of order (OO)."
+      rec-lbr-frames:
         type: "integer"
         format: "int32"
-        description: "See 802.1AX:\r\n                    The current operational\
-          \ value of the Key for the Aggregator’s current protocol Partner. If the\
-          \ aggregation is manually configured, this Key value will be a value assigned\
-          \ by the local System.\r\n                    range of type : 16-bit"
-      traffic-conditioning:
+        description: "G.8052: This parameter returns the total number of received\
+          \ LBR messages, including the out of order LBR frames."
+  tapi.eth.EthMegSpec:
+    type: "object"
+    properties:
+      client-mel:
+        type: "integer"
+        format: "int32"
         description: "none"
-        $ref: "#/definitions/tapi.eth.TrafficConditioningPac"
-      actor-system-priority:
-        type: "integer"
-        format: "int32"
-        description: "See 802.1AX:\r\n                    Indicating the priority\
-          \ associated with the Actor’s System ID.\r\n                    range of\
-          \ type : 2-octet"
-      actor-oper-key:
-        type: "integer"
-        format: "int32"
-        description: "See 802.1AX:\r\n                    The current operational\
-          \ value of the Key for the Aggregator. The administrative Key value may\
-          \ differ from the operational Key value for the reasons discussed in 5.6.2.\r\
-          \n                    The meaning of particular Key values is of local significance.\r\
-          \n                    range of type : 16 bit"
-      collector-max-delay:
-        type: "integer"
-        format: "int32"
-        description: "See 802.1AX:\r\n                    The value of this attribute\
-          \ defines the maximum delay, in tens of microseconds, that may be imposed\
-          \ by the Frame Collector between receiving a frame from an Aggregator Parser,\
-          \ and either delivering the frame to its MAC Client or discarding the frame\
-          \ (see IEEE 802.1AX clause 5.2.3.1.1).\r\n                    range of type\
-          \ : 16-bit"
-      is-ssf-reported:
-        type: "boolean"
-        description: "This attribute provisions whether the SSF defect should be reported\
-          \ as fault cause or not.\r\n                    It models the ETH-LAG_FT_Sk_MI_SSF_Reported\
-          \ defined in G.8021."
-        default: false
-      data-rate:
-        type: "integer"
-        format: "int32"
-        description: "See 802.1AX:\r\n                    The current data rate, in\
-          \ bits per second, of the aggregate link. The value is calculated as N times\
-          \ the data rate of a single link in the aggregation, where N is the number\
-          \ of active links."
-      traffic-shaping:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.TrafficShapingPac"
-      actor-system-id:
-        type: "string"
-        description: "See 802.1AX:\r\n                    A MAC address used as a\
-          \ unique identifier for the System that contains this Aggregator."
-      auxiliary-function-position-sequence:
-        type: "array"
-        description: "This attribute indicates the positions (i.e., the relative order)\
-          \ of all the MEP, MIP, and TCS objects which are associated with the CTP."
-        items:
-          type: "integer"
-          format: "int32"
   tapi.eth.EthMepCommon:
     type: "object"
     properties:
@@ -3220,6 +2122,20 @@ definitions:
         description: "This attribute specifies the priority of the APS messages.\r\
           \n                    See section 8.1.5    APS insert process in G.8021."
         default: 7
+  tapi.eth.EthMepSpec:
+    type: "object"
+    properties:
+      eth-mep-common:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthMepCommon"
+      eth-mep-sink:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthMepSink"
+      eth-mep-source-pac:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthMepSource"
+  tapi.eth.EthMipSpec:
+    type: "object"
   tapi.eth.EthOamMsgCommonPac:
     allOf:
     - $ref: "#/definitions/tapi.eth.EthOamOperationCommonPac"
@@ -3265,6 +2181,57 @@ definitions:
         type: "string"
         description: "G.8052: This parameter provides the destination address, i.e.,\
           \ the MAC Address of the target MEP or MIP."
+  tapi.eth.EthOnDemand1DmPerformanceData:
+    type: "object"
+    properties:
+      on-demand-near-end-1-dm-parameters:
+        description: "This attribute contains the results of an on-demand frame delay\
+          \ measurement job in the ingress direction."
+        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+  tapi.eth.EthOnDemand1LmPerformanceData:
+    type: "object"
+    properties:
+      on-demand-near-end-1-lm-parameters:
+        description: "This attribute contains the results of an on-demand synthetic\
+          \ loss measurement job in the ingress direction."
+        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
+  tapi.eth.EthOnDemand1wayMeasurementJob:
+    type: "object"
+    properties:
+      on-demand-control-1way-source:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandMeasurementJobControlSource"
+      on-demand-control-1way-sink:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandMeasurementJobControlSink"
+  tapi.eth.EthOnDemand2wayMeasurementJob:
+    type: "object"
+    properties:
+      on-demand-control-2way-source:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandMeasurementJobControlSource"
+  tapi.eth.EthOnDemandDmPerformanceData:
+    type: "object"
+    properties:
+      on-demand-far-end-dm-parameters:
+        description: "This attribute contains the results of an on-demand frame delay\
+          \ measurement job in the ingress direction."
+        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+      on-demand-near-end-dm-parameters:
+        description: "This attribute contains the results of an on-demand frame delay\
+          \ measurement job in the ingress direction."
+        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+  tapi.eth.EthOnDemandLmPerformanceData:
+    type: "object"
+    properties:
+      on-demand-far-end-lm-parameters:
+        description: "This attribute contains the results of an on-demand synthetic\
+          \ loss measurement job in the egress direction."
+        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
+      on-demand-near-end-lm-parameters:
+        description: "This attribute contains the results of an on-demand synthetic\
+          \ loss measurement job in the ingress direction."
+        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
   tapi.eth.EthOnDemandMeasurementJobControlSink:
     type: "object"
     properties:
@@ -3354,6 +2321,67 @@ definitions:
           \ intervals. Note that the value 0 means a degenerated measurement interval\
           \ with a single OAM message and the report is sent as immediately as possible.\r\
           \n                    range of type : Non-negative"
+  tapi.eth.EthProActive1DmPerformanceData:
+    type: "object"
+    properties:
+      pro-active-near-end-1-dm-parameters:
+        description: "This attribute contains the statistical near end performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+  tapi.eth.EthProActive1LmPerformanceData:
+    type: "object"
+    properties:
+      pro-active-near-end-1-lm-parameters:
+        description: "This attribute contains the statistical near end performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+  tapi.eth.EthProActive1wayMeasurementJob:
+    type: "object"
+    properties:
+      pro-active-control-1way-source:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveMeasurementJobControlSource"
+      pro-active-control-1way-sink:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveMeasurementJobControlSink"
+  tapi.eth.EthProActive2wayMeasurementJob:
+    type: "object"
+    properties:
+      pro-active-control-2way-source:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveMeasurementJobControlSource"
+  tapi.eth.EthProActiveDmPerformanceData:
+    type: "object"
+    properties:
+      pro-active-bi-dir-dm-parameters:
+        description: "This attribute contains the statistical bidirectional performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      pro-active-far-end-dm-parameters:
+        description: "This attribute contains the statistical far end performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      pro-active-near-end-dm-parameters:
+        description: "This attribute contains the statistical near end performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+  tapi.eth.EthProActiveLmPerformanceData:
+    type: "object"
+    properties:
+      bidirectional-uas:
+        type: "integer"
+        format: "int32"
+        description: "This attribute contains the bidirectional UAS (unavailable seconds)\
+          \ detected in the monitoring interval.\r\n                    range of type\
+          \ : 0..900 for 15min interval or 0..86400 for 24 hr interval."
+      pro-active-far-end-lm-parameters:
+        description: "This attribute contains the statistical far end performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      pro-active-near-end-lm-parameters:
+        description: "This attribute contains the statistical near end performnace\
+          \ parameters."
+        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
   tapi.eth.EthProActiveMeasurementJobControlSink:
     type: "object"
     properties:
@@ -3427,97 +2455,20 @@ definitions:
         description: "This attribute identifies the state of the measurement job.\
           \ If set to TRUE, the MEP performs proactive Performance Measurement."
         default: true
-  tapi.eth.EthTerminationPac:
+  tapi.eth.EthTestJob:
     type: "object"
     properties:
-      filter-config-1:
-        type: "array"
-        description: "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information\
-          \ defined in G.8021.\r\n                    It indicates the configured\
-          \ filter action for each of the 33 group MAC addresses for control frames.\r\
-          \n                    The 33 MAC addresses are:\r\n                    01-80-C2-00-00-10,\
-          \ \r\n                    01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \r\
-          \n                    01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\r\n      \
-          \              The filter action is Pass or Block. \r\n                \
-          \    If the destination address of the incoming ETH_CI_D matches one of\
-          \ the above addresses, the filter process shall perform the corresponding\
-          \ configured filter action. \r\n                    If none of the above\
-          \ addresses match, the ETH_CI_D is passed.\r\n                    range\
-          \ of type : MacAddress: \r\n                    01-80-C2-00-00-10, \r\n\
-          \                    01-80-C2-00-00-00 to \r\n                    01-80-C2-00-00-0F,\
-          \ and \r\n                    01-80-C2-00-00-20 to \r\n                \
-          \    01-80-C2-00-00-2F;\r\n                    ActionEnum:\r\n         \
-          \           PASS, BLOCK"
-        items:
-          type: "string"
-      ether-type:
-        description: "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information\
-          \ defined in G.8021."
-        $ref: "#/definitions/tapi.eth.VlanType"
-      priority-code-point-config:
-        description: "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information\
-          \ defined in G.8021.\r\n                    range of type : see Enumeration"
-        $ref: "#/definitions/tapi.eth.PcpCoding"
-      frametype-config:
-        description: "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config\
-          \ information defined in G.8021.\r\n                    range of type :\
-          \ see Enumeration"
-        $ref: "#/definitions/tapi.eth.FrameType"
-      port-vid:
-        type: "string"
-        description: "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information\
-          \ defined in G.8021."
-        default: "1"
-      priority-regenerate:
-        description: "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information\
-          \ defined in G.8021."
-        $ref: "#/definitions/tapi.eth.PriorityMapping"
-  tapi.eth.EtyPhyType:
-    type: "string"
-    enum:
-    - "OTHER"
-    - "UNKNOWN"
-    - "NONE"
-    - "2BASE_TL"
-    - "10MBIT_S"
-    - "10PASS_TS"
-    - "100BASE_T4"
-    - "100BASE_X"
-    - "100BASE_T2"
-    - "1000BASE_X"
-    - "1000BASE_T"
-    - "10GBASE-X"
-    - "10GBASE_R"
-    - "10GBASE_W"
-  tapi.eth.EtyTerminationPac:
+      eth-test-msg:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOamMsgCommonPac"
+  tapi.eth.EthTestResultData:
     type: "object"
     properties:
-      phy-type:
-        description: "This attribute identifies the PHY type of the ETY trail termination.\
-          \ See IEEE 802.3 clause 30.3.2.1.2."
-        $ref: "#/definitions/tapi.eth.EtyPhyType"
-      is-fts-enabled:
-        type: "boolean"
-        description: "This attribute indicates whether Forced Transmitter Shutdown\
-          \ (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information."
-        default: false
-      is-tx-pause-enabled:
-        type: "boolean"
-        description: "This attribute identifies whether the Transmit Pause process\
-          \ is enabled or not. It models the MI_TxPauseEnable defined in G.8021."
-        default: false
-      phy-type-list:
-        type: "array"
-        description: "This attribute identifies the possible PHY types that could\
-          \ be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3."
-        items:
-          $ref: "#/definitions/tapi.eth.EtyPhyType"
-  tapi.eth.FrameType:
-    type: "string"
-    enum:
-    - "ADMIT_ONLY_VLAN_TAGGED_FRAMES"
-    - "ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES"
-    - "ADMIT_ALL_FRAMES"
+      sent-tst-frames:
+        type: "integer"
+        format: "int32"
+        description: "G.8052: This parameter returns the total number of sent TST\
+          \ frames."
   tapi.eth.LinkTraceResult:
     type: "object"
     properties:
@@ -3538,25 +2489,18 @@ definitions:
   tapi.eth.MegAugmentation1:
     type: "object"
     properties:
-      client-mel:
-        type: "integer"
-        format: "int32"
+      eth-meg-spec:
         description: "none"
+        $ref: "#/definitions/tapi.eth.EthMegSpec"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.MepAugmentation1:
     type: "object"
     properties:
-      eth-mep-common:
+      eth-mep-spec:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthMepCommon"
-      eth-mep-sink:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EthMepSink"
-      eth-mep-source-pac:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EthMepSource"
+        $ref: "#/definitions/tapi.eth.EthMepSpec"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
@@ -3570,88 +2514,73 @@ definitions:
     - "0"
   tapi.eth.MipAugmentation1:
     type: "object"
+    properties:
+      eth-mip-spec:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthMipSpec"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation1:
     type: "object"
     properties:
-      on-demand-control-2way-source:
+      eth-on-demand-2way-measurement-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthOnDemandMeasurementJobControlSource"
+        $ref: "#/definitions/tapi.eth.EthOnDemand2wayMeasurementJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation2:
     type: "object"
     properties:
-      number:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter specifies how many LB messages to be\
-          \ sent for the LB_Series process."
-      eth-lb-msg:
+      eth-loopback-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthOamMsgCommonPac"
+        $ref: "#/definitions/tapi.eth.EthLoopbackJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation3:
     type: "object"
     properties:
-      pro-active-control-2way-source:
+      eth-pro-active-2way-measurement-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthProActiveMeasurementJobControlSource"
+        $ref: "#/definitions/tapi.eth.EthProActive2wayMeasurementJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation4:
     type: "object"
     properties:
-      pro-active-control-1way-source:
+      eth-pro-active-1way-measurement-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthProActiveMeasurementJobControlSource"
-      pro-active-control-1way-sink:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EthProActiveMeasurementJobControlSink"
+        $ref: "#/definitions/tapi.eth.EthProActive1wayMeasurementJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation5:
     type: "object"
     properties:
-      time-to-live:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter provides the Time To Live (TTL) parameter\
-          \ of the Link Track protocol.\r\n                    The TTL parameter allows\
-          \ the receiver (MIP or MEP) of the LTM frame to determine if the frame can\
-          \ be terminated. TTL is decremented every time the LTM frame is relayed.\
-          \ LTM frame with TTL<=1 is terminated and not relayed."
-      eth-lt-msg:
+      eth-link-trace-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthOamOperationCommonPac"
+        $ref: "#/definitions/tapi.eth.EthLinkTraceJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation6:
     type: "object"
     properties:
-      on-demand-control-1way-source:
+      eth-on-demand-1way-measurement-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthOnDemandMeasurementJobControlSource"
-      on-demand-control-1way-sink:
-        description: "none"
-        $ref: "#/definitions/tapi.eth.EthOnDemandMeasurementJobControlSink"
+        $ref: "#/definitions/tapi.eth.EthOnDemand1wayMeasurementJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.OamJobAugmentation7:
     type: "object"
     properties:
-      eth-test-msg:
+      eth-test-job:
         description: "none"
-        $ref: "#/definitions/tapi.eth.EthOamMsgCommonPac"
+        $ref: "#/definitions/tapi.eth.EthTestJob"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
@@ -3713,462 +2642,213 @@ definitions:
         type: "integer"
         format: "int32"
         description: "This attribute contains the total number of frames lost."
-  tapi.eth.PcpCoding:
-    type: "string"
-    enum:
-    - "8P0D"
-    - "7P1D"
-    - "6P2D"
-    - "5P3D"
-    - "DEI"
   tapi.eth.PmCurrentDataAugmentation1:
     type: "object"
     properties:
-      sent-tst-frames:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter returns the total number of sent TST\
-          \ frames."
+      eth-test-result-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthTestResultData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation10:
     type: "object"
     properties:
-      on-demand-near-end-1-dm-parameters:
-        description: "This attribute contains the results of an on-demand frame delay\
-          \ measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+      eth-on-demand-1-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemand1DmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation11:
     type: "object"
     properties:
-      on-demand-far-end-lm-parameters:
-        description: "This attribute contains the results of an on-demand synthetic\
-          \ loss measurement job in the egress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
-      on-demand-near-end-lm-parameters:
-        description: "This attribute contains the results of an on-demand synthetic\
-          \ loss measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
+      eth-on-demand-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandLmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation2:
     type: "object"
     properties:
-      pro-active-near-end-1-dm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      eth-pro-active-1-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActive1DmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation3:
     type: "object"
     properties:
-      pro-active-near-end-1-lm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      eth-pro-active-1-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActive1LmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation4:
     type: "object"
     properties:
-      ber-lbr-frames:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter returns the number of LBR frames where\
-          \ there was a bit error in the pattern."
-      crc-lbr-frames:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter returns the number of LBR frames where\
-          \ the CRC in the pattern failed."
-      detected-peer-mep:
-        type: "array"
-        description: "G.8052: This parameter returns the MAC addresses of the discovered\
-          \ peer MEPs of the subject MEP."
-        items:
-          type: "string"
-      sent-lbm-frames:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter returns the total number of sent LBM\
-          \ frames."
-      out-of-order-lbr-frames:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter returns the number of LBR traffic unites\
-          \ (messages) that were received out of order (OO)."
-      rec-lbr-frames:
-        type: "integer"
-        format: "int32"
-        description: "G.8052: This parameter returns the total number of received\
-          \ LBR messages, including the out of order LBR frames."
+      eth-loopback-result-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthLoopbackResultData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation5:
     type: "object"
     properties:
-      on-demand-far-end-dm-parameters:
-        description: "This attribute contains the results of an on-demand frame delay\
-          \ measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
-      on-demand-near-end-dm-parameters:
-        description: "This attribute contains the results of an on-demand frame delay\
-          \ measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+      eth-on-demand-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandDmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation6:
     type: "object"
     properties:
-      bidirectional-uas:
-        type: "integer"
-        format: "int32"
-        description: "This attribute contains the bidirectional UAS (unavailable seconds)\
-          \ detected in the monitoring interval.\r\n                    range of type\
-          \ : 0..900 for 15min interval or 0..86400 for 24 hr interval."
-      pro-active-far-end-lm-parameters:
-        description: "This attribute contains the statistical far end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
-      pro-active-near-end-lm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      eth-pro-active-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveLmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation7:
     type: "object"
     properties:
-      pro-active-bi-dir-dm-parameters:
-        description: "This attribute contains the statistical bidirectional performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      pro-active-far-end-dm-parameters:
-        description: "This attribute contains the statistical far end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      pro-active-near-end-dm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      eth-pro-active-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveDmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation8:
     type: "object"
     properties:
-      on-demand-near-end-1-lm-parameters:
-        description: "This attribute contains the results of an on-demand synthetic\
-          \ loss measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
+      eth-on-demand-1-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemand1LmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmCurrentDataAugmentation9:
     type: "object"
     properties:
-      result-list:
-        type: "array"
-        description: "G.8052: This parameter returns the results of the LT process.\
-          \ It contains a list of the result received from the individual LTR frames.\r\
-          \n                    The result from the individual LTR frame include the\
-          \ Source Mac Address, the TTL, and TLV."
-        items:
-          $ref: "#/definitions/tapi.eth.LinkTraceResult"
+      eth-link-trace-result-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthLinkTraceResultData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation1:
     type: "object"
     properties:
-      on-demand-near-end-1-lm-parameters:
-        description: "This attribute contains the results of an on-demand synthetic\
-          \ loss measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
+      eth-on-demand-1-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemand1LmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation2:
     type: "object"
     properties:
-      on-demand-far-end-lm-parameters:
-        description: "This attribute contains the results of an on-demand synthetic\
-          \ loss measurement job in the egress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
-      on-demand-near-end-lm-parameters:
-        description: "This attribute contains the results of an on-demand synthetic\
-          \ loss measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandLmPerformanceParameters"
+      eth-on-demand-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandLmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation3:
     type: "object"
     properties:
-      on-demand-far-end-dm-parameters:
-        description: "This attribute contains the results of an on-demand frame delay\
-          \ measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
-      on-demand-near-end-dm-parameters:
-        description: "This attribute contains the results of an on-demand frame delay\
-          \ measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+      eth-on-demand-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemandDmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation4:
     type: "object"
     properties:
-      pro-active-near-end-1-lm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      eth-pro-active-1-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActive1LmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation5:
     type: "object"
     properties:
-      on-demand-near-end-1-dm-parameters:
-        description: "This attribute contains the results of an on-demand frame delay\
-          \ measurement job in the ingress direction."
-        $ref: "#/definitions/tapi.eth.OnDemandDmPerformanceParameters"
+      eth-on-demand-1-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthOnDemand1DmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation6:
     type: "object"
     properties:
-      pro-active-bi-dir-dm-parameters:
-        description: "This attribute contains the statistical bidirectional performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      pro-active-far-end-dm-parameters:
-        description: "This attribute contains the statistical far end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      pro-active-near-end-dm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      eth-pro-active-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveDmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation7:
     type: "object"
     properties:
-      bidirectional-uas:
-        type: "integer"
-        format: "int32"
-        description: "This attribute contains the bidirectional UAS (unavailable seconds)\
-          \ detected in the monitoring interval.\r\n                    range of type\
-          \ : 0..900 for 15min interval or 0..86400 for 24 hr interval."
-      pro-active-far-end-lm-parameters:
-        description: "This attribute contains the statistical far end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
-      pro-active-near-end-lm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      eth-pro-active-lm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActiveLmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmHistoryDataAugmentation8:
     type: "object"
     properties:
-      pro-active-near-end-1-dm-parameters:
-        description: "This attribute contains the statistical near end performnace\
-          \ parameters."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      eth-pro-active-1-dm-performance-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthProActive1DmPerformanceData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmThresholdDataAugmentation1:
     type: "object"
     properties:
-      near-end-1-dm-cross-threshold:
-        description: "This attribute contains the near end cross threshold values\
-          \ of the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      near-end-1-dm-clear-threshold:
-        description: "This attribute contains the near end clear threshold values\
-          \ of the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      eth-1-dm-threshold-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.Eth1DmThresholdData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmThresholdDataAugmentation2:
     type: "object"
     properties:
-      far-end-lm-clear-threshold:
-        description: "This attribute is only valid for frame loss ratio parameters\
-          \ and counter type parameters working in the 'standing condition method'\
-          \ (see G.7710, section 10.1.7.2: Threshold reporting) and contains the far\
-          \ end clear threshold values of the loss measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
-      far-end-lm-cross-threshold:
-        description: "This attribute contains the far end cross threshold values of\
-          \ the loss measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
-      near-end-lm-clear-threshold:
-        description: "This attribute is only valid for frame loss ratio parameters\
-          \ and counter type parameters working in the 'standing condition method'\
-          \ (see G.7710, section 10.1.7.2: Threshold reporting) and contains the near\
-          \ end clear threshold values of the loss measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
-      bi-dir-lm-uas-cross-threshold:
-        type: "integer"
-        format: "int32"
-        description: "This attribute contains the bidirectional cross threshold value\
-          \ of the UAS loss measurement."
-      bi-dir-lm-uas-clear-threshold:
-        type: "integer"
-        format: "int32"
-        description: "This attribute is only valid for the UAS parameter working in\
-          \ the 'standing condition method' (see G.7710, section 10.1.7.2: Threshold\
-          \ reporting) and contains the bidirectional clear threshold value of the\
-          \ UAS loss measurement."
-      near-end-lm-cross-threshold:
-        description: "This attribute contains the near end cross threshold values\
-          \ of the loss measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      eth-lm-threshold-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthLmThresholdData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmThresholdDataAugmentation3:
     type: "object"
     properties:
-      near-end-1-lm-cross-threshold:
-        description: "This attribute contains the near end cross threshold values\
-          \ of the loss measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
-      near-end-1-lm-clear-threshold:
-        description: "This attribute is only valid for frame loss ratio parameters\
-          \ and counter type parameters working in the 'standing condition method'\
-          \ (see G.7710, section 10.1.7.2: Threshold reporting) and contains the near\
-          \ end clear threshold values of the loss measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalLmPerformanceParameters"
+      eth-1-lm-threshold-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.Eth1LmThresholdData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
   tapi.eth.PmThresholdDataAugmentation4:
     type: "object"
     properties:
-      bi-dir-dm-clear-threshold:
-        description: "This attribute contains the bidirectional clear threshold values\
-          \ of the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      near-end-dm-cross-threshold:
-        description: "This attribute contains the near end cross threshold values\
-          \ of the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      far-end-dm-clear-threshold:
-        description: "This attribute contains the far end clear threshold values of\
-          \ the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      far-end-dm-cross-threshold:
-        description: "This attribute contains the far end cross threshold values of\
-          \ the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      bi-dir-dm-cross-threshold:
-        description: "This attribute contains the bidirectional cross threshold values\
-          \ of the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
-      near-end-dm-clear-threshold:
-        description: "This attribute contains the near end clear threshold values\
-          \ of the delay measurements."
-        $ref: "#/definitions/tapi.eth.StatisticalDmPerformanceParameters"
+      eth-dm-threshold-data:
+        description: "none"
+        $ref: "#/definitions/tapi.eth.EthDmThresholdData"
     x-augmentation:
       prefix: "tapi-eth"
       namespace: "urn:onf:otcc:yang:tapi-eth"
-  tapi.eth.PriorityConfiguration:
-    type: "object"
-    properties:
-      priority:
-        type: "integer"
-        format: "int32"
-        description: "none"
-      queue-id:
-        type: "integer"
-        format: "int32"
-        description: "none"
-  tapi.eth.PriorityMapping:
-    type: "object"
-    properties:
-      priority-0:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 0."
-      priority-1:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 1."
-        default: 1
-      priority-2:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 2."
-        default: 2
-      priority-3:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 3."
-        default: 3
-      priority-4:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 4."
-        default: 4
-      priority-5:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 5."
-        default: 5
-      priority-6:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 6."
-        default: 6
-      priority-7:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the new priority value for the old priority\
-          \ value 7."
-        default: 7
-  tapi.eth.QueueConfiguration:
-    type: "object"
-    properties:
-      queue-threshold:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the threshold of the queue in bytes."
-      queue-id:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the queue id."
-      queue-depth:
-        type: "integer"
-        format: "int32"
-        description: "This attribute defines the depth of the queue in bytes."
   tapi.eth.RepetitionPeriod:
     type: "string"
     enum:
@@ -4242,111 +2922,6 @@ definitions:
         description: "This attribute contains the minimum frame loss ratio calculated\
           \ over a period of time.\r\n                    The accuracy of the value\
           \ is for further study."
-  tapi.eth.TrafficConditioningConfiguration:
-    type: "object"
-    properties:
-      queue-id:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the queue id."
-      coupling-flag:
-        type: "boolean"
-        description: "This attribute indicates the coupling flag."
-        default: false
-      cbs:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the Committed Burst Size in bytes."
-      ebs:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the Excess Burst Size in bytes."
-      colour-mode:
-        description: "This attribute indicates the colour mode."
-        $ref: "#/definitions/tapi.eth.ColourMode"
-      cir:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the Committed Information Rate in bits/s."
-      eir:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the Excess Information Rate in bits/s."
-  tapi.eth.TrafficConditioningPac:
-    type: "object"
-    properties:
-      codirectional:
-        type: "boolean"
-        description: "This attribute indicates the direction of the conditioner. The\
-          \ value of true means that the conditioner (modeled as a TCS Sink according\
-          \ to G.8021) is associated with the sink part of the containing CTP. The\
-          \ value of false means that the conditioner (modeled as a TCS Sink according\
-          \ to G.8021) is associated with the source part of the containing CTP."
-        default: false
-      prio-config-list:
-        type: "array"
-        description: "This attribute indicates the Priority Splitter function for\
-          \ the mapping of the Ethernet frame priority (ETH_CI_P) values to the output\
-          \ queue."
-        items:
-          $ref: "#/definitions/tapi.eth.PriorityConfiguration"
-      cond-config-list:
-        type: "array"
-        description: "This attribute indicates for the conditioner process the conditioning\
-          \ parameters:\r\n                    - Queue ID: Indicates the Queue ID\r\
-          \n                    - Committed Information Rate (CIR): number of bits\
-          \ per second\r\n                    - Committed Burst Size (CBS): number\
-          \ of bytes\r\n                    - Excess Information Rate (EIR): number\
-          \ of bits per second\r\n                    - Excess Burst Size (EBS): number\
-          \ of bytes\r\n                    - Coupling flag (CF): 0 or 1\r\n     \
-          \               - Color mode (CM): color-blind and color-aware."
-        items:
-          $ref: "#/definitions/tapi.eth.TrafficConditioningConfiguration"
-  tapi.eth.TrafficShapingPac:
-    type: "object"
-    properties:
-      codirectional:
-        type: "boolean"
-        description: "This attribute indicates the direction of the shaping function.\
-          \ The value of true means that the shaping (modeled as a TCS Source according\
-          \ to G.8021) is associated with the source part of the containing CTP. The\
-          \ value of false means that the shaping (modeled as a TCS Source according\
-          \ to G.8021) is associated with the sink part of the containing CTP."
-        default: false
-      sched-config:
-        type: "string"
-        description: "This attribute configures the scheduler process. The value of\
-          \ this attribute is for further study because it is for further study in\
-          \ G.8021.\r\n                    Scheduler is a pointer to a Scheduler object,\
-          \ which is to be defined in the future (because in G.8021, this is FFS).\r\
-          \n                    Note that the only significance of the GTCS function\
-          \ defined in G.8021 is the use of a common scheduler for shaping. Given\
-          \ that, G.8052 models the common scheduler feature by having a common value\
-          \ for this attribute."
-      queue-config-list:
-        type: "array"
-        description: "This attribute configures the Queue depth and Dropping threshold\
-          \ parameters of the Queue process. The Queue depth sets the maximum size\
-          \ of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there\
-          \ is insufficient space in the queue to hold the whole unit. The Dropping\
-          \ threshold sets the threshold of the queue. If the queue is filled beyond\
-          \ this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE\
-          \ signal set are dropped."
-        items:
-          $ref: "#/definitions/tapi.eth.QueueConfiguration"
-      prio-config-list:
-        type: "array"
-        description: "This attribute configures the Priority Splitter function for\
-          \ the mapping of the Ethernet frame priority (ETH_CI_P) values to the output\
-          \ queue."
-        items:
-          $ref: "#/definitions/tapi.eth.PriorityConfiguration"
-  tapi.eth.VlanType:
-    type: "string"
-    enum:
-    - "C_Tag"
-    - "S_Tag"
-    - "I_Tag"
   tapi.notification.AlarmInfo:
     type: "object"
     properties:
@@ -4366,16 +2941,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -4493,6 +3061,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -4751,45 +3332,12 @@ definitions:
       subscription-service:
         description: "none"
         $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-  tapi.oam.ConnectionEndPointAugmentation2:
-    type: "object"
-    properties:
-      mip:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MipRef"
-      mep:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MepRef"
-    x-augmentation:
-      prefix: "tapi-oam"
-      namespace: "urn:onf:otcc:yang:tapi-oam"
   tapi.oam.ContextAugmentation2:
     type: "object"
     properties:
-      oam-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamService"
-      oam-profile:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamProfile"
-      oam-job:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.oamcontext.OamJob"
-      meg:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.oamcontext.Meg"
+      oam-context:
+        description: "Augments the base TAPI Context with OamService information"
+        $ref: "#/definitions/tapi.oam.context.OamContext"
     x-augmentation:
       prefix: "tapi-oam"
       namespace: "urn:onf:otcc:yang:tapi-oam"
@@ -4896,7 +3444,7 @@ definitions:
       meg-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:uuid"
   tapi.oam.Mep:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -4929,7 +3477,7 @@ definitions:
         mep-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
       description: "none"
   tapi.oam.Mip:
     allOf:
@@ -4951,7 +3499,7 @@ definitions:
         mip-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamConstraint:
     type: "object"
@@ -5021,7 +3569,7 @@ definitions:
       oam-profile-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:uuid"
   tapi.oam.OamService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -5074,7 +3622,7 @@ definitions:
         oam-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamServiceRef:
     type: "object"
@@ -5082,7 +3630,7 @@ definitions:
       oam-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:uuid"
   tapi.oam.PmBinData:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -5176,6 +3724,31 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.oam.updateoamserviceendpoint.Output"
+  tapi.oam.context.OamContext:
+    allOf:
+    - type: "object"
+      properties:
+        oam-service:
+          type: "array"
+          description: "none"
+          items:
+            $ref: "#/definitions/tapi.oam.OamService"
+        oam-profile:
+          type: "array"
+          description: "none"
+          items:
+            $ref: "#/definitions/tapi.oam.oamcontext.OamProfile"
+        oam-job:
+          type: "array"
+          description: "none"
+          items:
+            $ref: "#/definitions/tapi.oam.oamcontext.OamJob"
+        meg:
+          type: "array"
+          description: "none"
+          items:
+            $ref: "#/definitions/tapi.oam.oamcontext.Meg"
+      description: "Augments the base TAPI Context with OamService information"
   tapi.oam.createoamjob.Input:
     type: "object"
     properties:
@@ -5574,16 +4147,9 @@ definitions:
   tapi.path.computation.ContextAugmentation3:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -5628,6 +4194,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -5692,7 +4271,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -5883,14 +4462,9 @@ definitions:
   tapi.topology.ContextAugmentation5:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -6038,7 +4612,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -6138,7 +4712,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -6148,7 +4722,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -6188,7 +4762,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -6295,13 +4869,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -6444,41 +5029,3 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.topology.Topology"
-  tapi.topology.node.OwnedNodeEdgePoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.OwnedNodeEdgePointAugmentation1"
-    - $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-  tapi.topology.topology.Node:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.CapacityPac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.topology.TransferCostPac"
-    - $ref: "#/definitions/tapi.topology.TransferIntegrityPac"
-    - $ref: "#/definitions/tapi.topology.TransferTimingPac"
-    - type: "object"
-      properties:
-        layer-protocol-name:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.common.LayerProtocolName"
-        encap-topology:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.TopologyRef"
-        owned-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        node-rule-group:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        aggregated-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-      description: "none"

--- a/OAS/tapi-notification@2018-08-31.yaml
+++ b/OAS/tapi-notification@2018-08-31.yaml
@@ -69,148 +69,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -746,16 +604,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -873,6 +724,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"

--- a/OAS/tapi-oam@2018-08-31.yaml
+++ b/OAS/tapi-oam@2018-08-31.yaml
@@ -71,731 +71,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/connection={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.Connection"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.Connection"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.Connection"
-        400:
-          description: "Internal error"
-  /data/context/connection={uuid}/switch-control={switch-control-uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.SwitchControl"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      - name: "switch-control-uuid"
-        in: "path"
-        description: "Id of switch-control"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.SwitchControl"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.SwitchControl"
-        400:
-          description: "Internal error"
-  /data/context/connectivity-service/:
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/connectivity-service={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ConnectivityService"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-connectivity"
-      description: "creates or updates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-connectivity"
-      description: "removes tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/meg={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.Meg"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of meg"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.Meg"
-          schema:
-            $ref: "#/definitions/tapi.oam.Meg"
-        400:
-          description: "Internal error"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/oam-job/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-job={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamJob"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamJob"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-profile/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-profile={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamProfile"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamProfile"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-service/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-service={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamService"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -894,192 +169,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.node.OwnedNodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.node.OwnedNodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        400:
-          description: "Internal error"
-  ? /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/connection-end-point={connection-end-point-uuid}/
-  : get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ceplist.ConnectionEndPoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      - name: "connection-end-point-uuid"
-        in: "path"
-        description: "Id of connection-end-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ceplist.ConnectionEndPoint"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -2217,44 +1306,6 @@ definitions:
         \ protocol including all circuit and packet forms.\r\n                At the\
         \ lowest level of recursion, a FC represents a cross-connection within an\
         \ NE."
-  tapi.connectivity.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - $ref: "#/definitions/tapi.common.TerminationPac"
-    - type: "object"
-      properties:
-        client-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        connection-port-role:
-          description: "Each EP of the FC has a role (e.g., working, protection, protected,\
-            \ symmetric, hub, spoke, leaf, root)  in the context of the FC with respect\
-            \ to the FC function. "
-          $ref: "#/definitions/tapi.common.PortRole"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        layer-protocol-qualifier:
-          type: "string"
-          description: "none"
-        parent-node-edge-point:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        aggregated-connection-end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPointRef"
-        connection-port-direction:
-          description: "The orientation of defined flow at the EndPoint."
-          $ref: "#/definitions/tapi.common.PortDirection"
-      description: "The LogicalTerminationPoint (LTP) object class encapsulates the\
-        \ termination and adaptation functions of one or more transport layers. \r\
-        \n                The structure of LTP supports all transport protocols including\
-        \ circuit and packet forms."
   tapi.connectivity.ConnectionEndPointRef:
     allOf:
     - $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
@@ -2263,7 +1314,7 @@ definitions:
         connection-end-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.ConnectionRef:
     type: "object"
@@ -2271,7 +1322,7 @@ definitions:
       connection-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid"
   tapi.connectivity.ConnectivityConstraint:
     type: "object"
     properties:
@@ -2303,6 +1354,19 @@ definitions:
       coroute-inclusion:
         description: "none"
         $ref: "#/definitions/tapi.connectivity.ConnectivityServiceRef"
+  tapi.connectivity.ConnectivityContext:
+    type: "object"
+    properties:
+      connectivity-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
+      connection:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.Connection"
   tapi.connectivity.ConnectivityService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -2382,7 +1446,7 @@ definitions:
         connectivity-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.ConnectivityServiceRef:
     type: "object"
@@ -2390,20 +1454,13 @@ definitions:
       connectivity-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
   tapi.connectivity.ContextAugmentation4:
     type: "object"
     properties:
-      connectivity-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      connection:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.Connection"
+      connectivity-context:
+        description: "Augments the base TAPI Context with ConnectivityService information"
+        $ref: "#/definitions/tapi.connectivity.ConnectivityContext"
     x-augmentation:
       prefix: "tapi-connectivity"
       namespace: "urn:onf:otcc:yang:tapi-connectivity"
@@ -2433,17 +1490,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.getconnectivityservicelist.Output"
-  tapi.connectivity.OwnedNodeEdgePointAugmentation1:
-    type: "object"
-    properties:
-      connection-end-point:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-    x-augmentation:
-      prefix: "tapi-connectivity"
-      namespace: "urn:onf:otcc:yang:tapi-connectivity"
   tapi.connectivity.ProtectionRole:
     type: "string"
     enum:
@@ -2543,7 +1589,7 @@ definitions:
         route-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.SelectionControl:
     type: "string"
@@ -2649,17 +1695,13 @@ definitions:
         switch-control-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.UpdateConnectivityService:
     type: "object"
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.updateconnectivityservice.Output"
-  tapi.connectivity.ceplist.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-    - $ref: "#/definitions/tapi.oam.ConnectionEndPointAugmentation1"
   tapi.connectivity.createconnectivityservice.Input:
     type: "object"
     properties:
@@ -2783,16 +1825,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -2910,6 +1945,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3168,45 +2216,12 @@ definitions:
       subscription-service:
         description: "none"
         $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-  tapi.oam.ConnectionEndPointAugmentation1:
-    type: "object"
-    properties:
-      mip:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MipRef"
-      mep:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MepRef"
-    x-augmentation:
-      prefix: "tapi-oam"
-      namespace: "urn:onf:otcc:yang:tapi-oam"
   tapi.oam.ContextAugmentation2:
     type: "object"
     properties:
-      oam-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamService"
-      oam-profile:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      oam-job:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      meg:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.Meg"
+      oam-context:
+        description: "Augments the base TAPI Context with OamService information"
+        $ref: "#/definitions/tapi.oam.OamContext"
     x-augmentation:
       prefix: "tapi-oam"
       namespace: "urn:onf:otcc:yang:tapi-oam"
@@ -3313,7 +2328,7 @@ definitions:
       meg-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:uuid"
   tapi.oam.Mep:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3346,7 +2361,7 @@ definitions:
         mep-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
       description: "none"
   tapi.oam.Mip:
     allOf:
@@ -3368,7 +2383,7 @@ definitions:
         mip-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamConstraint:
     type: "object"
@@ -3383,6 +2398,29 @@ definitions:
       direction:
         description: "none"
         $ref: "#/definitions/tapi.common.ForwardingDirection"
+  tapi.oam.OamContext:
+    type: "object"
+    properties:
+      oam-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamService"
+      oam-profile:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamProfile"
+      oam-job:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamJob"
+      meg:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.Meg"
   tapi.oam.OamJob:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3438,7 +2476,7 @@ definitions:
       oam-profile-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:uuid"
   tapi.oam.OamService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3491,7 +2529,7 @@ definitions:
         oam-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamServiceRef:
     type: "object"
@@ -3499,7 +2537,7 @@ definitions:
       oam-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:uuid"
   tapi.oam.PmBinData:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3816,16 +2854,9 @@ definitions:
   tapi.path.computation.ContextAugmentation3:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -3870,6 +2901,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3934,7 +2978,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -4125,14 +3169,9 @@ definitions:
   tapi.topology.ContextAugmentation5:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -4280,7 +3319,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -4380,7 +3419,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -4390,7 +3429,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -4430,7 +3469,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -4537,13 +3576,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -4686,41 +3736,3 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.topology.Topology"
-  tapi.topology.node.OwnedNodeEdgePoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.OwnedNodeEdgePointAugmentation1"
-    - $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-  tapi.topology.topology.Node:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.CapacityPac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.topology.TransferCostPac"
-    - $ref: "#/definitions/tapi.topology.TransferIntegrityPac"
-    - $ref: "#/definitions/tapi.topology.TransferTimingPac"
-    - type: "object"
-      properties:
-        layer-protocol-name:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.common.LayerProtocolName"
-        encap-topology:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.TopologyRef"
-        owned-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        node-rule-group:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        aggregated-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-      description: "none"

--- a/OAS/tapi-odu@2018-08-31.yaml
+++ b/OAS/tapi-odu@2018-08-31.yaml
@@ -71,731 +71,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/connection={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.Connection"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.Connection"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.Connection"
-        400:
-          description: "Internal error"
-  /data/context/connection={uuid}/switch-control={switch-control-uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.SwitchControl"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      - name: "switch-control-uuid"
-        in: "path"
-        description: "Id of switch-control"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.SwitchControl"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.SwitchControl"
-        400:
-          description: "Internal error"
-  /data/context/connectivity-service/:
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/connectivity-service={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ConnectivityService"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-connectivity"
-      description: "creates or updates tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.ConnectivityService.body-param"
-        description: "tapi.connectivity.ConnectivityService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-connectivity"
-      description: "removes tapi.connectivity.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/meg={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.oamcontext.Meg"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of meg"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.oamcontext.Meg"
-          schema:
-            $ref: "#/definitions/tapi.oam.oamcontext.Meg"
-        400:
-          description: "Internal error"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/oam-job/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-job={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamJob"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamJob"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-profile/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-profile={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamProfile"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamProfile"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-service/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-service={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamService"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -894,192 +169,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.node.OwnedNodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.node.OwnedNodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        400:
-          description: "Internal error"
-  ? /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/connection-end-point={connection-end-point-uuid}/
-  : get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ceplist.ConnectionEndPoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      - name: "connection-end-point-uuid"
-        in: "path"
-        description: "Id of connection-end-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ceplist.ConnectionEndPoint"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -2217,44 +1306,6 @@ definitions:
         \ protocol including all circuit and packet forms.\r\n                At the\
         \ lowest level of recursion, a FC represents a cross-connection within an\
         \ NE."
-  tapi.connectivity.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - $ref: "#/definitions/tapi.common.TerminationPac"
-    - type: "object"
-      properties:
-        client-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        connection-port-role:
-          description: "Each EP of the FC has a role (e.g., working, protection, protected,\
-            \ symmetric, hub, spoke, leaf, root)  in the context of the FC with respect\
-            \ to the FC function. "
-          $ref: "#/definitions/tapi.common.PortRole"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        layer-protocol-qualifier:
-          type: "string"
-          description: "none"
-        parent-node-edge-point:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        aggregated-connection-end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPointRef"
-        connection-port-direction:
-          description: "The orientation of defined flow at the EndPoint."
-          $ref: "#/definitions/tapi.common.PortDirection"
-      description: "The LogicalTerminationPoint (LTP) object class encapsulates the\
-        \ termination and adaptation functions of one or more transport layers. \r\
-        \n                The structure of LTP supports all transport protocols including\
-        \ circuit and packet forms."
   tapi.connectivity.ConnectionEndPointRef:
     allOf:
     - $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
@@ -2263,7 +1314,7 @@ definitions:
         connection-end-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.ConnectionRef:
     type: "object"
@@ -2271,7 +1322,7 @@ definitions:
       connection-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid"
   tapi.connectivity.ConnectivityConstraint:
     type: "object"
     properties:
@@ -2303,6 +1354,19 @@ definitions:
       coroute-inclusion:
         description: "none"
         $ref: "#/definitions/tapi.connectivity.ConnectivityServiceRef"
+  tapi.connectivity.ConnectivityContext:
+    type: "object"
+    properties:
+      connectivity-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
+      connection:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.Connection"
   tapi.connectivity.ConnectivityService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -2382,7 +1446,7 @@ definitions:
         connectivity-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.ConnectivityServiceRef:
     type: "object"
@@ -2390,20 +1454,13 @@ definitions:
       connectivity-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
   tapi.connectivity.ContextAugmentation4:
     type: "object"
     properties:
-      connectivity-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
-      connection:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.Connection"
+      connectivity-context:
+        description: "Augments the base TAPI Context with ConnectivityService information"
+        $ref: "#/definitions/tapi.connectivity.ConnectivityContext"
     x-augmentation:
       prefix: "tapi-connectivity"
       namespace: "urn:onf:otcc:yang:tapi-connectivity"
@@ -2433,17 +1490,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.getconnectivityservicelist.Output"
-  tapi.connectivity.OwnedNodeEdgePointAugmentation1:
-    type: "object"
-    properties:
-      connection-end-point:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-    x-augmentation:
-      prefix: "tapi-connectivity"
-      namespace: "urn:onf:otcc:yang:tapi-connectivity"
   tapi.connectivity.ProtectionRole:
     type: "string"
     enum:
@@ -2543,7 +1589,7 @@ definitions:
         route-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.SelectionControl:
     type: "string"
@@ -2649,18 +1695,13 @@ definitions:
         switch-control-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.UpdateConnectivityService:
     type: "object"
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.updateconnectivityservice.Output"
-  tapi.connectivity.ceplist.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-    - $ref: "#/definitions/tapi.oam.ConnectionEndPointAugmentation1"
-    - $ref: "#/definitions/tapi.odu.ConnectionEndPointAugmentation2"
   tapi.connectivity.createconnectivityservice.Input:
     type: "object"
     properties:
@@ -2784,16 +1825,9 @@ definitions:
   tapi.notification.ContextAugmentation2:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -2911,6 +1945,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3169,45 +2216,12 @@ definitions:
       subscription-service:
         description: "none"
         $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-  tapi.oam.ConnectionEndPointAugmentation1:
-    type: "object"
-    properties:
-      mip:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MipRef"
-      mep:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MepRef"
-    x-augmentation:
-      prefix: "tapi-oam"
-      namespace: "urn:onf:otcc:yang:tapi-oam"
   tapi.oam.ContextAugmentation1:
     type: "object"
     properties:
-      oam-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamService"
-      oam-profile:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      oam-job:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      meg:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.oamcontext.Meg"
+      oam-context:
+        description: "Augments the base TAPI Context with OamService information"
+        $ref: "#/definitions/tapi.oam.OamContext"
     x-augmentation:
       prefix: "tapi-oam"
       namespace: "urn:onf:otcc:yang:tapi-oam"
@@ -3314,7 +2328,7 @@ definitions:
       meg-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:uuid"
   tapi.oam.Mep:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3347,7 +2361,7 @@ definitions:
         mep-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
       description: "none"
   tapi.oam.Mip:
     allOf:
@@ -3369,7 +2383,7 @@ definitions:
         mip-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamConstraint:
     type: "object"
@@ -3384,6 +2398,29 @@ definitions:
       direction:
         description: "none"
         $ref: "#/definitions/tapi.common.ForwardingDirection"
+  tapi.oam.OamContext:
+    type: "object"
+    properties:
+      oam-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamService"
+      oam-profile:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamProfile"
+      oam-job:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamJob"
+      meg:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.Meg"
   tapi.oam.OamJob:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3439,7 +2476,7 @@ definitions:
       oam-profile-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:uuid"
   tapi.oam.OamService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3492,7 +2529,7 @@ definitions:
         oam-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamServiceRef:
     type: "object"
@@ -3500,7 +2537,7 @@ definitions:
       oam-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:uuid"
   tapi.oam.PmBinData:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3747,52 +2784,6 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.oam.OamService"
-  tapi.oam.meg.Mep:
-    allOf:
-    - $ref: "#/definitions/tapi.oam.Mep"
-    - $ref: "#/definitions/tapi.odu.MepAugmentation1"
-  tapi.oam.meg.Mip:
-    allOf:
-    - $ref: "#/definitions/tapi.oam.Mip"
-    - $ref: "#/definitions/tapi.odu.MipAugmentation1"
-  tapi.oam.oamcontext.Meg:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - type: "object"
-      properties:
-        meg-identifier:
-          type: "string"
-          description: "none"
-        meg-level:
-          type: "integer"
-          format: "int32"
-          description: "none"
-        mip:
-          type: "array"
-          description: "ME may 0, 1, or more MIPs"
-          items:
-            $ref: "#/definitions/tapi.oam.meg.Mip"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
-        mep:
-          type: "array"
-          description: "1. ME may have 0 MEPs (case of transit domains where at least\
-            \ 1 MIP is present)\r\n                    2. ME may have 1 MEP (case\
-            \ of edge domaind, where the peer MEP is ouside the managed domain)\r\n\
-            \                    3. ME may have 2 MEPs"
-          items:
-            $ref: "#/definitions/tapi.oam.meg.Mep"
-        direction:
-          description: "none"
-          $ref: "#/definitions/tapi.common.ForwardingDirection"
-      description: "none"
   tapi.oam.updateoamjob.Input:
     type: "object"
     properties:
@@ -3855,395 +2846,6 @@ definitions:
       end-point:
         description: "none"
         $ref: "#/definitions/tapi.oam.OamServiceEndPoint"
-  tapi.odu.ConnectionEndPointAugmentation2:
-    type: "object"
-    properties:
-      odu-term-and-adapter:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduTerminationAndClientAdaptationPac"
-      odu-common:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduCommonPac"
-      odu-ctp:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduCtpPac"
-      odu-protection:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduProtectionPac"
-    x-augmentation:
-      prefix: "tapi-odu"
-      namespace: "urn:onf:otcc:yang:tapi-odu"
-  tapi.odu.DegThr:
-    type: "object"
-    properties:
-      deg-thr-value:
-        type: "integer"
-        format: "int32"
-        description: "Percentage of detected errored blocks"
-      percentage-granularity:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.PercentageGranularity"
-      deg-thr-type:
-        description: "Number of errored blocks"
-        $ref: "#/definitions/tapi.odu.DegThrType"
-  tapi.odu.DegThrType:
-    type: "string"
-    enum:
-    - "PERCENTAGE"
-    - "NUMBER_ERRORED_BLOCKS"
-  tapi.odu.MappingType:
-    type: "string"
-    enum:
-    - "AMP"
-    - "BMP"
-    - "GFP-F"
-    - "GMP"
-    - "TTP_GFP_BMP"
-    - "NULL"
-  tapi.odu.MepAugmentation1:
-    type: "object"
-    properties:
-      odu-term-and-adapter:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduTerminationAndClientAdaptationPac"
-      odu-common:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduCommonPac"
-      odu-ctp:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduCtpPac"
-      odu-protection:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduProtectionPac"
-    x-augmentation:
-      prefix: "tapi-odu"
-      namespace: "urn:onf:otcc:yang:tapi-odu"
-  tapi.odu.MipAugmentation1:
-    type: "object"
-    properties:
-      odu-mip:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduMipPac"
-      odu-pm:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduPmPac"
-      odu-ncm:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduNcmPac"
-      odu-tcm:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduTcmMipPac"
-      odu-defect:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduDefectPac"
-    x-augmentation:
-      prefix: "tapi-odu"
-      namespace: "urn:onf:otcc:yang:tapi-odu"
-  tapi.odu.OduCommonPac:
-    type: "object"
-    properties:
-      odu-rate-tolerance:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the rate tolerance of the ODU termination\
-          \ point. \r\n                    Valid values are real value in the unit\
-          \ of ppm. \r\n                    Standardized values are defined in Table\
-          \ 7-2/G.709."
-      odu-rate:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the rate of the ODU terminatino point.\
-          \ \r\n                    This attribute is Set at create; i.e., once created\
-          \ it cannot be changed directly. \r\n                    In case of resizable\
-          \ ODU flex, its value can be changed via HAO (not directly on the attribute).\
-          \ \r\n                    "
-      odu-type:
-        type: "string"
-        description: "This attribute specifies the type of the ODU termination point."
-  tapi.odu.OduCtpPac:
-    type: "object"
-    properties:
-      accepted-msi:
-        type: "string"
-        description: "This attribute is applicable when the ODU CTP object instance\
-          \ represents a lower order ODU1 or ODU2 CTP Sink at the client layer of\
-          \ the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP\
-          \ Sink at the client layer of the ODUP/ODUj-21 adaptation function. This\
-          \ attribute is a 1-byte field that represents the accepted multiplex structure\
-          \ of the adaptation function. "
-      tributary-port-number:
-        type: "integer"
-        format: "int32"
-        description: "This attribute identifies the tributary port number that is\
-          \ associated with the ODU CTP.\r\n                    range of type : The\
-          \ value range depends on the size of the Tributary Port Number (TPN) field\
-          \ used which depends on th server-layer ODU or OTU.\r\n                \
-          \    In case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber\
-          \ shall be zero.\r\n                    In case of LO ODUj mapping over\
-          \ ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range\
-          \ is 0-63. See clause 14.4.1/G.709-2016.\r\n                    In case\
-          \ of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the\
-          \ value range is 0-127. See clause 14.4.1.4/G.709-2016.\r\n            \
-          \        In case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit\
-          \ field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.\r\
-          \n                    "
-      tributary-slot-list:
-        type: "array"
-        description: "This attribute contains a set of distinct (i.e. unique) integers\
-          \ (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9\
-          \ and TS15) which represents the resources occupied by the Low Order ODU\
-          \ Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). \r\
-          \n                    This attribute applies when the LO ODU_ ConnectionTerminationPoint\
-          \ connects with an HO ODU_TrailTerminationPoint object. \r\n           \
-          \         It will not apply if this ODU_ ConnectionTerminationPoint object\
-          \ directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has\
-          \ no trib slots). \r\n                    The upper bound of the integer\
-          \ allowed in this set is a function of the HO-ODU server layer to which\
-          \ the ODU connection has been mapped (adapted). \r\n                   \
-          \ Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively).\
-          \ Note that the value of this attribute can be changed only in the case\
-          \ of ODUflex and has to be through specific operations (i.e. not be changing\
-          \ the attribute tributarySlotList directly)."
-        items:
-          type: "integer"
-          format: "int32"
-  tapi.odu.OduDefectPac:
-    type: "object"
-    properties:
-      oci:
-        type: "boolean"
-        description: "Open Connection Indicator"
-        default: false
-      lck:
-        type: "boolean"
-        description: "Locked"
-        default: false
-      bdi:
-        type: "boolean"
-        description: "Backward Defect Indication"
-        default: false
-      ssf:
-        type: "boolean"
-        description: "Server Signal Failure"
-        default: false
-      deg:
-        type: "boolean"
-        description: "Signal Degraded"
-        default: false
-      tim:
-        type: "boolean"
-        description: "Trail Trace Identifier Mismatch"
-        default: false
-  tapi.odu.OduMipPac:
-    type: "object"
-    properties:
-      tim-det-mode:
-        description: "This attribute indicates the mode of the Trace Identifier Mismatch\
-          \ (TIM) Detection function allowed values: OFF, SAPIonly, DAPIonly, SAPIandDAPI"
-        $ref: "#/definitions/tapi.odu.TimDetMo"
-      ex-dapi:
-        type: "string"
-        description: "The Expected Destination Access Point Identifier (ExDAPI), provisioned\
-          \ by the managing system, to be compared with the TTI accepted at the overhead\
-          \ position of the sink for the purpose of checking the integrity of connectivity."
-      deg-m:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the threshold level for declaring a\
-          \ Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive\
-          \ bad PM Seconds are detected."
-      acti:
-        type: "string"
-        description: "The Trail Trace Identifier (TTI) information recovered (Accepted)\
-          \ from the TTI overhead position at the sink of a trail."
-      ex-sapi:
-        type: "string"
-        description: "The Expected Source Access Point Identifier (ExSAPI), provisioned\
-          \ by the managing system, to be compared with the TTI accepted at the overhead\
-          \ position of the sink for the purpose of checking the integrity of connectivity.\r\
-          \n                    "
-      deg-thr:
-        description: "This attribute indicates the threshold level for declaring a\
-          \ performance monitoring (PM) Second to be bad. The value of the threshold\
-          \ can be provisioned in terms of number of errored blocks or in terms of\
-          \ percentage of errored blocks. For percentage-based specification, in order\
-          \ to support provision of less than 1%, the specification consists of two\
-          \ fields. The first field indicates the granularity of percentage. For examples,\
-          \ in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple\
-          \ of the granularity. For number of errored block based, the value is a\
-          \ positive integer."
-        $ref: "#/definitions/tapi.odu.DegThr"
-      tim-act-disabled:
-        type: "boolean"
-        description: "This attribute provides the control capability for the managing\
-          \ system to enable or disable the Consequent Action function when detecting\
-          \ Trace Identifier Mismatch (TIM) at the trail termination sink."
-        default: true
-  tapi.odu.OduNamedPayloadType:
-    type: "string"
-    enum:
-    - "UNKNOWN"
-    - "UNINTERPRETABLE"
-  tapi.odu.OduNcmPac:
-    type: "object"
-    properties:
-      tcm-fields-in-use:
-        type: "array"
-        description: "This attribute indicates the used TCM fields of the ODU OH."
-        items:
-          type: "integer"
-          format: "int32"
-  tapi.odu.OduPayloadType:
-    type: "object"
-    properties:
-      hex-payload-type:
-        type: "integer"
-        format: "int32"
-        description: "none"
-      named-payload-type:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduNamedPayloadType"
-  tapi.odu.OduPmPac:
-    type: "object"
-    properties:
-      f-ses:
-        type: "integer"
-        format: "int32"
-        description: "Far-end Severely Errored Second"
-      n-bbe:
-        type: "integer"
-        format: "int32"
-        description: "Near-end Background Block Error"
-      f-bbe:
-        type: "integer"
-        format: "int32"
-        description: "Far-end Background Block Error"
-      uas:
-        description: "UnAvailable Second"
-        $ref: "#/definitions/tapi.odu.UasChoice"
-      n-ses:
-        type: "integer"
-        format: "int32"
-        description: "Near-end Severely Errored Second"
-  tapi.odu.OduPoolPac:
-    type: "object"
-    properties:
-      client-capacity:
-        type: "integer"
-        format: "int32"
-        description: "none"
-      max-client-size:
-        type: "integer"
-        format: "int32"
-        description: "none"
-      max-client-instances:
-        type: "integer"
-        format: "int32"
-        description: "none"
-  tapi.odu.OduProtectionPac:
-    type: "object"
-    properties:
-      aps-enable:
-        type: "boolean"
-        description: "This attribute is for enabling/disabling the automatic protection\
-          \ switching (APS) capability at the transport adaptation function that is\
-          \ represented by the ODU_ConnectionTerminationPoint object class. It triggers\
-          \ the MI_APS_EN signal to the transport adaptation function."
-        default: true
-      aps-level:
-        type: "integer"
-        format: "int32"
-        description: "This attribute is for configuring the automatic protection switching\
-          \ (APS) level that should operate at the transport adaptation function that\
-          \ is represented by the ODU_ConnectionTerminationPoint object class. It\
-          \ triggers the MI_APS_LVL signal to the transport adaptation function. The\
-          \ value 0 means path and the values 1 through 6 mean TCM level 1 through\
-          \ 6 respectively."
-  tapi.odu.OduSlotSize:
-    type: "string"
-    enum:
-    - "1G25"
-    - "2G5"
-  tapi.odu.OduTcmMipPac:
-    type: "object"
-    properties:
-      tcm-field:
-        type: "integer"
-        format: "int32"
-        description: "This attribute indicates the tandem connection monitoring field\
-          \ of the ODU OH."
-  tapi.odu.OduTerminationAndClientAdaptationPac:
-    type: "object"
-    properties:
-      configured-mapping-type:
-        description: "This attributes indicates the configured mapping type."
-        $ref: "#/definitions/tapi.odu.MappingType"
-      auto-payload-type:
-        type: "boolean"
-        description: "This attribute is applicable when the ODU CTP object instance\
-          \ represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21\
-          \ adaptation function. The value of true of this attribute configures that\
-          \ the adaptation source function shall fall back to the payload type PT=20\
-          \ if the conditions specified in 14.3.10.1/G.798 are satisfied. "
-        default: false
-      accepted-payload-type:
-        description: "This attribute is applicable when the ODU CTP object instance\
-          \ represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j\
-          \ or ODUP/ODUj-21 adaptation function. \r\n                    This attribute\
-          \ is a 2-digit Hex code that indicates the new accepted payload type.\r\n\
-          \                    Valid values are defined in Table 15-8 of ITU-T Recommendation\
-          \ G.709 with one additional value UN_INTERPRETABLE."
-        $ref: "#/definitions/tapi.odu.OduPayloadType"
-      opu-tributary-slot-size:
-        description: "This attribute is applicable for ODU2 and ODU3 CTP only. It\
-          \ indicates the slot size of the ODU CTP."
-        $ref: "#/definitions/tapi.odu.OduSlotSize"
-      configured-client-type:
-        type: "string"
-        description: "This attribute configures the type of the client CTP of the\
-          \ server ODU TTP."
-  tapi.odu.OwnedNodeEdgePointAugmentation2:
-    type: "object"
-    properties:
-      odu-pool:
-        description: "none"
-        $ref: "#/definitions/tapi.odu.OduPoolPac"
-    x-augmentation:
-      prefix: "tapi-odu"
-      namespace: "urn:onf:otcc:yang:tapi-odu"
-  tapi.odu.PercentageGranularity:
-    type: "string"
-    enum:
-    - "ONES"
-    - "ONE_TENTHS"
-    - "ONE_HUNDREDTHS"
-    - "ONE_THOUSANDTHS"
-  tapi.odu.TimDetMo:
-    type: "string"
-    enum:
-    - "DAPI"
-    - "SAPI"
-    - "BOTH"
-    - "OFF"
-  tapi.odu.UasChoice:
-    type: "object"
-    properties:
-      fuas:
-        type: "integer"
-        format: "int32"
-        description: "none"
-      bidirectional:
-        type: "boolean"
-        description: "none"
-        default: true
-      nuas:
-        type: "integer"
-        format: "int32"
-        description: "none"
-      uas:
-        type: "integer"
-        format: "int32"
-        description: "none"
   tapi.path.computation.ComputeP2PPath:
     type: "object"
     properties:
@@ -4252,16 +2854,9 @@ definitions:
   tapi.path.computation.ContextAugmentation3:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -4306,6 +2901,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -4370,7 +2978,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -4561,14 +3169,9 @@ definitions:
   tapi.topology.ContextAugmentation5:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -4716,7 +3319,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -4816,7 +3419,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -4826,7 +3429,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -4866,7 +3469,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -4973,13 +3576,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -5122,42 +3736,3 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.topology.Topology"
-  tapi.topology.node.OwnedNodeEdgePoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.OwnedNodeEdgePointAugmentation1"
-    - $ref: "#/definitions/tapi.odu.OwnedNodeEdgePointAugmentation2"
-    - $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-  tapi.topology.topology.Node:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.CapacityPac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.topology.TransferCostPac"
-    - $ref: "#/definitions/tapi.topology.TransferIntegrityPac"
-    - $ref: "#/definitions/tapi.topology.TransferTimingPac"
-    - type: "object"
-      properties:
-        layer-protocol-name:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.common.LayerProtocolName"
-        encap-topology:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.TopologyRef"
-        owned-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        node-rule-group:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        aggregated-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-      description: "none"

--- a/OAS/tapi-path-computation@2018-08-31.yaml
+++ b/OAS/tapi-path-computation@2018-08-31.yaml
@@ -70,280 +70,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -442,159 +168,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -1261,16 +834,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -1388,6 +954,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -1654,16 +1233,9 @@ definitions:
   tapi.path.computation.ContextAugmentation2:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -1708,6 +1280,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -1772,7 +1357,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -1963,14 +1548,9 @@ definitions:
   tapi.topology.ContextAugmentation3:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -2118,7 +1698,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -2218,7 +1798,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -2228,7 +1808,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -2268,7 +1848,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -2375,13 +1955,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:

--- a/OAS/tapi-photonic-media@2018-08-31.yaml
+++ b/OAS/tapi-photonic-media@2018-08-31.yaml
@@ -71,734 +71,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/connection={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.Connection"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.Connection"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.Connection"
-        400:
-          description: "Internal error"
-  /data/context/connection={uuid}/switch-control={switch-control-uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.SwitchControl"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connection"
-        required: true
-        type: "string"
-      - name: "switch-control-uuid"
-        in: "path"
-        description: "Id of switch-control"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.SwitchControl"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.SwitchControl"
-        400:
-          description: "Internal error"
-  /data/context/connectivity-service/:
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.connectivitycontext.ConnectivityService"
-      parameters:
-      - in: "body"
-        name: "tapi.connectivity.connectivitycontext.ConnectivityService.body-param"
-        description: "tapi.connectivity.connectivitycontext.ConnectivityService to\
-          \ be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.connectivitycontext.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/connectivity-service={uuid}/:
-    get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.connectivitycontext.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.connectivitycontext.ConnectivityService"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.connectivitycontext.ConnectivityService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-connectivity"
-      description: "creates tapi.connectivity.connectivitycontext.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.connectivitycontext.ConnectivityService.body-param"
-        description: "tapi.connectivity.connectivitycontext.ConnectivityService to\
-          \ be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.connectivitycontext.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-connectivity"
-      description: "creates or updates tapi.connectivity.connectivitycontext.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.connectivity.connectivitycontext.ConnectivityService.body-param"
-        description: "tapi.connectivity.connectivitycontext.ConnectivityService to\
-          \ be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.connectivity.connectivitycontext.ConnectivityService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-connectivity"
-      description: "removes tapi.connectivity.connectivitycontext.ConnectivityService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of connectivity-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/meg={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.Meg"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of meg"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.Meg"
-          schema:
-            $ref: "#/definitions/tapi.oam.Meg"
-        400:
-          description: "Internal error"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
-  /data/context/oam-job/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-job={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamJob"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamJob"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamJob.body-param"
-        description: "tapi.oam.OamJob to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamJob"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-job"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-profile/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-profile={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamProfile"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamProfile"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamProfile.body-param"
-        description: "tapi.oam.OamProfile to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamProfile"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-profile"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/oam-service/:
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/oam-service={uuid}/:
-    get:
-      tags:
-      - "tapi-oam"
-      description: "returns tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.oam.OamService"
-          schema:
-            $ref: "#/definitions/tapi.oam.OamService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-oam"
-      description: "creates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-oam"
-      description: "creates or updates tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.oam.OamService.body-param"
-        description: "tapi.oam.OamService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.oam.OamService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-oam"
-      description: "removes tapi.oam.OamService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of oam-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path-comp-service/:
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/path-comp-service={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.PathComputationService"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.PathComputationService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-path-computation"
-      description: "creates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added to\
-          \ list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-path-computation"
-      description: "creates or updates tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.path.computation.PathComputationService.body-param"
-        description: "tapi.path.computation.PathComputationService to be added or\
-          \ updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-path-computation"
-      description: "removes tapi.path.computation.PathComputationService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path-comp-service"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/path={uuid}/:
-    get:
-      tags:
-      - "tapi-path-computation"
-      description: "returns tapi.path.computation.Path"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.path.computation.Path"
-          schema:
-            $ref: "#/definitions/tapi.path.computation.Path"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -897,192 +169,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.node.OwnedNodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.node.OwnedNodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        400:
-          description: "Internal error"
-  ? /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/connection-end-point={connection-end-point-uuid}/
-  : get:
-      tags:
-      - "tapi-connectivity"
-      description: "returns tapi.connectivity.ceplist.ConnectionEndPoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      - name: "connection-end-point-uuid"
-        in: "path"
-        description: "Id of connection-end-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.connectivity.ceplist.ConnectionEndPoint"
-          schema:
-            $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-        400:
-          description: "Internal error"
   /operations/compute-p-2-p-path/:
     post:
       tags:
@@ -2219,44 +1305,6 @@ definitions:
         \ protocol including all circuit and packet forms.\r\n                At the\
         \ lowest level of recursion, a FC represents a cross-connection within an\
         \ NE."
-  tapi.connectivity.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.common.OperationalStatePac"
-    - $ref: "#/definitions/tapi.common.TerminationPac"
-    - type: "object"
-      properties:
-        client-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        connection-port-role:
-          description: "Each EP of the FC has a role (e.g., working, protection, protected,\
-            \ symmetric, hub, spoke, leaf, root)  in the context of the FC with respect\
-            \ to the FC function. "
-          $ref: "#/definitions/tapi.common.PortRole"
-        layer-protocol-name:
-          description: "none"
-          $ref: "#/definitions/tapi.common.LayerProtocolName"
-        layer-protocol-qualifier:
-          type: "string"
-          description: "none"
-        parent-node-edge-point:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-        aggregated-connection-end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionEndPointRef"
-        connection-port-direction:
-          description: "The orientation of defined flow at the EndPoint."
-          $ref: "#/definitions/tapi.common.PortDirection"
-      description: "The LogicalTerminationPoint (LTP) object class encapsulates the\
-        \ termination and adaptation functions of one or more transport layers. \r\
-        \n                The structure of LTP supports all transport protocols including\
-        \ circuit and packet forms."
   tapi.connectivity.ConnectionEndPointRef:
     allOf:
     - $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
@@ -2265,7 +1313,7 @@ definitions:
         connection-end-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.ConnectionRef:
     type: "object"
@@ -2273,7 +1321,7 @@ definitions:
       connection-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid"
   tapi.connectivity.ConnectivityConstraint:
     type: "object"
     properties:
@@ -2305,6 +1353,19 @@ definitions:
       coroute-inclusion:
         description: "none"
         $ref: "#/definitions/tapi.connectivity.ConnectivityServiceRef"
+  tapi.connectivity.ConnectivityContext:
+    type: "object"
+    properties:
+      connectivity-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.ConnectivityService"
+      connection:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.connectivity.Connection"
   tapi.connectivity.ConnectivityService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -2384,7 +1445,7 @@ definitions:
         connectivity-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.ConnectivityServiceRef:
     type: "object"
@@ -2392,20 +1453,13 @@ definitions:
       connectivity-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+        x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
   tapi.connectivity.ContextAugmentation4:
     type: "object"
     properties:
-      connectivity-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.connectivitycontext.ConnectivityService"
-      connection:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.Connection"
+      connectivity-context:
+        description: "Augments the base TAPI Context with ConnectivityService information"
+        $ref: "#/definitions/tapi.connectivity.ConnectivityContext"
     x-augmentation:
       prefix: "tapi-connectivity"
       namespace: "urn:onf:otcc:yang:tapi-connectivity"
@@ -2435,17 +1489,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.getconnectivityservicelist.Output"
-  tapi.connectivity.OwnedNodeEdgePointAugmentation2:
-    type: "object"
-    properties:
-      connection-end-point:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.connectivity.ceplist.ConnectionEndPoint"
-    x-augmentation:
-      prefix: "tapi-connectivity"
-      namespace: "urn:onf:otcc:yang:tapi-connectivity"
   tapi.connectivity.ProtectionRole:
     type: "string"
     enum:
@@ -2545,7 +1588,7 @@ definitions:
         route-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
       description: "none"
   tapi.connectivity.SelectionControl:
     type: "string"
@@ -2651,48 +1694,13 @@ definitions:
         switch-control-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
+          x-path: "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
       description: "none"
   tapi.connectivity.UpdateConnectivityService:
     type: "object"
     properties:
       output:
         $ref: "#/definitions/tapi.connectivity.updateconnectivityservice.Output"
-  tapi.connectivity.ceplist.ConnectionEndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.ConnectionEndPoint"
-    - $ref: "#/definitions/tapi.oam.ConnectionEndPointAugmentation1"
-    - $ref: "#/definitions/tapi.photonic.media.ConnectionEndPointAugmentation2"
-    - $ref: "#/definitions/tapi.photonic.media.ConnectionEndPointAugmentation3"
-    - $ref: "#/definitions/tapi.photonic.media.ConnectionEndPointAugmentation4"
-    - $ref: "#/definitions/tapi.photonic.media.ConnectionEndPointAugmentation5"
-    - $ref: "#/definitions/tapi.photonic.media.ConnectionEndPointAugmentation6"
-  tapi.connectivity.connectivitycontext.ConnectivityService:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.connectivity.ConnectivityConstraint"
-    - $ref: "#/definitions/tapi.connectivity.ResilienceConstraint"
-    - $ref: "#/definitions/tapi.path.computation.RoutingConstraint"
-    - $ref: "#/definitions/tapi.path.computation.TopologyConstraint"
-    - type: "object"
-      properties:
-        end-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.connectivityservice.EndPoint"
-        connection:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.connectivity.ConnectionRef"
-      description: "none"
-  tapi.connectivity.connectivityservice.EndPoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.ConnectivityServiceEndPoint"
-    - $ref: "#/definitions/tapi.photonic.media.EndPointAugmentation1"
-    - $ref: "#/definitions/tapi.photonic.media.EndPointAugmentation2"
   tapi.connectivity.createconnectivityservice.Input:
     type: "object"
     properties:
@@ -2816,16 +1824,9 @@ definitions:
   tapi.notification.ContextAugmentation2:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -2943,6 +1944,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3201,45 +2215,12 @@ definitions:
       subscription-service:
         description: "none"
         $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-  tapi.oam.ConnectionEndPointAugmentation1:
-    type: "object"
-    properties:
-      mip:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MipRef"
-      mep:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.MepRef"
-    x-augmentation:
-      prefix: "tapi-oam"
-      namespace: "urn:onf:otcc:yang:tapi-oam"
   tapi.oam.ContextAugmentation1:
     type: "object"
     properties:
-      oam-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamService"
-      oam-profile:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamProfile"
-      oam-job:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.OamJob"
-      meg:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.oam.Meg"
+      oam-context:
+        description: "Augments the base TAPI Context with OamService information"
+        $ref: "#/definitions/tapi.oam.OamContext"
     x-augmentation:
       prefix: "tapi-oam"
       namespace: "urn:onf:otcc:yang:tapi-oam"
@@ -3346,7 +2327,7 @@ definitions:
       meg-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:uuid"
   tapi.oam.Mep:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3379,7 +2360,7 @@ definitions:
         mep-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
       description: "none"
   tapi.oam.Mip:
     allOf:
@@ -3401,7 +2382,7 @@ definitions:
         mip-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamConstraint:
     type: "object"
@@ -3416,6 +2397,29 @@ definitions:
       direction:
         description: "none"
         $ref: "#/definitions/tapi.common.ForwardingDirection"
+  tapi.oam.OamContext:
+    type: "object"
+    properties:
+      oam-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamService"
+      oam-profile:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamProfile"
+      oam-job:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.OamJob"
+      meg:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.oam.Meg"
   tapi.oam.OamJob:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3471,7 +2475,7 @@ definitions:
       oam-profile-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:uuid"
   tapi.oam.OamService:
     allOf:
     - $ref: "#/definitions/tapi.common.AdminStatePac"
@@ -3524,7 +2528,7 @@ definitions:
         oam-service-end-point-local-id:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
+          x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id"
       description: "none"
   tapi.oam.OamServiceRef:
     type: "object"
@@ -3532,7 +2536,7 @@ definitions:
       oam-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-oam:oam-service/tapi-oam:uuid"
+        x-path: "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:uuid"
   tapi.oam.PmBinData:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -3849,16 +2853,9 @@ definitions:
   tapi.path.computation.ContextAugmentation3:
     type: "object"
     properties:
-      path-comp-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.PathComputationService"
-      path:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.path.computation.Path"
+      path-computation-context:
+        description: "Augments the base TAPI Context with PathComputationService information"
+        $ref: "#/definitions/tapi.path.computation.PathComputationContext"
     x-augmentation:
       prefix: "tapi-path-computation"
       namespace: "urn:onf:otcc:yang:tapi-path-computation"
@@ -3903,6 +2900,19 @@ definitions:
         \ defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by\
         \ concatenating link resources (associated with a Link) and the lower-level\
         \ connections (cross-connections) in the different nodes"
+  tapi.path.computation.PathComputationContext:
+    type: "object"
+    properties:
+      path-comp-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.PathComputationService"
+      path:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.path.computation.Path"
   tapi.path.computation.PathComputationService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3967,7 +2977,7 @@ definitions:
       path-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+        x-path: "/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid"
   tapi.path.computation.PathServiceEndPoint:
     allOf:
     - $ref: "#/definitions/tapi.common.LocalClass"
@@ -4195,95 +3205,6 @@ definitions:
       frequency-constraint:
         description: "none"
         $ref: "#/definitions/tapi.photonic.media.FrequencyConstraint"
-  tapi.photonic.media.ConnectionEndPointAugmentation2:
-    type: "object"
-    properties:
-      ots-media-channel:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.MediaChannelPropertiesPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.ConnectionEndPointAugmentation3:
-    type: "object"
-    properties:
-      media-channel:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.MediaChannelPropertiesPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.ConnectionEndPointAugmentation4:
-    type: "object"
-    properties:
-      otsi-adapter:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.OtsiGserverAdaptationPac"
-      fec-parameters:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.FecPropertiesPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.ConnectionEndPointAugmentation5:
-    type: "object"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.ConnectionEndPointAugmentation6:
-    type: "object"
-    properties:
-      otsi-termination:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.OtsiTerminationPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.EndPointAugmentation1:
-    type: "object"
-    properties:
-      otsi-config:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.OtsiTerminationConfigPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.EndPointAugmentation2:
-    type: "object"
-    properties:
-      mc-pool:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.MediaChannelPoolCapabilityPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.FecPropertiesPac:
-    type: "object"
-    properties:
-      uncorrectable-bytes:
-        type: "integer"
-        format: "int32"
-        description: "Bytes that could not be corrected by FEC"
-      corrected-bits:
-        type: "integer"
-        format: "int32"
-        description: "Bits corrected between those that were received corrupted"
-      pre-fec-ber:
-        type: "integer"
-        format: "int32"
-        description: "counter: bit error rate before correction by FEC"
-      uncorrectable-bits:
-        type: "integer"
-        format: "int32"
-        description: "Bits that could not be corrected by FEC"
-      corrected-bytes:
-        type: "integer"
-        format: "int32"
-        description: "Bytes corrected between those that were received corrupted"
-      post-fec-ber:
-        type: "integer"
-        format: "int32"
-        description: "counter: bit error rate after correction by FEC"
   tapi.photonic.media.FrequencyConstraint:
     type: "object"
     properties:
@@ -4303,43 +3224,6 @@ definitions:
     - "FLEX"
     - "GRIDLESS"
     - "UNSPECIFIED"
-  tapi.photonic.media.LaserControlStatusType:
-    type: "string"
-    enum:
-    - "ON"
-    - "OFF"
-    - "PULSING"
-    - "UNDEFINED"
-  tapi.photonic.media.LaserControlType:
-    type: "string"
-    enum:
-    - "FORCED-ON"
-    - "FORCED-OFF"
-    - "AUTOMATIC-LASER-SHUTDOWN"
-    - "UNDEFINED"
-  tapi.photonic.media.LaserPropertiesPac:
-    type: "object"
-    properties:
-      laser-application-type:
-        description: "The type of laser, its operational wavelengths, and its applications.\
-          \ String size 255."
-        $ref: "#/definitions/tapi.photonic.media.LaserType"
-      laser-bias-current:
-        type: "string"
-        description: "The Bias current of the laser that is the medium polarization\
-          \ current of the laser."
-      laser-temperature:
-        type: "string"
-        description: "The temperature of the laser"
-      laser-status:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.LaserControlStatusType"
-  tapi.photonic.media.LaserType:
-    type: "string"
-    enum:
-    - "PUMP"
-    - "MODULATED"
-    - "PULSE"
   tapi.photonic.media.MediaChannelPoolCapabilityPac:
     type: "object"
     properties:
@@ -4358,18 +3242,12 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
-  tapi.photonic.media.MediaChannelPropertiesPac:
+  tapi.photonic.media.MediaChannelServiceInterfacePointSpec:
     type: "object"
     properties:
-      occupied-spectrum:
+      mc-pool:
         description: "none"
-        $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
-      measured-power-egress:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
-      measured-power-ingress:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
+        $ref: "#/definitions/tapi.photonic.media.MediaChannelPoolCapabilityPac"
   tapi.photonic.media.ModulationTechnique:
     type: "string"
     enum:
@@ -4409,132 +3287,27 @@ definitions:
         description: "The Upper frequency of the channel spectrum"
         items:
           $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
-  tapi.photonic.media.OtsiGserverAdaptationPac:
+  tapi.photonic.media.OtsiServiceInterfacePointSpec:
     type: "object"
     properties:
-      number-of-otsi:
-        type: "integer"
-        format: "int32"
+      otsi-capability:
         description: "none"
-  tapi.photonic.media.OtsiTerminationConfigPac:
-    type: "object"
-    properties:
-      application-identifier:
-        description: "This attribute indicates the selected Application Identifier."
-        $ref: "#/definitions/tapi.photonic.media.ApplicationIdentifier"
-      central-frequency:
-        description: "The central frequency of the laser. It is the oscillation frequency\
-          \ of the corresponding electromagnetic wave"
-        $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
-      modulation:
-        description: "The modulation techniqu selected at the source."
-        $ref: "#/definitions/tapi.photonic.media.ModulationTechnique"
-      spectrum:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
-      laser-control:
-        description: "Laser control can be FORCED-ON, FORCED-OFF or LASER-SHUTDOWN"
-        $ref: "#/definitions/tapi.photonic.media.LaserControlType"
-      total-power-warn-threshold-lower:
-        type: "string"
-        description: "Allows to configure the Lowerpower threshold which is expected\
-          \ to be different from Default, but within the Min and Max values specified\
-          \ as OTSi SIP capability."
-      total-power-warn-threshold-upper:
-        type: "string"
-        description: "Allows to configure the Upper power threshold which is expected\
-          \ to be different from Default, but within the Min and Max values specified\
-          \ as OTSi SIP capability."
-      transmit-power:
-        description: "Transmit power as requested."
-        $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
-  tapi.photonic.media.OtsiTerminationPac:
-    type: "object"
-    properties:
-      selected-application-identifier:
-        description: "This attribute indicates the selected Application Identifier\
-          \ that is used by the OCh trail termination function. The syntax of ApplicationIdentifier\
-          \ is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType\
-          \ is either STANDARD or PROPRIETARY. The value of PrintableString represents\
-          \ the standard application code as defined in the ITU-T Recommendations\
-          \ or a vendor-specific proprietary code. If the ApplicationIdentifierType\
-          \ is STANDARD the value of PrintableString represents a standard application\
-          \ code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType\
-          \ is PROPRIETARY, the first six characters of the PrintableString must contain\
-          \ the Hexadecimal representation of an OUI assigned to the vendor whose\
-          \ implementation generated the Application Identifier; the remaining octets\
-          \ of the PrintableString are unspecified. The value of this attribute of\
-          \ an object instance has to be one of the values identified in the attribute\
-          \ SupportableApplicationIdentifierList of the same object instance. The\
-          \ values and value ranges of the optical interface parameters of a standard\
-          \ application code must be consistent with those values specified in the\
-          \ ITU-T Recommendation for that application code."
-        $ref: "#/definitions/tapi.photonic.media.ApplicationIdentifier"
-      received-power:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
-      selected-central-frequency:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.CentralFrequency"
-      transmited-power:
-        description: "Measured power at the Transmitter."
-        $ref: "#/definitions/tapi.photonic.media.PowerPropertiesPac"
-      selected-modulation:
-        description: "This parameter defines the modulation used at the source"
-        $ref: "#/definitions/tapi.photonic.media.SelectedModulation"
-      laser-properties:
-        description: "Laser properties."
-        $ref: "#/definitions/tapi.photonic.media.LaserPropertiesPac"
-      selected-spectrum:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.SpectrumBand"
-  tapi.photonic.media.OwnedNodeEdgePointAugmentation1:
-    type: "object"
-    properties:
-      mc-pool:
-        description: "none"
-        $ref: "#/definitions/tapi.photonic.media.MediaChannelPoolCapabilityPac"
-    x-augmentation:
-      prefix: "tapi-photonic-media"
-      namespace: "urn:onf:otcc:yang:tapi-photonic-media"
-  tapi.photonic.media.PowerPropertiesPac:
-    type: "object"
-    properties:
-      power-spectral-density:
-        type: "string"
-        description: "This describes how power of a signal  is distributed over frequency\
-          \ specified in nW/MHz"
-      total-power:
-        type: "string"
-        description: "The total power at any point in a channel specified in dBm."
-  tapi.photonic.media.SelectedModulation:
-    type: "string"
-    enum:
-    - "RZ"
-    - "NRZ"
-    - "BPSK"
-    - "DPSK"
-    - "QPSK"
-    - "8QAM"
-    - "16QAM"
-    - "PAM4"
-    - "PAM8"
-    - "UNDEFINED"
+        $ref: "#/definitions/tapi.photonic.media.OtsiCapabilityPac"
   tapi.photonic.media.ServiceInterfacePointAugmentation1:
     type: "object"
     properties:
-      mc-pool:
+      media-channel-service-interface-point-spec:
         description: "none"
-        $ref: "#/definitions/tapi.photonic.media.MediaChannelPoolCapabilityPac"
+        $ref: "#/definitions/tapi.photonic.media.MediaChannelServiceInterfacePointSpec"
     x-augmentation:
       prefix: "tapi-photonic-media"
       namespace: "urn:onf:otcc:yang:tapi-photonic-media"
   tapi.photonic.media.ServiceInterfacePointAugmentation2:
     type: "object"
     properties:
-      otsi-capability:
+      otsi-service-interface-point-spec:
         description: "none"
-        $ref: "#/definitions/tapi.photonic.media.OtsiCapabilityPac"
+        $ref: "#/definitions/tapi.photonic.media.OtsiServiceInterfacePointSpec"
     x-augmentation:
       prefix: "tapi-photonic-media"
       namespace: "urn:onf:otcc:yang:tapi-photonic-media"
@@ -4578,14 +3351,9 @@ definitions:
   tapi.topology.ContextAugmentation5:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -4733,7 +3501,7 @@ definitions:
         link-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
       description: "none"
   tapi.topology.NetworkTopologyService:
     allOf:
@@ -4833,7 +3601,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -4843,7 +3611,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -4883,7 +3651,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -4990,13 +3758,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -5139,42 +3918,3 @@ definitions:
         description: "none"
         items:
           $ref: "#/definitions/tapi.topology.Topology"
-  tapi.topology.node.OwnedNodeEdgePoint:
-    allOf:
-    - $ref: "#/definitions/tapi.connectivity.OwnedNodeEdgePointAugmentation2"
-    - $ref: "#/definitions/tapi.photonic.media.OwnedNodeEdgePointAugmentation1"
-    - $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-  tapi.topology.topology.Node:
-    allOf:
-    - $ref: "#/definitions/tapi.common.AdminStatePac"
-    - $ref: "#/definitions/tapi.common.CapacityPac"
-    - $ref: "#/definitions/tapi.common.GlobalClass"
-    - $ref: "#/definitions/tapi.topology.TransferCostPac"
-    - $ref: "#/definitions/tapi.topology.TransferIntegrityPac"
-    - $ref: "#/definitions/tapi.topology.TransferTimingPac"
-    - type: "object"
-      properties:
-        layer-protocol-name:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.common.LayerProtocolName"
-        encap-topology:
-          description: "none"
-          $ref: "#/definitions/tapi.topology.TopologyRef"
-        owned-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.node.OwnedNodeEdgePoint"
-        node-rule-group:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        aggregated-node-edge-point:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.topology.NodeEdgePointRef"
-      description: "none"

--- a/OAS/tapi-topology@2018-08-31.yaml
+++ b/OAS/tapi-topology@2018-08-31.yaml
@@ -70,161 +70,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -323,159 +168,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-        400:
-          description: "Internal error"
   /operations/create-notification-subscription-service/:
     post:
       tags:
@@ -1070,16 +762,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -1197,6 +882,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -1458,14 +1156,9 @@ definitions:
   tapi.topology.ContextAugmentation2:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -1703,7 +1396,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -1713,7 +1406,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -1753,7 +1446,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -1860,13 +1553,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:

--- a/OAS/tapi-virtual-network@2018-08-31.yaml
+++ b/OAS/tapi-virtual-network@2018-08-31.yaml
@@ -70,161 +70,6 @@ paths:
           description: "Internal error"
         204:
           description: "Object deleted"
-  /data/context/notif-subscription/:
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/notif-subscription={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.NotificationSubscriptionService"
-          schema:
-            $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-notification"
-      description: "creates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-notification"
-      description: "creates or updates tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.notification.NotificationSubscriptionService.body-param"
-        description: "tapi.notification.NotificationSubscriptionService to be added\
-          \ or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-notification"
-      description: "removes tapi.notification.NotificationSubscriptionService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/notif-subscription={uuid}/notification={notification-uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notif-subscription"
-        required: true
-        type: "string"
-      - name: "notification-uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/notification={uuid}/:
-    get:
-      tags:
-      - "tapi-notification"
-      description: "returns tapi.notification.Notification"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of notification"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.notification.Notification"
-          schema:
-            $ref: "#/definitions/tapi.notification.Notification"
-        400:
-          description: "Internal error"
-  /data/context/nw-topology-service/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NetworkTopologyService"
-      parameters: []
-      responses:
-        200:
-          description: "tapi.topology.NetworkTopologyService"
-          schema:
-            $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-        400:
-          description: "Internal error"
   /data/context/service-interface-point/:
     post:
       tags:
@@ -316,257 +161,6 @@ paths:
       - name: "uuid"
         in: "path"
         description: "Id of service-interface-point"
-        required: true
-        type: "string"
-      responses:
-        400:
-          description: "Internal error"
-        204:
-          description: "Object deleted"
-  /data/context/topology={uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Topology"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Topology"
-          schema:
-            $ref: "#/definitions/tapi.topology.Topology"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/link={link-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Link"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "link-uuid"
-        in: "path"
-        description: "Id of link"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Link"
-          schema:
-            $ref: "#/definitions/tapi.topology.Link"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.Node"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.Node"
-          schema:
-            $ref: "#/definitions/tapi.topology.Node"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/node-rule-group={node-rule-group-uuid}/inter-rule-group={inter-rule-group-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.InterRuleGroup"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "node-rule-group-uuid"
-        in: "path"
-        description: "Id of node-rule-group"
-        required: true
-        type: "string"
-      - name: "inter-rule-group-uuid"
-        in: "path"
-        description: "Id of inter-rule-group"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.InterRuleGroup"
-          schema:
-            $ref: "#/definitions/tapi.topology.InterRuleGroup"
-        400:
-          description: "Internal error"
-  /data/context/topology={uuid}/node={node-uuid}/owned-node-edge-point={owned-node-edge-point-uuid}/:
-    get:
-      tags:
-      - "tapi-topology"
-      description: "returns tapi.topology.NodeEdgePoint"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of topology"
-        required: true
-        type: "string"
-      - name: "node-uuid"
-        in: "path"
-        description: "Id of node"
-        required: true
-        type: "string"
-      - name: "owned-node-edge-point-uuid"
-        in: "path"
-        description: "Id of owned-node-edge-point"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.topology.NodeEdgePoint"
-          schema:
-            $ref: "#/definitions/tapi.topology.NodeEdgePoint"
-        400:
-          description: "Internal error"
-  /data/context/virtual-nw-service/:
-    post:
-      tags:
-      - "tapi-virtual-network"
-      description: "creates tapi.virtual.network.VirtualNetworkService"
-      parameters:
-      - in: "body"
-        name: "tapi.virtual.network.VirtualNetworkService.body-param"
-        description: "tapi.virtual.network.VirtualNetworkService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.virtual.network.VirtualNetworkService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-  /data/context/virtual-nw-service={uuid}/:
-    get:
-      tags:
-      - "tapi-virtual-network"
-      description: "returns tapi.virtual.network.VirtualNetworkService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of virtual-nw-service"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "tapi.virtual.network.VirtualNetworkService"
-          schema:
-            $ref: "#/definitions/tapi.virtual.network.VirtualNetworkService"
-        400:
-          description: "Internal error"
-    post:
-      tags:
-      - "tapi-virtual-network"
-      description: "creates tapi.virtual.network.VirtualNetworkService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of virtual-nw-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.virtual.network.VirtualNetworkService.body-param"
-        description: "tapi.virtual.network.VirtualNetworkService to be added to list"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.virtual.network.VirtualNetworkService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        409:
-          description: "Object already exists"
-    put:
-      tags:
-      - "tapi-virtual-network"
-      description: "creates or updates tapi.virtual.network.VirtualNetworkService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of virtual-nw-service"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "tapi.virtual.network.VirtualNetworkService.body-param"
-        description: "tapi.virtual.network.VirtualNetworkService to be added or updated"
-        required: false
-        schema:
-          $ref: "#/definitions/tapi.virtual.network.VirtualNetworkService"
-      responses:
-        201:
-          description: "Object created"
-        400:
-          description: "Internal error"
-        204:
-          description: "Object modified"
-    delete:
-      tags:
-      - "tapi-virtual-network"
-      description: "removes tapi.virtual.network.VirtualNetworkService"
-      parameters:
-      - name: "uuid"
-        in: "path"
-        description: "Id of virtual-nw-service"
         required: true
         type: "string"
       responses:
@@ -1246,16 +840,9 @@ definitions:
   tapi.notification.ContextAugmentation1:
     type: "object"
     properties:
-      notif-subscription:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
-      notification:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.notification.Notification"
+      notification-context:
+        description: "Augments the base TAPI Context with NotificationService information"
+        $ref: "#/definitions/tapi.notification.NotificationContext"
     x-augmentation:
       prefix: "tapi-notification"
       namespace: "urn:onf:otcc:yang:tapi-notification"
@@ -1373,6 +960,19 @@ definitions:
             \ specifics of this is typically dependent on the implementation protocol\
             \ & mechanism and hence is typed as a string."
       description: "none"
+  tapi.notification.NotificationContext:
+    type: "object"
+    properties:
+      notif-subscription:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.NotificationSubscriptionService"
+      notification:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.notification.Notification"
   tapi.notification.NotificationSubscriptionService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -1634,14 +1234,9 @@ definitions:
   tapi.topology.ContextAugmentation3:
     type: "object"
     properties:
-      nw-topology-service:
-        description: "none"
-        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
-      topology:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.topology.Topology"
+      topology-context:
+        description: "Augments the base TAPI Context with TopologyService information"
+        $ref: "#/definitions/tapi.topology.TopologyContext"
     x-augmentation:
       prefix: "tapi-topology"
       namespace: "urn:onf:otcc:yang:tapi-topology"
@@ -1879,7 +1474,7 @@ definitions:
         node-edge-point-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRef:
     allOf:
@@ -1889,7 +1484,7 @@ definitions:
         node-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
       description: "none"
   tapi.topology.NodeRuleGroup:
     allOf:
@@ -1929,7 +1524,7 @@ definitions:
         node-rule-group-uuid:
           type: "string"
           description: "none"
-          x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
+          x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
       description: "none"
   tapi.topology.ProtectionType:
     type: "string"
@@ -2036,13 +1631,24 @@ definitions:
         \        At the lowest level of recursion, an FD (within a network element\
         \ (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass\
         \ multiple switch matrices (FDs). "
+  tapi.topology.TopologyContext:
+    type: "object"
+    properties:
+      nw-topology-service:
+        description: "none"
+        $ref: "#/definitions/tapi.topology.NetworkTopologyService"
+      topology:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.topology.Topology"
   tapi.topology.TopologyRef:
     type: "object"
     properties:
       topology-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+        x-path: "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid"
   tapi.topology.TransferCostPac:
     type: "object"
     properties:
@@ -2188,11 +1794,9 @@ definitions:
   tapi.virtual.network.ContextAugmentation2:
     type: "object"
     properties:
-      virtual-nw-service:
-        type: "array"
-        description: "none"
-        items:
-          $ref: "#/definitions/tapi.virtual.network.VirtualNetworkService"
+      virtual-network-context:
+        description: "Augments the base TAPI Context with VirtualNetworkService information"
+        $ref: "#/definitions/tapi.virtual.network.VirtualNetworkContext"
     x-augmentation:
       prefix: "tapi-virtual-network"
       namespace: "urn:onf:otcc:yang:tapi-virtual-network"
@@ -2258,6 +1862,14 @@ definitions:
           items:
             $ref: "#/definitions/tapi.topology.LatencyCharacteristic"
       description: "none"
+  tapi.virtual.network.VirtualNetworkContext:
+    type: "object"
+    properties:
+      virtual-nw-service:
+        type: "array"
+        description: "none"
+        items:
+          $ref: "#/definitions/tapi.virtual.network.VirtualNetworkService"
   tapi.virtual.network.VirtualNetworkService:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2328,7 +1940,7 @@ definitions:
       virtual-nw-service-uuid:
         type: "string"
         description: "none"
-        x-path: "/tapi-common:context/tapi-virtual-network:virtual-nw-service/tapi-virtual-network:uuid"
+        x-path: "/tapi-common:context/tapi-virtual-network:virtual-network-context/tapi-virtual-network:virtual-nw-service/tapi-virtual-network:uuid"
   tapi.virtual.network.createvirtualnetworkservice.Input:
     type: "object"
     properties:

--- a/YANG/tapi-connectivity@2018-08-31.tree
+++ b/YANG/tapi-connectivity@2018-08-31.tree
@@ -1,231 +1,233 @@
 
 module: tapi-connectivity
   augment /tapi-common:context:
-    +--rw connectivity-service* [uuid]
-    |  +--rw end-point* [local-id]
-    |  |  +--rw layer-protocol-name?        tapi-common:layer-protocol-name
-    |  |  +--rw layer-protocol-qualifier?   tapi-common:layer-protocol-qualifier
-    |  |  +--rw service-interface-point
-    |  |  |  +--rw service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |  |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |  |  +--rw capacity
-    |  |  |  +--rw total-size
-    |  |  |  |  +--rw value?   uint64
-    |  |  |  |  +--rw unit?    capacity-unit
-    |  |  |  +--rw bandwidth-profile
-    |  |  |     +--rw bw-profile-type?              bandwidth-profile-type
-    |  |  |     +--rw committed-information-rate
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw committed-burst-size
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw peak-information-rate
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw peak-burst-size
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw color-aware?                  boolean
-    |  |  |     +--rw coupling-flag?                boolean
-    |  |  +--rw direction?                  tapi-common:port-direction
-    |  |  +--rw role?                       tapi-common:port-role
-    |  |  +--rw protection-role?            protection-role
-    |  |  +--rw local-id                    string
-    |  |  +--rw name* [value-name]
-    |  |  |  +--rw value-name    string
-    |  |  |  +--rw value?        string
-    |  |  +--rw administrative-state?       administrative-state
-    |  |  +--ro operational-state?          operational-state
-    |  |  +--ro lifecycle-state?            lifecycle-state
-    |  +--ro connection* [connection-uuid]
-    |  |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |  +--rw uuid                                  uuid
-    |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw service-layer?                        tapi-common:layer-protocol-name
-    |  +--rw service-type?                         service-type
-    |  +--rw service-level?                        string
-    |  +--rw requested-capacity
-    |  |  +--rw total-size
-    |  |  |  +--rw value?   uint64
-    |  |  |  +--rw unit?    capacity-unit
-    |  |  +--rw bandwidth-profile
-    |  |     +--rw bw-profile-type?              bandwidth-profile-type
-    |  |     +--rw committed-information-rate
-    |  |     |  +--rw value?   uint64
-    |  |     |  +--rw unit?    capacity-unit
-    |  |     +--rw committed-burst-size
-    |  |     |  +--rw value?   uint64
-    |  |     |  +--rw unit?    capacity-unit
-    |  |     +--rw peak-information-rate
-    |  |     |  +--rw value?   uint64
-    |  |     |  +--rw unit?    capacity-unit
-    |  |     +--rw peak-burst-size
-    |  |     |  +--rw value?   uint64
-    |  |     |  +--rw unit?    capacity-unit
-    |  |     +--rw color-aware?                  boolean
-    |  |     +--rw coupling-flag?                boolean
-    |  +--rw connectivity-direction?               tapi-common:forwarding-direction
-    |  +--rw schedule
-    |  |  +--rw end-time?     date-and-time
-    |  |  +--rw start-time?   date-and-time
-    |  +--rw coroute-inclusion
-    |  |  +--rw connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  +--rw diversity-exclusion* [connectivity-service-uuid]
-    |  |  +--rw connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  +--rw cost-characteristic* [cost-name]
-    |  |  +--rw cost-name         string
-    |  |  +--rw cost-value?       string
-    |  |  +--rw cost-algorithm?   string
-    |  +--rw latency-characteristic* [traffic-property-name]
-    |  |  +--rw traffic-property-name            string
-    |  |  +--ro fixed-latency-characteristic?    string
-    |  |  +--rw queing-latency-characteristic?   string
-    |  |  +--ro jitter-characteristic?           string
-    |  |  +--ro wander-characteristic?           string
-    |  +--rw risk-diversity-characteristic* [risk-characteristic-name]
-    |  |  +--rw risk-characteristic-name    string
-    |  |  +--rw risk-identifier-list*       string
-    |  +--rw diversity-policy?                     diversity-policy
-    |  +--rw route-objective-function?             route-objective-function
-    |  +--rw route-direction?                      tapi-common:forwarding-direction
-    |  +--rw is-exclusive?                         boolean
-    |  +--ro include-topology* [topology-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  +--ro avoid-topology* [topology-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  +--ro include-path* [path-uuid]
-    |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  +--ro exclude-path* [path-uuid]
-    |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  +--ro include-link* [topology-uuid link-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |  +--ro exclude-link* [topology-uuid link-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |  +--ro include-node* [topology-uuid node-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  +--ro exclude-node* [topology-uuid node-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
-    |  +--rw resilience-type
-    |  |  +--rw restoration-policy?   restoration-policy
-    |  |  +--rw protection-type?      protection-type
-    |  +--rw restoration-coordinate-type?          coordinate-type
-    |  +--rw restore-priority?                     uint64
-    |  +--rw reversion-mode?                       reversion-mode
-    |  +--rw wait-to-revert-time?                  uint64
-    |  +--rw hold-off-time?                        uint64
-    |  +--rw is-lock-out?                          boolean
-    |  +--rw is-frozen?                            boolean
-    |  +--rw is-coordinated-switching-both-ends?   boolean
-    |  +--rw max-switch-times?                     uint64
-    |  +--rw preferred-restoration-layer*          tapi-common:layer-protocol-name
-    |  +--rw administrative-state?                 administrative-state
-    |  +--ro operational-state?                    operational-state
-    |  +--ro lifecycle-state?                      lifecycle-state
-    +--ro connection* [uuid]
-       +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-       |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-       +--ro lower-connection* [connection-uuid]
-       |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
-       +--ro supported-client-link* [topology-uuid link-uuid]
-       |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
-       +--ro route* [local-id]
-       |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-       |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-       |  +--ro local-id                string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro switch-control* [uuid]
-       |  +--ro sub-switch-control* [connection-uuid switch-control-uuid]
-       |  |  +--ro connection-uuid        -> /tapi-common:context/tapi-connectivity:connection/uuid
-       |  |  +--ro switch-control-uuid    -> /tapi-common:context/tapi-connectivity:connection/switch-control/uuid
-       |  +--ro switch* [local-id]
-       |  |  +--ro selected-connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-       |  |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-       |  |  +--ro selected-route* [connection-uuid route-local-id]
-       |  |  |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
-       |  |  |  +--ro route-local-id     -> /tapi-common:context/tapi-connectivity:connection/route/local-id
-       |  |  +--ro selection-control?               selection-control
-       |  |  +--ro selection-reason?                selection-reason
-       |  |  +--ro switch-direction?                tapi-common:port-direction
-       |  |  +--ro local-id                         string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro uuid                                  uuid
-       |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro resilience-type
-       |  |  +--ro restoration-policy?   restoration-policy
-       |  |  +--ro protection-type?      protection-type
-       |  +--ro restoration-coordinate-type?          coordinate-type
-       |  +--ro restore-priority?                     uint64
-       |  +--ro reversion-mode?                       reversion-mode
-       |  +--ro wait-to-revert-time?                  uint64
-       |  +--ro hold-off-time?                        uint64
-       |  +--ro is-lock-out?                          boolean
-       |  +--ro is-frozen?                            boolean
-       |  +--ro is-coordinated-switching-both-ends?   boolean
-       |  +--ro max-switch-times?                     uint64
-       |  +--ro preferred-restoration-layer*          tapi-common:layer-protocol-name
-       +--ro direction?               tapi-common:forwarding-direction
-       +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-       +--ro uuid                     uuid
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro operational-state?       operational-state
-       +--ro lifecycle-state?         lifecycle-state
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro connection-end-point* [uuid]
-       +--ro layer-protocol-name?               tapi-common:layer-protocol-name
-       +--ro layer-protocol-qualifier?          tapi-common:layer-protocol-qualifier
-       +--ro parent-node-edge-point
-       |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       +--ro client-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-       |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       +--ro aggregated-connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-       |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-       +--ro connection-port-direction?         tapi-common:port-direction
-       +--ro connection-port-role?              tapi-common:port-role
-       +--ro uuid                               uuid
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro operational-state?                 operational-state
-       +--ro lifecycle-state?                   lifecycle-state
-       +--ro termination-direction?             termination-direction
-       +--ro termination-state?                 termination-state
+    +--rw connectivity-context
+       +--rw connectivity-service* [uuid]
+       |  +--rw end-point* [local-id]
+       |  |  +--rw layer-protocol-name?        tapi-common:layer-protocol-name
+       |  |  +--rw layer-protocol-qualifier?   tapi-common:layer-protocol-qualifier
+       |  |  +--rw service-interface-point
+       |  |  |  +--rw service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+       |  |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
+       |  |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+       |  |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
+       |  |  +--rw capacity
+       |  |  |  +--rw total-size
+       |  |  |  |  +--rw value?   uint64
+       |  |  |  |  +--rw unit?    capacity-unit
+       |  |  |  +--rw bandwidth-profile
+       |  |  |     +--rw bw-profile-type?              bandwidth-profile-type
+       |  |  |     +--rw committed-information-rate
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw committed-burst-size
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw peak-information-rate
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw peak-burst-size
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw color-aware?                  boolean
+       |  |  |     +--rw coupling-flag?                boolean
+       |  |  +--rw direction?                  tapi-common:port-direction
+       |  |  +--rw role?                       tapi-common:port-role
+       |  |  +--rw protection-role?            protection-role
+       |  |  +--rw local-id                    string
+       |  |  +--rw name* [value-name]
+       |  |  |  +--rw value-name    string
+       |  |  |  +--rw value?        string
+       |  |  +--rw administrative-state?       administrative-state
+       |  |  +--ro operational-state?          operational-state
+       |  |  +--ro lifecycle-state?            lifecycle-state
+       |  +--ro connection* [connection-uuid]
+       |  |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+       |  +--rw uuid                                  uuid
+       |  +--rw name* [value-name]
+       |  |  +--rw value-name    string
+       |  |  +--rw value?        string
+       |  +--rw service-layer?                        tapi-common:layer-protocol-name
+       |  +--rw service-type?                         service-type
+       |  +--rw service-level?                        string
+       |  +--rw requested-capacity
+       |  |  +--rw total-size
+       |  |  |  +--rw value?   uint64
+       |  |  |  +--rw unit?    capacity-unit
+       |  |  +--rw bandwidth-profile
+       |  |     +--rw bw-profile-type?              bandwidth-profile-type
+       |  |     +--rw committed-information-rate
+       |  |     |  +--rw value?   uint64
+       |  |     |  +--rw unit?    capacity-unit
+       |  |     +--rw committed-burst-size
+       |  |     |  +--rw value?   uint64
+       |  |     |  +--rw unit?    capacity-unit
+       |  |     +--rw peak-information-rate
+       |  |     |  +--rw value?   uint64
+       |  |     |  +--rw unit?    capacity-unit
+       |  |     +--rw peak-burst-size
+       |  |     |  +--rw value?   uint64
+       |  |     |  +--rw unit?    capacity-unit
+       |  |     +--rw color-aware?                  boolean
+       |  |     +--rw coupling-flag?                boolean
+       |  +--rw connectivity-direction?               tapi-common:forwarding-direction
+       |  +--rw schedule
+       |  |  +--rw end-time?     date-and-time
+       |  |  +--rw start-time?   date-and-time
+       |  +--rw coroute-inclusion
+       |  |  +--rw connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+       |  +--rw diversity-exclusion* [connectivity-service-uuid]
+       |  |  +--rw connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+       |  +--rw cost-characteristic* [cost-name]
+       |  |  +--rw cost-name         string
+       |  |  +--rw cost-value?       string
+       |  |  +--rw cost-algorithm?   string
+       |  +--rw latency-characteristic* [traffic-property-name]
+       |  |  +--rw traffic-property-name            string
+       |  |  +--ro fixed-latency-characteristic?    string
+       |  |  +--rw queing-latency-characteristic?   string
+       |  |  +--ro jitter-characteristic?           string
+       |  |  +--ro wander-characteristic?           string
+       |  +--rw risk-diversity-characteristic* [risk-characteristic-name]
+       |  |  +--rw risk-characteristic-name    string
+       |  |  +--rw risk-identifier-list*       string
+       |  +--rw diversity-policy?                     diversity-policy
+       |  +--rw route-objective-function?             route-objective-function
+       |  +--rw route-direction?                      tapi-common:forwarding-direction
+       |  +--rw is-exclusive?                         boolean
+       |  +--ro include-topology* [topology-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  +--ro avoid-topology* [topology-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  +--ro include-path* [path-uuid]
+       |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
+       |  +--ro exclude-path* [path-uuid]
+       |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
+       |  +--ro include-link* [topology-uuid link-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+       |  +--ro exclude-link* [topology-uuid link-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+       |  +--ro include-node* [topology-uuid node-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  +--ro exclude-node* [topology-uuid node-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+       |  +--rw resilience-type
+       |  |  +--rw restoration-policy?   restoration-policy
+       |  |  +--rw protection-type?      protection-type
+       |  +--rw restoration-coordinate-type?          coordinate-type
+       |  +--rw restore-priority?                     uint64
+       |  +--rw reversion-mode?                       reversion-mode
+       |  +--rw wait-to-revert-time?                  uint64
+       |  +--rw hold-off-time?                        uint64
+       |  +--rw is-lock-out?                          boolean
+       |  +--rw is-frozen?                            boolean
+       |  +--rw is-coordinated-switching-both-ends?   boolean
+       |  +--rw max-switch-times?                     uint64
+       |  +--rw preferred-restoration-layer*          tapi-common:layer-protocol-name
+       |  +--rw administrative-state?                 administrative-state
+       |  +--ro operational-state?                    operational-state
+       |  +--ro lifecycle-state?                      lifecycle-state
+       +--ro connection* [uuid]
+          +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
+          |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
+          +--ro lower-connection* [connection-uuid]
+          |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+          +--ro supported-client-link* [topology-uuid link-uuid]
+          |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+          +--ro route* [local-id]
+          |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
+          |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
+          |  +--ro local-id                string
+          |  +--ro name* [value-name]
+          |     +--ro value-name    string
+          |     +--ro value?        string
+          +--ro switch-control* [uuid]
+          |  +--ro sub-switch-control* [connection-uuid switch-control-uuid]
+          |  |  +--ro connection-uuid        -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+          |  |  +--ro switch-control-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/switch-control/uuid
+          |  +--ro switch* [local-id]
+          |  |  +--ro selected-connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
+          |  |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
+          |  |  +--ro selected-route* [connection-uuid route-local-id]
+          |  |  |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+          |  |  |  +--ro route-local-id     -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/route/local-id
+          |  |  +--ro selection-control?               selection-control
+          |  |  +--ro selection-reason?                selection-reason
+          |  |  +--ro switch-direction?                tapi-common:port-direction
+          |  |  +--ro local-id                         string
+          |  |  +--ro name* [value-name]
+          |  |     +--ro value-name    string
+          |  |     +--ro value?        string
+          |  +--ro uuid                                  uuid
+          |  +--ro name* [value-name]
+          |  |  +--ro value-name    string
+          |  |  +--ro value?        string
+          |  +--ro resilience-type
+          |  |  +--ro restoration-policy?   restoration-policy
+          |  |  +--ro protection-type?      protection-type
+          |  +--ro restoration-coordinate-type?          coordinate-type
+          |  +--ro restore-priority?                     uint64
+          |  +--ro reversion-mode?                       reversion-mode
+          |  +--ro wait-to-revert-time?                  uint64
+          |  +--ro hold-off-time?                        uint64
+          |  +--ro is-lock-out?                          boolean
+          |  +--ro is-frozen?                            boolean
+          |  +--ro is-coordinated-switching-both-ends?   boolean
+          |  +--ro max-switch-times?                     uint64
+          |  +--ro preferred-restoration-layer*          tapi-common:layer-protocol-name
+          +--ro direction?               tapi-common:forwarding-direction
+          +--ro layer-protocol-name?     tapi-common:layer-protocol-name
+          +--ro uuid                     uuid
+          +--ro name* [value-name]
+          |  +--ro value-name    string
+          |  +--ro value?        string
+          +--ro operational-state?       operational-state
+          +--ro lifecycle-state?         lifecycle-state
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
+    +--ro cep-list
+       +--ro connection-end-point* [uuid]
+          +--ro layer-protocol-name?               tapi-common:layer-protocol-name
+          +--ro layer-protocol-qualifier?          tapi-common:layer-protocol-qualifier
+          +--ro parent-node-edge-point
+          |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          +--ro client-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
+          |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          +--ro aggregated-connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
+          |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
+          +--ro connection-port-direction?         tapi-common:port-direction
+          +--ro connection-port-role?              tapi-common:port-role
+          +--ro uuid                               uuid
+          +--ro name* [value-name]
+          |  +--ro value-name    string
+          |  +--ro value?        string
+          +--ro operational-state?                 operational-state
+          +--ro lifecycle-state?                   lifecycle-state
+          +--ro termination-direction?             termination-direction
+          +--ro termination-state?                 termination-state
 
   rpcs:
     +---x get-connection-details
@@ -235,38 +237,38 @@ module: tapi-connectivity
     |  +--ro output
     |     +--ro connection
     |        +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        +--ro lower-connection* [connection-uuid]
-    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
     |        +--ro supported-client-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro route* [local-id]
     |        |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        |  +--ro local-id                string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro switch-control* [uuid]
     |        |  +--ro sub-switch-control* [connection-uuid switch-control-uuid]
-    |        |  |  +--ro connection-uuid        -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        |  |  +--ro switch-control-uuid    -> /tapi-common:context/tapi-connectivity:connection/switch-control/uuid
+    |        |  |  +--ro connection-uuid        -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+    |        |  |  +--ro switch-control-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/switch-control/uuid
     |        |  +--ro switch* [local-id]
     |        |  |  +--ro selected-connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        |  |  +--ro selected-route* [connection-uuid route-local-id]
-    |        |  |  |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        |  |  |  +--ro route-local-id     -> /tapi-common:context/tapi-connectivity:connection/route/local-id
+    |        |  |  |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+    |        |  |  |  +--ro route-local-id     -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/route/local-id
     |        |  |  +--ro selection-control?               selection-control
     |        |  |  +--ro selection-reason?                selection-reason
     |        |  |  +--ro switch-direction?                tapi-common:port-direction
@@ -308,10 +310,10 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -343,7 +345,7 @@ module: tapi-connectivity
     |        |  +--ro operational-state?          operational-state
     |        |  +--ro lifecycle-state?            lifecycle-state
     |        +--ro connection* [connection-uuid]
-    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
     |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -376,9 +378,9 @@ module: tapi-connectivity
     |        |  +--ro end-time?     date-and-time
     |        |  +--ro start-time?   date-and-time
     |        +--ro coroute-inclusion
-    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro diversity-exclusion* [connectivity-service-uuid]
-    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro cost-characteristic* [cost-name]
     |        |  +--ro cost-name         string
     |        |  +--ro cost-value?       string
@@ -397,25 +399,25 @@ module: tapi-connectivity
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
     |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
@@ -444,10 +446,10 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -479,7 +481,7 @@ module: tapi-connectivity
     |        |  +--ro operational-state?          operational-state
     |        |  +--ro lifecycle-state?            lifecycle-state
     |        +--ro connection* [connection-uuid]
-    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
     |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -512,9 +514,9 @@ module: tapi-connectivity
     |        |  +--ro end-time?     date-and-time
     |        |  +--ro start-time?   date-and-time
     |        +--ro coroute-inclusion
-    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro diversity-exclusion* [connectivity-service-uuid]
-    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro cost-characteristic* [cost-name]
     |        |  +--ro cost-name         string
     |        |  +--ro cost-value?       string
@@ -533,25 +535,25 @@ module: tapi-connectivity
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
     |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
@@ -577,10 +579,10 @@ module: tapi-connectivity
     |  |  |  +---w service-interface-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |  |  |  |  +---w topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |  |  |  |  +---w topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |  |  |  |  +---w node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |  |  |  |  +---w connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |  |  |  +---w capacity
     |  |  |  |  +---w total-size
     |  |  |  |  |  +---w value?   uint64
@@ -640,9 +642,9 @@ module: tapi-connectivity
     |  |  |  |  +---w end-time?     date-and-time
     |  |  |  |  +---w start-time?   date-and-time
     |  |  |  +---w coroute-inclusion
-    |  |  |  |  +---w connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |  |  +---w connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |  |  |  +---w diversity-exclusion* [connectivity-service-uuid]
-    |  |  |     +---w connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |     +---w connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |  |  +---w routing-constraint
     |  |  |  +---w cost-characteristic* [cost-name]
     |  |  |  |  +---w cost-name         string
@@ -663,25 +665,25 @@ module: tapi-connectivity
     |  |  |  +---w is-exclusive?                    boolean
     |  |  +---w topology-constraint
     |  |  |  +---w include-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |  |  |  +---w avoid-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |  |  |  +---w include-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |  |  |  +---w exclude-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |  |  |  +---w include-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |  |  |  +---w exclude-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |  |  |  +---w include-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |  |  |  +---w exclude-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +---w resilience-constraint* []
     |  |  |  +---w resilience-type
@@ -706,10 +708,10 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -741,7 +743,7 @@ module: tapi-connectivity
     |        |  +--ro operational-state?          operational-state
     |        |  +--ro lifecycle-state?            lifecycle-state
     |        +--ro connection* [connection-uuid]
-    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
     |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -774,9 +776,9 @@ module: tapi-connectivity
     |        |  +--ro end-time?     date-and-time
     |        |  +--ro start-time?   date-and-time
     |        +--ro coroute-inclusion
-    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro diversity-exclusion* [connectivity-service-uuid]
-    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro cost-characteristic* [cost-name]
     |        |  +--ro cost-name         string
     |        |  +--ro cost-value?       string
@@ -795,25 +797,25 @@ module: tapi-connectivity
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
     |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
@@ -840,10 +842,10 @@ module: tapi-connectivity
     |  |  |  +---w service-interface-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |  |  |  |  +---w topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |  |  |  |  +---w topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |  |  |  |  +---w node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |  |  |  |  +---w connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |  |  |  +---w capacity
     |  |  |  |  +---w total-size
     |  |  |  |  |  +---w value?   uint64
@@ -903,9 +905,9 @@ module: tapi-connectivity
     |  |  |  |  +---w end-time?     date-and-time
     |  |  |  |  +---w start-time?   date-and-time
     |  |  |  +---w coroute-inclusion
-    |  |  |  |  +---w connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |  |  +---w connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |  |  |  +---w diversity-exclusion* [connectivity-service-uuid]
-    |  |  |     +---w connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |     +---w connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |  |  +---w routing-constraint
     |  |  |  +---w cost-characteristic* [cost-name]
     |  |  |  |  +---w cost-name         string
@@ -926,25 +928,25 @@ module: tapi-connectivity
     |  |  |  +---w is-exclusive?                    boolean
     |  |  +---w topology-constraint
     |  |  |  +---w include-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |  |  |  +---w avoid-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |  |  |  +---w include-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |  |  |  +---w exclude-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |  |  |  +---w include-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |  |  |  +---w exclude-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |  |  |  +---w include-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |  |  |  +---w exclude-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +---w resilience-constraint* []
     |  |  |  +---w resilience-type
@@ -969,10 +971,10 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
-    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
+    |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid                    -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid         -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro connection-end-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/tapi-connectivity:cep-list/connection-end-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -1004,7 +1006,7 @@ module: tapi-connectivity
     |        |  +--ro operational-state?          operational-state
     |        |  +--ro lifecycle-state?            lifecycle-state
     |        +--ro connection* [connection-uuid]
-    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        |  +--ro connection-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
     |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -1037,9 +1039,9 @@ module: tapi-connectivity
     |        |  +--ro end-time?     date-and-time
     |        |  +--ro start-time?   date-and-time
     |        +--ro coroute-inclusion
-    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro diversity-exclusion* [connectivity-service-uuid]
-    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        |  +--ro connectivity-service-uuid    -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
     |        +--ro cost-characteristic* [cost-name]
     |        |  +--ro cost-name         string
     |        |  +--ro cost-value?       string
@@ -1058,25 +1060,25 @@ module: tapi-connectivity
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
     |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy

--- a/YANG/tapi-connectivity@2018-08-31.yang
+++ b/YANG/tapi-connectivity@2018-08-31.yang
@@ -50,11 +50,17 @@ module tapi-connectivity {
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
     augment "/tapi-common:context" {
-        uses connectivity-context;
+        container connectivity-context {
+            uses connectivity-context;
+            description "Augments the base TAPI Context with ConnectivityService information";
+        }
         description "Augments the base TAPI Context with ConnectivityService information";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
-        uses cep-list;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
+    	container cep-list {
+            uses cep-list;
+            description "none";
+        }
         description "none";
     }
 
@@ -64,7 +70,7 @@ module tapi-connectivity {
     grouping connectivity-service-ref {
         leaf connectivity-service-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
+                path '/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
             }
             description "none";
         }
@@ -75,7 +81,7 @@ module tapi-connectivity {
     	uses connectivity-service-ref;
     	leaf connectivity-service-end-point-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id';
+	            path '/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id';
 	        }
 	    	description "none";
     	}
@@ -85,7 +91,7 @@ module tapi-connectivity {
         uses tapi-topology:node-edge-point-ref;
         leaf connection-end-point-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
+                path '/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
             }
             description "none";
         }
@@ -95,7 +101,7 @@ module tapi-connectivity {
     grouping connection-ref {
         leaf connection-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid';
+                path '/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:uuid';
             }
             description "none";
         }
@@ -106,7 +112,7 @@ module tapi-connectivity {
         uses connection-ref;
         leaf switch-control-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid';
+                path '/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid';
             }
             description "none";
         }
@@ -117,7 +123,7 @@ module tapi-connectivity {
     	uses connection-ref;
         leaf route-local-id {
             type leafref {
-                path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id';
+                path '/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id';
             }
             description "none";
         }

--- a/YANG/tapi-eth@2018-08-31.tree
+++ b/YANG/tapi-eth@2018-08-31.tree
@@ -1,471 +1,505 @@
 
 module: tapi-eth
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro ety-term
-    |  +--ro is-fts-enabled?        boolean
-    |  +--ro is-tx-pause-enabled?   boolean
-    |  +--ro phy-type?              ety-phy-type
-    |  +--ro phy-type-list*         ety-phy-type
-    +--ro eth-term
-    |  +--ro priority-regenerate
-    |  |  +--ro priority-0?   uint64
-    |  |  +--ro priority-1?   uint64
-    |  |  +--ro priority-2?   uint64
-    |  |  +--ro priority-3?   uint64
-    |  |  +--ro priority-4?   uint64
-    |  |  +--ro priority-5?   uint64
-    |  |  +--ro priority-6?   uint64
-    |  |  +--ro priority-7?   uint64
-    |  +--ro ether-type?                   vlan-type
-    |  +--ro filter-config-1*              mac-address
-    |  +--ro frametype-config?             frame-type
-    |  +--ro port-vid?                     vid
-    |  +--ro priority-code-point-config?   pcp-coding
-    +--ro eth-ctp
-       +--ro auxiliary-function-position-sequence*   uint64
-       +--ro vlan-config?                            uint64
-       +--ro csf-rdi-fdi-enable?                     boolean
-       +--ro csf-report?                             boolean
-       +--ro filter-config-snk*                      mac-address
-       +--ro mac-length?                             uint64
-       +--ro filter-config
-       |  +--ro c-2-00-00-10?    boolean
-       |  +--ro c-2-00-00-00?    boolean
-       |  +--ro c-2-00-00-01?    boolean
-       |  +--ro c-2-00-00-02?    boolean
-       |  +--ro c-2-00-00-03?    boolean
-       |  +--ro c-2-00-00-04?    boolean
-       |  +--ro c-2-00-00-05?    boolean
-       |  +--ro c-2-00-00-06?    boolean
-       |  +--ro c-2-00-00-07?    boolean
-       |  +--ro c-2-00-00-08?    boolean
-       |  +--ro c-2-00-00-09?    boolean
-       |  +--ro c-2-00-00-0-a?   boolean
-       |  +--ro c-2-00-00-0-b?   boolean
-       |  +--ro c-2-00-00-0-c?   boolean
-       |  +--ro c-2-00-00-0-d?   boolean
-       |  +--ro c-2-00-00-0-e?   boolean
-       |  +--ro c-2-00-00-0-f?   boolean
-       |  +--ro c-2-00-00-20?    boolean
-       |  +--ro c-2-00-00-21?    boolean
-       |  +--ro c-2-00-00-22?    boolean
-       |  +--ro c-2-00-00-23?    boolean
-       |  +--ro c-2-00-00-24?    boolean
-       |  +--ro c-2-00-00-25?    boolean
-       |  +--ro c-2-00-00-26?    boolean
-       |  +--ro c-2-00-00-27?    boolean
-       |  +--ro c-2-00-00-28?    boolean
-       |  +--ro c-2-00-00-29?    boolean
-       |  +--ro c-2-00-00-2-a?   boolean
-       |  +--ro c-2-00-00-2-b?   boolean
-       |  +--ro c-2-00-00-2-c?   boolean
-       |  +--ro c-2-00-00-2-d?   boolean
-       |  +--ro c-2-00-00-2-e?   boolean
-       |  +--ro c-2-00-00-2-f?   boolean
-       +--ro is-ssf-reported?                        boolean
-       +--ro pll-thr?                                uint64
-       +--ro actor-oper-key?                         uint64
-       +--ro actor-system-id?                        mac-address
-       +--ro actor-system-priority?                  uint64
-       +--ro collector-max-delay?                    uint64
-       +--ro data-rate?                              uint64
-       +--ro partner-oper-key?                       uint64
-       +--ro partner-system-id?                      mac-address
-       +--ro partner-system-priority?                uint64
-       +--ro csf-config?                             csf-config
-       +--ro traffic-shaping
-       |  +--ro prio-config-list* []
-       |  |  +--ro priority?   uint64
-       |  |  +--ro queue-id?   uint64
-       |  +--ro queue-config-list* []
-       |  |  +--ro queue-id?          uint64
-       |  |  +--ro queue-depth?       uint64
-       |  |  +--ro queue-threshold?   uint64
-       |  +--ro sched-config?        scheduling-configuration
-       |  +--ro codirectional?       boolean
-       +--ro traffic-conditioning
-          +--ro prio-config-list* []
-          |  +--ro priority?   uint64
-          |  +--ro queue-id?   uint64
-          +--ro cond-config-list* []
-          |  +--ro cir?             uint64
-          |  +--ro cbs?             uint64
-          |  +--ro eir?             uint64
-          |  +--ro ebs?             uint64
-          |  +--ro coupling-flag?   boolean
-          |  +--ro colour-mode?     colour-mode
-          |  +--ro queue-id?        uint64
-          +--ro codirectional?      boolean
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw eth-lb-msg
-    |  +--rw period?                oam-period
-    |  +--rw drop-eligibility?      boolean
-    |  +--rw data-tlv-length?       uint64
-    |  +--rw test-pattern?          uint64
-    |  +--rw destination-address?   mac-address
-    |  +--rw priority?              uint64
-    +--rw number?       uint64
-  augment /tapi-common:context/tapi-oam:meg:
-    +--ro client-mel?   uint64
-  augment /tapi-common:context/tapi-oam:meg/tapi-oam:mep:
-    +--ro eth-mep-common
-    |  +--ro mep-mac?         mac-address
-    |  +--ro is-cc-enabled?   boolean
-    |  +--ro cc-period?       oam-period
-    |  +--ro cc-priority?     uint64
-    |  +--ro lck-period?      oam-period
-    |  +--ro lck-priority?    uint64
-    +--ro eth-mep-source-pac
-    |  +--ro aps-priority?   uint64
-    |  +--ro csf-priority?   uint64
-    |  +--ro csf-period?     oam-period
-    |  +--ro csf-config?     csf-config
-    +--ro eth-mep-sink
-       +--ro dm-1-priority*            uint64
-       +--ro ais-priority?             uint64
-       +--ro ais-period?               oam-period
-       +--ro is-csf-reported?          boolean
-       +--ro is-csf-rdi-fdi-enabled?   boolean
-       +--ro bandwidth-report
-       |  +--ro source-mac-address?   mac-address
-       |  +--ro port-id?              uint64
-       |  +--ro nominal-bandwidth?    uint64
-       |  +--ro current-bandwidth?    uint64
-       +--ro lm-degm?                  uint64
-       +--ro lm-deg-thr?               uint64
-       +--ro lm-m?                     uint64
-       +--ro lm-tf-min?                uint64
-  augment /tapi-common:context/tapi-oam:meg/tapi-oam:mip:
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw pro-active-control-2way-source
-       +--rw controller-mep-id?     string
-       +--rw is-enabled?            boolean
-       +--rw destination-address?   mac-address
-       +--rw priority?              uint64
-       +--rw period?                oam-period
-       +--rw test-identifier?       uint64
-       +--rw data-tlv-length?       uint64
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw eth-lt-msg
-    |  +--rw destination-address?   mac-address
-    |  +--rw priority?              uint64
-    +--rw time-to-live?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw eth-test-msg
-       +--rw period?                oam-period
-       +--rw drop-eligibility?      boolean
-       +--rw data-tlv-length?       uint64
-       +--rw test-pattern?          uint64
-       +--rw destination-address?   mac-address
-       +--rw priority?              uint64
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw pro-active-control-1way-source
-    |  +--rw controller-mep-id?     string
-    |  +--rw is-enabled?            boolean
-    |  +--rw destination-address?   mac-address
-    |  +--rw priority?              uint64
-    |  +--rw period?                oam-period
-    |  +--rw test-identifier?       uint64
-    |  +--rw data-tlv-length?       uint64
-    +--rw pro-active-control-1way-sink
-       +--rw responder-mep-id?   string
-       +--rw is-enabled?         boolean
-       +--rw source-address?     mac-address
-       +--rw test-identifier?    uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro pro-active-bi-dir-dm-parameters
-    |  +--ro minimum-frame-delay?             uint64
-    |  +--ro average-frame-delay?             uint64
-    |  +--ro maximum-frame-delay?             uint64
-    |  +--ro minimum-frame-delay-variation?   uint64
-    |  +--ro average-frame-delay-variation?   uint64
-    |  +--ro maximum-frame-delay-variation?   uint64
-    +--ro pro-active-far-end-dm-parameters
-    |  +--ro minimum-frame-delay?             uint64
-    |  +--ro average-frame-delay?             uint64
-    |  +--ro maximum-frame-delay?             uint64
-    |  +--ro minimum-frame-delay-variation?   uint64
-    |  +--ro average-frame-delay-variation?   uint64
-    |  +--ro maximum-frame-delay-variation?   uint64
-    +--ro pro-active-near-end-dm-parameters
-       +--ro minimum-frame-delay?             uint64
-       +--ro average-frame-delay?             uint64
-       +--ro maximum-frame-delay?             uint64
-       +--ro minimum-frame-delay-variation?   uint64
-       +--ro average-frame-delay-variation?   uint64
-       +--ro maximum-frame-delay-variation?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro pro-active-bi-dir-dm-parameters
-    |  +--ro minimum-frame-delay?             uint64
-    |  +--ro average-frame-delay?             uint64
-    |  +--ro maximum-frame-delay?             uint64
-    |  +--ro minimum-frame-delay-variation?   uint64
-    |  +--ro average-frame-delay-variation?   uint64
-    |  +--ro maximum-frame-delay-variation?   uint64
-    +--ro pro-active-far-end-dm-parameters
-    |  +--ro minimum-frame-delay?             uint64
-    |  +--ro average-frame-delay?             uint64
-    |  +--ro maximum-frame-delay?             uint64
-    |  +--ro minimum-frame-delay-variation?   uint64
-    |  +--ro average-frame-delay-variation?   uint64
-    |  +--ro maximum-frame-delay-variation?   uint64
-    +--ro pro-active-near-end-dm-parameters
-       +--ro minimum-frame-delay?             uint64
-       +--ro average-frame-delay?             uint64
-       +--ro maximum-frame-delay?             uint64
-       +--ro minimum-frame-delay-variation?   uint64
-       +--ro average-frame-delay-variation?   uint64
-       +--ro maximum-frame-delay-variation?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro pro-active-far-end-lm-parameters
-    |  +--ro minimum-frame-loss-ratio?   decimal64
-    |  +--ro average-frame-loss-ratio?   decimal64
-    |  +--ro maximum-frame-loss-ratio?   decimal64
-    |  +--ro ses?                        uint64
-    |  +--ro uas?                        uint64
-    +--ro pro-active-near-end-lm-parameters
-    |  +--ro minimum-frame-loss-ratio?   decimal64
-    |  +--ro average-frame-loss-ratio?   decimal64
-    |  +--ro maximum-frame-loss-ratio?   decimal64
-    |  +--ro ses?                        uint64
-    |  +--ro uas?                        uint64
-    +--ro bidirectional-uas?                   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro pro-active-far-end-lm-parameters
-    |  +--ro minimum-frame-loss-ratio?   decimal64
-    |  +--ro average-frame-loss-ratio?   decimal64
-    |  +--ro maximum-frame-loss-ratio?   decimal64
-    |  +--ro ses?                        uint64
-    |  +--ro uas?                        uint64
-    +--ro pro-active-near-end-lm-parameters
-    |  +--ro minimum-frame-loss-ratio?   decimal64
-    |  +--ro average-frame-loss-ratio?   decimal64
-    |  +--ro maximum-frame-loss-ratio?   decimal64
-    |  +--ro ses?                        uint64
-    |  +--ro uas?                        uint64
-    +--ro bidirectional-uas?                   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro on-demand-far-end-dm-parameters
-    |  +--ro number-of-samples?            uint64
-    |  +--ro frame-delay-list*             uint64
-    |  +--ro frame-delay-variation-list*   uint64
-    +--ro on-demand-near-end-dm-parameters
-       +--ro number-of-samples?            uint64
-       +--ro frame-delay-list*             uint64
-       +--ro frame-delay-variation-list*   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro on-demand-near-end-1-lm-parameters
-       +--ro total-transmitted-frames?   uint64
-       +--ro total-lost-frames?          uint64
-       +--ro total-frame-loss-ratio?     decimal64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro on-demand-near-end-1-dm-parameters
-       +--ro number-of-samples?            uint64
-       +--ro frame-delay-list*             uint64
-       +--ro frame-delay-variation-list*   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro pro-active-near-end-1-dm-parameters
-       +--ro minimum-frame-delay?             uint64
-       +--ro average-frame-delay?             uint64
-       +--ro maximum-frame-delay?             uint64
-       +--ro minimum-frame-delay-variation?   uint64
-       +--ro average-frame-delay-variation?   uint64
-       +--ro maximum-frame-delay-variation?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro pro-active-near-end-1-dm-parameters
-       +--ro minimum-frame-delay?             uint64
-       +--ro average-frame-delay?             uint64
-       +--ro maximum-frame-delay?             uint64
-       +--ro minimum-frame-delay-variation?   uint64
-       +--ro average-frame-delay-variation?   uint64
-       +--ro maximum-frame-delay-variation?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro pro-active-near-end-1-lm-parameters
-       +--ro minimum-frame-loss-ratio?   decimal64
-       +--ro average-frame-loss-ratio?   decimal64
-       +--ro maximum-frame-loss-ratio?   decimal64
-       +--ro ses?                        uint64
-       +--ro uas?                        uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro pro-active-near-end-1-lm-parameters
-       +--ro minimum-frame-loss-ratio?   decimal64
-       +--ro average-frame-loss-ratio?   decimal64
-       +--ro maximum-frame-loss-ratio?   decimal64
-       +--ro ses?                        uint64
-       +--ro uas?                        uint64
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw on-demand-control-1way-source
-    |  +--rw controller-mep-id?         string
-    |  +--rw oam-pdu-generation-type?   oam-pdu-generation-type
-    |  +--rw destination-address?       mac-address
-    |  +--rw priority?                  uint64
-    |  +--rw message-period?            message-period
-    |  +--rw repetition-period?         repetition-period
-    |  +--rw measurement-interval?      uint64
-    |  +--rw test-identifier?           uint64
-    |  +--rw data-tlv-length?           uint64
-    +--rw on-demand-control-1way-sink
-       +--rw responder-mep-id?   string
-       +--rw source-address?     mac-address
-       +--rw priority?           uint64
-       +--rw test-identifier?    uint64
-  augment /tapi-common:context/tapi-oam:oam-job:
-    +--rw on-demand-control-2way-source
-       +--rw controller-mep-id?         string
-       +--rw oam-pdu-generation-type?   oam-pdu-generation-type
-       +--rw destination-address?       mac-address
-       +--rw priority?                  uint64
-       +--rw message-period?            message-period
-       +--rw repetition-period?         repetition-period
-       +--rw measurement-interval?      uint64
-       +--rw test-identifier?           uint64
-       +--rw data-tlv-length?           uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro on-demand-near-end-1-dm-parameters
-       +--ro number-of-samples?            uint64
-       +--ro frame-delay-list*             uint64
-       +--ro frame-delay-variation-list*   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro on-demand-near-end-1-lm-parameters
-       +--ro total-transmitted-frames?   uint64
-       +--ro total-lost-frames?          uint64
-       +--ro total-frame-loss-ratio?     decimal64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro on-demand-far-end-dm-parameters
-    |  +--ro number-of-samples?            uint64
-    |  +--ro frame-delay-list*             uint64
-    |  +--ro frame-delay-variation-list*   uint64
-    +--ro on-demand-near-end-dm-parameters
-       +--ro number-of-samples?            uint64
-       +--ro frame-delay-list*             uint64
-       +--ro frame-delay-variation-list*   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro on-demand-far-end-lm-parameters
-    |  +--ro total-transmitted-frames?   uint64
-    |  +--ro total-lost-frames?          uint64
-    |  +--ro total-frame-loss-ratio?     decimal64
-    +--ro on-demand-near-end-lm-parameters
-       +--ro total-transmitted-frames?   uint64
-       +--ro total-lost-frames?          uint64
-       +--ro total-frame-loss-ratio?     decimal64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
-    +--ro on-demand-far-end-lm-parameters
-    |  +--ro total-transmitted-frames?   uint64
-    |  +--ro total-lost-frames?          uint64
-    |  +--ro total-frame-loss-ratio?     decimal64
-    +--ro on-demand-near-end-lm-parameters
-       +--ro total-transmitted-frames?   uint64
-       +--ro total-lost-frames?          uint64
-       +--ro total-frame-loss-ratio?     decimal64
-  augment /tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
-    +--rw near-end-1-dm-cross-threshold
-    |  +--rw minimum-frame-delay?             uint64
-    |  +--rw average-frame-delay?             uint64
-    |  +--rw maximum-frame-delay?             uint64
-    |  +--rw minimum-frame-delay-variation?   uint64
-    |  +--rw average-frame-delay-variation?   uint64
-    |  +--rw maximum-frame-delay-variation?   uint64
-    +--rw near-end-1-dm-clear-threshold
-       +--rw minimum-frame-delay?             uint64
-       +--rw average-frame-delay?             uint64
-       +--rw maximum-frame-delay?             uint64
-       +--rw minimum-frame-delay-variation?   uint64
-       +--rw average-frame-delay-variation?   uint64
-       +--rw maximum-frame-delay-variation?   uint64
-  augment /tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
-    +--rw near-end-1-lm-cross-threshold
-    |  +--rw minimum-frame-loss-ratio?   decimal64
-    |  +--rw average-frame-loss-ratio?   decimal64
-    |  +--rw maximum-frame-loss-ratio?   decimal64
-    |  +--rw ses?                        uint64
-    |  +--rw uas?                        uint64
-    +--rw near-end-1-lm-clear-threshold
-       +--rw minimum-frame-loss-ratio?   decimal64
-       +--rw average-frame-loss-ratio?   decimal64
-       +--rw maximum-frame-loss-ratio?   decimal64
-       +--rw ses?                        uint64
-       +--rw uas?                        uint64
-  augment /tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
-    +--rw near-end-dm-cross-threshold
-    |  +--rw minimum-frame-delay?             uint64
-    |  +--rw average-frame-delay?             uint64
-    |  +--rw maximum-frame-delay?             uint64
-    |  +--rw minimum-frame-delay-variation?   uint64
-    |  +--rw average-frame-delay-variation?   uint64
-    |  +--rw maximum-frame-delay-variation?   uint64
-    +--rw near-end-dm-clear-threshold
-    |  +--rw minimum-frame-delay?             uint64
-    |  +--rw average-frame-delay?             uint64
-    |  +--rw maximum-frame-delay?             uint64
-    |  +--rw minimum-frame-delay-variation?   uint64
-    |  +--rw average-frame-delay-variation?   uint64
-    |  +--rw maximum-frame-delay-variation?   uint64
-    +--rw far-end-dm-cross-threshold
-    |  +--rw minimum-frame-delay?             uint64
-    |  +--rw average-frame-delay?             uint64
-    |  +--rw maximum-frame-delay?             uint64
-    |  +--rw minimum-frame-delay-variation?   uint64
-    |  +--rw average-frame-delay-variation?   uint64
-    |  +--rw maximum-frame-delay-variation?   uint64
-    +--rw far-end-dm-clear-threshold
-    |  +--rw minimum-frame-delay?             uint64
-    |  +--rw average-frame-delay?             uint64
-    |  +--rw maximum-frame-delay?             uint64
-    |  +--rw minimum-frame-delay-variation?   uint64
-    |  +--rw average-frame-delay-variation?   uint64
-    |  +--rw maximum-frame-delay-variation?   uint64
-    +--rw bi-dir-dm-cross-threshold
-    |  +--rw minimum-frame-delay?             uint64
-    |  +--rw average-frame-delay?             uint64
-    |  +--rw maximum-frame-delay?             uint64
-    |  +--rw minimum-frame-delay-variation?   uint64
-    |  +--rw average-frame-delay-variation?   uint64
-    |  +--rw maximum-frame-delay-variation?   uint64
-    +--rw bi-dir-dm-clear-threshold
-       +--rw minimum-frame-delay?             uint64
-       +--rw average-frame-delay?             uint64
-       +--rw maximum-frame-delay?             uint64
-       +--rw minimum-frame-delay-variation?   uint64
-       +--rw average-frame-delay-variation?   uint64
-       +--rw maximum-frame-delay-variation?   uint64
-  augment /tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
-    +--rw near-end-lm-cross-threshold
-    |  +--rw minimum-frame-loss-ratio?   decimal64
-    |  +--rw average-frame-loss-ratio?   decimal64
-    |  +--rw maximum-frame-loss-ratio?   decimal64
-    |  +--rw ses?                        uint64
-    |  +--rw uas?                        uint64
-    +--rw near-end-lm-clear-threshold
-    |  +--rw minimum-frame-loss-ratio?   decimal64
-    |  +--rw average-frame-loss-ratio?   decimal64
-    |  +--rw maximum-frame-loss-ratio?   decimal64
-    |  +--rw ses?                        uint64
-    |  +--rw uas?                        uint64
-    +--rw far-end-lm-cross-threshold
-    |  +--rw minimum-frame-loss-ratio?   decimal64
-    |  +--rw average-frame-loss-ratio?   decimal64
-    |  +--rw maximum-frame-loss-ratio?   decimal64
-    |  +--rw ses?                        uint64
-    |  +--rw uas?                        uint64
-    +--rw far-end-lm-clear-threshold
-    |  +--rw minimum-frame-loss-ratio?   decimal64
-    |  +--rw average-frame-loss-ratio?   decimal64
-    |  +--rw maximum-frame-loss-ratio?   decimal64
-    |  +--rw ses?                        uint64
-    |  +--rw uas?                        uint64
-    +--rw bi-dir-lm-uas-cross-threshold?   uint64
-    +--rw bi-dir-lm-uas-clear-threshold?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro result-list* []
-       +--ro source-address?    mac-address
-       +--ro time-to-live?      uint64
-       +--ro data-tlv-length?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro sent-tst-frames?   uint64
-  augment /tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data:
-    +--ro rec-lbr-frames?            uint64
-    +--ro out-of-order-lbr-frames?   uint64
-    +--ro sent-lbm-frames?           uint64
-    +--ro crc-lbr-frames?            uint64
-    +--ro ber-lbr-frames?            uint64
-    +--ro detected-peer-mep*         mac-address
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro eth-connection-end-point-spec
+       +--ro ety-term
+       |  +--ro is-fts-enabled?        boolean
+       |  +--ro is-tx-pause-enabled?   boolean
+       |  +--ro phy-type?              ety-phy-type
+       |  +--ro phy-type-list*         ety-phy-type
+       +--ro eth-term
+       |  +--ro priority-regenerate
+       |  |  +--ro priority-0?   uint64
+       |  |  +--ro priority-1?   uint64
+       |  |  +--ro priority-2?   uint64
+       |  |  +--ro priority-3?   uint64
+       |  |  +--ro priority-4?   uint64
+       |  |  +--ro priority-5?   uint64
+       |  |  +--ro priority-6?   uint64
+       |  |  +--ro priority-7?   uint64
+       |  +--ro ether-type?                   vlan-type
+       |  +--ro filter-config-1*              mac-address
+       |  +--ro frametype-config?             frame-type
+       |  +--ro port-vid?                     vid
+       |  +--ro priority-code-point-config?   pcp-coding
+       +--ro eth-ctp
+          +--ro auxiliary-function-position-sequence*   uint64
+          +--ro vlan-config?                            uint64
+          +--ro csf-rdi-fdi-enable?                     boolean
+          +--ro csf-report?                             boolean
+          +--ro filter-config-snk*                      mac-address
+          +--ro mac-length?                             uint64
+          +--ro filter-config
+          |  +--ro c-2-00-00-10?    boolean
+          |  +--ro c-2-00-00-00?    boolean
+          |  +--ro c-2-00-00-01?    boolean
+          |  +--ro c-2-00-00-02?    boolean
+          |  +--ro c-2-00-00-03?    boolean
+          |  +--ro c-2-00-00-04?    boolean
+          |  +--ro c-2-00-00-05?    boolean
+          |  +--ro c-2-00-00-06?    boolean
+          |  +--ro c-2-00-00-07?    boolean
+          |  +--ro c-2-00-00-08?    boolean
+          |  +--ro c-2-00-00-09?    boolean
+          |  +--ro c-2-00-00-0-a?   boolean
+          |  +--ro c-2-00-00-0-b?   boolean
+          |  +--ro c-2-00-00-0-c?   boolean
+          |  +--ro c-2-00-00-0-d?   boolean
+          |  +--ro c-2-00-00-0-e?   boolean
+          |  +--ro c-2-00-00-0-f?   boolean
+          |  +--ro c-2-00-00-20?    boolean
+          |  +--ro c-2-00-00-21?    boolean
+          |  +--ro c-2-00-00-22?    boolean
+          |  +--ro c-2-00-00-23?    boolean
+          |  +--ro c-2-00-00-24?    boolean
+          |  +--ro c-2-00-00-25?    boolean
+          |  +--ro c-2-00-00-26?    boolean
+          |  +--ro c-2-00-00-27?    boolean
+          |  +--ro c-2-00-00-28?    boolean
+          |  +--ro c-2-00-00-29?    boolean
+          |  +--ro c-2-00-00-2-a?   boolean
+          |  +--ro c-2-00-00-2-b?   boolean
+          |  +--ro c-2-00-00-2-c?   boolean
+          |  +--ro c-2-00-00-2-d?   boolean
+          |  +--ro c-2-00-00-2-e?   boolean
+          |  +--ro c-2-00-00-2-f?   boolean
+          +--ro is-ssf-reported?                        boolean
+          +--ro pll-thr?                                uint64
+          +--ro actor-oper-key?                         uint64
+          +--ro actor-system-id?                        mac-address
+          +--ro actor-system-priority?                  uint64
+          +--ro collector-max-delay?                    uint64
+          +--ro data-rate?                              uint64
+          +--ro partner-oper-key?                       uint64
+          +--ro partner-system-id?                      mac-address
+          +--ro partner-system-priority?                uint64
+          +--ro csf-config?                             csf-config
+          +--ro traffic-shaping
+          |  +--ro prio-config-list* []
+          |  |  +--ro priority?   uint64
+          |  |  +--ro queue-id?   uint64
+          |  +--ro queue-config-list* []
+          |  |  +--ro queue-id?          uint64
+          |  |  +--ro queue-depth?       uint64
+          |  |  +--ro queue-threshold?   uint64
+          |  +--ro sched-config?        scheduling-configuration
+          |  +--ro codirectional?       boolean
+          +--ro traffic-conditioning
+             +--ro prio-config-list* []
+             |  +--ro priority?   uint64
+             |  +--ro queue-id?   uint64
+             +--ro cond-config-list* []
+             |  +--ro cir?             uint64
+             |  +--ro cbs?             uint64
+             |  +--ro eir?             uint64
+             |  +--ro ebs?             uint64
+             |  +--ro coupling-flag?   boolean
+             |  +--ro colour-mode?     colour-mode
+             |  +--ro queue-id?        uint64
+             +--ro codirectional?      boolean
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-loopback-job
+       +--rw eth-lb-msg
+       |  +--rw period?                oam-period
+       |  +--rw drop-eligibility?      boolean
+       |  +--rw data-tlv-length?       uint64
+       |  +--rw test-pattern?          uint64
+       |  +--rw destination-address?   mac-address
+       |  +--rw priority?              uint64
+       +--rw number?       uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:meg:
+    +--ro eth-meg-spec
+       +--ro client-mel?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep:
+    +--ro eth-mep-spec
+       +--ro eth-mep-common
+       |  +--ro mep-mac?         mac-address
+       |  +--ro is-cc-enabled?   boolean
+       |  +--ro cc-period?       oam-period
+       |  +--ro cc-priority?     uint64
+       |  +--ro lck-period?      oam-period
+       |  +--ro lck-priority?    uint64
+       +--ro eth-mep-source-pac
+       |  +--ro aps-priority?   uint64
+       |  +--ro csf-priority?   uint64
+       |  +--ro csf-period?     oam-period
+       |  +--ro csf-config?     csf-config
+       +--ro eth-mep-sink
+          +--ro dm-1-priority*            uint64
+          +--ro ais-priority?             uint64
+          +--ro ais-period?               oam-period
+          +--ro is-csf-reported?          boolean
+          +--ro is-csf-rdi-fdi-enabled?   boolean
+          +--ro bandwidth-report
+          |  +--ro source-mac-address?   mac-address
+          |  +--ro port-id?              uint64
+          |  +--ro nominal-bandwidth?    uint64
+          |  +--ro current-bandwidth?    uint64
+          +--ro lm-degm?                  uint64
+          +--ro lm-deg-thr?               uint64
+          +--ro lm-m?                     uint64
+          +--ro lm-tf-min?                uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip:
+    +--ro eth-mip-spec
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-pro-active-2way-measurement-job
+       +--rw pro-active-control-2way-source
+          +--rw controller-mep-id?     string
+          +--rw is-enabled?            boolean
+          +--rw destination-address?   mac-address
+          +--rw priority?              uint64
+          +--rw period?                oam-period
+          +--rw test-identifier?       uint64
+          +--rw data-tlv-length?       uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-link-trace-job
+       +--rw eth-lt-msg
+       |  +--rw destination-address?   mac-address
+       |  +--rw priority?              uint64
+       +--rw time-to-live?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-test-job
+       +--rw eth-test-msg
+          +--rw period?                oam-period
+          +--rw drop-eligibility?      boolean
+          +--rw data-tlv-length?       uint64
+          +--rw test-pattern?          uint64
+          +--rw destination-address?   mac-address
+          +--rw priority?              uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-pro-active-1way-measurement-job
+       +--rw pro-active-control-1way-source
+       |  +--rw controller-mep-id?     string
+       |  +--rw is-enabled?            boolean
+       |  +--rw destination-address?   mac-address
+       |  +--rw priority?              uint64
+       |  +--rw period?                oam-period
+       |  +--rw test-identifier?       uint64
+       |  +--rw data-tlv-length?       uint64
+       +--rw pro-active-control-1way-sink
+          +--rw responder-mep-id?   string
+          +--rw is-enabled?         boolean
+          +--rw source-address?     mac-address
+          +--rw test-identifier?    uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-pro-active-dm-performance-data
+       +--ro pro-active-bi-dir-dm-parameters
+       |  +--ro minimum-frame-delay?             uint64
+       |  +--ro average-frame-delay?             uint64
+       |  +--ro maximum-frame-delay?             uint64
+       |  +--ro minimum-frame-delay-variation?   uint64
+       |  +--ro average-frame-delay-variation?   uint64
+       |  +--ro maximum-frame-delay-variation?   uint64
+       +--ro pro-active-far-end-dm-parameters
+       |  +--ro minimum-frame-delay?             uint64
+       |  +--ro average-frame-delay?             uint64
+       |  +--ro maximum-frame-delay?             uint64
+       |  +--ro minimum-frame-delay-variation?   uint64
+       |  +--ro average-frame-delay-variation?   uint64
+       |  +--ro maximum-frame-delay-variation?   uint64
+       +--ro pro-active-near-end-dm-parameters
+          +--ro minimum-frame-delay?             uint64
+          +--ro average-frame-delay?             uint64
+          +--ro maximum-frame-delay?             uint64
+          +--ro minimum-frame-delay-variation?   uint64
+          +--ro average-frame-delay-variation?   uint64
+          +--ro maximum-frame-delay-variation?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-pro-active-dm-performance-data
+       +--ro pro-active-bi-dir-dm-parameters
+       |  +--ro minimum-frame-delay?             uint64
+       |  +--ro average-frame-delay?             uint64
+       |  +--ro maximum-frame-delay?             uint64
+       |  +--ro minimum-frame-delay-variation?   uint64
+       |  +--ro average-frame-delay-variation?   uint64
+       |  +--ro maximum-frame-delay-variation?   uint64
+       +--ro pro-active-far-end-dm-parameters
+       |  +--ro minimum-frame-delay?             uint64
+       |  +--ro average-frame-delay?             uint64
+       |  +--ro maximum-frame-delay?             uint64
+       |  +--ro minimum-frame-delay-variation?   uint64
+       |  +--ro average-frame-delay-variation?   uint64
+       |  +--ro maximum-frame-delay-variation?   uint64
+       +--ro pro-active-near-end-dm-parameters
+          +--ro minimum-frame-delay?             uint64
+          +--ro average-frame-delay?             uint64
+          +--ro maximum-frame-delay?             uint64
+          +--ro minimum-frame-delay-variation?   uint64
+          +--ro average-frame-delay-variation?   uint64
+          +--ro maximum-frame-delay-variation?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-pro-active-lm-performance-data
+       +--ro pro-active-far-end-lm-parameters
+       |  +--ro minimum-frame-loss-ratio?   decimal64
+       |  +--ro average-frame-loss-ratio?   decimal64
+       |  +--ro maximum-frame-loss-ratio?   decimal64
+       |  +--ro ses?                        uint64
+       |  +--ro uas?                        uint64
+       +--ro pro-active-near-end-lm-parameters
+       |  +--ro minimum-frame-loss-ratio?   decimal64
+       |  +--ro average-frame-loss-ratio?   decimal64
+       |  +--ro maximum-frame-loss-ratio?   decimal64
+       |  +--ro ses?                        uint64
+       |  +--ro uas?                        uint64
+       +--ro bidirectional-uas?                   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-pro-active-lm-performance-data
+       +--ro pro-active-far-end-lm-parameters
+       |  +--ro minimum-frame-loss-ratio?   decimal64
+       |  +--ro average-frame-loss-ratio?   decimal64
+       |  +--ro maximum-frame-loss-ratio?   decimal64
+       |  +--ro ses?                        uint64
+       |  +--ro uas?                        uint64
+       +--ro pro-active-near-end-lm-parameters
+       |  +--ro minimum-frame-loss-ratio?   decimal64
+       |  +--ro average-frame-loss-ratio?   decimal64
+       |  +--ro maximum-frame-loss-ratio?   decimal64
+       |  +--ro ses?                        uint64
+       |  +--ro uas?                        uint64
+       +--ro bidirectional-uas?                   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-on-demand-dm-performance-data
+       +--ro on-demand-far-end-dm-parameters
+       |  +--ro number-of-samples?            uint64
+       |  +--ro frame-delay-list*             uint64
+       |  +--ro frame-delay-variation-list*   uint64
+       +--ro on-demand-near-end-dm-parameters
+          +--ro number-of-samples?            uint64
+          +--ro frame-delay-list*             uint64
+          +--ro frame-delay-variation-list*   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-on-demand-1-lm-performance-data
+       +--ro on-demand-near-end-1-lm-parameters
+          +--ro total-transmitted-frames?   uint64
+          +--ro total-lost-frames?          uint64
+          +--ro total-frame-loss-ratio?     decimal64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-on-demand-1-dm-performance-data
+       +--ro on-demand-near-end-1-dm-parameters
+          +--ro number-of-samples?            uint64
+          +--ro frame-delay-list*             uint64
+          +--ro frame-delay-variation-list*   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-pro-active-1-dm-performance-data
+       +--ro pro-active-near-end-1-dm-parameters
+          +--ro minimum-frame-delay?             uint64
+          +--ro average-frame-delay?             uint64
+          +--ro maximum-frame-delay?             uint64
+          +--ro minimum-frame-delay-variation?   uint64
+          +--ro average-frame-delay-variation?   uint64
+          +--ro maximum-frame-delay-variation?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-pro-active-1-dm-performance-data
+       +--ro pro-active-near-end-1-dm-parameters
+          +--ro minimum-frame-delay?             uint64
+          +--ro average-frame-delay?             uint64
+          +--ro maximum-frame-delay?             uint64
+          +--ro minimum-frame-delay-variation?   uint64
+          +--ro average-frame-delay-variation?   uint64
+          +--ro maximum-frame-delay-variation?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-pro-active-1-lm-performance-data
+       +--ro pro-active-near-end-1-lm-parameters
+          +--ro minimum-frame-loss-ratio?   decimal64
+          +--ro average-frame-loss-ratio?   decimal64
+          +--ro maximum-frame-loss-ratio?   decimal64
+          +--ro ses?                        uint64
+          +--ro uas?                        uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-pro-active-1-lm-performance-data
+       +--ro pro-active-near-end-1-lm-parameters
+          +--ro minimum-frame-loss-ratio?   decimal64
+          +--ro average-frame-loss-ratio?   decimal64
+          +--ro maximum-frame-loss-ratio?   decimal64
+          +--ro ses?                        uint64
+          +--ro uas?                        uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-on-demand-1way-measurement-job
+       +--rw on-demand-control-1way-source
+       |  +--rw controller-mep-id?         string
+       |  +--rw oam-pdu-generation-type?   oam-pdu-generation-type
+       |  +--rw destination-address?       mac-address
+       |  +--rw priority?                  uint64
+       |  +--rw message-period?            message-period
+       |  +--rw repetition-period?         repetition-period
+       |  +--rw measurement-interval?      uint64
+       |  +--rw test-identifier?           uint64
+       |  +--rw data-tlv-length?           uint64
+       +--rw on-demand-control-1way-sink
+          +--rw responder-mep-id?   string
+          +--rw source-address?     mac-address
+          +--rw priority?           uint64
+          +--rw test-identifier?    uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
+    +--rw eth-on-demand-2way-measurement-job
+       +--rw on-demand-control-2way-source
+          +--rw controller-mep-id?         string
+          +--rw oam-pdu-generation-type?   oam-pdu-generation-type
+          +--rw destination-address?       mac-address
+          +--rw priority?                  uint64
+          +--rw message-period?            message-period
+          +--rw repetition-period?         repetition-period
+          +--rw measurement-interval?      uint64
+          +--rw test-identifier?           uint64
+          +--rw data-tlv-length?           uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-on-demand-1-dm-performance-data
+       +--ro on-demand-near-end-1-dm-parameters
+          +--ro number-of-samples?            uint64
+          +--ro frame-delay-list*             uint64
+          +--ro frame-delay-variation-list*   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-on-demand-1-lm-performance-data
+       +--ro on-demand-near-end-1-lm-parameters
+          +--ro total-transmitted-frames?   uint64
+          +--ro total-lost-frames?          uint64
+          +--ro total-frame-loss-ratio?     decimal64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-on-demand-dm-performance-data
+       +--ro on-demand-far-end-dm-parameters
+       |  +--ro number-of-samples?            uint64
+       |  +--ro frame-delay-list*             uint64
+       |  +--ro frame-delay-variation-list*   uint64
+       +--ro on-demand-near-end-dm-parameters
+          +--ro number-of-samples?            uint64
+          +--ro frame-delay-list*             uint64
+          +--ro frame-delay-variation-list*   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-on-demand-lm-performance-data
+       +--ro on-demand-far-end-lm-parameters
+       |  +--ro total-transmitted-frames?   uint64
+       |  +--ro total-lost-frames?          uint64
+       |  +--ro total-frame-loss-ratio?     decimal64
+       +--ro on-demand-near-end-lm-parameters
+          +--ro total-transmitted-frames?   uint64
+          +--ro total-lost-frames?          uint64
+          +--ro total-frame-loss-ratio?     decimal64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data:
+    +--ro eth-on-demand-lm-performance-data
+       +--ro on-demand-far-end-lm-parameters
+       |  +--ro total-transmitted-frames?   uint64
+       |  +--ro total-lost-frames?          uint64
+       |  +--ro total-frame-loss-ratio?     decimal64
+       +--ro on-demand-near-end-lm-parameters
+          +--ro total-transmitted-frames?   uint64
+          +--ro total-lost-frames?          uint64
+          +--ro total-frame-loss-ratio?     decimal64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
+    +--rw eth-1-dm-threshold-data
+       +--rw near-end-1-dm-cross-threshold
+       |  +--rw minimum-frame-delay?             uint64
+       |  +--rw average-frame-delay?             uint64
+       |  +--rw maximum-frame-delay?             uint64
+       |  +--rw minimum-frame-delay-variation?   uint64
+       |  +--rw average-frame-delay-variation?   uint64
+       |  +--rw maximum-frame-delay-variation?   uint64
+       +--rw near-end-1-dm-clear-threshold
+          +--rw minimum-frame-delay?             uint64
+          +--rw average-frame-delay?             uint64
+          +--rw maximum-frame-delay?             uint64
+          +--rw minimum-frame-delay-variation?   uint64
+          +--rw average-frame-delay-variation?   uint64
+          +--rw maximum-frame-delay-variation?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
+    +--rw eth-1-lm-threshold-data
+       +--rw near-end-1-lm-cross-threshold
+       |  +--rw minimum-frame-loss-ratio?   decimal64
+       |  +--rw average-frame-loss-ratio?   decimal64
+       |  +--rw maximum-frame-loss-ratio?   decimal64
+       |  +--rw ses?                        uint64
+       |  +--rw uas?                        uint64
+       +--rw near-end-1-lm-clear-threshold
+          +--rw minimum-frame-loss-ratio?   decimal64
+          +--rw average-frame-loss-ratio?   decimal64
+          +--rw maximum-frame-loss-ratio?   decimal64
+          +--rw ses?                        uint64
+          +--rw uas?                        uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
+    +--rw eth-dm-threshold-data
+       +--rw near-end-dm-cross-threshold
+       |  +--rw minimum-frame-delay?             uint64
+       |  +--rw average-frame-delay?             uint64
+       |  +--rw maximum-frame-delay?             uint64
+       |  +--rw minimum-frame-delay-variation?   uint64
+       |  +--rw average-frame-delay-variation?   uint64
+       |  +--rw maximum-frame-delay-variation?   uint64
+       +--rw near-end-dm-clear-threshold
+       |  +--rw minimum-frame-delay?             uint64
+       |  +--rw average-frame-delay?             uint64
+       |  +--rw maximum-frame-delay?             uint64
+       |  +--rw minimum-frame-delay-variation?   uint64
+       |  +--rw average-frame-delay-variation?   uint64
+       |  +--rw maximum-frame-delay-variation?   uint64
+       +--rw far-end-dm-cross-threshold
+       |  +--rw minimum-frame-delay?             uint64
+       |  +--rw average-frame-delay?             uint64
+       |  +--rw maximum-frame-delay?             uint64
+       |  +--rw minimum-frame-delay-variation?   uint64
+       |  +--rw average-frame-delay-variation?   uint64
+       |  +--rw maximum-frame-delay-variation?   uint64
+       +--rw far-end-dm-clear-threshold
+       |  +--rw minimum-frame-delay?             uint64
+       |  +--rw average-frame-delay?             uint64
+       |  +--rw maximum-frame-delay?             uint64
+       |  +--rw minimum-frame-delay-variation?   uint64
+       |  +--rw average-frame-delay-variation?   uint64
+       |  +--rw maximum-frame-delay-variation?   uint64
+       +--rw bi-dir-dm-cross-threshold
+       |  +--rw minimum-frame-delay?             uint64
+       |  +--rw average-frame-delay?             uint64
+       |  +--rw maximum-frame-delay?             uint64
+       |  +--rw minimum-frame-delay-variation?   uint64
+       |  +--rw average-frame-delay-variation?   uint64
+       |  +--rw maximum-frame-delay-variation?   uint64
+       +--rw bi-dir-dm-clear-threshold
+          +--rw minimum-frame-delay?             uint64
+          +--rw average-frame-delay?             uint64
+          +--rw maximum-frame-delay?             uint64
+          +--rw minimum-frame-delay-variation?   uint64
+          +--rw average-frame-delay-variation?   uint64
+          +--rw maximum-frame-delay-variation?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data:
+    +--rw eth-lm-threshold-data
+       +--rw near-end-lm-cross-threshold
+       |  +--rw minimum-frame-loss-ratio?   decimal64
+       |  +--rw average-frame-loss-ratio?   decimal64
+       |  +--rw maximum-frame-loss-ratio?   decimal64
+       |  +--rw ses?                        uint64
+       |  +--rw uas?                        uint64
+       +--rw near-end-lm-clear-threshold
+       |  +--rw minimum-frame-loss-ratio?   decimal64
+       |  +--rw average-frame-loss-ratio?   decimal64
+       |  +--rw maximum-frame-loss-ratio?   decimal64
+       |  +--rw ses?                        uint64
+       |  +--rw uas?                        uint64
+       +--rw far-end-lm-cross-threshold
+       |  +--rw minimum-frame-loss-ratio?   decimal64
+       |  +--rw average-frame-loss-ratio?   decimal64
+       |  +--rw maximum-frame-loss-ratio?   decimal64
+       |  +--rw ses?                        uint64
+       |  +--rw uas?                        uint64
+       +--rw far-end-lm-clear-threshold
+       |  +--rw minimum-frame-loss-ratio?   decimal64
+       |  +--rw average-frame-loss-ratio?   decimal64
+       |  +--rw maximum-frame-loss-ratio?   decimal64
+       |  +--rw ses?                        uint64
+       |  +--rw uas?                        uint64
+       +--rw bi-dir-lm-uas-cross-threshold?   uint64
+       +--rw bi-dir-lm-uas-clear-threshold?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-link-trace-result-data
+       +--ro result-list* []
+          +--ro source-address?    mac-address
+          +--ro time-to-live?      uint64
+          +--ro data-tlv-length?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-test-result-data
+       +--ro sent-tst-frames?   uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data:
+    +--ro eth-loopback-result-data
+       +--ro rec-lbr-frames?            uint64
+       +--ro out-of-order-lbr-frames?   uint64
+       +--ro sent-lbm-frames?           uint64
+       +--ro crc-lbr-frames?            uint64
+       +--ro ber-lbr-frames?            uint64
+       +--ro detected-peer-mep*         mac-address

--- a/YANG/tapi-eth@2018-08-31.yang
+++ b/YANG/tapi-eth@2018-08-31.yang
@@ -51,140 +51,242 @@ module tapi-eth {
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses eth-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container eth-connection-end-point-spec {
+            uses eth-connection-end-point-spec;
+            description "Augments the base LayerProtocol information in ConnectionEndPoint with ETH-specific information";
+        }
         description "Augments the base LayerProtocol information in ConnectionEndPoint with ETH-specific information";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-loopback-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-loopback-job {
+            uses eth-loopback-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:meg" {
-        uses eth-meg-spec;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg" {
+        container eth-meg-spec {
+            uses eth-meg-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:meg/tapi-oam:mep" {
-        uses eth-mep-spec;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep" {
+        container eth-mep-spec {
+            uses eth-mep-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:meg/tapi-oam:mip" {
-        uses eth-mip-spec;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip" {
+        container eth-mip-spec {
+            uses eth-mip-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-pro-active-2way-measurement-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-pro-active-2way-measurement-job {
+            uses eth-pro-active-2way-measurement-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-link-trace-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-link-trace-job {
+            uses eth-link-trace-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-test-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-test-job {
+            uses eth-test-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-pro-active-1way-measurement-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-pro-active-1way-measurement-job {
+            uses eth-pro-active-1way-measurement-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-pro-active-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-pro-active-dm-performance-data {
+            uses eth-pro-active-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-pro-active-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-pro-active-dm-performance-data {
+            uses eth-pro-active-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-pro-active-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-pro-active-lm-performance-data {
+            uses eth-pro-active-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-pro-active-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-pro-active-lm-performance-data {
+            uses eth-pro-active-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-on-demand-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-on-demand-dm-performance-data {
+            uses eth-on-demand-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-on-demand-1-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-on-demand-1-lm-performance-data {
+            uses eth-on-demand-1-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-on-demand-1-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-on-demand-1-dm-performance-data {
+            uses eth-on-demand-1-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-pro-active-1-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-pro-active-1-dm-performance-data {
+            uses eth-pro-active-1-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-pro-active-1-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-pro-active-1-dm-performance-data {
+            uses eth-pro-active-1-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-pro-active-1-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-pro-active-1-lm-performance-data {
+            uses eth-pro-active-1-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-pro-active-1-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-pro-active-1-lm-performance-data {
+            uses eth-pro-active-1-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-on-demand-1way-measurement-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-on-demand-1way-measurement-job {
+            uses eth-on-demand-1way-measurement-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job" {
-        uses eth-on-demand-2way-measurement-job;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job" {
+        container eth-on-demand-2way-measurement-job {
+            uses eth-on-demand-2way-measurement-job;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-on-demand-1-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-on-demand-1-dm-performance-data {
+            uses eth-on-demand-1-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-on-demand-1-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-on-demand-1-lm-performance-data {
+            uses eth-on-demand-1-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-on-demand-dm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-on-demand-dm-performance-data {
+            uses eth-on-demand-dm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-on-demand-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-on-demand-lm-performance-data {
+            uses eth-on-demand-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
-        uses eth-on-demand-lm-performance-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data" {
+        container eth-on-demand-lm-performance-data {
+            uses eth-on-demand-lm-performance-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
-        uses eth-1-dm-threshold-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
+        container eth-1-dm-threshold-data {
+            uses eth-1-dm-threshold-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
-        uses eth-1-lm-threshold-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
+        container eth-1-lm-threshold-data {
+            uses eth-1-lm-threshold-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
-        uses eth-dm-threshold-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
+        container eth-dm-threshold-data {
+            uses eth-dm-threshold-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
-        uses eth-lm-threshold-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data" {
+        container eth-lm-threshold-data {
+            uses eth-lm-threshold-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-link-trace-result-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-link-trace-result-data {
+            uses eth-link-trace-result-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-test-result-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-test-result-data {
+            uses eth-test-result-data;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
-        uses eth-loopback-result-data;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data" {
+        container eth-loopback-result-data {
+            uses eth-loopback-result-data;
+            description "none";
+        }
         description "none";
     }
     /***********************
@@ -1676,8 +1778,8 @@ module tapi-eth {
                 description "This attribute contains the total number of frames lost.";
             }
             leaf total-frame-loss-ratio {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "This attribute contains the frame loss ratio (number of lost frames divided by the number of total frames (N_LF / N_TF)).
                     The accuracy of the value is for further study.";
@@ -1713,22 +1815,22 @@ module tapi-eth {
         }
         grouping statistical-lm-performance-parameters {
             leaf minimum-frame-loss-ratio {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "This attribute contains the minimum frame loss ratio calculated over a period of time.
                     The accuracy of the value is for further study.";
             }
             leaf average-frame-loss-ratio {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "This attribute contains the average frame loss ratio calculated over a period of time.
                     The accuracy of the value is for further study.";
             }
             leaf maximum-frame-loss-ratio {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "This attribute contains the maximum frame loss ratio calculated over a period of time.
                     The accuracy of the value is for further study.";

--- a/YANG/tapi-notification@2018-08-31.tree
+++ b/YANG/tapi-notification@2018-08-31.tree
@@ -1,103 +1,104 @@
 
 module: tapi-notification
   augment /tapi-common:context:
-    +--rw notif-subscription* [uuid]
-    |  +--ro notification* [uuid]
-    |  |  +--ro notification-type?          notification-type
-    |  |  +--ro target-object-type?         object-type
-    |  |  +--ro target-object-identifier?   tapi-common:uuid
-    |  |  +--ro target-object-name* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |  |  +--ro sequence-number?            uint64
-    |  |  +--ro source-indicator?           source-indicator
-    |  |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |  |  +--ro changed-attributes* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro old-value?    string
-    |  |  |  +--ro new-value?    string
-    |  |  +--ro additional-info* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro additional-text?            string
-    |  |  +--ro tca-info
-    |  |  |  +--ro is-transient?            boolean
-    |  |  |  +--ro threshold-crossing?      threshold-crossing-type
-    |  |  |  +--ro threshold-parameter?     string
-    |  |  |  +--ro threshold-value?         uint64
-    |  |  |  +--ro perceived-severity?      perceived-tca-severity
-    |  |  |  +--ro measurement-interval?    tapi-common:date-and-time
-    |  |  |  +--ro suspect-interval-flag?   boolean
-    |  |  +--ro alarm-info
-    |  |  |  +--ro is-transient?         boolean
-    |  |  |  +--ro perceived-severity?   perceived-severity-type
-    |  |  |  +--ro probable-cause?       string
-    |  |  |  +--ro service-affecting?    service-affecting
-    |  |  +--ro uuid                        uuid
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--rw notification-channel
-    |  |  +--ro stream-address?     string
-    |  |  +--ro next-sequence-no?   uint64
-    |  |  +--rw local-id?           string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw subscription-filter
-    |  |  +--ro requested-notification-types*   notification-type
-    |  |  +--ro requested-object-types*         object-type
-    |  |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |  |  +--ro requested-object-identifier*    tapi-common:uuid
-    |  |  +--ro include-content?                boolean
-    |  |  +--rw local-id?                       string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw subscription-state?             subscription-state
-    |  +--ro supported-notification-types*   notification-type
-    |  +--ro supported-object-types*         object-type
-    |  +--rw uuid                            uuid
-    |  +--rw name* [value-name]
-    |     +--rw value-name    string
-    |     +--rw value?        string
-    +--ro notification* [uuid]
-       +--ro notification-type?          notification-type
-       +--ro target-object-type?         object-type
-       +--ro target-object-identifier?   tapi-common:uuid
-       +--ro target-object-name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro event-time-stamp?           tapi-common:date-and-time
-       +--ro sequence-number?            uint64
-       +--ro source-indicator?           source-indicator
-       +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-       +--ro changed-attributes* [value-name]
-       |  +--ro value-name    string
-       |  +--ro old-value?    string
-       |  +--ro new-value?    string
-       +--ro additional-info* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro additional-text?            string
-       +--ro tca-info
-       |  +--ro is-transient?            boolean
-       |  +--ro threshold-crossing?      threshold-crossing-type
-       |  +--ro threshold-parameter?     string
-       |  +--ro threshold-value?         uint64
-       |  +--ro perceived-severity?      perceived-tca-severity
-       |  +--ro measurement-interval?    tapi-common:date-and-time
-       |  +--ro suspect-interval-flag?   boolean
-       +--ro alarm-info
-       |  +--ro is-transient?         boolean
-       |  +--ro perceived-severity?   perceived-severity-type
-       |  +--ro probable-cause?       string
-       |  +--ro service-affecting?    service-affecting
-       +--ro uuid                        uuid
-       +--ro name* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
+    +--rw notification-context
+       +--rw notif-subscription* [uuid]
+       |  +--ro notification* [uuid]
+       |  |  +--ro notification-type?          notification-type
+       |  |  +--ro target-object-type?         object-type
+       |  |  +--ro target-object-identifier?   tapi-common:uuid
+       |  |  +--ro target-object-name* [value-name]
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro value?        string
+       |  |  +--ro event-time-stamp?           tapi-common:date-and-time
+       |  |  +--ro sequence-number?            uint64
+       |  |  +--ro source-indicator?           source-indicator
+       |  |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+       |  |  +--ro changed-attributes* [value-name]
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro old-value?    string
+       |  |  |  +--ro new-value?    string
+       |  |  +--ro additional-info* [value-name]
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro value?        string
+       |  |  +--ro additional-text?            string
+       |  |  +--ro tca-info
+       |  |  |  +--ro is-transient?            boolean
+       |  |  |  +--ro threshold-crossing?      threshold-crossing-type
+       |  |  |  +--ro threshold-parameter?     string
+       |  |  |  +--ro threshold-value?         uint64
+       |  |  |  +--ro perceived-severity?      perceived-tca-severity
+       |  |  |  +--ro measurement-interval?    tapi-common:date-and-time
+       |  |  |  +--ro suspect-interval-flag?   boolean
+       |  |  +--ro alarm-info
+       |  |  |  +--ro is-transient?         boolean
+       |  |  |  +--ro perceived-severity?   perceived-severity-type
+       |  |  |  +--ro probable-cause?       string
+       |  |  |  +--ro service-affecting?    service-affecting
+       |  |  +--ro uuid                        uuid
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--rw notification-channel
+       |  |  +--ro stream-address?     string
+       |  |  +--ro next-sequence-no?   uint64
+       |  |  +--rw local-id?           string
+       |  |  +--rw name* [value-name]
+       |  |     +--rw value-name    string
+       |  |     +--rw value?        string
+       |  +--rw subscription-filter
+       |  |  +--ro requested-notification-types*   notification-type
+       |  |  +--ro requested-object-types*         object-type
+       |  |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+       |  |  +--ro requested-object-identifier*    tapi-common:uuid
+       |  |  +--ro include-content?                boolean
+       |  |  +--rw local-id?                       string
+       |  |  +--rw name* [value-name]
+       |  |     +--rw value-name    string
+       |  |     +--rw value?        string
+       |  +--rw subscription-state?             subscription-state
+       |  +--ro supported-notification-types*   notification-type
+       |  +--ro supported-object-types*         object-type
+       |  +--rw uuid                            uuid
+       |  +--rw name* [value-name]
+       |     +--rw value-name    string
+       |     +--rw value?        string
+       +--ro notification* [uuid]
+          +--ro notification-type?          notification-type
+          +--ro target-object-type?         object-type
+          +--ro target-object-identifier?   tapi-common:uuid
+          +--ro target-object-name* [value-name]
+          |  +--ro value-name    string
+          |  +--ro value?        string
+          +--ro event-time-stamp?           tapi-common:date-and-time
+          +--ro sequence-number?            uint64
+          +--ro source-indicator?           source-indicator
+          +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+          +--ro changed-attributes* [value-name]
+          |  +--ro value-name    string
+          |  +--ro old-value?    string
+          |  +--ro new-value?    string
+          +--ro additional-info* [value-name]
+          |  +--ro value-name    string
+          |  +--ro value?        string
+          +--ro additional-text?            string
+          +--ro tca-info
+          |  +--ro is-transient?            boolean
+          |  +--ro threshold-crossing?      threshold-crossing-type
+          |  +--ro threshold-parameter?     string
+          |  +--ro threshold-value?         uint64
+          |  +--ro perceived-severity?      perceived-tca-severity
+          |  +--ro measurement-interval?    tapi-common:date-and-time
+          |  +--ro suspect-interval-flag?   boolean
+          +--ro alarm-info
+          |  +--ro is-transient?         boolean
+          |  +--ro perceived-severity?   perceived-severity-type
+          |  +--ro probable-cause?       string
+          |  +--ro service-affecting?    service-affecting
+          +--ro uuid                        uuid
+          +--ro name* [value-name]
+             +--ro value-name    string
+             +--ro value?        string
 
   rpcs:
     +---x get-supported-notification-types

--- a/YANG/tapi-notification@2018-08-31.yang
+++ b/YANG/tapi-notification@2018-08-31.yang
@@ -44,7 +44,10 @@ module tapi-notification {
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
     augment "/tapi-common:context" {
-        uses notification-context;
+        container notification-context {
+            uses notification-context;
+            description "Augments the base TAPI Context with NotificationService information";
+        }
         description "Augments the base TAPI Context with NotificationService information";
     }
     /***********************

--- a/YANG/tapi-oam@2018-08-31.tree
+++ b/YANG/tapi-oam@2018-08-31.tree
@@ -1,161 +1,163 @@
 
 module: tapi-oam
   augment /tapi-common:context:
-    +--rw oam-service* [uuid]
-    |  +--rw end-point* [local-id]
-    |  |  +--rw service-interface-point
-    |  |  |  +--rw service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  +--rw connectivity-service-end-point
-    |  |  |  +--rw connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +--rw connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
-    |  |  +--ro mep
-    |  |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
-    |  |  +--ro mip
-    |  |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
-    |  |  +--rw layer-protocol-name?              tapi-common:layer-protocol-name
-    |  |  +--rw direction?                        tapi-common:port-direction
-    |  |  +--rw local-id                          string
-    |  |  +--rw name* [value-name]
-    |  |  |  +--rw value-name    string
-    |  |  |  +--rw value?        string
-    |  |  +--rw administrative-state?             administrative-state
-    |  |  +--ro operational-state?                operational-state
-    |  |  +--ro lifecycle-state?                  lifecycle-state
-    |  +--ro meg
-    |  |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:meg/uuid
-    |  +--rw oam-profile
-    |  |  +--rw oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
-    |  +--rw uuid                    uuid
-    |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw administrative-state?   administrative-state
-    |  +--ro operational-state?      operational-state
-    |  +--ro lifecycle-state?        lifecycle-state
-    |  +--rw layer-protocol-name?    tapi-common:layer-protocol-name
-    |  +--rw direction?              tapi-common:forwarding-direction
-    |  +--rw meg-level?              uint64
-    +--ro meg* [uuid]
-    |  +--ro me* [local-id]
-    |  |  +--ro mep* [meg-uuid mep-local-id]
-    |  |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  +--ro mep-local-id    -> /tapi-common:context/tapi-oam:meg/mep/local-id
-    |  |  +--ro mip* [meg-uuid mip-local-id]
-    |  |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:meg/mip/local-id
-    |  |  +--ro connection-route
-    |  |  |  +--ro connection-uuid?   -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |  |  |  +--ro route-local-id?    -> /tapi-common:context/tapi-connectivity:connection/route/local-id
-    |  |  +--ro local-id            string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro mep* [local-id]
-    |  |  +--ro oam-service-end-point
-    |  |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |  |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
-    |  |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |  |  +--ro direction?               tapi-common:termination-direction
-    |  |  +--ro mep-identifier?          string
-    |  |  +--ro peer-mep-identifier*     string
-    |  |  +--ro local-id                 string
-    |  |  +--ro name* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro operational-state?       operational-state
-    |  |  +--ro lifecycle-state?         lifecycle-state
-    |  +--ro mip* [local-id]
-    |  |  +--ro oam-service-end-point
-    |  |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |  |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
-    |  |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |  |  +--ro local-id                 string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |  +--ro direction?             tapi-common:forwarding-direction
-    |  +--ro meg-level?             uint64
-    |  +--ro meg-identifier?        string
-    |  +--ro uuid                   uuid
-    |  +--ro name* [value-name]
-    |  |  +--ro value-name    string
-    |  |  +--ro value?        string
-    |  +--ro operational-state?     operational-state
-    |  +--ro lifecycle-state?       lifecycle-state
-    +--rw oam-job* [uuid]
-    |  +--rw oam-service-end-point* [oam-service-uuid oam-service-end-point-local-id]
-    |  |  +--rw oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |  |  +--rw oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
-    |  +--rw oam-profile
-    |  |  +--rw oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
-    |  +--ro pm-current-data* [local-id]
-    |  |  +--ro pm-history-data* [local-id]
-    |  |  |  +--ro granularity-period
-    |  |  |  |  +--ro value?   uint64
-    |  |  |  |  +--ro unit?    time-unit
-    |  |  |  +--ro period-end-time?         tapi-common:date-and-time
-    |  |  |  +--ro suspect-interval-flag?   boolean
-    |  |  |  +--ro local-id                 string
-    |  |  |  +--ro name* [value-name]
-    |  |  |     +--ro value-name    string
-    |  |  |     +--ro value?        string
-    |  |  +--ro granularity-period
-    |  |  |  +--ro value?   uint64
-    |  |  |  +--ro unit?    time-unit
-    |  |  +--ro timestamp?               tapi-common:date-and-time
-    |  |  +--ro elapsed-time
-    |  |  |  +--ro period* []
-    |  |  |     +--ro value?   uint64
-    |  |  |     +--ro unit?    time-unit
-    |  |  +--ro suspect-interval-flag?   boolean
-    |  |  +--ro local-id                 string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--rw oam-job-type?            oam-job-type
-    |  +--rw schedule
-    |  |  +--rw end-time?     date-and-time
-    |  |  +--rw start-time?   date-and-time
-    |  +--ro creation-time?           tapi-common:date-and-time
-    |  +--rw uuid                     uuid
-    |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw administrative-state?    administrative-state
-    |  +--ro operational-state?       operational-state
-    |  +--ro lifecycle-state?         lifecycle-state
-    +--rw oam-profile* [uuid]
-       +--rw pm-threshold-data* [local-id]
-       |  +--rw granularity-period
-       |  |  +--rw value?   uint64
-       |  |  +--rw unit?    time-unit
-       |  +--rw is-transient?         boolean
-       |  +--rw local-id              string
+    +--rw oam-context
+       +--rw oam-service* [uuid]
+       |  +--rw end-point* [local-id]
+       |  |  +--rw service-interface-point
+       |  |  |  +--rw service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+       |  |  +--rw connectivity-service-end-point
+       |  |  |  +--rw connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+       |  |  |  +--rw connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
+       |  |  +--ro mep
+       |  |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+       |  |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
+       |  |  +--ro mip
+       |  |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+       |  |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
+       |  |  +--rw layer-protocol-name?              tapi-common:layer-protocol-name
+       |  |  +--rw direction?                        tapi-common:port-direction
+       |  |  +--rw local-id                          string
+       |  |  +--rw name* [value-name]
+       |  |  |  +--rw value-name    string
+       |  |  |  +--rw value?        string
+       |  |  +--rw administrative-state?             administrative-state
+       |  |  +--ro operational-state?                operational-state
+       |  |  +--ro lifecycle-state?                  lifecycle-state
+       |  +--ro meg
+       |  |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+       |  +--rw oam-profile
+       |  |  +--rw oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
+       |  +--rw uuid                    uuid
        |  +--rw name* [value-name]
-       |     +--rw value-name    string
-       |     +--rw value?        string
-       +--rw pm-bin-data* [local-id]
-       |  +--rw granularity-period
-       |  |  +--rw value?   uint64
-       |  |  +--rw unit?    time-unit
-       |  +--rw local-id              string
+       |  |  +--rw value-name    string
+       |  |  +--rw value?        string
+       |  +--rw administrative-state?   administrative-state
+       |  +--ro operational-state?      operational-state
+       |  +--ro lifecycle-state?        lifecycle-state
+       |  +--rw layer-protocol-name?    tapi-common:layer-protocol-name
+       |  +--rw direction?              tapi-common:forwarding-direction
+       |  +--rw meg-level?              uint64
+       +--ro meg* [uuid]
+       |  +--ro me* [local-id]
+       |  |  +--ro mep* [meg-uuid mep-local-id]
+       |  |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+       |  |  |  +--ro mep-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
+       |  |  +--ro mip* [meg-uuid mip-local-id]
+       |  |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+       |  |  |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
+       |  |  +--ro connection-route
+       |  |  |  +--ro connection-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+       |  |  |  +--ro route-local-id?    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/route/local-id
+       |  |  +--ro local-id            string
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--ro mep* [local-id]
+       |  |  +--ro oam-service-end-point
+       |  |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+       |  |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
+       |  |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
+       |  |  +--ro direction?               tapi-common:termination-direction
+       |  |  +--ro mep-identifier?          string
+       |  |  +--ro peer-mep-identifier*     string
+       |  |  +--ro local-id                 string
+       |  |  +--ro name* [value-name]
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro value?        string
+       |  |  +--ro operational-state?       operational-state
+       |  |  +--ro lifecycle-state?         lifecycle-state
+       |  +--ro mip* [local-id]
+       |  |  +--ro oam-service-end-point
+       |  |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+       |  |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
+       |  |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
+       |  |  +--ro local-id                 string
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+       |  +--ro direction?             tapi-common:forwarding-direction
+       |  +--ro meg-level?             uint64
+       |  +--ro meg-identifier?        string
+       |  +--ro uuid                   uuid
+       |  +--ro name* [value-name]
+       |  |  +--ro value-name    string
+       |  |  +--ro value?        string
+       |  +--ro operational-state?     operational-state
+       |  +--ro lifecycle-state?       lifecycle-state
+       +--rw oam-job* [uuid]
+       |  +--rw oam-service-end-point* [oam-service-uuid oam-service-end-point-local-id]
+       |  |  +--rw oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+       |  |  +--rw oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
+       |  +--rw oam-profile
+       |  |  +--rw oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
+       |  +--ro pm-current-data* [local-id]
+       |  |  +--ro pm-history-data* [local-id]
+       |  |  |  +--ro granularity-period
+       |  |  |  |  +--ro value?   uint64
+       |  |  |  |  +--ro unit?    time-unit
+       |  |  |  +--ro period-end-time?         tapi-common:date-and-time
+       |  |  |  +--ro suspect-interval-flag?   boolean
+       |  |  |  +--ro local-id                 string
+       |  |  |  +--ro name* [value-name]
+       |  |  |     +--ro value-name    string
+       |  |  |     +--ro value?        string
+       |  |  +--ro granularity-period
+       |  |  |  +--ro value?   uint64
+       |  |  |  +--ro unit?    time-unit
+       |  |  +--ro timestamp?               tapi-common:date-and-time
+       |  |  +--ro elapsed-time
+       |  |  |  +--ro period* []
+       |  |  |     +--ro value?   uint64
+       |  |  |     +--ro unit?    time-unit
+       |  |  +--ro suspect-interval-flag?   boolean
+       |  |  +--ro local-id                 string
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--rw oam-job-type?            oam-job-type
+       |  +--rw schedule
+       |  |  +--rw end-time?     date-and-time
+       |  |  +--rw start-time?   date-and-time
+       |  +--ro creation-time?           tapi-common:date-and-time
+       |  +--rw uuid                     uuid
        |  +--rw name* [value-name]
-       |     +--rw value-name    string
-       |     +--rw value?        string
-       +--rw uuid                 uuid
-       +--rw name* [value-name]
-          +--rw value-name    string
-          +--rw value?        string
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro mip* [meg-uuid mip-local-id]
-    |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:meg/uuid
-    |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:meg/mip/local-id
-    +--ro mep* [meg-uuid mep-local-id]
-       +--ro meg-uuid        -> /tapi-common:context/tapi-oam:meg/uuid
-       +--ro mep-local-id    -> /tapi-common:context/tapi-oam:meg/mep/local-id
+       |  |  +--rw value-name    string
+       |  |  +--rw value?        string
+       |  +--rw administrative-state?    administrative-state
+       |  +--ro operational-state?       operational-state
+       |  +--ro lifecycle-state?         lifecycle-state
+       +--rw oam-profile* [uuid]
+          +--rw pm-threshold-data* [local-id]
+          |  +--rw granularity-period
+          |  |  +--rw value?   uint64
+          |  |  +--rw unit?    time-unit
+          |  +--rw is-transient?         boolean
+          |  +--rw local-id              string
+          |  +--rw name* [value-name]
+          |     +--rw value-name    string
+          |     +--rw value?        string
+          +--rw pm-bin-data* [local-id]
+          |  +--rw granularity-period
+          |  |  +--rw value?   uint64
+          |  |  +--rw unit?    time-unit
+          |  +--rw local-id              string
+          |  +--rw name* [value-name]
+          |     +--rw value-name    string
+          |     +--rw value?        string
+          +--rw uuid                 uuid
+          +--rw name* [value-name]
+             +--rw value-name    string
+             +--rw value?        string
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro mep-mip-list
+       +--ro mip* [meg-uuid mip-local-id]
+       |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+       |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
+       +--ro mep* [meg-uuid mep-local-id]
+          +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+          +--ro mep-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
 
   rpcs:
     +---x create-oam-service
@@ -164,14 +166,14 @@ module: tapi-oam
     |  |  |  +---w service-interface-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connectivity-service-end-point
-    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |  |  |  +---w mep
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |  |  |  +---w mip
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
     |  |  |  +---w direction?                        tapi-common:port-direction
     |  |  |  +---w local-id?                         string
@@ -192,14 +194,14 @@ module: tapi-oam
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connectivity-service-end-point
-    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |        |  +--ro mep
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        |  +--ro mip
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
     |        |  +--ro local-id                          string
@@ -210,9 +212,9 @@ module: tapi-oam
     |        |  +--ro operational-state?                operational-state
     |        |  +--ro lifecycle-state?                  lifecycle-state
     |        +--ro meg
-    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:meg/uuid
+    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro uuid?                   uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -235,14 +237,14 @@ module: tapi-oam
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connectivity-service-end-point
-    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |        |  +--ro mep
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        |  +--ro mip
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
     |        |  +--ro local-id                          string
@@ -253,9 +255,9 @@ module: tapi-oam
     |        |  +--ro operational-state?                operational-state
     |        |  +--ro lifecycle-state?                  lifecycle-state
     |        +--ro meg
-    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:meg/uuid
+    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro uuid?                   uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -273,14 +275,14 @@ module: tapi-oam
     |  |  |  +---w service-interface-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connectivity-service-end-point
-    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |  |  |  +---w mep
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |  |  |  +---w mip
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
     |  |  |  +---w direction?                        tapi-common:port-direction
     |  |  |  +---w local-id?                         string
@@ -317,10 +319,10 @@ module: tapi-oam
     |  +--ro output
     |     +--ro oam-job
     |        +--ro oam-service-end-point* [oam-service-uuid oam-service-end-point-local-id]
-    |        |  +--ro oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |        |  +--ro oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
+    |        |  +--ro oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+    |        |  +--ro oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro pm-current-data* [local-id]
     |        |  +--ro pm-history-data* [local-id]
     |        |  |  +--ro granularity-period
@@ -363,10 +365,10 @@ module: tapi-oam
     |  +--ro output
     |     +--ro oam-job
     |        +--ro oam-service-end-point* [oam-service-uuid oam-service-end-point-local-id]
-    |        |  +--ro oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |        |  +--ro oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
+    |        |  +--ro oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+    |        |  +--ro oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro pm-current-data* [local-id]
     |        |  +--ro pm-history-data* [local-id]
     |        |  |  +--ro granularity-period
@@ -410,14 +412,14 @@ module: tapi-oam
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connectivity-service-end-point
-    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |        |  +--ro mep
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        |  +--ro mip
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
     |        |  +--ro local-id                          string
@@ -428,9 +430,9 @@ module: tapi-oam
     |        |  +--ro operational-state?                operational-state
     |        |  +--ro lifecycle-state?                  lifecycle-state
     |        +--ro meg
-    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:meg/uuid
+    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro uuid?                   uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -448,22 +450,22 @@ module: tapi-oam
     |     +--ro meg
     |        +--ro me* [local-id]
     |        |  +--ro mep* [meg-uuid mep-local-id]
-    |        |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mep-local-id    -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mep-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        |  +--ro mip* [meg-uuid mip-local-id]
-    |        |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro connection-route
-    |        |  |  +--ro connection-uuid?   -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        |  |  +--ro route-local-id?    -> /tapi-common:context/tapi-connectivity:connection/route/local-id
+    |        |  |  +--ro connection-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
+    |        |  |  +--ro route-local-id?    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/route/local-id
     |        |  +--ro local-id            string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro mep* [local-id]
     |        |  +--ro oam-service-end-point
-    |        |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |        |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
+    |        |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+    |        |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
     |        |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
     |        |  +--ro direction?               tapi-common:termination-direction
     |        |  +--ro mep-identifier?          string
@@ -476,8 +478,8 @@ module: tapi-oam
     |        |  +--ro lifecycle-state?         lifecycle-state
     |        +--ro mip* [local-id]
     |        |  +--ro oam-service-end-point
-    |        |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |        |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
+    |        |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+    |        |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
     |        |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
     |        |  +--ro local-id                 string
     |        |  +--ro name* [value-name]
@@ -500,14 +502,14 @@ module: tapi-oam
     |  |  |  +---w service-interface-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connectivity-service-end-point
-    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |  |  |  +---w mep
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |  |  |  +---w mip
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
     |  |  |  +---w direction?                        tapi-common:port-direction
     |  |  |  +---w local-id?                         string
@@ -528,14 +530,14 @@ module: tapi-oam
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connectivity-service-end-point
-    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |        |  |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |        |  |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |        |  +--ro mep
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        |  +--ro mip
-    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
     |        |  +--ro local-id                          string
@@ -546,9 +548,9 @@ module: tapi-oam
     |        |  +--ro operational-state?                operational-state
     |        |  +--ro lifecycle-state?                  lifecycle-state
     |        +--ro meg
-    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:meg/uuid
+    |        |  +--ro meg-uuid?   -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro uuid?                   uuid
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -592,10 +594,10 @@ module: tapi-oam
     |  +--ro output
     |     +--ro oam-job
     |        +--ro oam-service-end-point* [oam-service-uuid oam-service-end-point-local-id]
-    |        |  +--ro oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-service/uuid
-    |        |  +--ro oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-service/end-point/local-id
+    |        |  +--ro oam-service-uuid                  -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
+    |        |  +--ro oam-service-end-point-local-id    -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
     |        +--ro oam-profile
-    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-profile/uuid
+    |        |  +--ro oam-profile-uuid?   -> /tapi-common:context/tapi-oam:oam-context/oam-profile/uuid
     |        +--ro pm-current-data* [local-id]
     |        |  +--ro pm-history-data* [local-id]
     |        |  |  +--ro granularity-period
@@ -645,14 +647,14 @@ module: tapi-oam
     |        +--ro service-interface-point
     |        |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        +--ro connectivity-service-end-point
-    |        |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |        |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |        |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |        +--ro mep
-    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        +--ro mip
-    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        +--ro direction?                        tapi-common:port-direction
     |        +--ro local-id?                         string
@@ -676,14 +678,14 @@ module: tapi-oam
     |        +--ro service-interface-point
     |        |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        +--ro connectivity-service-end-point
-    |        |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+    |        |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |        |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
     |        +--ro mep
-    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
     |        +--ro mip
-    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-    |        |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+    |        |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |        |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        +--ro direction?                        tapi-common:port-direction
     |        +--ro local-id?                         string
@@ -702,14 +704,14 @@ module: tapi-oam
              +--ro service-interface-point
              |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
              +--ro connectivity-service-end-point
-             |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-             |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+             |  +--ro connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+             |  +--ro connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
              +--ro mep
-             |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-             |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:meg/mep/local-id
+             |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+             |  +--ro mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
              +--ro mip
-             |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:meg/uuid
-             |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:meg/mip/local-id
+             |  +--ro meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+             |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
              +--ro layer-protocol-name?              tapi-common:layer-protocol-name
              +--ro direction?                        tapi-common:port-direction
              +--ro local-id?                         string

--- a/YANG/tapi-oam@2018-08-31.yang
+++ b/YANG/tapi-oam@2018-08-31.yang
@@ -50,11 +50,17 @@ module tapi-oam {
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
     augment "/tapi-common:context" {
-        uses oam-context;
+        container oam-context {
+            uses oam-context;
+            description "Augments the base TAPI Context with OamService information";
+        }
         description "Augments the base TAPI Context with OamService information";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses mep-mip-list;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+    	container mep-mip-list {
+            uses mep-mip-list;
+            description "none";
+        }
         description "none";
     }
     
@@ -64,7 +70,7 @@ module tapi-oam {
     grouping oam-service-ref {
         leaf oam-service-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-oam:oam-service/tapi-oam:uuid';
+                path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:uuid';
             }
             description "none";
         }
@@ -75,7 +81,7 @@ module tapi-oam {
     	uses oam-service-ref;
     	leaf oam-service-end-point-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -85,7 +91,7 @@ module tapi-oam {
     grouping meg-ref {
         leaf meg-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-oam:meg/tapi-oam:uuid';
+                path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:uuid';
             }
             description "none";
         }
@@ -96,7 +102,7 @@ module tapi-oam {
     	uses meg-ref;
     	leaf maintenance-entity-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:meg/tapi-oam:me/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:me/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -107,7 +113,7 @@ module tapi-oam {
     	uses meg-ref;
     	leaf mep-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -118,7 +124,7 @@ module tapi-oam {
     	uses meg-ref;
     	leaf mip-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -128,7 +134,7 @@ module tapi-oam {
     grouping oam-job-ref {
         leaf oam-job-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-oam:oam-job/tapi-oam:uuid';
+                path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:uuid';
             }
             description "none";
         }
@@ -139,7 +145,7 @@ module tapi-oam {
     	uses oam-job-ref;
     	leaf pm-current-data-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -150,7 +156,7 @@ module tapi-oam {
     	uses pm-current-data-ref;
     	leaf pm-history-data-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job/tapi-oam:pm-current-data/tapi-oam:pm-history-data/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -160,7 +166,7 @@ module tapi-oam {
     grouping oam-profile-ref {
         leaf oam-profile-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-oam:oam-profile/tapi-oam:uuid';
+                path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:uuid';
             }
             description "none";
         }
@@ -171,7 +177,7 @@ module tapi-oam {
     	uses oam-profile-ref;
     	leaf pm-threshold-data-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-threshold-data/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}
@@ -182,7 +188,7 @@ module tapi-oam {
     	uses oam-profile-ref;
     	leaf pm-bin-data-local-id {
 	    	type leafref {
-	            path '/tapi-common:context/tapi-oam:oam-profile/tapi-oam:pm-bin-data/tapi-oam:local-id';
+	            path '/tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-profile/tapi-oam:pm-bin-data/tapi-oam:local-id';
 	        }
 	    	description "none";
     	}

--- a/YANG/tapi-odu@2018-08-31.tree
+++ b/YANG/tapi-odu@2018-08-31.tree
@@ -1,80 +1,84 @@
 
 module: tapi-odu
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro odu-pool
-       +--ro client-capacity?        uint64
-       +--ro max-client-instances?   uint64
-       +--ro max-client-size?        uint64
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro odu-common
-    |  +--ro odu-type?             odu-type
-    |  +--ro odu-rate?             uint64
-    |  +--ro odu-rate-tolerance?   uint64
-    +--ro odu-term-and-adapter
-    |  +--ro opu-tributary-slot-size?   odu-slot-size
-    |  +--ro auto-payload-type?         boolean
-    |  +--ro configured-client-type?    tapi-dsr:digital-signal-type
-    |  +--ro configured-mapping-type?   mapping-type
-    |  +--ro accepted-payload-type
-    |     +--ro named-payload-type?   odu-named-payload-type
-    |     +--ro hex-payload-type?     uint64
-    +--ro odu-ctp
-    |  +--ro tributary-slot-list*     uint64
-    |  +--ro tributary-port-number?   uint64
-    |  +--ro accepted-msi?            string
-    +--ro odu-protection
-       +--ro aps-enable?   boolean
-       +--ro aps-level?    uint64
-  augment /tapi-common:context/tapi-oam:meg/tapi-oam:mep:
-    +--ro odu-common
-    |  +--ro odu-type?             odu-type
-    |  +--ro odu-rate?             uint64
-    |  +--ro odu-rate-tolerance?   uint64
-    +--ro odu-term-and-adapter
-    |  +--ro opu-tributary-slot-size?   odu-slot-size
-    |  +--ro auto-payload-type?         boolean
-    |  +--ro configured-client-type?    tapi-dsr:digital-signal-type
-    |  +--ro configured-mapping-type?   mapping-type
-    |  +--ro accepted-payload-type
-    |     +--ro named-payload-type?   odu-named-payload-type
-    |     +--ro hex-payload-type?     uint64
-    +--ro odu-ctp
-    |  +--ro tributary-slot-list*     uint64
-    |  +--ro tributary-port-number?   uint64
-    |  +--ro accepted-msi?            string
-    +--ro odu-protection
-       +--ro aps-enable?   boolean
-       +--ro aps-level?    uint64
-  augment /tapi-common:context/tapi-oam:meg/tapi-oam:mip:
-    +--ro odu-mip
-    |  +--ro acti?               string
-    |  +--ro ex-dapi?            string
-    |  +--ro ex-sapi?            string
-    |  +--ro tim-act-disabled?   boolean
-    |  +--ro tim-det-mode?       tim-det-mo
-    |  +--ro deg-m?              uint64
-    |  +--ro deg-thr
-    |     +--ro deg-thr-value?            uint64
-    |     +--ro deg-thr-type?             deg-thr-type
-    |     +--ro percentage-granularity?   percentage-granularity
-    +--ro odu-ncm
-    |  +--ro tcm-fields-in-use*   uint64
-    +--ro odu-tcm
-    |  +--ro tcm-field?   uint64
-    +--ro odu-pm
-    |  +--ro n-bbe?   uint64
-    |  +--ro f-bbe?   uint64
-    |  +--ro n-ses?   uint64
-    |  +--ro f-ses?   uint64
-    |  +--ro uas
-    |     +--ro bidirectional?   boolean
-    |     +--ro uas?             uint64
-    |     +--ro nuas?            uint64
-    |     +--ro fuas?            uint64
-    +--ro odu-defect
-       +--ro bdi?   boolean
-       +--ro deg?   boolean
-       +--ro lck?   boolean
-       +--ro oci?   boolean
-       +--ro ssf?   boolean
-       +--ro tim?   boolean
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
+    +--ro odu-node-edge-point-spec
+       +--ro odu-pool
+          +--ro client-capacity?        uint64
+          +--ro max-client-instances?   uint64
+          +--ro max-client-size?        uint64
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro odu-connection-end-point-spec
+       +--ro odu-common
+       |  +--ro odu-type?             odu-type
+       |  +--ro odu-rate?             uint64
+       |  +--ro odu-rate-tolerance?   uint64
+       +--ro odu-term-and-adapter
+       |  +--ro opu-tributary-slot-size?   odu-slot-size
+       |  +--ro auto-payload-type?         boolean
+       |  +--ro configured-client-type?    tapi-dsr:digital-signal-type
+       |  +--ro configured-mapping-type?   mapping-type
+       |  +--ro accepted-payload-type
+       |     +--ro named-payload-type?   odu-named-payload-type
+       |     +--ro hex-payload-type?     uint64
+       +--ro odu-ctp
+       |  +--ro tributary-slot-list*     uint64
+       |  +--ro tributary-port-number?   uint64
+       |  +--ro accepted-msi?            string
+       +--ro odu-protection
+          +--ro aps-enable?   boolean
+          +--ro aps-level?    uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep:
+    +--ro odu-connection-end-point-spec
+       +--ro odu-common
+       |  +--ro odu-type?             odu-type
+       |  +--ro odu-rate?             uint64
+       |  +--ro odu-rate-tolerance?   uint64
+       +--ro odu-term-and-adapter
+       |  +--ro opu-tributary-slot-size?   odu-slot-size
+       |  +--ro auto-payload-type?         boolean
+       |  +--ro configured-client-type?    tapi-dsr:digital-signal-type
+       |  +--ro configured-mapping-type?   mapping-type
+       |  +--ro accepted-payload-type
+       |     +--ro named-payload-type?   odu-named-payload-type
+       |     +--ro hex-payload-type?     uint64
+       +--ro odu-ctp
+       |  +--ro tributary-slot-list*     uint64
+       |  +--ro tributary-port-number?   uint64
+       |  +--ro accepted-msi?            string
+       +--ro odu-protection
+          +--ro aps-enable?   boolean
+          +--ro aps-level?    uint64
+  augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip:
+    +--ro odu-mip-spec
+       +--ro odu-mip
+       |  +--ro acti?               string
+       |  +--ro ex-dapi?            string
+       |  +--ro ex-sapi?            string
+       |  +--ro tim-act-disabled?   boolean
+       |  +--ro tim-det-mode?       tim-det-mo
+       |  +--ro deg-m?              uint64
+       |  +--ro deg-thr
+       |     +--ro deg-thr-value?            uint64
+       |     +--ro deg-thr-type?             deg-thr-type
+       |     +--ro percentage-granularity?   percentage-granularity
+       +--ro odu-ncm
+       |  +--ro tcm-fields-in-use*   uint64
+       +--ro odu-tcm
+       |  +--ro tcm-field?   uint64
+       +--ro odu-pm
+       |  +--ro n-bbe?   uint64
+       |  +--ro f-bbe?   uint64
+       |  +--ro n-ses?   uint64
+       |  +--ro f-ses?   uint64
+       |  +--ro uas
+       |     +--ro bidirectional?   boolean
+       |     +--ro uas?             uint64
+       |     +--ro nuas?            uint64
+       |     +--ro fuas?            uint64
+       +--ro odu-defect
+          +--ro bdi?   boolean
+          +--ro deg?   boolean
+          +--ro lck?   boolean
+          +--ro oci?   boolean
+          +--ro ssf?   boolean
+          +--ro tim?   boolean

--- a/YANG/tapi-odu@2018-08-31.yang
+++ b/YANG/tapi-odu@2018-08-31.yang
@@ -55,20 +55,32 @@ module tapi-odu {
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
-        uses odu-node-edge-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
+        container odu-node-edge-point-spec {
+            uses odu-node-edge-point-spec;
+            description "Augments the base LayerProtocol information in NodeEdgePoint with ODU-specific information";
+        }
         description "Augments the base LayerProtocol information in NodeEdgePoint with ODU-specific information";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses odu-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container odu-connection-end-point-spec {
+            uses odu-connection-end-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:meg/tapi-oam:mep" {
-        uses odu-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mep" {
+        container odu-connection-end-point-spec {
+            uses odu-connection-end-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-oam:meg/tapi-oam:mip" {
-        uses odu-mip-spec;
+    augment "/tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip" {
+        container odu-mip-spec {
+            uses odu-mip-spec;
+            description "none";
+        }
         description "none";
     }
     /***********************

--- a/YANG/tapi-path-computation@2018-08-31.tree
+++ b/YANG/tapi-path-computation@2018-08-31.tree
@@ -1,128 +1,129 @@
 
 module: tapi-path-computation
   augment /tapi-common:context:
-    +--rw path-comp-service* [uuid]
-    |  +--ro path* [path-uuid]
-    |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  +--rw end-point* [local-id]
-    |  |  +--ro service-interface-point
-    |  |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |  |  +--rw layer-protocol-qualifier?   tapi-common:layer-protocol-qualifier
-    |  |  +--rw capacity
-    |  |  |  +--rw total-size
-    |  |  |  |  +--rw value?   uint64
-    |  |  |  |  +--rw unit?    capacity-unit
-    |  |  |  +--rw bandwidth-profile
-    |  |  |     +--rw bw-profile-type?              bandwidth-profile-type
-    |  |  |     +--rw committed-information-rate
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw committed-burst-size
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw peak-information-rate
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw peak-burst-size
-    |  |  |     |  +--rw value?   uint64
-    |  |  |     |  +--rw unit?    capacity-unit
-    |  |  |     +--rw color-aware?                  boolean
-    |  |  |     +--rw coupling-flag?                boolean
-    |  |  +--ro role?                       tapi-common:port-role
-    |  |  +--ro direction?                  tapi-common:port-direction
-    |  |  +--rw local-id                    string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw routing-constraint
-    |  |  +--rw cost-characteristic* [cost-name]
-    |  |  |  +--rw cost-name         string
-    |  |  |  +--rw cost-value?       string
-    |  |  |  +--rw cost-algorithm?   string
-    |  |  +--rw latency-characteristic* [traffic-property-name]
-    |  |  |  +--rw traffic-property-name            string
-    |  |  |  +--ro fixed-latency-characteristic?    string
-    |  |  |  +--rw queing-latency-characteristic?   string
-    |  |  |  +--ro jitter-characteristic?           string
-    |  |  |  +--ro wander-characteristic?           string
-    |  |  +--rw risk-diversity-characteristic* [risk-characteristic-name]
-    |  |  |  +--rw risk-characteristic-name    string
-    |  |  |  +--rw risk-identifier-list*       string
-    |  |  +--rw diversity-policy?                diversity-policy
-    |  |  +--rw route-objective-function?        route-objective-function
-    |  |  +--rw route-direction?                 tapi-common:forwarding-direction
-    |  |  +--rw is-exclusive?                    boolean
-    |  +--rw topology-constraint
-    |  |  +--ro include-topology* [topology-uuid]
-    |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro avoid-topology* [topology-uuid]
-    |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro include-path* [path-uuid]
-    |  |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  +--ro exclude-path* [path-uuid]
-    |  |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  +--ro include-link* [topology-uuid link-uuid]
-    |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |  |  +--ro exclude-link* [topology-uuid link-uuid]
-    |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |  |  +--ro include-node* [topology-uuid node-uuid]
-    |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  +--ro exclude-node* [topology-uuid node-uuid]
-    |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  +--rw objective-function
-    |  |  +--ro bandwidth-optimization?   tapi-common:directive-value
-    |  |  +--ro concurrent-paths?         tapi-common:directive-value
-    |  |  +--ro cost-optimization?        tapi-common:directive-value
-    |  |  +--ro link-utilization?         tapi-common:directive-value
-    |  |  +--ro resource-sharing?         tapi-common:directive-value
-    |  |  +--rw local-id?                 string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw optimization-constraint
-    |  |  +--ro traffic-interruption?   tapi-common:directive-value
-    |  |  +--rw local-id?               string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw uuid                       uuid
-    |  +--rw name* [value-name]
-    |     +--rw value-name    string
-    |     +--rw value?        string
-    +--ro path* [uuid]
-       +--ro link* [topology-uuid link-uuid]
-       |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
-       +--ro routing-constraint
-       |  +--ro cost-characteristic* [cost-name]
-       |  |  +--ro cost-name         string
-       |  |  +--ro cost-value?       string
-       |  |  +--ro cost-algorithm?   string
-       |  +--ro latency-characteristic* [traffic-property-name]
-       |  |  +--ro traffic-property-name            string
-       |  |  +--ro fixed-latency-characteristic?    string
-       |  |  +--ro queing-latency-characteristic?   string
-       |  |  +--ro jitter-characteristic?           string
-       |  |  +--ro wander-characteristic?           string
-       |  +--ro risk-diversity-characteristic* [risk-characteristic-name]
-       |  |  +--ro risk-characteristic-name    string
-       |  |  +--ro risk-identifier-list*       string
-       |  +--ro diversity-policy?                diversity-policy
-       |  +--ro route-objective-function?        route-objective-function
-       |  +--ro route-direction?                 tapi-common:forwarding-direction
-       |  +--ro is-exclusive?                    boolean
-       +--ro direction?             tapi-common:forwarding-direction
-       +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-       +--ro uuid                   uuid
-       +--ro name* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
+    +--rw path-computation-context
+       +--rw path-comp-service* [uuid]
+       |  +--ro path* [path-uuid]
+       |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
+       |  +--rw end-point* [local-id]
+       |  |  +--ro service-interface-point
+       |  |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+       |  |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+       |  |  +--rw layer-protocol-qualifier?   tapi-common:layer-protocol-qualifier
+       |  |  +--rw capacity
+       |  |  |  +--rw total-size
+       |  |  |  |  +--rw value?   uint64
+       |  |  |  |  +--rw unit?    capacity-unit
+       |  |  |  +--rw bandwidth-profile
+       |  |  |     +--rw bw-profile-type?              bandwidth-profile-type
+       |  |  |     +--rw committed-information-rate
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw committed-burst-size
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw peak-information-rate
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw peak-burst-size
+       |  |  |     |  +--rw value?   uint64
+       |  |  |     |  +--rw unit?    capacity-unit
+       |  |  |     +--rw color-aware?                  boolean
+       |  |  |     +--rw coupling-flag?                boolean
+       |  |  +--ro role?                       tapi-common:port-role
+       |  |  +--ro direction?                  tapi-common:port-direction
+       |  |  +--rw local-id                    string
+       |  |  +--rw name* [value-name]
+       |  |     +--rw value-name    string
+       |  |     +--rw value?        string
+       |  +--rw routing-constraint
+       |  |  +--rw cost-characteristic* [cost-name]
+       |  |  |  +--rw cost-name         string
+       |  |  |  +--rw cost-value?       string
+       |  |  |  +--rw cost-algorithm?   string
+       |  |  +--rw latency-characteristic* [traffic-property-name]
+       |  |  |  +--rw traffic-property-name            string
+       |  |  |  +--ro fixed-latency-characteristic?    string
+       |  |  |  +--rw queing-latency-characteristic?   string
+       |  |  |  +--ro jitter-characteristic?           string
+       |  |  |  +--ro wander-characteristic?           string
+       |  |  +--rw risk-diversity-characteristic* [risk-characteristic-name]
+       |  |  |  +--rw risk-characteristic-name    string
+       |  |  |  +--rw risk-identifier-list*       string
+       |  |  +--rw diversity-policy?                diversity-policy
+       |  |  +--rw route-objective-function?        route-objective-function
+       |  |  +--rw route-direction?                 tapi-common:forwarding-direction
+       |  |  +--rw is-exclusive?                    boolean
+       |  +--rw topology-constraint
+       |  |  +--ro include-topology* [topology-uuid]
+       |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  +--ro avoid-topology* [topology-uuid]
+       |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  +--ro include-path* [path-uuid]
+       |  |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
+       |  |  +--ro exclude-path* [path-uuid]
+       |  |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
+       |  |  +--ro include-link* [topology-uuid link-uuid]
+       |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+       |  |  +--ro exclude-link* [topology-uuid link-uuid]
+       |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+       |  |  +--ro include-node* [topology-uuid node-uuid]
+       |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  |  +--ro exclude-node* [topology-uuid node-uuid]
+       |  |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+       |  +--rw objective-function
+       |  |  +--ro bandwidth-optimization?   tapi-common:directive-value
+       |  |  +--ro concurrent-paths?         tapi-common:directive-value
+       |  |  +--ro cost-optimization?        tapi-common:directive-value
+       |  |  +--ro link-utilization?         tapi-common:directive-value
+       |  |  +--ro resource-sharing?         tapi-common:directive-value
+       |  |  +--rw local-id?                 string
+       |  |  +--rw name* [value-name]
+       |  |     +--rw value-name    string
+       |  |     +--rw value?        string
+       |  +--rw optimization-constraint
+       |  |  +--ro traffic-interruption?   tapi-common:directive-value
+       |  |  +--rw local-id?               string
+       |  |  +--rw name* [value-name]
+       |  |     +--rw value-name    string
+       |  |     +--rw value?        string
+       |  +--rw uuid                       uuid
+       |  +--rw name* [value-name]
+       |     +--rw value-name    string
+       |     +--rw value?        string
+       +--ro path* [uuid]
+          +--ro link* [topology-uuid link-uuid]
+          |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+          +--ro routing-constraint
+          |  +--ro cost-characteristic* [cost-name]
+          |  |  +--ro cost-name         string
+          |  |  +--ro cost-value?       string
+          |  |  +--ro cost-algorithm?   string
+          |  +--ro latency-characteristic* [traffic-property-name]
+          |  |  +--ro traffic-property-name            string
+          |  |  +--ro fixed-latency-characteristic?    string
+          |  |  +--ro queing-latency-characteristic?   string
+          |  |  +--ro jitter-characteristic?           string
+          |  |  +--ro wander-characteristic?           string
+          |  +--ro risk-diversity-characteristic* [risk-characteristic-name]
+          |  |  +--ro risk-characteristic-name    string
+          |  |  +--ro risk-identifier-list*       string
+          |  +--ro diversity-policy?                diversity-policy
+          |  +--ro route-objective-function?        route-objective-function
+          |  +--ro route-direction?                 tapi-common:forwarding-direction
+          |  +--ro is-exclusive?                    boolean
+          +--ro direction?             tapi-common:forwarding-direction
+          +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+          +--ro uuid                   uuid
+          +--ro name* [value-name]
+             +--ro value-name    string
+             +--ro value?        string
 
   rpcs:
     +---x compute-p-2-p-path
@@ -178,25 +179,25 @@ module: tapi-path-computation
     |  |  |  +---w is-exclusive?                    boolean
     |  |  +---w topology-constraint
     |  |  |  +---w include-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |  |  |  +---w avoid-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |  |  |  +---w include-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |  |  |  +---w exclude-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |  |  |  +---w include-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |  |  |  +---w exclude-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |  |  |  +---w include-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |  |  |  +---w exclude-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +---w objective-function
     |  |     +---w bandwidth-optimization?   tapi-common:directive-value
@@ -211,7 +212,7 @@ module: tapi-path-computation
     |  +--ro output
     |     +--ro service
     |        +--ro path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -263,25 +264,25 @@ module: tapi-path-computation
     |        |  +--ro is-exclusive?                    boolean
     |        +--ro topology-constraint
     |        |  +--ro include-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        |  +--ro avoid-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        |  +--ro include-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        |  +--ro exclude-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        |  +--ro include-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        |  +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        |  +--ro include-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        |  +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        +--ro objective-function
     |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
@@ -343,7 +344,7 @@ module: tapi-path-computation
     |  +--ro output
     |     +--ro service
     |        +--ro path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -395,25 +396,25 @@ module: tapi-path-computation
     |        |  +--ro is-exclusive?                    boolean
     |        +--ro topology-constraint
     |        |  +--ro include-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        |  +--ro avoid-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        |  +--ro include-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        |  +--ro exclude-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
     |        |  +--ro include-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        |  +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
     |        |  +--ro include-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        |  +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        +--ro objective-function
     |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
@@ -441,7 +442,7 @@ module: tapi-path-computation
        +--ro output
           +--ro service
              +--ro path* [path-uuid]
-             |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+             |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
              +--ro end-point* [local-id]
              |  +--ro service-interface-point
              |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -493,25 +494,25 @@ module: tapi-path-computation
              |  +--ro is-exclusive?                    boolean
              +--ro topology-constraint
              |  +--ro include-topology* [topology-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
              |  +--ro avoid-topology* [topology-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
+             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
              |  +--ro include-path* [path-uuid]
-             |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+             |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
              |  +--ro exclude-path* [path-uuid]
-             |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path/uuid
+             |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
              |  +--ro include-link* [topology-uuid link-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
              |  +--ro exclude-link* [topology-uuid link-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology/link/uuid
+             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
              |  +--ro include-node* [topology-uuid node-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
              |  +--ro exclude-node* [topology-uuid node-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology/node/uuid
+             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
              |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
              +--ro objective-function
              |  +--ro bandwidth-optimization?   tapi-common:directive-value

--- a/YANG/tapi-path-computation@2018-08-31.yang
+++ b/YANG/tapi-path-computation@2018-08-31.yang
@@ -47,7 +47,10 @@ module tapi-path-computation {
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
     augment "/tapi-common:context" {
-        uses path-computation-context;
+    	container path-computation-context {
+            uses path-computation-context;
+            description "Augments the base TAPI Context with PathComputationService information";
+        }
         description "Augments the base TAPI Context with PathComputationService information";
     }
 
@@ -57,7 +60,7 @@ module tapi-path-computation {
     grouping path-ref {
         leaf path-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid';
+                path '/tapi-common:context/tapi-path-computation:path-computation-context/tapi-path-computation:path/tapi-path-computation:uuid';
             }
             description "none";
         }

--- a/YANG/tapi-photonic-media@2018-08-31.tree
+++ b/YANG/tapi-photonic-media@2018-08-31.tree
@@ -1,175 +1,185 @@
 
 module: tapi-photonic-media
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro otsi-termination
-       +--ro selected-central-frequency
-       |  +--ro frequency-constraint
-       |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  +--ro grid-type?                grid-type
-       |  +--ro central-frequency?      uint64
-       +--ro selected-application-identifier
-       |  +--ro application-identifier-type?   application-identifier-type
-       |  +--ro application-code?              string
-       +--ro selected-modulation?               modulation-technique
-       +--ro selected-spectrum
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro transmited-power
-       |  +--ro total-power?              decimal64
-       |  +--ro power-spectral-density?   decimal64
-       +--ro received-power
-       |  +--ro total-power?              decimal64
-       |  +--ro power-spectral-density?   decimal64
-       +--ro laser-properties
-          +--ro laser-status?             laser-control-status-type
-          +--ro laser-application-type?   laser-type
-          +--ro laser-bias-current?       decimal64
-          +--ro laser-temperature?        decimal64
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro mc-pool
-       +--ro supportable-spectrum* []
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro available-spectrum* []
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro occupied-spectrum* []
-          +--ro upper-frequency?        uint64
-          +--ro lower-frequency?        uint64
-          +--ro frequency-constraint
-             +--ro adjustment-granularity?   adjustment-granularity
-             +--ro grid-type?                grid-type
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro otsi-adapter
-    |  +--ro number-of-otsi?   uint64
-    +--ro fec-parameters
-       +--ro pre-fec-ber?           uint64
-       +--ro post-fec-ber?          uint64
-       +--ro corrected-bytes?       uint64
-       +--ro corrected-bits?        uint64
-       +--ro uncorrectable-bytes?   uint64
-       +--ro uncorrectable-bits?    uint64
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro otsi-connection-end-point-spec
+       +--ro otsi-termination
+          +--ro selected-central-frequency
+          |  +--ro frequency-constraint
+          |  |  +--ro adjustment-granularity?   adjustment-granularity
+          |  |  +--ro grid-type?                grid-type
+          |  +--ro central-frequency?      uint64
+          +--ro selected-application-identifier
+          |  +--ro application-identifier-type?   application-identifier-type
+          |  +--ro application-code?              string
+          +--ro selected-modulation?               modulation-technique
+          +--ro selected-spectrum
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro transmited-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro received-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro laser-properties
+             +--ro laser-status?             laser-control-status-type
+             +--ro laser-application-type?   laser-type
+             +--ro laser-bias-current?       decimal64
+             +--ro laser-temperature?        decimal64
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
+    +--ro media-channel-node-edge-point-spec
+       +--ro mc-pool
+          +--ro supportable-spectrum* []
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro available-spectrum* []
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro occupied-spectrum* []
+             +--ro upper-frequency?        uint64
+             +--ro lower-frequency?        uint64
+             +--ro frequency-constraint
+                +--ro adjustment-granularity?   adjustment-granularity
+                +--ro grid-type?                grid-type
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro otsi-assembly-connection-end-point-spec
+       +--ro otsi-adapter
+       |  +--ro number-of-otsi?   uint64
+       +--ro fec-parameters
+          +--ro pre-fec-ber?           uint64
+          +--ro post-fec-ber?          uint64
+          +--ro corrected-bytes?       uint64
+          +--ro corrected-bits?        uint64
+          +--ro uncorrectable-bytes?   uint64
+          +--ro uncorrectable-bits?    uint64
   augment /tapi-common:context/tapi-common:service-interface-point:
-    +--ro otsi-capability
-       +--ro supportable-lower-central-frequency* []
-       |  +--ro frequency-constraint
-       |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  +--ro grid-type?                grid-type
-       |  +--ro central-frequency?      uint64
-       +--ro supportable-upper-central-frequency* []
-       |  +--ro frequency-constraint
-       |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  +--ro grid-type?                grid-type
-       |  +--ro central-frequency?      uint64
-       +--ro supportable-application-identifier* []
-       |  +--ro application-identifier-type?   application-identifier-type
-       |  +--ro application-code?              string
-       +--ro supportable-modulation*                modulation-technique
-       +--ro total-power-warn-threshold
-          +--ro total-power-upper-warn-threshold-default?   decimal64
-          +--ro total-power-upper-warn-threshold-min?       decimal64
-          +--ro total-power-upper-warn-threshold-max?       decimal64
-          +--ro total-power-lower-warn-threshold-default?   decimal64
-          +--ro total-power-lower-warn-threshold-max?       decimal64
-          +--ro total-power-lower-warn-threshold-min?       decimal64
-  augment /tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
-    +--rw otsi-config
-       +--rw central-frequency
-       |  +--rw frequency-constraint
-       |  |  +--rw adjustment-granularity?   adjustment-granularity
-       |  |  +--rw grid-type?                grid-type
-       |  +--rw central-frequency?      uint64
-       +--rw spectrum
-       |  +--rw upper-frequency?        uint64
-       |  +--rw lower-frequency?        uint64
-       |  +--rw frequency-constraint
-       |     +--rw adjustment-granularity?   adjustment-granularity
-       |     +--rw grid-type?                grid-type
-       +--rw application-identifier
-       |  +--rw application-identifier-type?   application-identifier-type
-       |  +--rw application-code?              string
-       +--rw modulation?                         modulation-technique
-       +--rw laser-control?                      laser-control-type
-       +--rw transmit-power
-       |  +--rw total-power?              decimal64
-       |  +--ro power-spectral-density?   decimal64
-       +--rw total-power-warn-threshold-upper?   decimal64
-       +--rw total-power-warn-threshold-lower?   decimal64
+    +--rw otsi-service-interface-point-spec
+       +--ro otsi-capability
+          +--ro supportable-lower-central-frequency* []
+          |  +--ro frequency-constraint
+          |  |  +--ro adjustment-granularity?   adjustment-granularity
+          |  |  +--ro grid-type?                grid-type
+          |  +--ro central-frequency?      uint64
+          +--ro supportable-upper-central-frequency* []
+          |  +--ro frequency-constraint
+          |  |  +--ro adjustment-granularity?   adjustment-granularity
+          |  |  +--ro grid-type?                grid-type
+          |  +--ro central-frequency?      uint64
+          +--ro supportable-application-identifier* []
+          |  +--ro application-identifier-type?   application-identifier-type
+          |  +--ro application-code?              string
+          +--ro supportable-modulation*                modulation-technique
+          +--ro total-power-warn-threshold
+             +--ro total-power-upper-warn-threshold-default?   decimal64
+             +--ro total-power-upper-warn-threshold-min?       decimal64
+             +--ro total-power-upper-warn-threshold-max?       decimal64
+             +--ro total-power-lower-warn-threshold-default?   decimal64
+             +--ro total-power-lower-warn-threshold-max?       decimal64
+             +--ro total-power-lower-warn-threshold-min?       decimal64
+  augment /tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
+    +--rw otsi-connectivity-service-end-point-spec
+       +--rw otsi-config
+          +--rw central-frequency
+          |  +--rw frequency-constraint
+          |  |  +--rw adjustment-granularity?   adjustment-granularity
+          |  |  +--rw grid-type?                grid-type
+          |  +--rw central-frequency?      uint64
+          +--rw spectrum
+          |  +--rw upper-frequency?        uint64
+          |  +--rw lower-frequency?        uint64
+          |  +--rw frequency-constraint
+          |     +--rw adjustment-granularity?   adjustment-granularity
+          |     +--rw grid-type?                grid-type
+          +--rw application-identifier
+          |  +--rw application-identifier-type?   application-identifier-type
+          |  +--rw application-code?              string
+          +--rw modulation?                         modulation-technique
+          +--rw laser-control?                      laser-control-type
+          +--rw transmit-power
+          |  +--rw total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--rw total-power-warn-threshold-upper?   decimal64
+          +--rw total-power-warn-threshold-lower?   decimal64
   augment /tapi-common:context/tapi-common:service-interface-point:
-    +--ro mc-pool
-       +--ro supportable-spectrum* []
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro available-spectrum* []
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro occupied-spectrum* []
-          +--ro upper-frequency?        uint64
-          +--ro lower-frequency?        uint64
-          +--ro frequency-constraint
-             +--ro adjustment-granularity?   adjustment-granularity
-             +--ro grid-type?                grid-type
-  augment /tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
-    +--ro mc-pool
-       +--ro supportable-spectrum* []
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro available-spectrum* []
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro occupied-spectrum* []
-          +--ro upper-frequency?        uint64
-          +--ro lower-frequency?        uint64
-          +--ro frequency-constraint
-             +--ro adjustment-granularity?   adjustment-granularity
-             +--ro grid-type?                grid-type
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro media-channel
-       +--ro occupied-spectrum
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro measured-power-ingress
-       |  +--ro total-power?              decimal64
-       |  +--ro power-spectral-density?   decimal64
-       +--ro measured-power-egress
-          +--ro total-power?              decimal64
-          +--ro power-spectral-density?   decimal64
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro ots-media-channel
-       +--ro occupied-spectrum
-       |  +--ro upper-frequency?        uint64
-       |  +--ro lower-frequency?        uint64
-       |  +--ro frequency-constraint
-       |     +--ro adjustment-granularity?   adjustment-granularity
-       |     +--ro grid-type?                grid-type
-       +--ro measured-power-ingress
-       |  +--ro total-power?              decimal64
-       |  +--ro power-spectral-density?   decimal64
-       +--ro measured-power-egress
-          +--ro total-power?              decimal64
-          +--ro power-spectral-density?   decimal64
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
+    +--rw media-channel-service-interface-point-spec
+       +--ro mc-pool
+          +--ro supportable-spectrum* []
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro available-spectrum* []
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro occupied-spectrum* []
+             +--ro upper-frequency?        uint64
+             +--ro lower-frequency?        uint64
+             +--ro frequency-constraint
+                +--ro adjustment-granularity?   adjustment-granularity
+                +--ro grid-type?                grid-type
+  augment /tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
+    +--rw media-channel-service-interface-point-spec
+       +--ro mc-pool
+          +--ro supportable-spectrum* []
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro available-spectrum* []
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro occupied-spectrum* []
+             +--ro upper-frequency?        uint64
+             +--ro lower-frequency?        uint64
+             +--ro frequency-constraint
+                +--ro adjustment-granularity?   adjustment-granularity
+                +--ro grid-type?                grid-type
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro media-channel-connection-end-point-spec
+       +--ro media-channel
+          +--ro occupied-spectrum
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro measured-power-ingress
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro measured-power-egress
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro ots-connection-end-point-spec
+       +--ro ots-media-channel
+          +--ro occupied-spectrum
+          |  +--ro upper-frequency?        uint64
+          |  +--ro lower-frequency?        uint64
+          |  +--ro frequency-constraint
+          |     +--ro adjustment-granularity?   adjustment-granularity
+          |     +--ro grid-type?                grid-type
+          +--ro measured-power-ingress
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro measured-power-egress
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
+    +--ro media-channel-assembly-spec

--- a/YANG/tapi-photonic-media@2018-08-31.yang
+++ b/YANG/tapi-photonic-media@2018-08-31.yang
@@ -49,44 +49,74 @@ module tapi-photonic-media {
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses otsi-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container otsi-connection-end-point-spec {
+            uses otsi-connection-end-point-spec;
+            description "Augments the base LayerProtocol information in ConnectionEndPoint with OCH-specific information";
+        }
         description "Augments the base LayerProtocol information in ConnectionEndPoint with OCH-specific information";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
-        uses media-channel-node-edge-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
+        container media-channel-node-edge-point-spec {
+            uses media-channel-node-edge-point-spec;
+            description "Augments the base LayerProtocol information in NodeEdgePoint with OCH-specific information";
+        }
         description "Augments the base LayerProtocol information in NodeEdgePoint with OCH-specific information";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses otsi-assembly-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container otsi-assembly-connection-end-point-spec {
+            uses otsi-assembly-connection-end-point-spec;
+            description "none";
+        }
         description "none";
     }
     augment "/tapi-common:context/tapi-common:service-interface-point" {
-        uses otsi-service-interface-point-spec;
+        container otsi-service-interface-point-spec {
+            uses otsi-service-interface-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point" {
-        uses otsi-connectivity-service-end-point-spec;
+    augment "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point" {
+        container otsi-connectivity-service-end-point-spec {
+            uses otsi-connectivity-service-end-point-spec;
+            description "none";
+        }
         description "none";
     }
     augment "/tapi-common:context/tapi-common:service-interface-point" {
-        uses media-channel-service-interface-point-spec;
+        container media-channel-service-interface-point-spec {
+            uses media-channel-service-interface-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point" {
-        uses media-channel-service-interface-point-spec;
+    augment "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point" {
+        container media-channel-service-interface-point-spec {
+            uses media-channel-service-interface-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses media-channel-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container media-channel-connection-end-point-spec {
+            uses media-channel-connection-end-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses ots-connection-end-point-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container ots-connection-end-point-spec {
+            uses ots-connection-end-point-spec;
+            description "none";
+        }
         description "none";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
-        uses media-channel-assembly-spec;
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
+        container media-channel-assembly-spec {
+            uses media-channel-assembly-spec;
+            description "none";
+        }
         description "none";
     }
     /***********************
@@ -278,14 +308,14 @@ module tapi-photonic-media {
                 description "Transmit power as requested.";
             }
             leaf total-power-warn-threshold-upper {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Allows to configure the Upper power threshold which is expected to be different from Default, but within the Min and Max values specified as OTSi SIP capability.";
             }
             leaf total-power-warn-threshold-lower {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Allows to configure the Lowerpower threshold which is expected to be different from Default, but within the Min and Max values specified as OTSi SIP capability.";
             }
@@ -377,15 +407,15 @@ module tapi-photonic-media {
                 description "The type of laser, its operational wavelengths, and its applications. String size 255.";
             }
             leaf laser-bias-current {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 config false;
                 description "The Bias current of the laser that is the medium polarization current of the laser.";
             }
             leaf laser-temperature {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 config false;
                 description "The temperature of the laser";
@@ -394,14 +424,14 @@ module tapi-photonic-media {
         }
         grouping power-properties-pac {
             leaf total-power {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "The total power at any point in a channel specified in dBm.";
             }
             leaf power-spectral-density {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 config false;
                 description "This describes how power of a signal  is distributed over frequency specified in nW/MHz";
@@ -410,38 +440,38 @@ module tapi-photonic-media {
         }
         grouping total-power-threshold-pac {
             leaf total-power-upper-warn-threshold-default {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Can read the value of the default  threshold that was set";
             }
             leaf total-power-upper-warn-threshold-min {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Can read the value of the lower threshold that was set";
             }
             leaf total-power-upper-warn-threshold-max {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Can  read the value of the upper threshold that was set";
             }
             leaf total-power-lower-warn-threshold-default {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Can read the value of the default  threshold that was set";
             }
             leaf total-power-lower-warn-threshold-max {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Can  read the value of the upper threshold that was set";
             }
             leaf total-power-lower-warn-threshold-min {
-            	type decimal64 {
-                	fraction-digits 7;
+                type decimal64 {
+                    fraction-digits 7;
                 }
                 description "Can read the value of the lower threshold that was set";
             }

--- a/YANG/tapi-topology@2018-08-31.tree
+++ b/YANG/tapi-topology@2018-08-31.tree
@@ -1,375 +1,376 @@
 
 module: tapi-topology
   augment /tapi-common:context:
-    +--ro nw-topology-service
-    |  +--ro topology* [topology-uuid]
-    |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology/uuid
-    |  +--ro uuid?       uuid
-    |  +--ro name* [value-name]
-    |     +--ro value-name    string
-    |     +--ro value?        string
-    +--ro topology* [uuid]
-       +--ro node* [uuid]
-       |  +--ro owned-node-edge-point* [uuid]
-       |  |  +--ro layer-protocol-name?                      tapi-common:layer-protocol-name
-       |  |  +--ro supported-cep-layer-protocol-qualifier*   tapi-common:layer-protocol-qualifier
-       |  |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-       |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro mapped-service-interface-point* [service-interface-point-uuid]
-       |  |  |  +--ro service-interface-point-uuid    -> /tapi-common:context/service-interface-point/uuid
-       |  |  +--ro link-port-direction?                      tapi-common:port-direction
-       |  |  +--ro link-port-role?                           tapi-common:port-role
-       |  |  +--ro uuid                                      uuid
-       |  |  +--ro name* [value-name]
-       |  |  |  +--ro value-name    string
-       |  |  |  +--ro value?        string
-       |  |  +--ro administrative-state?                     administrative-state
-       |  |  +--ro operational-state?                        operational-state
-       |  |  +--ro lifecycle-state?                          lifecycle-state
-       |  |  +--ro termination-direction?                    termination-direction
-       |  |  +--ro termination-state?                        termination-state
-       |  |  +--ro total-potential-capacity
-       |  |  |  +--ro total-size
-       |  |  |  |  +--ro value?   uint64
-       |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  +--ro bandwidth-profile
-       |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |     +--ro committed-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro committed-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro color-aware?                  boolean
-       |  |  |     +--ro coupling-flag?                boolean
-       |  |  +--ro available-capacity
-       |  |     +--ro total-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro bandwidth-profile
-       |  |        +--ro bw-profile-type?              bandwidth-profile-type
-       |  |        +--ro committed-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro committed-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro color-aware?                  boolean
-       |  |        +--ro coupling-flag?                boolean
-       |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-       |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro node-rule-group* [uuid]
-       |  |  +--ro rule* [local-id]
-       |  |  |  +--ro rule-type?           rule-type
-       |  |  |  +--ro forwarding-rule?     forwarding-rule
-       |  |  |  +--ro override-priority?   uint64
-       |  |  |  +--ro local-id             string
-       |  |  |  +--ro name* [value-name]
-       |  |  |     +--ro value-name    string
-       |  |  |     +--ro value?        string
-       |  |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-       |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro composed-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-       |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
-       |  |  +--ro inter-rule-group* [uuid]
-       |  |  |  +--ro rule* [local-id]
-       |  |  |  |  +--ro rule-type?           rule-type
-       |  |  |  |  +--ro forwarding-rule?     forwarding-rule
-       |  |  |  |  +--ro override-priority?   uint64
-       |  |  |  |  +--ro local-id             string
-       |  |  |  |  +--ro name* [value-name]
-       |  |  |  |     +--ro value-name    string
-       |  |  |  |     +--ro value?        string
-       |  |  |  +--ro associated-node-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-       |  |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
-       |  |  |  +--ro uuid                          uuid
-       |  |  |  +--ro name* [value-name]
-       |  |  |  |  +--ro value-name    string
-       |  |  |  |  +--ro value?        string
-       |  |  |  +--ro total-potential-capacity
-       |  |  |  |  +--ro total-size
-       |  |  |  |  |  +--ro value?   uint64
-       |  |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  |  +--ro bandwidth-profile
-       |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |  |     +--ro committed-information-rate
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro committed-burst-size
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro peak-information-rate
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro peak-burst-size
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro color-aware?                  boolean
-       |  |  |  |     +--ro coupling-flag?                boolean
-       |  |  |  +--ro available-capacity
-       |  |  |  |  +--ro total-size
-       |  |  |  |  |  +--ro value?   uint64
-       |  |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  |  +--ro bandwidth-profile
-       |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |  |     +--ro committed-information-rate
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro committed-burst-size
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro peak-information-rate
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro peak-burst-size
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro color-aware?                  boolean
-       |  |  |  |     +--ro coupling-flag?                boolean
-       |  |  |  +--ro cost-characteristic* [cost-name]
-       |  |  |  |  +--ro cost-name         string
-       |  |  |  |  +--ro cost-value?       string
-       |  |  |  |  +--ro cost-algorithm?   string
-       |  |  |  +--ro latency-characteristic* [traffic-property-name]
-       |  |  |  |  +--ro traffic-property-name            string
-       |  |  |  |  +--ro fixed-latency-characteristic?    string
-       |  |  |  |  +--ro queing-latency-characteristic?   string
-       |  |  |  |  +--ro jitter-characteristic?           string
-       |  |  |  |  +--ro wander-characteristic?           string
-       |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
-       |  |  |     +--ro risk-characteristic-name    string
-       |  |  |     +--ro risk-identifier-list*       string
-       |  |  +--ro uuid                        uuid
-       |  |  +--ro name* [value-name]
-       |  |  |  +--ro value-name    string
-       |  |  |  +--ro value?        string
-       |  |  +--ro total-potential-capacity
-       |  |  |  +--ro total-size
-       |  |  |  |  +--ro value?   uint64
-       |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  +--ro bandwidth-profile
-       |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |     +--ro committed-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro committed-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro color-aware?                  boolean
-       |  |  |     +--ro coupling-flag?                boolean
-       |  |  +--ro available-capacity
-       |  |  |  +--ro total-size
-       |  |  |  |  +--ro value?   uint64
-       |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  +--ro bandwidth-profile
-       |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |     +--ro committed-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro committed-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro color-aware?                  boolean
-       |  |  |     +--ro coupling-flag?                boolean
-       |  |  +--ro cost-characteristic* [cost-name]
-       |  |  |  +--ro cost-name         string
-       |  |  |  +--ro cost-value?       string
-       |  |  |  +--ro cost-algorithm?   string
-       |  |  +--ro latency-characteristic* [traffic-property-name]
-       |  |  |  +--ro traffic-property-name            string
-       |  |  |  +--ro fixed-latency-characteristic?    string
-       |  |  |  +--ro queing-latency-characteristic?   string
-       |  |  |  +--ro jitter-characteristic?           string
-       |  |  |  +--ro wander-characteristic?           string
-       |  |  +--ro risk-characteristic* [risk-characteristic-name]
-       |  |     +--ro risk-characteristic-name    string
-       |  |     +--ro risk-identifier-list*       string
-       |  +--ro encap-topology
-       |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
-       |  +--ro uuid                                       uuid
+    +--rw topology-context
+       +--ro nw-topology-service
+       |  +--ro topology* [topology-uuid]
+       |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+       |  +--ro uuid?       uuid
        |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro administrative-state?                      administrative-state
-       |  +--ro operational-state?                         operational-state
-       |  +--ro lifecycle-state?                           lifecycle-state
-       |  +--ro total-potential-capacity
-       |  |  +--ro total-size
-       |  |  |  +--ro value?   uint64
-       |  |  |  +--ro unit?    capacity-unit
-       |  |  +--ro bandwidth-profile
-       |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |     +--ro committed-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro committed-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro color-aware?                  boolean
-       |  |     +--ro coupling-flag?                boolean
-       |  +--ro available-capacity
-       |  |  +--ro total-size
-       |  |  |  +--ro value?   uint64
-       |  |  |  +--ro unit?    capacity-unit
-       |  |  +--ro bandwidth-profile
-       |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |     +--ro committed-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro committed-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro color-aware?                  boolean
-       |  |     +--ro coupling-flag?                boolean
-       |  +--ro cost-characteristic* [cost-name]
-       |  |  +--ro cost-name         string
-       |  |  +--ro cost-value?       string
-       |  |  +--ro cost-algorithm?   string
-       |  +--ro error-characteristic?                      string
-       |  +--ro loss-characteristic?                       string
-       |  +--ro repeat-delivery-characteristic?            string
-       |  +--ro delivery-order-characteristic?             string
-       |  +--ro unavailable-time-characteristic?           string
-       |  +--ro server-integrity-process-characteristic?   string
-       |  +--ro latency-characteristic* [traffic-property-name]
-       |     +--ro traffic-property-name            string
-       |     +--ro fixed-latency-characteristic?    string
-       |     +--ro queing-latency-characteristic?   string
-       |     +--ro jitter-characteristic?           string
-       |     +--ro wander-characteristic?           string
-       +--ro link* [uuid]
-       |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-       |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
-       |  +--ro direction?                                 tapi-common:forwarding-direction
-       |  +--ro resilience-type
-       |  |  +--ro restoration-policy?   restoration-policy
-       |  |  +--ro protection-type?      protection-type
-       |  +--ro uuid                                       uuid
-       |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro administrative-state?                      administrative-state
-       |  +--ro operational-state?                         operational-state
-       |  +--ro lifecycle-state?                           lifecycle-state
-       |  +--ro total-potential-capacity
-       |  |  +--ro total-size
-       |  |  |  +--ro value?   uint64
-       |  |  |  +--ro unit?    capacity-unit
-       |  |  +--ro bandwidth-profile
-       |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |     +--ro committed-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro committed-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro color-aware?                  boolean
-       |  |     +--ro coupling-flag?                boolean
-       |  +--ro available-capacity
-       |  |  +--ro total-size
-       |  |  |  +--ro value?   uint64
-       |  |  |  +--ro unit?    capacity-unit
-       |  |  +--ro bandwidth-profile
-       |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |     +--ro committed-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro committed-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-information-rate
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro peak-burst-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro color-aware?                  boolean
-       |  |     +--ro coupling-flag?                boolean
-       |  +--ro cost-characteristic* [cost-name]
-       |  |  +--ro cost-name         string
-       |  |  +--ro cost-value?       string
-       |  |  +--ro cost-algorithm?   string
-       |  +--ro error-characteristic?                      string
-       |  +--ro loss-characteristic?                       string
-       |  +--ro repeat-delivery-characteristic?            string
-       |  +--ro delivery-order-characteristic?             string
-       |  +--ro unavailable-time-characteristic?           string
-       |  +--ro server-integrity-process-characteristic?   string
-       |  +--ro latency-characteristic* [traffic-property-name]
-       |  |  +--ro traffic-property-name            string
-       |  |  +--ro fixed-latency-characteristic?    string
-       |  |  +--ro queing-latency-characteristic?   string
-       |  |  +--ro jitter-characteristic?           string
-       |  |  +--ro wander-characteristic?           string
-       |  +--ro risk-characteristic* [risk-characteristic-name]
-       |  |  +--ro risk-characteristic-name    string
-       |  |  +--ro risk-identifier-list*       string
-       |  +--ro validation-mechanism* [validation-mechanism]
-       |  |  +--ro validation-mechanism                  string
-       |  |  +--ro layer-protocol-adjacency-validated?   string
-       |  |  +--ro validation-robustness?                string
-       |  +--ro transitioned-layer-protocol-name*          string
-       +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-       +--ro uuid                   uuid
-       +--ro name* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
+       |     +--ro value-name    string
+       |     +--ro value?        string
+       +--ro topology* [uuid]
+          +--ro node* [uuid]
+          |  +--ro owned-node-edge-point* [uuid]
+          |  |  +--ro layer-protocol-name?                      tapi-common:layer-protocol-name
+          |  |  +--ro supported-cep-layer-protocol-qualifier*   tapi-common:layer-protocol-qualifier
+          |  |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
+          |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  |  +--ro mapped-service-interface-point* [service-interface-point-uuid]
+          |  |  |  +--ro service-interface-point-uuid    -> /tapi-common:context/service-interface-point/uuid
+          |  |  +--ro link-port-direction?                      tapi-common:port-direction
+          |  |  +--ro link-port-role?                           tapi-common:port-role
+          |  |  +--ro uuid                                      uuid
+          |  |  +--ro name* [value-name]
+          |  |  |  +--ro value-name    string
+          |  |  |  +--ro value?        string
+          |  |  +--ro administrative-state?                     administrative-state
+          |  |  +--ro operational-state?                        operational-state
+          |  |  +--ro lifecycle-state?                          lifecycle-state
+          |  |  +--ro termination-direction?                    termination-direction
+          |  |  +--ro termination-state?                        termination-state
+          |  |  +--ro total-potential-capacity
+          |  |  |  +--ro total-size
+          |  |  |  |  +--ro value?   uint64
+          |  |  |  |  +--ro unit?    capacity-unit
+          |  |  |  +--ro bandwidth-profile
+          |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |  |     +--ro committed-information-rate
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro committed-burst-size
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro peak-information-rate
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro peak-burst-size
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro color-aware?                  boolean
+          |  |  |     +--ro coupling-flag?                boolean
+          |  |  +--ro available-capacity
+          |  |     +--ro total-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro bandwidth-profile
+          |  |        +--ro bw-profile-type?              bandwidth-profile-type
+          |  |        +--ro committed-information-rate
+          |  |        |  +--ro value?   uint64
+          |  |        |  +--ro unit?    capacity-unit
+          |  |        +--ro committed-burst-size
+          |  |        |  +--ro value?   uint64
+          |  |        |  +--ro unit?    capacity-unit
+          |  |        +--ro peak-information-rate
+          |  |        |  +--ro value?   uint64
+          |  |        |  +--ro unit?    capacity-unit
+          |  |        +--ro peak-burst-size
+          |  |        |  +--ro value?   uint64
+          |  |        |  +--ro unit?    capacity-unit
+          |  |        +--ro color-aware?                  boolean
+          |  |        +--ro coupling-flag?                boolean
+          |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
+          |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  +--ro node-rule-group* [uuid]
+          |  |  +--ro rule* [local-id]
+          |  |  |  +--ro rule-type?           rule-type
+          |  |  |  +--ro forwarding-rule?     forwarding-rule
+          |  |  |  +--ro override-priority?   uint64
+          |  |  |  +--ro local-id             string
+          |  |  |  +--ro name* [value-name]
+          |  |  |     +--ro value-name    string
+          |  |  |     +--ro value?        string
+          |  |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
+          |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  |  +--ro composed-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
+          |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
+          |  |  +--ro inter-rule-group* [uuid]
+          |  |  |  +--ro rule* [local-id]
+          |  |  |  |  +--ro rule-type?           rule-type
+          |  |  |  |  +--ro forwarding-rule?     forwarding-rule
+          |  |  |  |  +--ro override-priority?   uint64
+          |  |  |  |  +--ro local-id             string
+          |  |  |  |  +--ro name* [value-name]
+          |  |  |  |     +--ro value-name    string
+          |  |  |  |     +--ro value?        string
+          |  |  |  +--ro associated-node-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
+          |  |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
+          |  |  |  +--ro uuid                          uuid
+          |  |  |  +--ro name* [value-name]
+          |  |  |  |  +--ro value-name    string
+          |  |  |  |  +--ro value?        string
+          |  |  |  +--ro total-potential-capacity
+          |  |  |  |  +--ro total-size
+          |  |  |  |  |  +--ro value?   uint64
+          |  |  |  |  |  +--ro unit?    capacity-unit
+          |  |  |  |  +--ro bandwidth-profile
+          |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |  |  |     +--ro committed-information-rate
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro committed-burst-size
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro peak-information-rate
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro peak-burst-size
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro color-aware?                  boolean
+          |  |  |  |     +--ro coupling-flag?                boolean
+          |  |  |  +--ro available-capacity
+          |  |  |  |  +--ro total-size
+          |  |  |  |  |  +--ro value?   uint64
+          |  |  |  |  |  +--ro unit?    capacity-unit
+          |  |  |  |  +--ro bandwidth-profile
+          |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |  |  |     +--ro committed-information-rate
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro committed-burst-size
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro peak-information-rate
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro peak-burst-size
+          |  |  |  |     |  +--ro value?   uint64
+          |  |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |  |     +--ro color-aware?                  boolean
+          |  |  |  |     +--ro coupling-flag?                boolean
+          |  |  |  +--ro cost-characteristic* [cost-name]
+          |  |  |  |  +--ro cost-name         string
+          |  |  |  |  +--ro cost-value?       string
+          |  |  |  |  +--ro cost-algorithm?   string
+          |  |  |  +--ro latency-characteristic* [traffic-property-name]
+          |  |  |  |  +--ro traffic-property-name            string
+          |  |  |  |  +--ro fixed-latency-characteristic?    string
+          |  |  |  |  +--ro queing-latency-characteristic?   string
+          |  |  |  |  +--ro jitter-characteristic?           string
+          |  |  |  |  +--ro wander-characteristic?           string
+          |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
+          |  |  |     +--ro risk-characteristic-name    string
+          |  |  |     +--ro risk-identifier-list*       string
+          |  |  +--ro uuid                        uuid
+          |  |  +--ro name* [value-name]
+          |  |  |  +--ro value-name    string
+          |  |  |  +--ro value?        string
+          |  |  +--ro total-potential-capacity
+          |  |  |  +--ro total-size
+          |  |  |  |  +--ro value?   uint64
+          |  |  |  |  +--ro unit?    capacity-unit
+          |  |  |  +--ro bandwidth-profile
+          |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |  |     +--ro committed-information-rate
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro committed-burst-size
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro peak-information-rate
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro peak-burst-size
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro color-aware?                  boolean
+          |  |  |     +--ro coupling-flag?                boolean
+          |  |  +--ro available-capacity
+          |  |  |  +--ro total-size
+          |  |  |  |  +--ro value?   uint64
+          |  |  |  |  +--ro unit?    capacity-unit
+          |  |  |  +--ro bandwidth-profile
+          |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |  |     +--ro committed-information-rate
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro committed-burst-size
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro peak-information-rate
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro peak-burst-size
+          |  |  |     |  +--ro value?   uint64
+          |  |  |     |  +--ro unit?    capacity-unit
+          |  |  |     +--ro color-aware?                  boolean
+          |  |  |     +--ro coupling-flag?                boolean
+          |  |  +--ro cost-characteristic* [cost-name]
+          |  |  |  +--ro cost-name         string
+          |  |  |  +--ro cost-value?       string
+          |  |  |  +--ro cost-algorithm?   string
+          |  |  +--ro latency-characteristic* [traffic-property-name]
+          |  |  |  +--ro traffic-property-name            string
+          |  |  |  +--ro fixed-latency-characteristic?    string
+          |  |  |  +--ro queing-latency-characteristic?   string
+          |  |  |  +--ro jitter-characteristic?           string
+          |  |  |  +--ro wander-characteristic?           string
+          |  |  +--ro risk-characteristic* [risk-characteristic-name]
+          |  |     +--ro risk-characteristic-name    string
+          |  |     +--ro risk-identifier-list*       string
+          |  +--ro encap-topology
+          |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+          |  +--ro uuid                                       uuid
+          |  +--ro name* [value-name]
+          |  |  +--ro value-name    string
+          |  |  +--ro value?        string
+          |  +--ro administrative-state?                      administrative-state
+          |  +--ro operational-state?                         operational-state
+          |  +--ro lifecycle-state?                           lifecycle-state
+          |  +--ro total-potential-capacity
+          |  |  +--ro total-size
+          |  |  |  +--ro value?   uint64
+          |  |  |  +--ro unit?    capacity-unit
+          |  |  +--ro bandwidth-profile
+          |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |     +--ro committed-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro committed-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro color-aware?                  boolean
+          |  |     +--ro coupling-flag?                boolean
+          |  +--ro available-capacity
+          |  |  +--ro total-size
+          |  |  |  +--ro value?   uint64
+          |  |  |  +--ro unit?    capacity-unit
+          |  |  +--ro bandwidth-profile
+          |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |     +--ro committed-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro committed-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro color-aware?                  boolean
+          |  |     +--ro coupling-flag?                boolean
+          |  +--ro cost-characteristic* [cost-name]
+          |  |  +--ro cost-name         string
+          |  |  +--ro cost-value?       string
+          |  |  +--ro cost-algorithm?   string
+          |  +--ro error-characteristic?                      string
+          |  +--ro loss-characteristic?                       string
+          |  +--ro repeat-delivery-characteristic?            string
+          |  +--ro delivery-order-characteristic?             string
+          |  +--ro unavailable-time-characteristic?           string
+          |  +--ro server-integrity-process-characteristic?   string
+          |  +--ro latency-characteristic* [traffic-property-name]
+          |     +--ro traffic-property-name            string
+          |     +--ro fixed-latency-characteristic?    string
+          |     +--ro queing-latency-characteristic?   string
+          |     +--ro jitter-characteristic?           string
+          |     +--ro wander-characteristic?           string
+          +--ro link* [uuid]
+          |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
+          |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+          |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
+          |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+          |  +--ro direction?                                 tapi-common:forwarding-direction
+          |  +--ro resilience-type
+          |  |  +--ro restoration-policy?   restoration-policy
+          |  |  +--ro protection-type?      protection-type
+          |  +--ro uuid                                       uuid
+          |  +--ro name* [value-name]
+          |  |  +--ro value-name    string
+          |  |  +--ro value?        string
+          |  +--ro administrative-state?                      administrative-state
+          |  +--ro operational-state?                         operational-state
+          |  +--ro lifecycle-state?                           lifecycle-state
+          |  +--ro total-potential-capacity
+          |  |  +--ro total-size
+          |  |  |  +--ro value?   uint64
+          |  |  |  +--ro unit?    capacity-unit
+          |  |  +--ro bandwidth-profile
+          |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |     +--ro committed-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro committed-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro color-aware?                  boolean
+          |  |     +--ro coupling-flag?                boolean
+          |  +--ro available-capacity
+          |  |  +--ro total-size
+          |  |  |  +--ro value?   uint64
+          |  |  |  +--ro unit?    capacity-unit
+          |  |  +--ro bandwidth-profile
+          |  |     +--ro bw-profile-type?              bandwidth-profile-type
+          |  |     +--ro committed-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro committed-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-information-rate
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro peak-burst-size
+          |  |     |  +--ro value?   uint64
+          |  |     |  +--ro unit?    capacity-unit
+          |  |     +--ro color-aware?                  boolean
+          |  |     +--ro coupling-flag?                boolean
+          |  +--ro cost-characteristic* [cost-name]
+          |  |  +--ro cost-name         string
+          |  |  +--ro cost-value?       string
+          |  |  +--ro cost-algorithm?   string
+          |  +--ro error-characteristic?                      string
+          |  +--ro loss-characteristic?                       string
+          |  +--ro repeat-delivery-characteristic?            string
+          |  +--ro delivery-order-characteristic?             string
+          |  +--ro unavailable-time-characteristic?           string
+          |  +--ro server-integrity-process-characteristic?   string
+          |  +--ro latency-characteristic* [traffic-property-name]
+          |  |  +--ro traffic-property-name            string
+          |  |  +--ro fixed-latency-characteristic?    string
+          |  |  +--ro queing-latency-characteristic?   string
+          |  |  +--ro jitter-characteristic?           string
+          |  |  +--ro wander-characteristic?           string
+          |  +--ro risk-characteristic* [risk-characteristic-name]
+          |  |  +--ro risk-characteristic-name    string
+          |  |  +--ro risk-identifier-list*       string
+          |  +--ro validation-mechanism* [validation-mechanism]
+          |  |  +--ro validation-mechanism                  string
+          |  |  +--ro layer-protocol-adjacency-validated?   string
+          |  |  +--ro validation-robustness?                string
+          |  +--ro transitioned-layer-protocol-name*          string
+          +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+          +--ro uuid                   uuid
+          +--ro name* [value-name]
+             +--ro value-name    string
+             +--ro value?        string
 
   rpcs:
     +---x get-topology-details
@@ -382,9 +383,9 @@ module: tapi-topology
     |        |  |  +--ro layer-protocol-name?                      tapi-common:layer-protocol-name
     |        |  |  +--ro supported-cep-layer-protocol-qualifier*   tapi-common:layer-protocol-qualifier
     |        |  |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        |  |  +--ro mapped-service-interface-point* [service-interface-point-uuid]
     |        |  |  |  +--ro service-interface-point-uuid    -> /tapi-common:context/service-interface-point/uuid
     |        |  |  +--ro link-port-direction?                      tapi-common:port-direction
@@ -439,9 +440,9 @@ module: tapi-topology
     |        |  |        +--ro color-aware?                  boolean
     |        |  |        +--ro coupling-flag?                boolean
     |        |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        |  +--ro node-rule-group* [uuid]
     |        |  |  +--ro rule* [local-id]
     |        |  |  |  +--ro rule-type?           rule-type
@@ -452,13 +453,13 @@ module: tapi-topology
     |        |  |  |     +--ro value-name    string
     |        |  |  |     +--ro value?        string
     |        |  |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        |  |  +--ro composed-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
     |        |  |  +--ro inter-rule-group* [uuid]
     |        |  |  |  +--ro rule* [local-id]
     |        |  |  |  |  +--ro rule-type?           rule-type
@@ -469,9 +470,9 @@ module: tapi-topology
     |        |  |  |  |     +--ro value-name    string
     |        |  |  |  |     +--ro value?        string
     |        |  |  |  +--ro associated-node-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-    |        |  |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+    |        |  |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
     |        |  |  |  +--ro uuid                          uuid
     |        |  |  |  +--ro name* [value-name]
     |        |  |  |  |  +--ro value-name    string
@@ -587,7 +588,7 @@ module: tapi-topology
     |        |  |     +--ro risk-characteristic-name    string
     |        |  |     +--ro risk-identifier-list*       string
     |        |  +--ro encap-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
     |        |  +--ro uuid                                       uuid
     |        |  +--ro name* [value-name]
@@ -654,9 +655,9 @@ module: tapi-topology
     |        |     +--ro wander-characteristic?           string
     |        +--ro link* [uuid]
     |        |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
     |        |  +--ro direction?                                 tapi-common:forwarding-direction
     |        |  +--ro resilience-type
@@ -748,9 +749,9 @@ module: tapi-topology
     |        |  +--ro layer-protocol-name?                      tapi-common:layer-protocol-name
     |        |  +--ro supported-cep-layer-protocol-qualifier*   tapi-common:layer-protocol-qualifier
     |        |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        |  +--ro mapped-service-interface-point* [service-interface-point-uuid]
     |        |  |  +--ro service-interface-point-uuid    -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro link-port-direction?                      tapi-common:port-direction
@@ -805,9 +806,9 @@ module: tapi-topology
     |        |        +--ro color-aware?                  boolean
     |        |        +--ro coupling-flag?                boolean
     |        +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        +--ro node-rule-group* [uuid]
     |        |  +--ro rule* [local-id]
     |        |  |  +--ro rule-type?           rule-type
@@ -818,13 +819,13 @@ module: tapi-topology
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
     |        |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        |  +--ro composed-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+    |        |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
     |        |  +--ro inter-rule-group* [uuid]
     |        |  |  +--ro rule* [local-id]
     |        |  |  |  +--ro rule-type?           rule-type
@@ -835,9 +836,9 @@ module: tapi-topology
     |        |  |  |     +--ro value-name    string
     |        |  |  |     +--ro value?        string
     |        |  |  +--ro associated-node-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+    |        |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
     |        |  |  +--ro uuid                          uuid
     |        |  |  +--ro name* [value-name]
     |        |  |  |  +--ro value-name    string
@@ -953,7 +954,7 @@ module: tapi-topology
     |        |     +--ro risk-characteristic-name    string
     |        |     +--ro risk-identifier-list*       string
     |        +--ro encap-topology
-    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
     |        +--ro uuid?                                      uuid
     |        +--ro name* [value-name]
@@ -1028,9 +1029,9 @@ module: tapi-topology
     |        +--ro layer-protocol-name?                      tapi-common:layer-protocol-name
     |        +--ro supported-cep-layer-protocol-qualifier*   tapi-common:layer-protocol-qualifier
     |        +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        +--ro mapped-service-interface-point* [service-interface-point-uuid]
     |        |  +--ro service-interface-point-uuid    -> /tapi-common:context/service-interface-point/uuid
     |        +--ro link-port-direction?                      tapi-common:port-direction
@@ -1091,9 +1092,9 @@ module: tapi-topology
     |  +--ro output
     |     +--ro link
     |        +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-    |        |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
     |        +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
     |        +--ro direction?                                 tapi-common:forwarding-direction
     |        +--ro resilience-type
@@ -1178,9 +1179,9 @@ module: tapi-topology
              |  |  +--ro layer-protocol-name?                      tapi-common:layer-protocol-name
              |  |  +--ro supported-cep-layer-protocol-qualifier*   tapi-common:layer-protocol-qualifier
              |  |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-             |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
              |  |  +--ro mapped-service-interface-point* [service-interface-point-uuid]
              |  |  |  +--ro service-interface-point-uuid    -> /tapi-common:context/service-interface-point/uuid
              |  |  +--ro link-port-direction?                      tapi-common:port-direction
@@ -1235,9 +1236,9 @@ module: tapi-topology
              |  |        +--ro color-aware?                  boolean
              |  |        +--ro coupling-flag?                boolean
              |  +--ro aggregated-node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-             |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
              |  +--ro node-rule-group* [uuid]
              |  |  +--ro rule* [local-id]
              |  |  |  +--ro rule-type?           rule-type
@@ -1248,13 +1249,13 @@ module: tapi-topology
              |  |  |     +--ro value-name    string
              |  |  |     +--ro value?        string
              |  |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-             |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
              |  |  +--ro composed-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-             |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+             |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
              |  |  +--ro inter-rule-group* [uuid]
              |  |  |  +--ro rule* [local-id]
              |  |  |  |  +--ro rule-type?           rule-type
@@ -1265,9 +1266,9 @@ module: tapi-topology
              |  |  |  |     +--ro value-name    string
              |  |  |  |     +--ro value?        string
              |  |  |  +--ro associated-node-rule-group* [topology-uuid node-uuid node-rule-group-uuid]
-             |  |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+             |  |  |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  |  |  |  +--ro node-rule-group-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-rule-group/uuid
              |  |  |  +--ro uuid                          uuid
              |  |  |  +--ro name* [value-name]
              |  |  |  |  +--ro value-name    string
@@ -1383,7 +1384,7 @@ module: tapi-topology
              |  |     +--ro risk-characteristic-name    string
              |  |     +--ro risk-identifier-list*       string
              |  +--ro encap-topology
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
              |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
              |  +--ro uuid                                       uuid
              |  +--ro name* [value-name]
@@ -1450,9 +1451,9 @@ module: tapi-topology
              |     +--ro wander-characteristic?           string
              +--ro link* [uuid]
              |  +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]
-             |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  |  +--ro topology-uuid           -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+             |  |  +--ro node-uuid               -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  |  +--ro node-edge-point-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/node/owned-node-edge-point/uuid
              |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
              |  +--ro direction?                                 tapi-common:forwarding-direction
              |  +--ro resilience-type

--- a/YANG/tapi-topology@2018-08-31.yang
+++ b/YANG/tapi-topology@2018-08-31.yang
@@ -44,7 +44,10 @@ module tapi-topology {
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
     augment "/tapi-common:context" {
-        uses topology-context;
+    	container topology-context {
+            uses topology-context;
+            description "Augments the base TAPI Context with TopologyService information";
+        }
         description "Augments the base TAPI Context with TopologyService information";
     }
 
@@ -55,7 +58,7 @@ module tapi-topology {
     grouping topology-ref {
         leaf topology-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-topology:topology/tapi-topology:uuid';
+                path '/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:uuid';
             }
             description "none";
         }
@@ -66,7 +69,7 @@ module tapi-topology {
         uses topology-ref;
         leaf link-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid';
+                path '/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid';
             }
             description "none";
         }
@@ -77,7 +80,7 @@ module tapi-topology {
         uses topology-ref;
         leaf node-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
+                path '/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
             }
             description "none";
         }
@@ -88,7 +91,7 @@ module tapi-topology {
         uses node-ref;
         leaf node-edge-point-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                path '/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
             }
             description "none";
         }
@@ -99,7 +102,7 @@ module tapi-topology {
         uses node-ref;
         leaf node-rule-group-uuid {
             type leafref {
-                path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid';
+                path '/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid';
             }
             description "none";
         }

--- a/YANG/tapi-virtual-network@2018-08-31.tree
+++ b/YANG/tapi-virtual-network@2018-08-31.tree
@@ -1,72 +1,73 @@
 
 module: tapi-virtual-network
   augment /tapi-common:context:
-    +--rw virtual-nw-service* [uuid]
-       +--ro topology
-       |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
-       +--rw end-point* [local-id]
-       |  +--ro service-interface-point
-       |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-       |  +--ro role?                      tapi-common:port-role
-       |  +--ro direction?                 tapi-common:port-direction
-       |  +--ro service-layer?             tapi-common:layer-protocol-name
-       |  +--rw local-id                   string
-       |  +--rw name* [value-name]
-       |     +--rw value-name    string
-       |     +--rw value?        string
-       +--rw vnw-constraint* [local-id]
-       |  +--ro src-service-end-point
-       |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-       |  +--ro sink-service-end-point
-       |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-       |  +--ro diversity-exclusion* [virtual-nw-service-uuid]
-       |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/uuid
-       |  +--rw requested-capacity
-       |  |  +--rw total-size
-       |  |  |  +--rw value?   uint64
-       |  |  |  +--rw unit?    capacity-unit
-       |  |  +--rw bandwidth-profile
-       |  |     +--rw bw-profile-type?              bandwidth-profile-type
-       |  |     +--rw committed-information-rate
-       |  |     |  +--rw value?   uint64
-       |  |     |  +--rw unit?    capacity-unit
-       |  |     +--rw committed-burst-size
-       |  |     |  +--rw value?   uint64
-       |  |     |  +--rw unit?    capacity-unit
-       |  |     +--rw peak-information-rate
-       |  |     |  +--rw value?   uint64
-       |  |     |  +--rw unit?    capacity-unit
-       |  |     +--rw peak-burst-size
-       |  |     |  +--rw value?   uint64
-       |  |     |  +--rw unit?    capacity-unit
-       |  |     +--rw color-aware?                  boolean
-       |  |     +--rw coupling-flag?                boolean
-       |  +--rw service-level?            string
-       |  +--rw service-layer*            tapi-common:layer-protocol-name
-       |  +--rw cost-characteristic* [cost-name]
-       |  |  +--rw cost-name         string
-       |  |  +--rw cost-value?       string
-       |  |  +--rw cost-algorithm?   string
-       |  +--rw latency-characteristic* [traffic-property-name]
-       |  |  +--rw traffic-property-name            string
-       |  |  +--ro fixed-latency-characteristic?    string
-       |  |  +--rw queing-latency-characteristic?   string
-       |  |  +--ro jitter-characteristic?           string
-       |  |  +--ro wander-characteristic?           string
-       |  +--rw local-id                  string
-       |  +--rw name* [value-name]
-       |     +--rw value-name    string
-       |     +--rw value?        string
-       +--rw schedule?              string
-       +--rw state
-       |  +--rw administrative-state?   administrative-state
-       |  +--ro operational-state?      operational-state
-       |  +--ro lifecycle-state?        lifecycle-state
-       +--rw layer-protocol-name*   tapi-common:layer-protocol-name
-       +--rw uuid                   uuid
-       +--rw name* [value-name]
-          +--rw value-name    string
-          +--rw value?        string
+    +--rw virtual-network-context
+       +--rw virtual-nw-service* [uuid]
+          +--ro topology
+          |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          +--rw end-point* [local-id]
+          |  +--ro service-interface-point
+          |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+          |  +--ro role?                      tapi-common:port-role
+          |  +--ro direction?                 tapi-common:port-direction
+          |  +--ro service-layer?             tapi-common:layer-protocol-name
+          |  +--rw local-id                   string
+          |  +--rw name* [value-name]
+          |     +--rw value-name    string
+          |     +--rw value?        string
+          +--rw vnw-constraint* [local-id]
+          |  +--ro src-service-end-point
+          |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+          |  +--ro sink-service-end-point
+          |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+          |  +--ro diversity-exclusion* [virtual-nw-service-uuid]
+          |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-network-context/virtual-nw-service/uuid
+          |  +--rw requested-capacity
+          |  |  +--rw total-size
+          |  |  |  +--rw value?   uint64
+          |  |  |  +--rw unit?    capacity-unit
+          |  |  +--rw bandwidth-profile
+          |  |     +--rw bw-profile-type?              bandwidth-profile-type
+          |  |     +--rw committed-information-rate
+          |  |     |  +--rw value?   uint64
+          |  |     |  +--rw unit?    capacity-unit
+          |  |     +--rw committed-burst-size
+          |  |     |  +--rw value?   uint64
+          |  |     |  +--rw unit?    capacity-unit
+          |  |     +--rw peak-information-rate
+          |  |     |  +--rw value?   uint64
+          |  |     |  +--rw unit?    capacity-unit
+          |  |     +--rw peak-burst-size
+          |  |     |  +--rw value?   uint64
+          |  |     |  +--rw unit?    capacity-unit
+          |  |     +--rw color-aware?                  boolean
+          |  |     +--rw coupling-flag?                boolean
+          |  +--rw service-level?            string
+          |  +--rw service-layer*            tapi-common:layer-protocol-name
+          |  +--rw cost-characteristic* [cost-name]
+          |  |  +--rw cost-name         string
+          |  |  +--rw cost-value?       string
+          |  |  +--rw cost-algorithm?   string
+          |  +--rw latency-characteristic* [traffic-property-name]
+          |  |  +--rw traffic-property-name            string
+          |  |  +--ro fixed-latency-characteristic?    string
+          |  |  +--rw queing-latency-characteristic?   string
+          |  |  +--ro jitter-characteristic?           string
+          |  |  +--ro wander-characteristic?           string
+          |  +--rw local-id                  string
+          |  +--rw name* [value-name]
+          |     +--rw value-name    string
+          |     +--rw value?        string
+          +--rw schedule?              string
+          +--rw state
+          |  +--rw administrative-state?   administrative-state
+          |  +--ro operational-state?      operational-state
+          |  +--ro lifecycle-state?        lifecycle-state
+          +--rw layer-protocol-name*   tapi-common:layer-protocol-name
+          +--rw uuid                   uuid
+          +--rw name* [value-name]
+             +--rw value-name    string
+             +--rw value?        string
 
   rpcs:
     +---x create-virtual-network-service
@@ -87,7 +88,7 @@ module: tapi-virtual-network
     |  |  |  +---w sink-service-end-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w diversity-exclusion* [virtual-nw-service-uuid]
-    |  |  |  |  +---w virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/uuid
+    |  |  |  |  +---w virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-network-context/virtual-nw-service/uuid
     |  |  |  +---w requested-capacity
     |  |  |  |  +---w total-size
     |  |  |  |  |  +---w value?   uint64
@@ -128,7 +129,7 @@ module: tapi-virtual-network
     |  +--ro output
     |     +--ro service
     |        +--ro topology
-    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -145,7 +146,7 @@ module: tapi-virtual-network
     |        |  +--ro sink-service-end-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro diversity-exclusion* [virtual-nw-service-uuid]
-    |        |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/uuid
+    |        |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-network-context/virtual-nw-service/uuid
     |        |  +--ro requested-capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -198,7 +199,7 @@ module: tapi-virtual-network
     |  +--ro output
     |     +--ro service
     |        +--ro topology
-    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -215,7 +216,7 @@ module: tapi-virtual-network
     |        |  +--ro sink-service-end-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro diversity-exclusion* [virtual-nw-service-uuid]
-    |        |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/uuid
+    |        |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-network-context/virtual-nw-service/uuid
     |        |  +--ro requested-capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -268,7 +269,7 @@ module: tapi-virtual-network
     |  +--ro output
     |     +--ro service
     |        +--ro topology
-    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -285,7 +286,7 @@ module: tapi-virtual-network
     |        |  +--ro sink-service-end-point
     |        |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro diversity-exclusion* [virtual-nw-service-uuid]
-    |        |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/uuid
+    |        |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-network-context/virtual-nw-service/uuid
     |        |  +--ro requested-capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -336,7 +337,7 @@ module: tapi-virtual-network
        +--ro output
           +--ro service* []
              +--ro topology
-             |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology/uuid
+             |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
              +--ro end-point* [local-id]
              |  +--ro service-interface-point
              |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
@@ -353,7 +354,7 @@ module: tapi-virtual-network
              |  +--ro sink-service-end-point
              |  |  +--ro service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
              |  +--ro diversity-exclusion* [virtual-nw-service-uuid]
-             |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/uuid
+             |  |  +--ro virtual-nw-service-uuid    -> /tapi-common:context/tapi-virtual-network:virtual-network-context/virtual-nw-service/uuid
              |  +--ro requested-capacity
              |  |  +--ro total-size
              |  |  |  +--ro value?   uint64

--- a/YANG/tapi-virtual-network@2018-08-31.yang
+++ b/YANG/tapi-virtual-network@2018-08-31.yang
@@ -47,7 +47,10 @@ module tapi-virtual-network {
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
     augment "/tapi-common:context" {
-        uses virtual-network-context;
+        container virtual-network-context {
+            uses virtual-network-context;
+            description "Augments the base TAPI Context with VirtualNetworkService information";
+        }
         description "Augments the base TAPI Context with VirtualNetworkService information";
     }
     /*************************
@@ -56,7 +59,7 @@ module tapi-virtual-network {
      grouping virtual-nw-service-ref {
          leaf virtual-nw-service-uuid {
              type leafref {
-                 path '/tapi-common:context/tapi-virtual-network:virtual-nw-service/tapi-virtual-network:uuid';
+                 path '/tapi-common:context/tapi-virtual-network:virtual-network-context/tapi-virtual-network:virtual-nw-service/tapi-virtual-network:uuid';
              }
              description "none";
          }


### PR DESCRIPTION
Fixes #356 : The Eagle Uml2Yang tool and mapping guidelines have all _classes_ directly mapped to YANG _groupings_. And the _grouping_ is wrapped with either a _list_ or a _container_ statement when an instance of the class is contained within another class (as an composed attribute).
To allow for an augmenting class/node to be further augmented by other modules, updated TAPI YANG _augments_ to use a wrapper _container_ sub-statement that encloses the _uses <grouping>_ statement.