### PR TITLE
 Fixes #354 as per TAPI 10/02/2018 call discussions

### DIFF
--- a/OAS/tapi-dsr@2018-08-31.yaml
+++ b/OAS/tapi-dsr@2018-08-31.yaml
@@ -2265,25 +2265,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.oam.getoamservicelist.Output"
-  tapi.oam.MaintenanceEntity:
-    allOf:
-    - $ref: "#/definitions/tapi.common.LocalClass"
-    - type: "object"
-      properties:
-        connection-route:
-          description: "none"
-          $ref: "#/definitions/tapi.connectivity.RouteRef"
-        mep:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MepRef"
-        mip:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MipRef"
-      description: "none"
   tapi.oam.Meg:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2305,11 +2286,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
         mep:
           type: "array"
           description: "1. ME may have 0 MEPs (case of transit domains where at least\
@@ -2343,9 +2319,6 @@ definitions:
           description: "none"
           items:
             type: "string"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
         mep-identifier:
           type: "string"
           description: "none"
@@ -2371,9 +2344,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
       description: "none"
   tapi.oam.MipRef:
     allOf:
@@ -2502,6 +2472,16 @@ definitions:
     - $ref: "#/definitions/tapi.common.LocalClass"
     - type: "object"
       properties:
+        peer-mep-identifier:
+          type: "array"
+          description: "This attribute models the MI_PeerMEP_ID[i] defined in G.8021\
+            \ and configured as specified in G.8051. It provides the identifiers of\
+            \ the MEPs which are peer to the subject MEP.\r\n                    This\
+            \ attribute is not specified in case the OSEP relates to the provisioing\
+            \ of an MIP.\r\n                    In case of P2P, there is only one\
+            \ peer"
+          items:
+            type: "string"
         connectivity-service-end-point:
           description: "none"
           $ref: "#/definitions/tapi.connectivity.ConnectivityServiceEndPointRef"
@@ -2517,6 +2497,11 @@ definitions:
         mep:
           description: "none"
           $ref: "#/definitions/tapi.oam.MepRef"
+        mep-identifier:
+          type: "string"
+          description: "This attribute contains the identifier of the MEP.\r\n   \
+            \                 This attribute is empty in case the OSEP relates to\
+            \ the provisioing of an MIP.\r\n                    "
         direction:
           description: "none"
           $ref: "#/definitions/tapi.common.PortDirection"
@@ -2680,6 +2665,11 @@ definitions:
   tapi.oam.createoamserviceendpoint.Input:
     type: "object"
     properties:
+      peer-mep-identifier:
+        type: "array"
+        description: "none"
+        items:
+          type: "string"
       service-id:
         type: "string"
         description: "none"
@@ -2687,6 +2677,9 @@ definitions:
         type: "string"
         description: "none"
       c-sep-id:
+        type: "string"
+        description: "none"
+      mep-identifier:
         type: "string"
         description: "none"
       state:

--- a/OAS/tapi-eth@2018-08-31.yaml
+++ b/OAS/tapi-eth@2018-08-31.yaml
@@ -2136,6 +2136,15 @@ definitions:
         $ref: "#/definitions/tapi.eth.EthMepSource"
   tapi.eth.EthMipSpec:
     type: "object"
+    properties:
+      mip-mac:
+        type: "string"
+        description: "This attribute contains the MAC address of the MIP instance."
+      is-full-mip:
+        type: "boolean"
+        description: "This attribute indicates whether the MIP is a full MIP (true)\
+          \ or a down-half MIP (false)."
+        default: false
   tapi.eth.EthOamMsgCommonPac:
     allOf:
     - $ref: "#/definitions/tapi.eth.EthOamOperationCommonPac"
@@ -3381,25 +3390,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.oam.getoamservicelist.Output"
-  tapi.oam.MaintenanceEntity:
-    allOf:
-    - $ref: "#/definitions/tapi.common.LocalClass"
-    - type: "object"
-      properties:
-        connection-route:
-          description: "none"
-          $ref: "#/definitions/tapi.connectivity.RouteRef"
-        mep:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MepRef"
-        mip:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MipRef"
-      description: "none"
   tapi.oam.Meg:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -3421,11 +3411,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
         mep:
           type: "array"
           description: "1. ME may have 0 MEPs (case of transit domains where at least\
@@ -3459,9 +3444,6 @@ definitions:
           description: "none"
           items:
             type: "string"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
         mep-identifier:
           type: "string"
           description: "none"
@@ -3487,9 +3469,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
       description: "none"
   tapi.oam.MipRef:
     allOf:
@@ -3595,6 +3574,16 @@ definitions:
     - $ref: "#/definitions/tapi.common.LocalClass"
     - type: "object"
       properties:
+        peer-mep-identifier:
+          type: "array"
+          description: "This attribute models the MI_PeerMEP_ID[i] defined in G.8021\
+            \ and configured as specified in G.8051. It provides the identifiers of\
+            \ the MEPs which are peer to the subject MEP.\r\n                    This\
+            \ attribute is not specified in case the OSEP relates to the provisioing\
+            \ of an MIP.\r\n                    In case of P2P, there is only one\
+            \ peer"
+          items:
+            type: "string"
         connectivity-service-end-point:
           description: "none"
           $ref: "#/definitions/tapi.connectivity.ConnectivityServiceEndPointRef"
@@ -3610,6 +3599,11 @@ definitions:
         mep:
           description: "none"
           $ref: "#/definitions/tapi.oam.MepRef"
+        mep-identifier:
+          type: "string"
+          description: "This attribute contains the identifier of the MEP.\r\n   \
+            \                 This attribute is empty in case the OSEP relates to\
+            \ the provisioing of an MIP.\r\n                    "
         direction:
           description: "none"
           $ref: "#/definitions/tapi.common.PortDirection"
@@ -3798,6 +3792,11 @@ definitions:
   tapi.oam.createoamserviceendpoint.Input:
     type: "object"
     properties:
+      peer-mep-identifier:
+        type: "array"
+        description: "none"
+        items:
+          type: "string"
       service-id:
         type: "string"
         description: "none"
@@ -3805,6 +3804,9 @@ definitions:
         type: "string"
         description: "none"
       c-sep-id:
+        type: "string"
+        description: "none"
+      mep-identifier:
         type: "string"
         description: "none"
       state:
@@ -3932,11 +3934,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
         mep:
           type: "array"
           description: "1. ME may have 0 MEPs (case of transit domains where at least\

--- a/OAS/tapi-oam@2018-08-31.yaml
+++ b/OAS/tapi-oam@2018-08-31.yaml
@@ -2265,25 +2265,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.oam.getoamservicelist.Output"
-  tapi.oam.MaintenanceEntity:
-    allOf:
-    - $ref: "#/definitions/tapi.common.LocalClass"
-    - type: "object"
-      properties:
-        connection-route:
-          description: "none"
-          $ref: "#/definitions/tapi.connectivity.RouteRef"
-        mep:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MepRef"
-        mip:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MipRef"
-      description: "none"
   tapi.oam.Meg:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2305,11 +2286,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
         mep:
           type: "array"
           description: "1. ME may have 0 MEPs (case of transit domains where at least\
@@ -2343,9 +2319,6 @@ definitions:
           description: "none"
           items:
             type: "string"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
         mep-identifier:
           type: "string"
           description: "none"
@@ -2371,9 +2344,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
       description: "none"
   tapi.oam.MipRef:
     allOf:
@@ -2502,6 +2472,16 @@ definitions:
     - $ref: "#/definitions/tapi.common.LocalClass"
     - type: "object"
       properties:
+        peer-mep-identifier:
+          type: "array"
+          description: "This attribute models the MI_PeerMEP_ID[i] defined in G.8021\
+            \ and configured as specified in G.8051. It provides the identifiers of\
+            \ the MEPs which are peer to the subject MEP.\r\n                    This\
+            \ attribute is not specified in case the OSEP relates to the provisioing\
+            \ of an MIP.\r\n                    In case of P2P, there is only one\
+            \ peer"
+          items:
+            type: "string"
         connectivity-service-end-point:
           description: "none"
           $ref: "#/definitions/tapi.connectivity.ConnectivityServiceEndPointRef"
@@ -2517,6 +2497,11 @@ definitions:
         mep:
           description: "none"
           $ref: "#/definitions/tapi.oam.MepRef"
+        mep-identifier:
+          type: "string"
+          description: "This attribute contains the identifier of the MEP.\r\n   \
+            \                 This attribute is empty in case the OSEP relates to\
+            \ the provisioing of an MIP.\r\n                    "
         direction:
           description: "none"
           $ref: "#/definitions/tapi.common.PortDirection"
@@ -2680,6 +2665,11 @@ definitions:
   tapi.oam.createoamserviceendpoint.Input:
     type: "object"
     properties:
+      peer-mep-identifier:
+        type: "array"
+        description: "none"
+        items:
+          type: "string"
       service-id:
         type: "string"
         description: "none"
@@ -2687,6 +2677,9 @@ definitions:
         type: "string"
         description: "none"
       c-sep-id:
+        type: "string"
+        description: "none"
+      mep-identifier:
         type: "string"
         description: "none"
       state:

--- a/OAS/tapi-odu@2018-08-31.yaml
+++ b/OAS/tapi-odu@2018-08-31.yaml
@@ -2265,25 +2265,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.oam.getoamservicelist.Output"
-  tapi.oam.MaintenanceEntity:
-    allOf:
-    - $ref: "#/definitions/tapi.common.LocalClass"
-    - type: "object"
-      properties:
-        connection-route:
-          description: "none"
-          $ref: "#/definitions/tapi.connectivity.RouteRef"
-        mep:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MepRef"
-        mip:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MipRef"
-      description: "none"
   tapi.oam.Meg:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2305,11 +2286,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
         mep:
           type: "array"
           description: "1. ME may have 0 MEPs (case of transit domains where at least\
@@ -2343,9 +2319,6 @@ definitions:
           description: "none"
           items:
             type: "string"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
         mep-identifier:
           type: "string"
           description: "none"
@@ -2371,9 +2344,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
       description: "none"
   tapi.oam.MipRef:
     allOf:
@@ -2502,6 +2472,16 @@ definitions:
     - $ref: "#/definitions/tapi.common.LocalClass"
     - type: "object"
       properties:
+        peer-mep-identifier:
+          type: "array"
+          description: "This attribute models the MI_PeerMEP_ID[i] defined in G.8021\
+            \ and configured as specified in G.8051. It provides the identifiers of\
+            \ the MEPs which are peer to the subject MEP.\r\n                    This\
+            \ attribute is not specified in case the OSEP relates to the provisioing\
+            \ of an MIP.\r\n                    In case of P2P, there is only one\
+            \ peer"
+          items:
+            type: "string"
         connectivity-service-end-point:
           description: "none"
           $ref: "#/definitions/tapi.connectivity.ConnectivityServiceEndPointRef"
@@ -2517,6 +2497,11 @@ definitions:
         mep:
           description: "none"
           $ref: "#/definitions/tapi.oam.MepRef"
+        mep-identifier:
+          type: "string"
+          description: "This attribute contains the identifier of the MEP.\r\n   \
+            \                 This attribute is empty in case the OSEP relates to\
+            \ the provisioing of an MIP.\r\n                    "
         direction:
           description: "none"
           $ref: "#/definitions/tapi.common.PortDirection"
@@ -2680,6 +2665,11 @@ definitions:
   tapi.oam.createoamserviceendpoint.Input:
     type: "object"
     properties:
+      peer-mep-identifier:
+        type: "array"
+        description: "none"
+        items:
+          type: "string"
       service-id:
         type: "string"
         description: "none"
@@ -2687,6 +2677,9 @@ definitions:
         type: "string"
         description: "none"
       c-sep-id:
+        type: "string"
+        description: "none"
+      mep-identifier:
         type: "string"
         description: "none"
       state:

--- a/OAS/tapi-photonic-media@2018-08-31.yaml
+++ b/OAS/tapi-photonic-media@2018-08-31.yaml
@@ -2264,25 +2264,6 @@ definitions:
     properties:
       output:
         $ref: "#/definitions/tapi.oam.getoamservicelist.Output"
-  tapi.oam.MaintenanceEntity:
-    allOf:
-    - $ref: "#/definitions/tapi.common.LocalClass"
-    - type: "object"
-      properties:
-        connection-route:
-          description: "none"
-          $ref: "#/definitions/tapi.connectivity.RouteRef"
-        mep:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MepRef"
-        mip:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MipRef"
-      description: "none"
   tapi.oam.Meg:
     allOf:
     - $ref: "#/definitions/tapi.common.GlobalClass"
@@ -2304,11 +2285,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        me:
-          type: "array"
-          description: "none"
-          items:
-            $ref: "#/definitions/tapi.oam.MaintenanceEntity"
         mep:
           type: "array"
           description: "1. ME may have 0 MEPs (case of transit domains where at least\
@@ -2342,9 +2318,6 @@ definitions:
           description: "none"
           items:
             type: "string"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
         mep-identifier:
           type: "string"
           description: "none"
@@ -2370,9 +2343,6 @@ definitions:
         layer-protocol-name:
           description: "none"
           $ref: "#/definitions/tapi.common.LayerProtocolName"
-        oam-service-end-point:
-          description: "none"
-          $ref: "#/definitions/tapi.oam.OamServiceEndPointRef"
       description: "none"
   tapi.oam.MipRef:
     allOf:
@@ -2501,6 +2471,16 @@ definitions:
     - $ref: "#/definitions/tapi.common.LocalClass"
     - type: "object"
       properties:
+        peer-mep-identifier:
+          type: "array"
+          description: "This attribute models the MI_PeerMEP_ID[i] defined in G.8021\
+            \ and configured as specified in G.8051. It provides the identifiers of\
+            \ the MEPs which are peer to the subject MEP.\r\n                    This\
+            \ attribute is not specified in case the OSEP relates to the provisioing\
+            \ of an MIP.\r\n                    In case of P2P, there is only one\
+            \ peer"
+          items:
+            type: "string"
         connectivity-service-end-point:
           description: "none"
           $ref: "#/definitions/tapi.connectivity.ConnectivityServiceEndPointRef"
@@ -2516,6 +2496,11 @@ definitions:
         mep:
           description: "none"
           $ref: "#/definitions/tapi.oam.MepRef"
+        mep-identifier:
+          type: "string"
+          description: "This attribute contains the identifier of the MEP.\r\n   \
+            \                 This attribute is empty in case the OSEP relates to\
+            \ the provisioing of an MIP.\r\n                    "
         direction:
           description: "none"
           $ref: "#/definitions/tapi.common.PortDirection"
@@ -2679,6 +2664,11 @@ definitions:
   tapi.oam.createoamserviceendpoint.Input:
     type: "object"
     properties:
+      peer-mep-identifier:
+        type: "array"
+        description: "none"
+        items:
+          type: "string"
       service-id:
         type: "string"
         description: "none"
@@ -2686,6 +2676,9 @@ definitions:
         type: "string"
         description: "none"
       c-sep-id:
+        type: "string"
+        description: "none"
+      mep-identifier:
         type: "string"
         description: "none"
       state:

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -980,10 +980,6 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_eW6C8GA8Eei7_-Uhq6CryQ" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_eW6C8WA8Eei7_-Uhq6CryQ" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_KvYcoG6IEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_khqLYMbMEeaVKq30FmMykA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KvYcoW6IEeivMcJ3aRh7eg"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_KvZDsG6IEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_-ePpMMbMEeaVKq30FmMykA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_KvZDsW6IEeivMcJ3aRh7eg"/>
@@ -1147,6 +1143,14 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_psFLcGA8Eei7_-Uhq6CryQ" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_psFLcWA8Eei7_-Uhq6CryQ" key="visible" value="true"/>
         </eAnnotations>
+        <children xmi:type="notation:Shape" xmi:id="_j5hPEMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_crKK8MWWEeiWCKGKl1wb8w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j5hPEcWWEeiWCKGKl1wb8w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_j5hPEsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_i_B8wMWWEeiWCKGKl1wb8w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j5hPE8WWEeiWCKGKl1wb8w"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_lJLiZk-xEeitY7qZgkO_XQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_lJLiZ0-xEeitY7qZgkO_XQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_lJLiaE-xEeitY7qZgkO_XQ"/>
@@ -2449,6 +2453,54 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D9HzYpyjEeihoemEj9HqGA" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nf1kkMWNEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nf1kkcWNEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nf1kk8WNEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nf1kksWNEeiWCKGKl1wb8w" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nllAM8WNEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nllANMWNEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nllANsWNEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nllANcWNEeiWCKGKl1wb8w" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LdCSEMWWEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LdCSEcWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LdIYsMWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LdCSEsWWEeiWCKGKl1wb8w" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Li8s0MWWEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Li8s0cWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Li8s08WWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Li8s0sWWEeiWCKGKl1wb8w" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-SL9MMWcEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-SL9McWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-SL9M8WcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-SL9MsWcEeiWCKGKl1wb8w" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-Yc9QMWcEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-Yc9QcWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-Yc9Q8WcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Yc9QsWcEeiWCKGKl1wb8w" x="554" y="-98"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_--vAkU-wEeitY7qZgkO_XQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_--vAkk-wEeitY7qZgkO_XQ"/>
@@ -3926,6 +3978,66 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9IacJyjEeihoemEj9HqGA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9IacZyjEeihoemEj9HqGA"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nf1klMWNEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_nf1kkMWNEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nf1klcWNEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nf1kmcWNEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nf1klsWNEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nf1kl8WNEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nf1kmMWNEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nllAN8WNEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_nllAM8WNEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nllAOMWNEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nllAPMWNEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nllAOcWNEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nllAOsWNEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nllAO8WNEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LdIYscWWEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_LdCSEMWWEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LdIYssWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LdIYtsWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LdIYs8WWEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LdIYtMWWEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LdIYtcWWEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Li8s1MWWEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_Li8s0MWWEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Li8s1cWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Li8s2cWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Li8s1sWWEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li8s18WWEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li8s2MWWEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-SL9NMWcEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_-SL9MMWcEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-SL9NcWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-SL9OcWcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-SL9NsWcEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-SL9N8WcEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-SL9OMWcEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-Yc9RMWcEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_-Yc9QMWcEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-Yc9RcWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-Yc9ScWcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-Yc9RsWcEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Yc9R8WcEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Yc9SMWcEeiWCKGKl1wb8w"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_ODB7UFhmEeiYiLRYKaTpTw" type="PapyrusUMLClassDiagram" name="EthProActiveJobs" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_4UpIAFiAEei2nODetmeP6A" type="Class_Shape">
@@ -3988,7 +4100,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4UpIE1iAEei2nODetmeP6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4UpIAViAEei2nODetmeP6A" x="-112" y="-56" width="271" height="174"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4UpIAViAEei2nODetmeP6A" x="-112" y="-56" width="307" height="174"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_bFkJQFiBEei2nODetmeP6A" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_bFkJQliBEei2nODetmeP6A" type="Class_NameLabel"/>
@@ -4850,7 +4962,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mk0rSV6qEeitO-Stqhyn1g"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiEth.uml#_M5RXUF3fEeit4-HSxnZlvw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mk0rQV6qEeitO-Stqhyn1g" x="-232" y="72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mk0rQV6qEeitO-Stqhyn1g" x="-246" y="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_mmmM4F6qEeitO-Stqhyn1g" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_mmmM4l6qEeitO-Stqhyn1g" type="Enumeration_NameLabel"/>
@@ -4864,7 +4976,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmmM6V6qEeitO-Stqhyn1g"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiOam.uml#_tqiDYF3eEeit4-HSxnZlvw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmmM4V6qEeitO-Stqhyn1g" x="-230" y="-55" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmmM4V6qEeitO-Stqhyn1g" x="-244" y="-55" height="67"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_mp70w16qEeitO-Stqhyn1g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_mp70xF6qEeitO-Stqhyn1g" showTitle="true"/>
@@ -5728,6 +5840,54 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RqeM8rEXEeiB1L1dQuD1kw" x="560" y="-140"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_neumwMWMEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_neumwcWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_neumw8WMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_neumwsWMEeiWCKGKl1wb8w" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nhTZo8WMEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nhTZpMWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nhTZpsWMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nhTZpcWMEeiWCKGKl1wb8w" x="560" y="-140"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MWCWoMWWEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MWCWocWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MWCWo8WWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MWCWosWWEeiWCKGKl1wb8w" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MXwN48WWEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MXwN5MWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MXwN5sWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MXwN5cWWEeiWCKGKl1wb8w" x="560" y="-140"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_89NHQMWcEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_89NHQcWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_89NHQ8WcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_89NHQsWcEeiWCKGKl1wb8w" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8_4Aw8WcEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8_4AxMWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8_4AxsWcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8_4AxcWcEeiWCKGKl1wb8w" x="560" y="-140"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_ODB7UVhmEeiYiLRYKaTpTw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_ODB7UlhmEeiYiLRYKaTpTw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_brdm8IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -6177,14 +6337,16 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_moseoF6qEeitO-Stqhyn1g" type="Dependency_Edge" source="_mk0rQF6qEeitO-Stqhyn1g" target="_mmmM4F6qEeitO-Stqhyn1g">
       <children xmi:type="notation:DecorationNode" xmi:id="_motFsF6qEeitO-Stqhyn1g" visible="false" type="Dependency_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6w9scMWMEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_motFsV6qEeitO-Stqhyn1g" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_motFsl6qEeitO-Stqhyn1g" type="Dependency_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_64mlgMWMEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_motFs16qEeitO-Stqhyn1g" x="-2"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_moseoV6qEeitO-Stqhyn1g"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Pb3P4F3fEeit4-HSxnZlvw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_moseol6qEeitO-Stqhyn1g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_moseol6qEeitO-Stqhyn1g" points="[-196, 72, -643984, -643984]$[-196, 12, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_motFtF6qEeitO-Stqhyn1g" id="(0.42016806722689076,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_motFtV6qEeitO-Stqhyn1g" id="(0.48,1.0)"/>
     </edges>
@@ -6910,7 +7072,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_YeeEcYt0Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YeeEcot0Eeiu6boZkiJHCA" points="[19, 103, -643984, -643984]$[13, 240, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hwqRcJyfEeihoemEj9HqGA" id="(0.4833948339483395,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hwqRcJyfEeihoemEj9HqGA" id="(0.42671009771986973,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Yest9It0Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_YeeEcIt0Eeiu6boZkiJHCA" target="_Yest8It0Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Yest9Yt0Eeiu6boZkiJHCA"/>
@@ -7167,6 +7329,66 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RqeM9rEXEeiB1L1dQuD1kw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RqeM97EXEeiB1L1dQuD1kw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RqeM-LEXEeiB1L1dQuD1kw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_neumxMWMEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_neumwMWMEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_neumxcWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_neumycWMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_neumxsWMEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_neumx8WMEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_neumyMWMEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nhTZp8WMEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_nhTZo8WMEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nhTZqMWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nhTZrMWMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nhTZqcWMEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nhTZqsWMEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nhTZq8WMEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MWCWpMWWEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_MWCWoMWWEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MWCWpcWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MWCWqcWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MWCWpsWWEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MWCWp8WWEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MWCWqMWWEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MXwN58WWEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_MXwN48WWEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MXwN6MWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MXwN7MWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MXwN6cWWEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXwN6sWWEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXwN68WWEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_89NHRMWcEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_89NHQMWcEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_89NHRcWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_89NHScWcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_89NHRsWcEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_89NHR8WcEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_89NHSMWcEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8_4Ax8WcEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_8_4Aw8WcEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8_4AyMWcEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8_4AzMWcEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8_4AycWcEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8_4AysWcEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8_4Ay8WcEeiWCKGKl1wb8w"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_tC4KUGBLEei7_-Uhq6CryQ" type="PapyrusUMLClassDiagram" name="EthOnDemandJobs" measurementUnit="Pixel">
@@ -10138,6 +10360,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QCFVArEmEeiB1L1dQuD1kw" x="557" y="13"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_MO-sY8WWEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MO-sZMWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MO-sZsWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MO-sZcWWEeiWCKGKl1wb8w" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D1yvsMWdEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D1yvscWdEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D1yvs8WdEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D1yvssWdEeiWCKGKl1wb8w" x="557" y="13"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_e0rQkYbqEeil5oKL3Vgl-g" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_e0rQkobqEeil5oKL3Vgl-g"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_b6T7QIqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -10457,6 +10695,26 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QCFVBrEmEeiB1L1dQuD1kw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QCFVB7EmEeiB1L1dQuD1kw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QCFVCLEmEeiB1L1dQuD1kw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MO-sZ8WWEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_MO-sY8WWEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MO-saMWWEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MO-sbMWWEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MO-sacWWEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MO-sasWWEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MO-sa8WWEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D1yvtMWdEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_D1yvsMWdEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D1yvtcWdEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D1yvucWdEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D1yvtsWdEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D1yvt8WdEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D1yvuMWdEeiWCKGKl1wb8w"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -430,7 +430,19 @@ Note that the only significance of the GTCS function defined in G.8021 is the us
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cNkVQFRyEeitkMFXBYQFcg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_lJFbwE-xEeitY7qZgkO_XQ" name="EthMipSpec"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_lJFbwE-xEeitY7qZgkO_XQ" name="EthMipSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_crKK8MWWEeiWCKGKl1wb8w" name="mipMac" type="_hYZs0BWEEd-Si5Ih_dYBog" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_crKK8cWWEeiWCKGKl1wb8w" annotatedElement="_crKK8MWWEeiWCKGKl1wb8w">
+            <body>This attribute contains the MAC address of the MIP instance.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_i_B8wMWWEeiWCKGKl1wb8w" name="isFullMip" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_i_B8wcWWEeiWCKGKl1wb8w" annotatedElement="_i_B8wMWWEeiWCKGKl1wb8w">
+            <body>This attribute indicates whether the MIP is a full MIP (true) or a down-half MIP (false).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_noRbAE-xEeitY7qZgkO_XQ" name="EthLoopbackJob">
         <ownedComment xmi:type="uml:Comment" xmi:id="_JPzRMIrMEeiT7s5en7ligw" annotatedElement="_noRbAE-xEeitY7qZgkO_XQ">
           <body>This class represents the Loopback (LB) process (send a series of LB messages carrying a test pattern to a particular MEP). The termination occurs at specified stop time (schedule attribute of OamJob).&#xD;
@@ -6670,4 +6682,8 @@ The accuracy of the value is for further study.</body>
   <OpenModel_Profile_3:StrictComposite xmi:id="_W71G8LEZEeiB1L1dQuD1kw" base_Association="_Ay79MLEZEeiB1L1dQuD1kw"/>
   <OpenModel_Profile_3:StrictComposite xmi:id="_ZN53QLEZEeiB1L1dQuD1kw" base_Association="_BrbEYLEZEeiB1L1dQuD1kw"/>
   <OpenModel_Profile_3:StrictComposite xmi:id="_ajTj8LEZEeiB1L1dQuD1kw" base_Association="_umHAYLEYEeiB1L1dQuD1kw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ctXxcMWWEeiWCKGKl1wb8w" base_Property="_crKK8MWWEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_ctXxccWWEeiWCKGKl1wb8w" base_StructuralFeature="_crKK8MWWEeiWCKGKl1wb8w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_i_B8wsWWEeiWCKGKl1wb8w" base_Property="_i_B8wMWWEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_i_B8w8WWEeiWCKGKl1wb8w" base_StructuralFeature="_i_B8wMWWEeiWCKGKl1wb8w"/>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -73,40 +73,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewjFdMEeejsLaQeGcDdg" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_dPewjVdMEeejsLaQeGcDdg" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dPewjldMEeejsLaQeGcDdg" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dPewj1dMEeejsLaQeGcDdg" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPewkFdMEeejsLaQeGcDdg" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewkVdMEeejsLaQeGcDdg" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewkldMEeejsLaQeGcDdg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewk1dMEeejsLaQeGcDdg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewlFdMEeejsLaQeGcDdg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewlVdMEeejsLaQeGcDdg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewlldMEeejsLaQeGcDdg" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewl1dMEeejsLaQeGcDdg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewmFdMEeejsLaQeGcDdg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewmVdMEeejsLaQeGcDdg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewmldMEeejsLaQeGcDdg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewm1dMEeejsLaQeGcDdg" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewnFdMEeejsLaQeGcDdg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewnVdMEeejsLaQeGcDdg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewnldMEeejsLaQeGcDdg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewn1dMEeejsLaQeGcDdg"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewtldMEeejsLaQeGcDdg" x="-422" y="157" width="166" height="63"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_dPewt1dMEeejsLaQeGcDdg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_dPewuFdMEeejsLaQeGcDdg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPewuVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewyldMEeejsLaQeGcDdg" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_dPewy1dMEeejsLaQeGcDdg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_dPewzFdMEeejsLaQeGcDdg" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_dPewzVdMEeejsLaQeGcDdg" type="Class_FloatingNameLabel">
@@ -954,7 +920,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD_w84UxEeiYFOBVMQg1QQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD_w4YUxEeiYFOBVMQg1QQ" x="37" y="-134" width="122" height="57"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD_w4YUxEeiYFOBVMQg1QQ" x="37" y="-134" width="128" height="57"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l72084VFEeiYFOBVMQg1QQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_l7209IVFEeiYFOBVMQg1QQ" showTitle="true"/>
@@ -1124,14 +1090,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kHAUMot8Eeiu6boZkiJHCA" x="-255" y="-275"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lOA_k4t8Eeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lOA_lIt8Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lOBmoIt8Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lOA_lYt8Eeiu6boZkiJHCA" x="-255" y="-275"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_mZ8nM4t8Eeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_mZ8nNIt8Eeiu6boZkiJHCA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mZ8nNot8Eeiu6boZkiJHCA" name="BASE_ELEMENT">
@@ -1164,6 +1122,38 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YdVVEpwUEeidac_mNnugIw" x="237" y="-134"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_39DLoMWSEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_39DLocWSEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_39DLo8WSEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_39DLosWSEeiWCKGKl1wb8w" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9V7lwMWbEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9V7lwcWbEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9V7lw8WbEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9V7lwsWbEeiWCKGKl1wb8w" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EickoMY9Eeitrfx5M35Hug" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EickocY9Eeitrfx5M35Hug"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EidLsMY9Eeitrfx5M35Hug" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EickosY9Eeitrfx5M35Hug" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NfMwQMcZEeiSV9wVm02xsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NfMwQccZEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NfQaoMcZEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NfMwQscZEeiSV9wVm02xsw" x="237" y="-134"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_dPf-21dMEeejsLaQeGcDdg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJlFgIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -1189,16 +1179,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-5ldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-51dMEeejsLaQeGcDdg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-6FdMEeejsLaQeGcDdg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dPf-6VdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPewjVdMEeejsLaQeGcDdg" target="_dPewt1dMEeejsLaQeGcDdg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-6ldMEeejsLaQeGcDdg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-61dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-7FdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-7VdMEeejsLaQeGcDdg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-7ldMEeejsLaQeGcDdg"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dPf-71dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPewy1dMEeejsLaQeGcDdg" target="_dPew9VdMEeejsLaQeGcDdg">
       <styles xmi:type="notation:FontStyle" xmi:id="_dPf-8FdMEeejsLaQeGcDdg"/>
@@ -1842,7 +1822,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ee41I4t8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ee41JIt8Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_f8xvcIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPeyH1dMEeejsLaQeGcDdg" target="_dPfZJldMEeejsLaQeGcDdg">
+    <edges xmi:type="notation:Connector" xmi:id="_f8xvcIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPeyH1dMEeejsLaQeGcDdg" target="_dPfZJldMEeejsLaQeGcDdg" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_f8yWgIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_p_2hcIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_f8yWgYt8Eeiu6boZkiJHCA" x="-9" y="1"/>
@@ -1865,7 +1845,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_f8yWiot8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qIlmsIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_f8yWi4t8Eeiu6boZkiJHCA" x="-13" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_f8yWi4t8Eeiu6boZkiJHCA" x="-15" y="19"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_f8xvcYt8Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
@@ -1883,7 +1863,10 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f9W-Sot8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f9W-S4t8Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_hVVd0It8Eeiu6boZkiJHCA" type="Association_Edge" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_CD_w4IUxEeiYFOBVMQg1QQ">
+    <edges xmi:type="notation:Connector" xmi:id="_hVVd0It8Eeiu6boZkiJHCA" type="Association_Edge" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_CD_w4IUxEeiYFOBVMQg1QQ" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dhcOgMWdEeiWCKGKl1wb8w" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dhiVIMWdEeiWCKGKl1wb8w" key="lineColor" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_hVVd04t8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qJ-t0It9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hVVd1It8Eeiu6boZkiJHCA" x="-11" y="-2"/>
@@ -1912,7 +1895,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hVVd0ot8Eeiu6boZkiJHCA" points="[21, -260, -643984, -643984]$[81, -161, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J-mLcIt9Eeiu6boZkiJHCA" id="(0.9111111111111111,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KT334It9Eeiu6boZkiJHCA" id="(0.3442622950819672,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KT334It9Eeiu6boZkiJHCA" id="(0.328125,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hV9v9It8Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_hVVd0It8Eeiu6boZkiJHCA" target="_hV9v8It8Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_hV9v9Yt8Eeiu6boZkiJHCA"/>
@@ -2006,47 +1989,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kHAUN4t8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kHAUOIt8Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lNjskIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPewT1dMEeejsLaQeGcDdg" target="_dPewjVdMEeejsLaQeGcDdg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_lNkToIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iQXGMIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lNkToYt8Eeiu6boZkiJHCA" x="-59" y="-7"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lNkToot8Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iRgVsIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lNkTo4t8Eeiu6boZkiJHCA" x="-75" y="-6"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lNkTpIt8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iS-8YIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lNkTpYt8Eeiu6boZkiJHCA" x="30" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lNkTpot8Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iUFIkIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lNkTp4t8Eeiu6boZkiJHCA" x="-31" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lNkTqIt8Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iVNJ8It9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lNk6sIt8Eeiu6boZkiJHCA" x="9" y="15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lNk6sYt8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iWotUIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lNk6sot8Eeiu6boZkiJHCA" x="-9" y="-21"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_lNjskYt8Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lNjskot8Eeiu6boZkiJHCA" points="[-340, -114, -643984, -643984]$[-332, 90, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYtw8Yt9Eeiu6boZkiJHCA" id="(0.4715447154471545,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYuYAIt9Eeiu6boZkiJHCA" id="(0.5,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lOBmoYt8Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_lNjskIt8Eeiu6boZkiJHCA" target="_lOA_k4t8Eeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lOBmoot8Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lOBmpot8Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lOBmo4t8Eeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lOBmpIt8Eeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lOBmpYt8Eeiu6boZkiJHCA"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mZQqsIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPewT1dMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg">
       <children xmi:type="notation:DecorationNode" xmi:id="_mZRRwIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jz-1EIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2088,69 +2030,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mZ9OQIt8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mZ9OQYt8Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_oEW6kIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPewjVdMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_oEXhoIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_h8kAcIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oEXhoYt8Eeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oEXhoot8Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_h96EQIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oEXho4t8Eeiu6boZkiJHCA" x="3" y="6"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oEXhpIt8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_h_pJoIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oEXhpYt8Eeiu6boZkiJHCA" x="11" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oEXhpot8Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iBinEIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oEXhp4t8Eeiu6boZkiJHCA" x="-11" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oEXhqIt8Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iDcEgIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oEXhqYt8Eeiu6boZkiJHCA" x="11" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oEXhqot8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iFQpcIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oEYIsIt8Eeiu6boZkiJHCA" x="-10" y="14"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_oEW6kYt8Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_6281IINHEeelF8AE_WZtHQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oEW6kot8Eeiu6boZkiJHCA" points="[-357, 110, -643984, -643984]$[-395, 39, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_47-_AIt8Eeiu6boZkiJHCA" id="(0.10843373493975904,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYtw8It9Eeiu6boZkiJHCA" id="(0.55,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qagSkIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPewjVdMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_qag5oIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iHVGAIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qag5oYt8Eeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qag5oot8Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iJHOsIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qag5o4t8Eeiu6boZkiJHCA" x="3" y="-1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qag5pIt8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iLRx4It9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qag5pYt8Eeiu6boZkiJHCA" x="10" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qag5pot8Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iMrgEIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qag5p4t8Eeiu6boZkiJHCA" x="-10" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qag5qIt8Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iOI4oIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qahgsIt8Eeiu6boZkiJHCA" x="10" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qahgsYt8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iPPE0It9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qahgsot8Eeiu6boZkiJHCA" x="-11" y="19"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_qagSkYt8Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_6KewsINHEeelF8AE_WZtHQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qagSkot8Eeiu6boZkiJHCA" points="[-318, 110, -643984, -643984]$[-269, 41, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3OXmoIt8Eeiu6boZkiJHCA" id="(0.8373493975903614,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_31FoYIt8Eeiu6boZkiJHCA" id="(0.20967741935483872,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_vK44YIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg">
+    <edges xmi:type="notation:Connector" xmi:id="_vK44YIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5fcIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wPgXEIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fcYt8Eeiu6boZkiJHCA" y="-20"/>
@@ -2173,7 +2053,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5feot8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wXNhkIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fe4t8Eeiu6boZkiJHCA" x="-52" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fe4t8Eeiu6boZkiJHCA" x="-14" y="-14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_vK44YYt8Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_GTLxYD2kEeihCtCrhJZ45g"/>
@@ -2181,7 +2061,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wNuOYIt8Eeiu6boZkiJHCA" id="(0.5,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wNuOYYt8Eeiu6boZkiJHCA" id="(1.0,0.3448275862068966)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_w_XGsIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg">
+    <edges xmi:type="notation:Connector" xmi:id="_w_XGsIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_w_XtwIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ynLZEIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_w_XtwYt8Eeiu6boZkiJHCA" x="-1" y="-20"/>
@@ -2232,14 +2112,14 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sKsnh5sXEeid4dfn4JFJZg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sKsniJsXEeid4dfn4JFJZg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wwS5oJsXEeid4dfn4JFJZg" type="Association_Edge" source="_x860YE4hEeiMYveOdt1-rQ" target="_dPfZJldMEeejsLaQeGcDdg" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_wwS5oJsXEeid4dfn4JFJZg" type="Association_Edge" source="_x860YE4hEeiMYveOdt1-rQ" target="_dPfZJldMEeejsLaQeGcDdg" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_wwS5o5sXEeid4dfn4JFJZg" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1113IJsXEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5pJsXEeid4dfn4JFJZg" x="1" y="-18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_wwS5pZsXEeid4dfn4JFJZg" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_13hSIJsXEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5ppsXEeid4dfn4JFJZg" x="-68" y="62"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5ppsXEeid4dfn4JFJZg" x="-40" y="57"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_wwS5p5sXEeid4dfn4JFJZg" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_15avkJsXEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2255,7 +2135,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_wwS5rZsXEeid4dfn4JFJZg" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2ARlgJsXEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5rpsXEeid4dfn4JFJZg" x="-64" y="-18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5rpsXEeid4dfn4JFJZg" x="-9" y="-13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_wwS5oZsXEeid4dfn4JFJZg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_wd3s4JsXEeid4dfn4JFJZg"/>
@@ -2273,6 +2153,46 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YdXKQ5wUEeidac_mNnugIw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YdXKRJwUEeidac_mNnugIw"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_39DLpMWSEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_39DLoMWSEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_39DLpcWSEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_39DLqcWSEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_39DLpsWSEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_39DLp8WSEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_39DLqMWSEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9V7lxMWbEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_9V7lwMWbEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9V7lxcWbEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9V7lycWbEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9V7lxsWbEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9V7lx8WbEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9V7lyMWbEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EidLscY9Eeitrfx5M35Hug" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_EickoMY9Eeitrfx5M35Hug">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EidLssY9Eeitrfx5M35Hug"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EidLtsY9Eeitrfx5M35Hug" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EidLs8Y9Eeitrfx5M35Hug" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EidLtMY9Eeitrfx5M35Hug"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EidLtcY9Eeitrfx5M35Hug"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NfRBsMcZEeiSV9wVm02xsw" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_NfMwQMcZEeiSV9wVm02xsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NfRBsccZEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NfRowscZEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NfRBsscZEeiSV9wVm02xsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NfRowMcZEeiSV9wVm02xsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NfRowccZEeiSV9wVm02xsw"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_LeWqMHMLEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_LeWqknMLEeeSiaQ95-6r9w" type="Class_Shape">
@@ -2284,10 +2204,6 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nkcyMHMLEeeSiaQ95-6r9w" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nkcyMXMLEeeSiaQ95-6r9w" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_Z4ipkG6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_khqLYMbMEeaVKq30FmMykA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z4ipkW6HEeivMcJ3aRh7eg"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_Z4m7AG6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_-ePpMMbMEeaVKq30FmMykA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Z4m7AW6HEeivMcJ3aRh7eg"/>
@@ -2351,63 +2267,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeWq8nMLEeeSiaQ95-6r9w" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_LeWq83MLEeeSiaQ95-6r9w" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_LeWq9HMLEeeSiaQ95-6r9w" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LeWq9XMLEeeSiaQ95-6r9w" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LeWq9nMLEeeSiaQ95-6r9w" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_LeWq93MLEeeSiaQ95-6r9w" type="Class_AttributeCompartment">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dlsqEHMLEeeSiaQ95-6r9w" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dltRIHMLEeeSiaQ95-6r9w" key="visible" value="true"/>
-        </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_isME4IVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_6Kews4NHEeelF8AE_WZtHQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_isME4YVOEeiYFOBVMQg1QQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_isSLgIVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_629cMoNHEeelF8AE_WZtHQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_isSLgYVOEeiYFOBVMQg1QQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_isSLgoVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_Aiipg4NJEeelF8AE_WZtHQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_isSLg4VOEeiYFOBVMQg1QQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_isSLhoVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_isSLh4VOEeiYFOBVMQg1QQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_isSLiIVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_isSLiYVOEeiYFOBVMQg1QQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_LeWq-HMLEeeSiaQ95-6r9w"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_LeWq-XMLEeeSiaQ95-6r9w"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_LeWq-nMLEeeSiaQ95-6r9w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeWq-3MLEeeSiaQ95-6r9w"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_LeWq_HMLEeeSiaQ95-6r9w" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_LeWq_XMLEeeSiaQ95-6r9w"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_LeWq_nMLEeeSiaQ95-6r9w"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_LeWq_3MLEeeSiaQ95-6r9w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeWrAHMLEeeSiaQ95-6r9w"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_LeWrAXMLEeeSiaQ95-6r9w" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_LeWrAnMLEeeSiaQ95-6r9w"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_LeWrA3MLEeeSiaQ95-6r9w"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_LeWrBHMLEeeSiaQ95-6r9w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeWrBXMLEeeSiaQ95-6r9w"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeWrL3MLEeeSiaQ95-6r9w" x="-391" y="217" width="240" height="124"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_LeWrMHMLEeeSiaQ95-6r9w" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_LeWrMXMLEeeSiaQ95-6r9w" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LeWrMnMLEeeSiaQ95-6r9w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeWrU3MLEeeSiaQ95-6r9w" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LeWrtXMLEeeSiaQ95-6r9w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_LeWrtnMLEeeSiaQ95-6r9w" showTitle="true"/>
@@ -2632,7 +2491,7 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LeXRUnMLEeeSiaQ95-6r9w" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_LeXRU3MLEeeSiaQ95-6r9w" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_pKTnwE-sEeitY7qZgkO_XQ" type="Operation_InterfaceOperationLabel">
+        <children xmi:type="notation:Shape" xmi:id="_pKTnwE-sEeitY7qZgkO_XQ" type="Operation_InterfaceOperationLabel" fontColor="255">
           <styles xmi:type="notation:StringListValueStyle" xmi:id="_6Yi1YE-sEeitY7qZgkO_XQ" name="maskLabel">
             <stringListValue>parametersName</stringListValue>
             <stringListValue>multiplicity</stringListValue>
@@ -2712,7 +2571,7 @@
           <element xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_q7yzgU-sEeitY7qZgkO_XQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ubt3AE-sEeitY7qZgkO_XQ" type="Operation_InterfaceOperationLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ubt3AE-sEeitY7qZgkO_XQ" type="Operation_InterfaceOperationLabel" fontColor="255">
           <styles xmi:type="notation:StringListValueStyle" xmi:id="_8_meEFg6Eei9GrLbn4i8vw" name="maskLabel">
             <stringListValue>parametersName</stringListValue>
             <stringListValue>multiplicity</stringListValue>
@@ -2776,7 +2635,7 @@
           <element xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_wV1aUU-sEeitY7qZgkO_XQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_x80mQE-sEeitY7qZgkO_XQ" type="Operation_InterfaceOperationLabel">
+        <children xmi:type="notation:Shape" xmi:id="_x80mQE-sEeitY7qZgkO_XQ" type="Operation_InterfaceOperationLabel" fontColor="255">
           <styles xmi:type="notation:StringListValueStyle" xmi:id="_4mwHIFg9Eei9GrLbn4i8vw" name="maskLabel">
             <stringListValue>parametersName</stringListValue>
             <stringListValue>multiplicity</stringListValue>
@@ -2867,7 +2726,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXRXHMLEeeSiaQ95-6r9w"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXRc3MLEeeSiaQ95-6r9w" x="-370" y="-766" width="1280" height="282"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXRc3MLEeeSiaQ95-6r9w" x="-370" y="-766" width="1591" height="282"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LeXRdHMLEeeSiaQ95-6r9w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_LeXRdXMLEeeSiaQ95-6r9w" showTitle="true"/>
@@ -2944,41 +2803,49 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_0oU4MHMLEeeSiaQ95-6r9w" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_0oVfQHMLEeeSiaQ95-6r9w" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_zN020G6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9vxbYMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_ktPoImWwEeeiceLWmAD6ng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN020W6HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9vxbYcWWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN020m6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9vxbYsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_1fy_UmWwEeeiceLWmAD6ng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN02026HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9vxbY8WWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN1d4G6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iAMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_-sQ1wXMgEeeSiaQ95-6r9w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN1d4W6HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iAcWWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN1d4m6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iAsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_GTViYD2kEeihCtCrhJZ45g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN1d426HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iA8WWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN1d5G6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iBMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_so_EcE8EEeiW8t12GIRjqQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN1d5W6HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iBcWWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN1d5m6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iBsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WRqhYE45EeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN1d526HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iB8WWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN2E8G6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iCMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_hJpKQBocEeeV4o0osG5stg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN2E8W6HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iCcWWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN2E8m6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iCsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_cXcaMMWVEeiWCKGKl1wb8w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iC8WWEeiWCKGKl1wb8w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_9v3iDMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_ft704MWVEeiWCKGKl1wb8w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iDcWWEeiWCKGKl1wb8w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_9v3iDsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN2E826HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iD8WWEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zN2E9G6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_9v3iEMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN2E9W6HEeivMcJ3aRh7eg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iEcWWEeiWCKGKl1wb8w"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_LeXSZXMLEeeSiaQ95-6r9w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_LeXSZnMLEeeSiaQ95-6r9w"/>
@@ -2998,7 +2865,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXScnMLEeeSiaQ95-6r9w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXSnHMLEeeSiaQ95-6r9w" x="191" y="-229" width="387" height="172"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXSnHMLEeeSiaQ95-6r9w" x="191" y="-241" width="387" height="202"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LeXSnXMLEeeSiaQ95-6r9w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_LeXSnnMLEeeSiaQ95-6r9w" showTitle="true"/>
@@ -3400,37 +3267,33 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_4QU_BHMeEeeSiaQ95-6r9w" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_4QU_BXMeEeeSiaQ95-6r9w" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_PtuSME8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_-sSD4HMgEeeSiaQ95-6r9w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtuSMU8IEeiW8t12GIRjqQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Ptu5Qk8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkEMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_d_jgcU8FEeiW8t12GIRjqQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ptu5Q08IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkEcWcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_PtvgUE8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkEsWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_B9eEoIHDEeeh4KO3PMo8Rw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtvgUU8IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkE8WcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_PtvgUk8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkFMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_A0XLAJPsEeePQIrrJoWPZA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtvgU08IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkFcWcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_PtvgVk8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkFsWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_QVmjwLxAEeSpn78DYJKtkA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtvgV08IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkF8WcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_PtwHYE8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkGMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_z2aJ0LxAEeSpn78DYJKtkA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtwHYU8IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkGcWcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_PtwHYk8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkGsWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtwHY08IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkG8WcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_PtwHZE8IEeiW8t12GIRjqQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_ysvkHMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PtwHZU8IEeiW8t12GIRjqQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkHcWcEeiWCKGKl1wb8w"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_4QU_BnMeEeeSiaQ95-6r9w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_4QU_B3MeEeeSiaQ95-6r9w"/>
@@ -3450,7 +3313,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4QVmGHMeEeeSiaQ95-6r9w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4QU_AXMeEeeSiaQ95-6r9w" x="326" y="105" width="332" height="176"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4QU_AXMeEeeSiaQ95-6r9w" x="326" y="105" width="332" height="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_4QeI83MeEeeSiaQ95-6r9w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_4QeI9HMeEeeSiaQ95-6r9w" showTitle="true"/>
@@ -3466,21 +3329,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_416YVHMeEeeSiaQ95-6r9w" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_416YVXMeEeeSiaQ95-6r9w" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_zTm6cD3OEeihCtCrhJZ45g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_GTZz0D2kEeihCtCrhJZ45g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zTm6cT3OEeihCtCrhJZ45g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_zTnhgD3OEeihCtCrhJZ45g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_1ZtgoMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_DOW0IILIEeelF8AE_WZtHQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zTnhgT3OEeihCtCrhJZ45g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1ZtgocWcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zTnhgj3OEeihCtCrhJZ45g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_1ZtgosWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zTnhgz3OEeihCtCrhJZ45g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1Ztgo8WcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zTnhhD3OEeihCtCrhJZ45g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_1ZtgpMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zTnhhT3OEeihCtCrhJZ45g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1ZtgpcWcEeiWCKGKl1wb8w"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_416YVnMeEeeSiaQ95-6r9w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_416YV3MeEeeSiaQ95-6r9w"/>
@@ -3570,7 +3429,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GDrJgU4xEeiMYveOdt1-rQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GDqiYU4xEeiMYveOdt1-rQ" x="548" y="-471" height="175"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GDqiYU4xEeiMYveOdt1-rQ" x="548" y="-471" height="199"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GVfmUE4-EeiMYveOdt1-rQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_GVfmUk4-EeiMYveOdt1-rQ" type="Class_NameLabel"/>
@@ -3874,7 +3733,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l_Zss4VPEeiYFOBVMQg1QQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l_ZsoYVPEeiYFOBVMQg1QQ" x="126" y="-390" height="91"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l_ZsoYVPEeiYFOBVMQg1QQ" x="126" y="-390" height="104"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l_l54IVPEeiYFOBVMQg1QQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_l_l54YVPEeiYFOBVMQg1QQ" showTitle="true"/>
@@ -4124,14 +3983,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fR-XlYt_Eeiu6boZkiJHCA" x="-184" y="-158"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_oU8M44t_Eeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_oU8M5It_Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oU8M5ot_Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oU8M5Yt_Eeiu6boZkiJHCA" x="-184" y="-158"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_58U9gIuDEeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_58U9gYuDEeiu6boZkiJHCA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_58U9g4uDEeiu6boZkiJHCA" name="BASE_ELEMENT">
@@ -4164,6 +4015,54 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZD3JkpwUEeidac_mNnugIw" x="748" y="-471"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_X9vlIMWMEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X9vlIcWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X9vlI8WMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X9vlIsWMEeiWCKGKl1wb8w" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ysuLYMWbEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ysuLYcWbEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysuLY8WbEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysuLYsWbEeiWCKGKl1wb8w" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CxsYsMY9Eeitrfx5M35Hug" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CxsYscY9Eeitrfx5M35Hug"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CxwDEMY9Eeitrfx5M35Hug" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CxsYssY9Eeitrfx5M35Hug" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UTGF8McZEeiSV9wVm02xsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UTGF8ccZEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTGtAMcZEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UTGF8scZEeiSV9wVm02xsw" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_X1TBYMcZEeiSV9wVm02xsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X1TBYccZEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X1TBY8cZEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X1TBYscZEeiSV9wVm02xsw" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_hnOZAMcaEeiSV9wVm02xsw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hnOZAccaEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hnPAEMcaEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hnOZAscaEeiSV9wVm02xsw" x="748" y="-471"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_LeXWvXMLEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJ-HEIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -4179,16 +4078,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LeXWyHMLEeeSiaQ95-6r9w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeXWyXMLEeeSiaQ95-6r9w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeXWynMLEeeSiaQ95-6r9w"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_LeXWy3MLEeeSiaQ95-6r9w" type="StereotypeCommentLink" source="_LeWq83MLEeeSiaQ95-6r9w" target="_LeWrMHMLEeeSiaQ95-6r9w">
-      <styles xmi:type="notation:FontStyle" xmi:id="_LeXWzHMLEeeSiaQ95-6r9w"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LeXWzXMLEeeSiaQ95-6r9w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LeXWznMLEeeSiaQ95-6r9w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeXWz3MLEeeSiaQ95-6r9w"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeXW0HMLEeeSiaQ95-6r9w"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LeXW13MLEeeSiaQ95-6r9w" type="StereotypeCommentLink" target="_LeWrtXMLEeeSiaQ95-6r9w">
       <styles xmi:type="notation:FontStyle" xmi:id="_LeXW2HMLEeeSiaQ95-6r9w"/>
@@ -4365,7 +4254,7 @@
       <element xmi:type="uml:InterfaceRealization" href="TapiOam.uml#_ojz6oFrnEeexvMtO2oNM9g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LeX5gnMLEeeSiaQ95-6r9w" points="[0, 0, -93, 134]$[0, -134, -93, 0]$[93, -134, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeX5g3MLEeeSiaQ95-6r9w" id="(0.5115511551155115,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeX5hHMLEeeSiaQ95-6r9w" id="(0.12109375,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeX5hHMLEeeSiaQ95-6r9w" id="(0.09742300439974859,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LeX6K3MLEeeSiaQ95-6r9w" type="StereotypeCommentLink" target="_LeXVunMLEeeSiaQ95-6r9w">
       <styles xmi:type="notation:FontStyle" xmi:id="_LeX6LHMLEeeSiaQ95-6r9w"/>
@@ -4599,7 +4488,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mfj1Eot-Eeiu6boZkiJHCA" points="[-67, -392, -643984, -643984]$[548, -385, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nuRq8It-Eeiu6boZkiJHCA" id="(1.0,0.2222222222222222)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oKHSYIt-Eeiu6boZkiJHCA" id="(0.0,0.2857142857142857)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oKHSYIt-Eeiu6boZkiJHCA" id="(0.0,0.25125628140703515)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mgx9FIt-Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_mfj1EIt-Eeiu6boZkiJHCA" target="_mgx9EIt-Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_mgx9FYt-Eeiu6boZkiJHCA"/>
@@ -4640,7 +4529,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qoO6oot-Eeiu6boZkiJHCA" points="[-67, -379, -643984, -643984]$[142, -359, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_twkkkIt-Eeiu6boZkiJHCA" id="(1.0,0.9090909090909091)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_04ELsIt-Eeiu6boZkiJHCA" id="(0.0,0.4065934065934066)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_04ELsIt-Eeiu6boZkiJHCA" id="(0.0,0.3557692307692308)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qpnat4t-Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_qoO6oIt-Eeiu6boZkiJHCA" target="_qpnas4t-Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_qpnauIt-Eeiu6boZkiJHCA"/>
@@ -4680,8 +4569,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_v-0k0Yt-Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_w25csIbmEeil5oKL3Vgl-g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v-0k0ot-Eeiu6boZkiJHCA" points="[548, -372, -643984, -643984]$[406, -358, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w-4ToIt-Eeiu6boZkiJHCA" id="(0.0,0.8571428571428571)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xWdGIIt-Eeiu6boZkiJHCA" id="(1.0,0.7582417582417582)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w-4ToIt-Eeiu6boZkiJHCA" id="(0.0,0.7537688442211056)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xWdGIIt-Eeiu6boZkiJHCA" id="(1.0,0.6634615384615384)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3_AHcIt-Eeiu6boZkiJHCA" type="Association_Edge" source="_LeWsy3MLEeeSiaQ95-6r9w" target="_l_ZsoIVPEeiYFOBVMQg1QQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_3_AugIt-Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -4737,7 +4626,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9bSJ8ot-Eeiu6boZkiJHCA" points="[-20, -190, -643984, -643984]$[191, -166, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u0PyoIt_Eeiu6boZkiJHCA" id="(1.0,0.6142857142857143)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-6t8YIt-Eeiu6boZkiJHCA" id="(0.0,0.22674418604651161)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-6t8YIt-Eeiu6boZkiJHCA" id="(0.0,0.2524752475247525)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9c3eVIt-Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_9bSJ8It-Eeiu6boZkiJHCA" target="_9c3eUIt-Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_9c3eVYt-Eeiu6boZkiJHCA"/>
@@ -4825,7 +4714,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IVo-tot_Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IVo-t4t_Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NKAsoIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeXSYHMLEeeSiaQ95-6r9w" target="_416YUHMeEeeSiaQ95-6r9w">
+    <edges xmi:type="notation:Connector" xmi:id="_NKAsoIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeXSYHMLEeeSiaQ95-6r9w" target="_416YUHMeEeeSiaQ95-6r9w" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_NKBTsIt_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_NKBTsYt_Eeiu6boZkiJHCA" y="-20"/>
       </children>
@@ -4847,10 +4736,10 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_NKAsoYt_Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_GTLxYD2kEeihCtCrhJZ45g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NKAsoot_Eeiu6boZkiJHCA" points="[314, -57, -643984, -643984]$[202, 81, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OGkbgIt_Eeiu6boZkiJHCA" id="(0.11627906976744186,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OYt7cIt_Eeiu6boZkiJHCA" id="(0.7389830508474576,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OGkbgIt_Eeiu6boZkiJHCA" id="(0.082687338501292,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OYt7cIt_Eeiu6boZkiJHCA" id="(0.7735849056603774,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P6G1sIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeXSYHMLEeeSiaQ95-6r9w" target="_4QU_AHMeEeeSiaQ95-6r9w">
+    <edges xmi:type="notation:Connector" xmi:id="_P6G1sIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeXSYHMLEeeSiaQ95-6r9w" target="_4QU_AHMeEeeSiaQ95-6r9w" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_P6HcwIt_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_P6HcwYt_Eeiu6boZkiJHCA" y="-20"/>
       </children>
@@ -4873,31 +4762,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_-sPnoHMgEeeSiaQ95-6r9w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P6G1sot_Eeiu6boZkiJHCA" points="[412, -57, -643984, -643984]$[463, 105, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RFzMwIt_Eeiu6boZkiJHCA" id="(0.7545219638242894,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Sh9owIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeWq83MLEeeSiaQ95-6r9w" target="_4QU_AHMeEeeSiaQ95-6r9w">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Sh9ow4t_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Sh9oxIt_Eeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Sh9oxYt_Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Sh9oxot_Eeiu6boZkiJHCA" x="-22" y="-14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Sh9ox4t_Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Sh9oyIt_Eeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Sh9oyYt_Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Sh9oyot_Eeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Sh9oy4t_Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Sh9ozIt_Eeiu6boZkiJHCA" x="-58" y="-15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Sh9ozYt_Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Sh9ozot_Eeiu6boZkiJHCA" x="54" y="-18"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Sh9owYt_Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_6KewsINHEeelF8AE_WZtHQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Sh9owot_Eeiu6boZkiJHCA" points="[-151, 265, -643984, -643984]$[326, 211, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VJoOkIt_Eeiu6boZkiJHCA" id="(1.0,0.3629032258064516)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UzlGEIt_Eeiu6boZkiJHCA" id="(0.0,0.8920454545454546)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LbjWQMWUEeiWCKGKl1wb8w" id="(0.47289156626506024,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_XUwpYIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeWqknMLEeeSiaQ95-6r9w" target="_4QU_AHMeEeeSiaQ95-6r9w">
       <children xmi:type="notation:DecorationNode" xmi:id="_XUwpY4t_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -4922,13 +4787,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_XUxQc4t_Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZdHdAIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_XUxQdIt_Eeiu6boZkiJHCA" x="-7" y="-16"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XUxQdIt_Eeiu6boZkiJHCA" x="-15" y="-15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_XUwpYYt_Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XUwpYot_Eeiu6boZkiJHCA" points="[-250, 131, -643984, -643984]$[-250, 209, -643984, -643984]$[326, 199, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y5S-QIt_Eeiu6boZkiJHCA" id="(0.5,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y5S-QYt_Eeiu6boZkiJHCA" id="(0.0,0.5909090909090909)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y5S-QYt_Eeiu6boZkiJHCA" id="(0.0,0.65)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_XU3XFIt_Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_XUwpYIt_Eeiu6boZkiJHCA" target="_XU3XEIt_Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_XU3XFYt_Eeiu6boZkiJHCA"/>
@@ -4981,41 +4846,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fR-Xmot_Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fR-Xm4t_Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_oUruMIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeWqknMLEeeSiaQ95-6r9w" target="_LeWq83MLEeeSiaQ95-6r9w">
-      <children xmi:type="notation:DecorationNode" xmi:id="_oUsVQIt_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oUsVQYt_Eeiu6boZkiJHCA" x="5" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oUsVQot_Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oUsVQ4t_Eeiu6boZkiJHCA" x="-13" y="4"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oUsVRIt_Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oUsVRYt_Eeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oUsVRot_Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oUsVR4t_Eeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oUsVSIt_Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oUsVSYt_Eeiu6boZkiJHCA" x="-2" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oUsVSot_Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oUsVS4t_Eeiu6boZkiJHCA" x="-1" y="18"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_oUruMYt_Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oUruMot_Eeiu6boZkiJHCA" points="[-259, 131, -643984, -643984]$[-266, 217, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piPGcIt_Eeiu6boZkiJHCA" id="(0.15298507462686567,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p9xy8It_Eeiu6boZkiJHCA" id="(0.2,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_oU8M54t_Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_oUruMIt_Eeiu6boZkiJHCA" target="_oU8M44t_Eeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_oU8M6It_Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oU8z8ot_Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oU8M6Yt_Eeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oU8z8It_Eeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oU8z8Yt_Eeiu6boZkiJHCA"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_58U9hIuDEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_58U9gIuDEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_58U9hYuDEeiu6boZkiJHCA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_58VkkouDEeiu6boZkiJHCA" name="BASE_ELEMENT">
@@ -5055,6 +4885,66 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZD3JlpwUEeidac_mNnugIw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZD3Jl5wUEeidac_mNnugIw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZD3JmJwUEeidac_mNnugIw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_X9vlJMWMEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_X9vlIMWMEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X9vlJcWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X9vlKcWMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X9vlJsWMEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X9vlJ8WMEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X9vlKMWMEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ysuLZMWbEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_ysuLYMWbEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ysuLZcWbEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysuLacWbEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ysuLZsWbEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysuLZ8WbEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysuLaMWbEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CxwqIMY9Eeitrfx5M35Hug" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_CxsYsMY9Eeitrfx5M35Hug">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CxwqIcY9Eeitrfx5M35Hug"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CxxRMMY9Eeitrfx5M35Hug" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CxwqIsY9Eeitrfx5M35Hug" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CxwqI8Y9Eeitrfx5M35Hug"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CxwqJMY9Eeitrfx5M35Hug"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UTGtAccZEeiSV9wVm02xsw" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_UTGF8McZEeiSV9wVm02xsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UTGtAscZEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTHUEMcZEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UTGtA8cZEeiSV9wVm02xsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTGtBMcZEeiSV9wVm02xsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTGtBccZEeiSV9wVm02xsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_X1TocMcZEeiSV9wVm02xsw" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_X1TBYMcZEeiSV9wVm02xsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X1TocccZEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X1TodccZEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X1TocscZEeiSV9wVm02xsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X1Toc8cZEeiSV9wVm02xsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X1TodMcZEeiSV9wVm02xsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hnPAEccaEeiSV9wVm02xsw" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_hnOZAMcaEeiSV9wVm02xsw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hnPAEscaEeiSV9wVm02xsw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hnPAFscaEeiSV9wVm02xsw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hnPAE8caEeiSV9wVm02xsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hnPAFMcaEeiSV9wVm02xsw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hnPAFccaEeiSV9wVm02xsw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_QUOkQHMcEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamJobDetails" measurementUnit="Pixel">
@@ -6191,6 +6081,30 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MLr0kpsUEeid4dfn4JFJZg" x="300" y="47"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_WplOkMWMEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WplOkcWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WplOk8WMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WplOksWMEeiWCKGKl1wb8w" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Jrzg0MWdEeiWCKGKl1wb8w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Jrzg0cWdEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jrzg08WdEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jrzg0sWdEeiWCKGKl1wb8w" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7bVZsMY9Eeitrfx5M35Hug" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7bVZscY9Eeitrfx5M35Hug"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7bVZs8Y9Eeitrfx5M35Hug" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7bVZssY9Eeitrfx5M35Hug" x="300" y="47"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_QUOkQXMcEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_QUOkQnMcEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OKYWwIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -6614,7 +6528,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_zPpVAYuBEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zPpVAouBEeiu6boZkiJHCA" points="[230, -25, -643984, -643984]$[239, 47, -643984, -643984]"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0zj-0IuBEeiu6boZkiJHCA" id="(0.40066225165562913,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0zj-0IuBEeiu6boZkiJHCA" id="(0.3543046357615894,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_zUVnx4uBEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_zPpVAIuBEeiu6boZkiJHCA" target="_zUVnw4uBEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_zUVnyIuBEeiu6boZkiJHCA"/>
@@ -6888,6 +6802,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLr0l5sUEeid4dfn4JFJZg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLr0mJsUEeid4dfn4JFJZg"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WplOlMWMEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_WplOkMWMEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WplOlcWMEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WplOmcWMEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WplOlsWMEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WplOl8WMEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WplOmMWMEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Jrzg1MWdEeiWCKGKl1wb8w" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_Jrzg0MWdEeiWCKGKl1wb8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Jrzg1cWdEeiWCKGKl1wb8w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jrzg2cWdEeiWCKGKl1wb8w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Jrzg1sWdEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jrzg18WdEeiWCKGKl1wb8w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jrzg2MWdEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7bVZtMY9Eeitrfx5M35Hug" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_7bVZsMY9Eeitrfx5M35Hug">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7bVZtcY9Eeitrfx5M35Hug"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7bWAwcY9Eeitrfx5M35Hug" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7bVZtsY9Eeitrfx5M35Hug" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7bVZt8Y9Eeitrfx5M35Hug"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7bWAwMY9Eeitrfx5M35Hug"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_DvMJsINfEeelF8AE_WZtHQ" type="PapyrusUMLClassDiagram" name="OamConnSkeleton" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_DvMJsYNfEeelF8AE_WZtHQ" type="Class_Shape">
@@ -6914,7 +6858,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMwxoNfEeelF8AE_WZtHQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMw8INfEeelF8AE_WZtHQ" x="-471" y="109" width="124" height="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMw8INfEeelF8AE_WZtHQ" x="-466" y="-2" width="124" height="60"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DvMw8YNfEeelF8AE_WZtHQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DvMw8oNfEeelF8AE_WZtHQ" showTitle="true"/>
@@ -6958,40 +6902,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMxdYNfEeelF8AE_WZtHQ" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_DvMxdoNfEeelF8AE_WZtHQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_DvMxd4NfEeelF8AE_WZtHQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DvMxeINfEeelF8AE_WZtHQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DvMxeYNfEeelF8AE_WZtHQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_DvMxeoNfEeelF8AE_WZtHQ" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_DvMxe4NfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_DvMxfINfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_DvMxfYNfEeelF8AE_WZtHQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMxfoNfEeelF8AE_WZtHQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_DvMxf4NfEeelF8AE_WZtHQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_DvMxgINfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_DvMxgYNfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_DvMxgoNfEeelF8AE_WZtHQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMxg4NfEeelF8AE_WZtHQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_DvMxhINfEeelF8AE_WZtHQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_DvMxhYNfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_DvMxhoNfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_DvMxh4NfEeelF8AE_WZtHQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMxiINfEeelF8AE_WZtHQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMxsoNfEeelF8AE_WZtHQ" x="-412" y="-32" width="148" height="63"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_DvMxs4NfEeelF8AE_WZtHQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_DvMxtINfEeelF8AE_WZtHQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvMxtYNfEeelF8AE_WZtHQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMx1oNfEeelF8AE_WZtHQ" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_DvMx14NfEeelF8AE_WZtHQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_DvMx2INfEeelF8AE_WZtHQ" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_DvMx2YNfEeelF8AE_WZtHQ" type="Class_FloatingNameLabel">
@@ -7016,7 +6926,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMx6YNfEeelF8AE_WZtHQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMyE4NfEeelF8AE_WZtHQ" x="-302" y="110" width="120" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMyE4NfEeelF8AE_WZtHQ" x="-306" y="-1" width="120" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DvMyFINfEeelF8AE_WZtHQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DvMyFYNfEeelF8AE_WZtHQ" showTitle="true"/>
@@ -7156,7 +7066,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMy_4NfEeelF8AE_WZtHQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMzKYNfEeelF8AE_WZtHQ" x="-311" y="-317" width="235" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvMzKYNfEeelF8AE_WZtHQ" x="-311" y="-317" width="289" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DvMzKoNfEeelF8AE_WZtHQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DvMzK4NfEeelF8AE_WZtHQ" showTitle="true"/>
@@ -7749,7 +7659,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNYMoNfEeelF8AE_WZtHQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_XTF4sGNWEee0bPnI-Gt-mQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNYXINfEeelF8AE_WZtHQ" x="-406" y="256" width="168" height="63"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNYXINfEeelF8AE_WZtHQ" x="-437" y="166" width="222" height="63"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DvNYXYNfEeelF8AE_WZtHQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DvNYXoNfEeelF8AE_WZtHQ" showTitle="true"/>
@@ -7943,7 +7853,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNae4NfEeelF8AE_WZtHQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNapYNfEeelF8AE_WZtHQ" x="-25" y="257" width="167" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNapYNfEeelF8AE_WZtHQ" x="-24" y="153" width="167" height="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DvNapoNfEeelF8AE_WZtHQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DvNap4NfEeelF8AE_WZtHQ" showTitle="true"/>
@@ -8000,40 +7910,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNbn4NfEeelF8AE_WZtHQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_DvNbrINfEeelF8AE_WZtHQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_DvNbrYNfEeelF8AE_WZtHQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DvNbroNfEeelF8AE_WZtHQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DvNbr4NfEeelF8AE_WZtHQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_DvNbsINfEeelF8AE_WZtHQ" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_DvNbsYNfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_DvNbsoNfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_DvNbs4NfEeelF8AE_WZtHQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNbtINfEeelF8AE_WZtHQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_DvNbtYNfEeelF8AE_WZtHQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_DvNbtoNfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_DvNbt4NfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_DvNbuINfEeelF8AE_WZtHQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNbuYNfEeelF8AE_WZtHQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_DvNbuoNfEeelF8AE_WZtHQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_DvNbu4NfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_DvNbvINfEeelF8AE_WZtHQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_DvNbvYNfEeelF8AE_WZtHQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNbvoNfEeelF8AE_WZtHQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNb6INfEeelF8AE_WZtHQ" x="440" y="-12" width="181" height="66"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_DvNb6YNfEeelF8AE_WZtHQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_DvNb6oNfEeelF8AE_WZtHQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvNb64NfEeelF8AE_WZtHQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvNcDINfEeelF8AE_WZtHQ" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_u0jyV1nbEeitcM-j9IIMGg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_u0jyWFnbEeitcM-j9IIMGg" showTitle="true"/>
@@ -8355,14 +8231,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2f024ouCEeiu6boZkiJHCA" x="-255" y="-275"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_75Pyo4uCEeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_75PypIuCEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_75PypouCEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_75PypYuCEeiu6boZkiJHCA" x="-255" y="-275"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_93dy0IuCEeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_93dy0YuCEeiu6boZkiJHCA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_93dy04uCEeiu6boZkiJHCA" name="BASE_ELEMENT">
@@ -8395,14 +8263,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U__0pYuDEeiu6boZkiJHCA" x="727" y="-281"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZjLr84uDEeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZjLr9IuDEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZjMTAIuDEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZjLr9YuDEeiu6boZkiJHCA" x="727" y="-281"/>
-    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_DvNcGYNfEeelF8AE_WZtHQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_DvNcGoNfEeelF8AE_WZtHQ"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OKqqoIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -8428,16 +8288,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvNcJYNfEeelF8AE_WZtHQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvNcJoNfEeelF8AE_WZtHQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvNcJ4NfEeelF8AE_WZtHQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DvNcKINfEeelF8AE_WZtHQ" type="StereotypeCommentLink" source="_DvMxdoNfEeelF8AE_WZtHQ" target="_DvMxs4NfEeelF8AE_WZtHQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_DvNcKYNfEeelF8AE_WZtHQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvNcKoNfEeelF8AE_WZtHQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvNcK4NfEeelF8AE_WZtHQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvNcLINfEeelF8AE_WZtHQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvNcLYNfEeelF8AE_WZtHQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DvNcLoNfEeelF8AE_WZtHQ" type="StereotypeCommentLink" source="_DvMx14NfEeelF8AE_WZtHQ" target="_DvMyFINfEeelF8AE_WZtHQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_DvNcL4NfEeelF8AE_WZtHQ"/>
@@ -8767,16 +8617,18 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DvOA4INfEeelF8AE_WZtHQ" type="Abstraction_Edge" source="_DvNYIINfEeelF8AE_WZtHQ" target="_DvNaaYNfEeelF8AE_WZtHQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_DvOA4YNfEeelF8AE_WZtHQ" type="Abstraction_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DvOA4oNfEeelF8AE_WZtHQ" x="-18" y="-9"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_b1Yg4MWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DvOA4oNfEeelF8AE_WZtHQ" x="-18" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_DvOA44NfEeelF8AE_WZtHQ" type="Abstraction_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DvOA5INfEeelF8AE_WZtHQ" x="-18" y="16"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_b4jJoMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DvOA5INfEeelF8AE_WZtHQ" x="-17" y="15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_DvOA5YNfEeelF8AE_WZtHQ"/>
       <element xmi:type="uml:Abstraction" href="TapiOam.uml#_GyHvYGY4EeeB_84HvuxJBw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvOA6YNfEeelF8AE_WZtHQ" points="[0, 0, -317, -37]$[299, 34, -18, -3]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvOA6YNfEeelF8AE_WZtHQ" points="[-237, 199, -643984, -643984]$[-42, 195, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOA6oNfEeelF8AE_WZtHQ" id="(1.0,0.5238095238095238)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOA64NfEeelF8AE_WZtHQ" id="(0.0,0.5344827586206896)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOA64NfEeelF8AE_WZtHQ" id="(0.0,0.625)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DvOA7INfEeelF8AE_WZtHQ" type="StereotypeCommentLink" source="_DvOA4INfEeelF8AE_WZtHQ" target="_DvNbK4NfEeelF8AE_WZtHQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_DvOA7YNfEeelF8AE_WZtHQ"/>
@@ -8805,16 +8657,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvOBHYNfEeelF8AE_WZtHQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOBHoNfEeelF8AE_WZtHQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOBH4NfEeelF8AE_WZtHQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DvOBOoNfEeelF8AE_WZtHQ" type="StereotypeCommentLink" source="_DvNbrINfEeelF8AE_WZtHQ" target="_DvNb6YNfEeelF8AE_WZtHQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_DvOBO4NfEeelF8AE_WZtHQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvOBPINfEeelF8AE_WZtHQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvOBPYNfEeelF8AE_WZtHQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOBPoNfEeelF8AE_WZtHQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvOBP4NfEeelF8AE_WZtHQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VBoo0IuCEeiu6boZkiJHCA" type="Association_Edge" source="_DvMyhINfEeelF8AE_WZtHQ" target="_DvMxFYNfEeelF8AE_WZtHQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_VBpP4IuCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -8874,7 +8716,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aET4gouCEeiu6boZkiJHCA" points="[-260, -389, -643984, -643984]$[-213, -317, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a8gr0IuCEeiu6boZkiJHCA" id="(0.8797814207650273,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWCmIIuCEeiu6boZkiJHCA" id="(0.42127659574468085,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWCmIIuCEeiu6boZkiJHCA" id="(0.34256055363321797,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_aEv9ZIuCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_aET4gIuCEeiu6boZkiJHCA" target="_aEv9YIuCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_aEv9ZYuCEeiu6boZkiJHCA"/>
@@ -8908,7 +8750,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_dCb2gYuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dCb2gouCEeiu6boZkiJHCA" points="[-222, -259, -643984, -643984]$[-303, -175, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eGQrAIuCEeiu6boZkiJHCA" id="(0.12340425531914893,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eGQrAIuCEeiu6boZkiJHCA" id="(0.10034602076124567,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eYayAIuCEeiu6boZkiJHCA" id="(0.7032520325203252,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dDAeR4uCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_dCb2gIuCEeiu6boZkiJHCA" target="_dDAeQ4uCEeiu6boZkiJHCA">
@@ -8943,8 +8785,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_gRVbcYuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gRVbcouCEeiu6boZkiJHCA" points="[-163, -259, -643984, -643984]$[-71, -174, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hGHHUIuCEeiu6boZkiJHCA" id="(0.8723404255319149,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hscHgIuCEeiu6boZkiJHCA" id="(0.11046511627906977,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hGHHUIuCEeiu6boZkiJHCA" id="(0.8477508650519031,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hscHgIuCEeiu6boZkiJHCA" id="(0.3430232558139535,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_gSHel4uCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_gRVbcIuCEeiu6boZkiJHCA" target="_gSHek4uCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_gSHemIuCEeiu6boZkiJHCA"/>
@@ -9097,28 +8939,34 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_2fZZEIuCEeiu6boZkiJHCA" type="Association_Edge" source="_DvMxFYNfEeelF8AE_WZtHQ" target="_DvMJsYNfEeelF8AE_WZtHQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_2fZZE4uCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2fZZFIuCEeiu6boZkiJHCA" x="-41" y="-4"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_axDWEMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2fZZFIuCEeiu6boZkiJHCA" x="11" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_2fZZFYuCEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2fZZFouCEeiu6boZkiJHCA" x="-56" y="-1"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_a0AjcMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2fZZFouCEeiu6boZkiJHCA" x="-10" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_2fZZF4uCEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAIIuCEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_a3D3cMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAIIuCEeiu6boZkiJHCA" x="33" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_2faAIYuCEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAIouCEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_a5WWcMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAIouCEeiu6boZkiJHCA" x="-33" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_2faAI4uCEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAJIuCEeiu6boZkiJHCA" x="-18" y="15"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_a7coMMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAJIuCEeiu6boZkiJHCA" x="15" y="15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_2faAJYuCEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAJouCEeiu6boZkiJHCA" x="26" y="17"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_a-f8MMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2faAJouCEeiu6boZkiJHCA" x="-7" y="17"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_2fZZEYuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2fZZEouCEeiu6boZkiJHCA" points="[-341, -114, -643984, -643984]$[-401, 109, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YyfMIuCEeiu6boZkiJHCA" id="(0.07317073170731707,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_339ugIuCEeiu6boZkiJHCA" id="(0.27419354838709675,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YyfMIuCEeiu6boZkiJHCA" id="(0.2032520325203252,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_339ugIuCEeiu6boZkiJHCA" id="(0.49193548387096775,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_2f025IuCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_2fZZEIuCEeiu6boZkiJHCA" target="_2f024IuCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_2f025YuCEeiu6boZkiJHCA"/>
@@ -9130,62 +8978,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2f0254uCEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2f026IuCEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_75C-UIuCEeiu6boZkiJHCA" type="Association_Edge" source="_DvMxFYNfEeelF8AE_WZtHQ" target="_DvMxdoNfEeelF8AE_WZtHQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_75C-U4uCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_75C-VIuCEeiu6boZkiJHCA" x="14" y="-3"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_75C-VYuCEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_75C-VouCEeiu6boZkiJHCA" x="-4" y="-1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_75C-V4uCEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_75C-WIuCEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_75C-WYuCEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_75C-WouCEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_75C-W4uCEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_75C-XIuCEeiu6boZkiJHCA" y="-21"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_75C-XYuCEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_75C-XouCEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_75C-UYuCEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_75C-UouCEeiu6boZkiJHCA" points="[-338, -114, -643984, -643984]$[-332, -32, -643984, -643984]"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_75Pyp4uCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_75C-UIuCEeiu6boZkiJHCA" target="_75Pyo4uCEeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_75PyqIuCEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_75QZsouCEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_75PyqYuCEeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_75QZsIuCEeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_75QZsYuCEeiu6boZkiJHCA"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_93PwYIuCEeiu6boZkiJHCA" type="Association_Edge" source="_DvMxFYNfEeelF8AE_WZtHQ" target="_DvMx14NfEeelF8AE_WZtHQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_93PwY4uCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXcIuCEeiu6boZkiJHCA" x="-44" y="-14"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bTetsMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXcIuCEeiu6boZkiJHCA" x="14" y="-5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_93QXcYuCEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXcouCEeiu6boZkiJHCA" x="-58" y="-5"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bVYyMMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXcouCEeiu6boZkiJHCA" x="-5" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_93QXc4uCEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXdIuCEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bYoTcMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXdIuCEeiu6boZkiJHCA" x="34" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_93QXdYuCEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXdouCEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bbNGUMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXdouCEeiu6boZkiJHCA" x="-34" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_93QXd4uCEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXeIuCEeiu6boZkiJHCA" x="-21" y="-15"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_beENEMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXeIuCEeiu6boZkiJHCA" x="13" y="-15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_93QXeYuCEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXeouCEeiu6boZkiJHCA" x="22" y="-12"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bhIvMMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_93QXeouCEeiu6boZkiJHCA" x="-12" y="-12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_93PwYYuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_93PwYouCEeiu6boZkiJHCA" points="[-323, -114, -643984, -643984]$[-252, 110, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-sLNQIuCEeiu6boZkiJHCA" id="(0.8983739837398373,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-sLNQIuCEeiu6boZkiJHCA" id="(0.8780487804878049,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_byzuAMWTEeiWCKGKl1wb8w" id="(0.5583333333333333,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_93dy1IuCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_93PwYIuCEeiu6boZkiJHCA" target="_93dy0IuCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_93dy1YuCEeiu6boZkiJHCA"/>
@@ -9197,80 +9019,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_93dy14uCEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_93dy2IuCEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AtWa0IuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvMxdoNfEeelF8AE_WZtHQ" target="_DvMx14NfEeelF8AE_WZtHQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_AtXB4IuDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtXB4YuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_AtXB4ouDEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtXB44uDEeiu6boZkiJHCA" y="-4"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_AtXB5IuDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtXB5YuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_AtXB5ouDEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtXB54uDEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_AtXB6IuDEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtXB6YuDEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_AtXB6ouDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtXB64uDEeiu6boZkiJHCA" x="1" y="10"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_AtWa0YuDEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_6281IINHEeelF8AE_WZtHQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AtWa0ouDEeiu6boZkiJHCA" points="[-317, 31, -643984, -643984]$[-262, 110, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CzwtsIuDEeiu6boZkiJHCA" id="(0.8918918918918919,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DaCqkIuDEeiu6boZkiJHCA" id="(0.18333333333333332,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FDvMQIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvMxdoNfEeelF8AE_WZtHQ" target="_DvMJsYNfEeelF8AE_WZtHQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_FDvMQ4uDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_FDvMRIuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_FDvMRYuDEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_FDvMRouDEeiu6boZkiJHCA"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_FDvMR4uDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_FDvMSIuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_FDvMSYuDEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_FDvMSouDEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_FDvMS4uDEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_FDvMTIuDEeiu6boZkiJHCA" x="1" y="-19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_FDvMTYuDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_FDvMTouDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_FDvMQYuDEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_6KewsINHEeelF8AE_WZtHQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FDvMQouDEeiu6boZkiJHCA" points="[-355, 31, -643984, -643984]$[-394, 109, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G4uX8IuDEeiu6boZkiJHCA" id="(0.18243243243243243,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HQfXsIuDEeiu6boZkiJHCA" id="(0.6935483870967742,0.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Iq4SEIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvNYIINfEeelF8AE_WZtHQ" target="_DvMJsYNfEeelF8AE_WZtHQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_Iq45IIuDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45IYuDEeiu6boZkiJHCA" x="-11" y="-19"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bB-G8MWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45IYuDEeiu6boZkiJHCA" x="-3" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Iq45IouDEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45I4uDEeiu6boZkiJHCA" x="2" y="-18"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bFi_YMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45I4uDEeiu6boZkiJHCA" x="8" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Iq45JIuDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45JYuDEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bIlsUMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45JYuDEeiu6boZkiJHCA" x="13" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Iq45JouDEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45J4uDEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bMhKEMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45J4uDEeiu6boZkiJHCA" x="-13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Iq45KIuDEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45KYuDEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bO_2UMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45KYuDEeiu6boZkiJHCA" x="13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Iq45KouDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45K4uDEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bQ560MWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iq45K4uDEeiu6boZkiJHCA" x="-13" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Iq4SEYuDEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_mncXEGNXEee0bPnI-Gt-mQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Iq4SEouDEeiu6boZkiJHCA" points="[-341, 256, -643984, -643984]$[-392, 169, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2tMAIuDEeiu6boZkiJHCA" id="(0.17857142857142858,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KR5TMIuDEeiu6boZkiJHCA" id="(0.7661290322580645,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Iq4SEouDEeiu6boZkiJHCA" points="[-340, 166, -643984, -643984]$[-391, 79, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2tMAIuDEeiu6boZkiJHCA" id="(0.15765765765765766,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KR5TMIuDEeiu6boZkiJHCA" id="(0.5161290322580645,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Irn49IuDEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_Iq4SEIuDEeiu6boZkiJHCA" target="_Irn48IuDEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Irn49YuDEeiu6boZkiJHCA"/>
@@ -9284,28 +9062,34 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LlY7YIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvNYIINfEeelF8AE_WZtHQ" target="_DvMx14NfEeelF8AE_WZtHQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_LlZicIuDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZicYuDEeiu6boZkiJHCA" x="-8" y="3"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bj69cMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZicYuDEeiu6boZkiJHCA" x="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_LlZicouDEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZic4uDEeiu6boZkiJHCA" x="5" y="-4"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bmTjEMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZic4uDEeiu6boZkiJHCA" x="12" y="-4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_LlZidIuDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZidYuDEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_boTuMMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZidYuDEeiu6boZkiJHCA" x="13" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_LlZidouDEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZid4uDEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bqsT0MWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZid4uDEeiu6boZkiJHCA" x="-13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_LlZieIuDEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZieYuDEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_btLAEMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlZieYuDEeiu6boZkiJHCA" x="13" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_LlaJgIuDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlaJgYuDEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bvqTYMWTEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LlaJgYuDEeiu6boZkiJHCA" x="-13" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_LlY7YYuDEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_GrFIIGNXEee0bPnI-Gt-mQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LlY7YouDEeiu6boZkiJHCA" points="[-306, 256, -643984, -643984]$[-258, 168, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MrirIIuDEeiu6boZkiJHCA" id="(0.8095238095238095,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NP4uUIuDEeiu6boZkiJHCA" id="(0.26666666666666666,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LlY7YouDEeiu6boZkiJHCA" points="[-305, 166, -643984, -643984]$[-257, 78, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MrirIIuDEeiu6boZkiJHCA" id="(0.8513513513513513,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NP4uUIuDEeiu6boZkiJHCA" id="(0.48333333333333334,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Lmpfp4uDEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_LlY7YIuDEeiu6boZkiJHCA" target="_Lmpfo4uDEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_LmpfqIuDEeiu6boZkiJHCA"/>
@@ -9317,39 +9101,14 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LmqGsIuDEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LmqGsYuDEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PSZ_sIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvMxdoNfEeelF8AE_WZtHQ" target="_DvNbrINfEeelF8AE_WZtHQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_PSamwIuDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSamwYuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PSamwouDEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSamw4uDEeiu6boZkiJHCA" x="-23" y="-12"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PSamxIuDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSamxYuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PSamxouDEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSamx4uDEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PSamyIuDEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSamyYuDEeiu6boZkiJHCA" x="-93" y="-12"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PSamyouDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSamy4uDEeiu6boZkiJHCA" x="92" y="-10"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_PSZ_sYuDEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_AiipgINJEeelF8AE_WZtHQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PSZ_souDEeiu6boZkiJHCA" points="[-264, 1, -643984, -643984]$[440, 18, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q3DpUIuDEeiu6boZkiJHCA" id="(1.0,0.7142857142857143)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWrgIIuDEeiu6boZkiJHCA" id="(0.0,0.3787878787878788)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_U-pJwIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvNbP4NfEeelF8AE_WZtHQ" target="_DvNaaYNfEeelF8AE_WZtHQ">
+    <edges xmi:type="notation:Connector" xmi:id="_U-pJwIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvNbP4NfEeelF8AE_WZtHQ" target="_DvNaaYNfEeelF8AE_WZtHQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_U-pJw4uDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WHXsYIuDEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U-pJxIuDEeiu6boZkiJHCA" x="-54" y="322"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U-pJxIuDEeiu6boZkiJHCA" x="-80" y="177"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U-pJxYuDEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WI3hMIuDEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U-pJxouDEeiu6boZkiJHCA" x="-52" y="338"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U-pJxouDEeiu6boZkiJHCA" x="-77" y="191"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U-pJx4uDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WKstMIuDEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -9365,13 +9124,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U-pJzYuDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WRyMoIuDEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U-pJzouDEeiu6boZkiJHCA" x="-30" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U-pJzouDEeiu6boZkiJHCA" x="-18" y="-12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_U-pJwYuDEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U-pJwouDEeiu6boZkiJHCA" points="[649, -118, -643984, -643984]$[649, 293, -643984, -643984]$[142, 293, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WE94oIuDEeiu6boZkiJHCA" id="(0.7721518987341772,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WE94oYuDEeiu6boZkiJHCA" id="(1.0,0.6206896551724138)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U-pJwouDEeiu6boZkiJHCA" points="[614, -118, -643984, -643984]$[614, 203, -643984, -643984]$[143, 203, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WE94oIuDEeiu6boZkiJHCA" id="(0.5506329113924051,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WE94oYuDEeiu6boZkiJHCA" id="(1.0,0.6944444444444444)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_U__0p4uDEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_U-pJwIuDEeiu6boZkiJHCA" target="_U__0o4uDEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_U__0qIuDEeiu6boZkiJHCA"/>
@@ -9383,42 +9142,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VAAbsIuDEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VAAbsYuDEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZiJKIIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvNbP4NfEeelF8AE_WZtHQ" target="_DvNbrINfEeelF8AE_WZtHQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZiJxMIuDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZiJxMYuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZiJxMouDEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZiJxM4uDEeiu6boZkiJHCA" x="-12" y="-8"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZiJxNIuDEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZiJxNYuDEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZiJxNouDEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZiJxN4uDEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZiJxOIuDEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZiJxOYuDEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZiJxOouDEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZiJxO4uDEeiu6boZkiJHCA" x="5" y="18"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZiJKIYuDEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZiJKIouDEeiu6boZkiJHCA" points="[592, -118, -643984, -643984]$[545, -12, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ci0F0IuDEeiu6boZkiJHCA" id="(0.18354430379746836,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_divRwIuDEeiu6boZkiJHCA" id="(0.6408839779005525,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZjMTAYuDEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_ZiJKIIuDEeiu6boZkiJHCA" target="_ZjLr84uDEeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZjMTAouDEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZjMTBouDEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZjMTA4uDEeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZjMTBIuDEeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZjMTBYuDEeiu6boZkiJHCA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iIwaoIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvM0foNfEeelF8AE_WZtHQ" target="_DvNZCoNfEeelF8AE_WZtHQ">
+    <edges xmi:type="notation:Connector" xmi:id="_iIwaoIuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvM0foNfEeelF8AE_WZtHQ" target="_DvNZCoNfEeelF8AE_WZtHQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_iIwao4uDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jMo5gIuDEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_iIwapIuDEeiu6boZkiJHCA" x="2" y="-17"/>
@@ -9445,11 +9169,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_iIwaoYuDEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_1fyYQGWwEeeiceLWmAD6ng"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iIwaoouDEeiu6boZkiJHCA" points="[-36, -116, -643984, -643984]$[-36, -45, -643984, -643984]$[395, -45, -643984, -643984]$[395, -113, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jKNQkIuDEeiu6boZkiJHCA" id="(0.5174418604651163,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iIwaoouDEeiu6boZkiJHCA" points="[4, -116, -643984, -643984]$[4, -43, -643984, -643984]$[395, -43, -643984, -643984]$[395, -113, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jKNQkIuDEeiu6boZkiJHCA" id="(0.7558139534883721,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jKNQkYuDEeiu6boZkiJHCA" id="(0.44329896907216493,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_meMJ0IuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvM0foNfEeelF8AE_WZtHQ" target="_DvNYqYNfEeelF8AE_WZtHQ">
+    <edges xmi:type="notation:Connector" xmi:id="_meMJ0IuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvM0foNfEeelF8AE_WZtHQ" target="_DvNYqYNfEeelF8AE_WZtHQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_meMJ04uDEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_nfTBgIuDEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_meMJ1IuDEeiu6boZkiJHCA" x="1" y="-18"/>
@@ -9476,8 +9200,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_meMJ0YuDEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ktOaAGWwEeeiceLWmAD6ng"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_meMJ0ouDEeiu6boZkiJHCA" points="[7, -116, -643984, -643984]$[7, -80, -643984, -643984]$[160, -80, -643984, -643984]$[141, -113, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nc4msIuDEeiu6boZkiJHCA" id="(0.7674418604651163,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_meMJ0ouDEeiu6boZkiJHCA" points="[27, -116, -643984, -643984]$[27, -80, -643984, -643984]$[160, -80, -643984, -643984]$[160, -113, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nc4msIuDEeiu6boZkiJHCA" id="(0.8895348837209303,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nc4msYuDEeiu6boZkiJHCA" id="(0.32919254658385094,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_q4BQ0IuDEeiu6boZkiJHCA" type="Association_Edge" source="_DvNZCoNfEeelF8AE_WZtHQ" target="_DvNYqYNfEeelF8AE_WZtHQ">
@@ -9510,6 +9234,99 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_q4BQ0ouDEeiu6boZkiJHCA" points="[316, -113, -643984, -643984]$[366, -80, -643984, -643984]$[208, -80, -643984, -643984]$[219, -113, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rqt5EIuDEeiu6boZkiJHCA" id="(0.29381443298969073,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rqt5EYuDEeiu6boZkiJHCA" id="(0.6273291925465838,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ddQoMMWUEeiWCKGKl1wb8w" type="Association_Edge" source="_DvNZCoNfEeelF8AE_WZtHQ" target="_DvNaaYNfEeelF8AE_WZtHQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ddQoM8WUEeiWCKGKl1wb8w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fPnWoMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddQoNMWUEeiWCKGKl1wb8w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ddQoNcWUEeiWCKGKl1wb8w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fSSQIMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddQoNsWUEeiWCKGKl1wb8w" x="-18" y="157"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ddQoN8WUEeiWCKGKl1wb8w" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fUq1wMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddQoOMWUEeiWCKGKl1wb8w" x="98" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ddQoOcWUEeiWCKGKl1wb8w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fWrA4MWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddQoOsWUEeiWCKGKl1wb8w" x="-98" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ddQoO8WUEeiWCKGKl1wb8w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fZoOQMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddQoPMWUEeiWCKGKl1wb8w" x="9" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ddQoPcWUEeiWCKGKl1wb8w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fc49oMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddQoPsWUEeiWCKGKl1wb8w" x="-9" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ddQoMcWUEeiWCKGKl1wb8w"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hF804HIzEeeSiaQ95-6r9w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ddQoMsWUEeiWCKGKl1wb8w" points="[465, -113, -643984, -643984]$[465, 174, -643984, -643984]$[143, 174, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fM2WgMWUEeiWCKGKl1wb8w" id="(0.8041237113402062,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fM2WgcWUEeiWCKGKl1wb8w" id="(1.0,0.2916666666666667)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5KT-EMWUEeiWCKGKl1wb8w" type="Association_Edge" source="_DvM0foNfEeelF8AE_WZtHQ" target="_DvMJsYNfEeelF8AE_WZtHQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KaEsMWUEeiWCKGKl1wb8w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9dg4oMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KaEscWUEeiWCKGKl1wb8w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KaEssWUEeiWCKGKl1wb8w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9gLyIMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KaEs8WUEeiWCKGKl1wb8w" x="-10" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KaEtMWUEeiWCKGKl1wb8w" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9iSD4MWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KaEtcWUEeiWCKGKl1wb8w" x="58" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KaEtsWUEeiWCKGKl1wb8w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9kwwIMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KaEt8WUEeiWCKGKl1wb8w" x="-58" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KaEuMWUEeiWCKGKl1wb8w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9nPcYMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KaEucWUEeiWCKGKl1wb8w" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KaEusWUEeiWCKGKl1wb8w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9qGjIMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KaEu8WUEeiWCKGKl1wb8w" x="-16" y="-14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5KT-EcWUEeiWCKGKl1wb8w"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_-sPnoHMgEeeSiaQ95-6r9w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5KT-EsWUEeiWCKGKl1wb8w" points="[-75, -116, -643984, -643984]$[-75, 16, -643984, -643984]$[-342, 16, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9bITAMWUEeiWCKGKl1wb8w" id="(0.29651162790697677,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9bITAcWUEeiWCKGKl1wb8w" id="(1.0,0.3)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5srEQMWUEeiWCKGKl1wb8w" type="Association_Edge" source="_DvM0foNfEeelF8AE_WZtHQ" target="_DvMx14NfEeelF8AE_WZtHQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5srEQ8WUEeiWCKGKl1wb8w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7X0-gMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5srERMWUEeiWCKGKl1wb8w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5srERcWUEeiWCKGKl1wb8w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7aZxYMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5srERsWUEeiWCKGKl1wb8w" x="15" y="63"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5srER8WUEeiWCKGKl1wb8w" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7dKxgMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5srESMWUEeiWCKGKl1wb8w" x="43" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5srEScWUEeiWCKGKl1wb8w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7ht6UMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5srESsWUEeiWCKGKl1wb8w" x="-43" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5srES8WUEeiWCKGKl1wb8w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7llGoMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5srETMWUEeiWCKGKl1wb8w" x="11" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5srETcWUEeiWCKGKl1wb8w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7pTJAMWUEeiWCKGKl1wb8w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5srETsWUEeiWCKGKl1wb8w" x="-13" y="11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5srEQcWUEeiWCKGKl1wb8w"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_GTLxYD2kEeihCtCrhJZ45g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5srEQsWUEeiWCKGKl1wb8w" points="[-32, -116, -643984, -643984]$[-32, 48, -643984, -643984]$[-186, 48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VWSQMWUEeiWCKGKl1wb8w" id="(0.5348837209302325,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VWSQcWUEeiWCKGKl1wb8w" id="(1.0,0.8448275862068966)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -13,10 +13,6 @@ License: This module is distributed under the Apache License 2.0</body>
         <generalization xmi:type="uml:Generalization" xmi:id="_rlQ1IE4pEeiMYveOdt1-rQ">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-sSD4HMgEeeSiaQ95-6r9w" name="_oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg" isReadOnly="true" association="_-sPnoHMgEeeSiaQ95-6r9w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_L6ubIHMhEeeSiaQ95-6r9w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_L6vCMHMhEeeSiaQ95-6r9w" value="1"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_d_jgcU8FEeiW8t12GIRjqQ" name="_state" aggregation="composite" association="_d_iSUE8FEeiW8t12GIRjqQ">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
         </ownedAttribute>
@@ -43,7 +39,7 @@ License: This module is distributed under the Apache License 2.0</body>
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_wd6JIZsXEeid4dfn4JFJZg" name="_oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg" association="_wd3s4JsXEeid4dfn4JFJZg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wd7-UJsXEeid4dfn4JFJZg" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wd7-UZsXEeid4dfn4JFJZg" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wd7-UZsXEeid4dfn4JFJZg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_w2_jUobmEeil5oKL3Vgl-g" name="_oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" association="_w25csIbmEeil5oKL3Vgl-g">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FuTwcIbnEeil5oKL3Vgl-g"/>
@@ -75,10 +71,6 @@ optionally one additional configurable (&lt; 15min)</body>
         <generalization xmi:type="uml:Generalization" xmi:id="_FSc8kPLuEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_khqLYMbMEeaVKq30FmMykA" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" isReadOnly="true" aggregation="composite" association="_kho9QMbMEeaVKq30FmMykA">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nJMOUMbMEeaVKq30FmMykA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nJPRoMbMEeaVKq30FmMykA" value="*"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_-ePpMMbMEeaVKq30FmMykA" name="_mep" type="_CE0kkLwmEeSpn78DYJKtkA" isReadOnly="true" aggregation="composite" association="_-eN0AMbMEeaVKq30FmMykA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_RdoaIHMNEeeSiaQ95-6r9w" annotatedElement="_-ePpMMbMEeaVKq30FmMykA">
             <body>1. ME may have 0 MEPs (case of transit domains where at least 1 MIP is present)&#xD;
@@ -113,32 +105,10 @@ optionally one additional configurable (&lt; 15min)</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dvzgELw1EeSpn78DYJKtkA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_iE9fcMbMEeaVKq30FmMykA" name="MaintenanceEntity">
-        <generalization xmi:type="uml:Generalization" xmi:id="_cBgHYPLuEeaAIfPpmDwI5Q">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-        </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_6Kews4NHEeelF8AE_WZtHQ" name="_mep" type="_CE0kkLwmEeSpn78DYJKtkA" isReadOnly="true" aggregation="shared" association="_6KewsINHEeelF8AE_WZtHQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GpjggINIEeelF8AE_WZtHQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GpkHkINIEeelF8AE_WZtHQ" value="2"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_629cMoNHEeelF8AE_WZtHQ" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" isReadOnly="true" aggregation="shared" association="_6281IINHEeelF8AE_WZtHQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_I_33oINIEeelF8AE_WZtHQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_I_5s0INIEeelF8AE_WZtHQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Aiipg4NJEeelF8AE_WZtHQ" name="_connectionRoute" isReadOnly="true" association="_AiipgINJEeelF8AE_WZtHQ">
-          <type xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QexqcINOEeelF8AE_WZtHQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Qe0twINOEeelF8AE_WZtHQ" value="1"/>
-        </ownedAttribute>
-      </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_k-OoENzEEeaMV83ubDcSig" name="Mip">
         <generalization xmi:type="uml:Generalization" xmi:id="_bPpzsPLuEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GTZz0D2kEeihCtCrhJZ45g" name="_oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg" association="_GTLxYD2kEeihCtCrhJZ45g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_O6ciID2kEeihCtCrhJZ45g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_O6eXUD2kEeihCtCrhJZ45g" value="1"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_DOW0IILIEeelF8AE_WZtHQ" name="layerProtocolName" isReadOnly="true">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
@@ -148,7 +118,7 @@ optionally one additional configurable (&lt; 15min)</body>
           <general xmi:type="uml:Class" href="TapiCommon.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_bsmIshP7EeepnPPr_BcZKg" name="_endPoint" type="_W48McBP7EeepnPPr_BcZKg" aggregation="composite" association="_bsgCEBP7EeepnPPr_BcZKg">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kW8CoBP7EeepnPPr_BcZKg" value="1"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kW8CoBP7EeepnPPr_BcZKg" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kXCJQBP7EeepnPPr_BcZKg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__n5DwNzDEeaMV83ubDcSig" name="_meg" type="_zR-agMbLEeaVKq30FmMykA" isReadOnly="true" aggregation="shared" association="__nuEoNzDEeaMV83ubDcSig">
@@ -213,6 +183,26 @@ optionally one additional configurable (&lt; 15min)</body>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hJpKQBocEeeV4o0osG5stg" name="direction">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cXcaMMWVEeiWCKGKl1wb8w" name="mepIdentifier">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AH0GQMWWEeiWCKGKl1wb8w" annotatedElement="_cXcaMMWVEeiWCKGKl1wb8w">
+            <body>This attribute contains the identifier of the MEP.&#xD;
+This attribute is empty in case the OSEP relates to the provisioing of an MIP.&#xD;
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gwgFIMWVEeiWCKGKl1wb8w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gwyZAMWVEeiWCKGKl1wb8w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ft704MWVEeiWCKGKl1wb8w" name="peerMepIdentifier">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wE_i4MWVEeiWCKGKl1wb8w" annotatedElement="_ft704MWVEeiWCKGKl1wb8w">
+            <body>This attribute models the MI_PeerMEP_ID[i] defined in G.8021 and configured as specified in G.8051. It provides the identifiers of the MEPs which are peer to the subject MEP.&#xD;
+This attribute is not specified in case the OSEP relates to the provisioing of an MIP.&#xD;
+In case of P2P, there is only one peer</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_i9nc8MWVEeiWCKGKl1wb8w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_i95w0MWVEeiWCKGKl1wb8w" value="*"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_XTF4sGNWEee0bPnI-Gt-mQ" name="MepMipList">
@@ -337,7 +327,7 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
       <packagedElement xmi:type="uml:Interface" xmi:id="_Nm0qoOxYEeaTUPmcu3rLwA" name="OamService">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_r-PDAMOdEeaFfJxGCRaf4A" name="createOamService">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_nNQpEE-oEeitY7qZgkO_XQ" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s39iEE-oEeitY7qZgkO_XQ" value="1"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s39iEE-oEeitY7qZgkO_XQ" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s3_-UE-oEeitY7qZgkO_XQ" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_w5FjQE-qEeitY7qZgkO_XQ" name="oamConstraint" type="_GVZfsE4-EeiMYveOdt1-rQ"/>
@@ -360,8 +350,8 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
         <ownedOperation xmi:type="uml:Operation" xmi:id="_mF1sQMOdEeaFfJxGCRaf4A" name="createOamJob">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_VJFbIJsZEeid4dfn4JFJZg" name="oamJobType" type="_tqiDYF3eEeit4-HSxnZlvw" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_0LKokJsYEeid4dfn4JFJZg" name="oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CtmUJsYEeid4dfn4JFJZg" value="1"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5C_6MJsYEeid4dfn4JFJZg" value="2"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CtmUJsYEeid4dfn4JFJZg" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5C_6MJsYEeid4dfn4JFJZg" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_bdSkIJsZEeid4dfn4JFJZg" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_C140oFg-Eei9GrLbn4i8vw" name="state">
@@ -457,6 +447,16 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_86ebkFg8Eei9GrLbn4i8vw" name="state" effect="update">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
           </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Sz5VcMWXEeiWCKGKl1wb8w" name="mepIdentifier">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UytLgMWXEeiWCKGKl1wb8w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UzLsoMWXEeiWCKGKl1wb8w" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_c_SycMWXEeiWCKGKl1wb8w" name="peerMepIdentifier">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eM84YMWXEeiWCKGKl1wb8w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eNbZgMWXEeiWCKGKl1wb8w" value="*"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_I2LDcFg7Eei9GrLbn4i8vw" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_GGP3IE5DEeiMYveOdt1-rQ" name="deleteOamServiceEndPoint">
@@ -493,15 +493,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_5sObUOvREealldJ4rm6P_g" name="Associations">
-      <packagedElement xmi:type="uml:Association" xmi:id="_kho9QMbMEeaVKq30FmMykA" name="MEGHasMEs" memberEnd="_khqLYMbMEeaVKq30FmMykA _khqLYcbMEeaVKq30FmMykA">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_khpkUMbMEeaVKq30FmMykA" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_khpkUcbMEeaVKq30FmMykA" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_khqLYcbMEeaVKq30FmMykA" name="_meg" type="_zR-agMbLEeaVKq30FmMykA" association="_kho9QMbMEeaVKq30FmMykA">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mEYiYMbMEeaVKq30FmMykA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mEblsMbMEeaVKq30FmMykA" value="1"/>
-        </ownedEnd>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_1i2mEMbNEeaVKq30FmMykA" name="ContextHasMegs" memberEnd="_1i30McbNEeaVKq30FmMykA _1i6QcMbNEeaVKq30FmMykA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1i3NIMbNEeaVKq30FmMykA" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1i30MMbNEeaVKq30FmMykA" key="nature" value="UML_Nature"/>
@@ -589,42 +580,23 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_GyHvYGY4EeeB_84HvuxJBw" name="MepMipListAugmentsCep" client="_XTF4sGNWEee0bPnI-Gt-mQ">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_-sPnoHMgEeeSiaQ95-6r9w" name="MEPRelatesToOSEP" memberEnd="_-sQ1wXMgEeeSiaQ95-6r9w _-sSD4HMgEeeSiaQ95-6r9w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_-sPnoHMgEeeSiaQ95-6r9w" name="OSEPRelatesToMEP" memberEnd="_-sQ1wXMgEeeSiaQ95-6r9w _-sSD4HMgEeeSiaQ95-6r9w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-sQOsHMgEeeSiaQ95-6r9w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_-sQ1wHMgEeeSiaQ95-6r9w" key="nature" value="UML_Nature"/>
         </eAnnotations>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_6KewsINHEeelF8AE_WZtHQ" name="MEHasMEPs" memberEnd="_6Kews4NHEeelF8AE_WZtHQ _6Kgl4INHEeelF8AE_WZtHQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6KewsYNHEeelF8AE_WZtHQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6KewsoNHEeelF8AE_WZtHQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_6Kgl4INHEeelF8AE_WZtHQ" name="me" type="_iE9fcMbMEeaVKq30FmMykA" association="_6KewsINHEeelF8AE_WZtHQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-9A1ED2jEeihCtCrhJZ45g" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__AYSID2jEeihCtCrhJZ45g" value="*"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_-sSD4HMgEeeSiaQ95-6r9w" name="_oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg" isReadOnly="true" association="_-sPnoHMgEeeSiaQ95-6r9w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_L6ubIHMhEeeSiaQ95-6r9w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_L6vCMHMhEeeSiaQ95-6r9w" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_6281IINHEeelF8AE_WZtHQ" name="MEHasMIPs" memberEnd="_629cMoNHEeelF8AE_WZtHQ _62-qUINHEeelF8AE_WZtHQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_629cMINHEeelF8AE_WZtHQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_629cMYNHEeelF8AE_WZtHQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_62-qUINHEeelF8AE_WZtHQ" name="me" type="_iE9fcMbMEeaVKq30FmMykA" association="_6281IINHEeelF8AE_WZtHQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BBdZED2kEeihCtCrhJZ45g" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BBfOQD2kEeihCtCrhJZ45g" value="*"/>
-        </ownedEnd>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_AiipgINJEeelF8AE_WZtHQ" name="MEMonitorsConnectionRoute" memberEnd="_Aiipg4NJEeelF8AE_WZtHQ _AijQkoNJEeelF8AE_WZtHQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AiipgYNJEeelF8AE_WZtHQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AiipgoNJEeelF8AE_WZtHQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_AijQkoNJEeelF8AE_WZtHQ" name="me" type="_iE9fcMbMEeaVKq30FmMykA" association="_AiipgINJEeelF8AE_WZtHQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RV8jAINOEeelF8AE_WZtHQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RV-_QINOEeelF8AE_WZtHQ" value="1"/>
-        </ownedEnd>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_GTLxYD2kEeihCtCrhJZ45g" name="MIPRelatesToOSEP" memberEnd="_GTViYD2kEeihCtCrhJZ45g _GTZz0D2kEeihCtCrhJZ45g">
+      <packagedElement xmi:type="uml:Association" xmi:id="_GTLxYD2kEeihCtCrhJZ45g" name="OSEPRelatesToMIP" memberEnd="_GTViYD2kEeihCtCrhJZ45g _GTZz0D2kEeihCtCrhJZ45g">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_GTTGID2kEeihCtCrhJZ45g" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_GTTtMD2kEeihCtCrhJZ45g" key="nature" value="UML_Nature"/>
         </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_GTZz0D2kEeihCtCrhJZ45g" name="_oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg" association="_GTLxYD2kEeihCtCrhJZ45g">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_O6ciID2kEeihCtCrhJZ45g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_O6eXUD2kEeihCtCrhJZ45g" value="1"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_KAXjIE4eEeiMYveOdt1-rQ" name="JobHasAdminStatePac" memberEnd="_KAXjI04eEeiMYveOdt1-rQ _KAdpwU4eEeiMYveOdt1-rQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_KAXjIU4eEeiMYveOdt1-rQ" source="org.eclipse.papyrus">
@@ -768,8 +740,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelAttribute xmi:id="__D9ft-vSEealldJ4rm6P_g" base_StructuralFeature="_QVmjwLxAEeSpn78DYJKtkA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__D9fvuvSEealldJ4rm6P_g" base_StructuralFeature="_z2aJ0LxAEeSpn78DYJKtkA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="__D9f3-vSEealldJ4rm6P_g" base_Class="_zR-agMbLEeaVKq30FmMykA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="__D9f4OvSEealldJ4rm6P_g" base_StructuralFeature="_khqLYMbMEeaVKq30FmMykA"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="__D9f5evSEealldJ4rm6P_g" base_Class="_iE9fcMbMEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__D9f5uvSEealldJ4rm6P_g" base_StructuralFeature="_-ePpMMbMEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__D9f8OvSEealldJ4rm6P_g" base_StructuralFeature="_1i30McbNEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__D9f9uvSEealldJ4rm6P_g" base_StructuralFeature="__n5DwNzDEeaMV83ubDcSig"/>
@@ -782,7 +752,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelOperation xmi:id="__EDmQ-vSEealldJ4rm6P_g" base_Operation="_NbJpQMOfEeaFfJxGCRaf4A"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="__EDmRevSEealldJ4rm6P_g" base_Operation="_SrzDgMOfEeaFfJxGCRaf4A"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="__EDmUevSEealldJ4rm6P_g" base_Operation="_ssZqINzDEeaMV83ubDcSig"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="__EDmaevSEealldJ4rm6P_g" base_StructuralFeature="_khqLYcbMEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__EDmbuvSEealldJ4rm6P_g" base_StructuralFeature="_1i6QcMbNEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__EDmfOvSEealldJ4rm6P_g" base_StructuralFeature="_ystxUNzEEeaMV83ubDcSig"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="__EDmf-vSEealldJ4rm6P_g" base_StructuralFeature="__n7gANzDEeaMV83ubDcSig"/>
@@ -796,7 +765,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:Specify xmi:id="_u2Lr8BM7Eee0L_IMWjydgQ" base_Abstraction="_pW0gQBM7Eee0L_IMWjydgQ">
     <target>/TapiCommon:Context:_context</target>
   </OpenModel_Profile:Specify>
-  <OpenModel_Profile:StrictComposite xmi:id="_b7lzgBPmEeepnPPr_BcZKg" base_Association="_kho9QMbMEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_W48McRP7EeepnPPr_BcZKg" base_Class="_W48McBP7EeepnPPr_BcZKg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_bsmItBP7EeepnPPr_BcZKg" base_StructuralFeature="_bsmIshP7EeepnPPr_BcZKg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_bssPUhP7EeepnPPr_BcZKg" base_StructuralFeature="_bssPUBP7EeepnPPr_BcZKg"/>
@@ -805,7 +773,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHDSZxhsEeewCs0lkpWskw" base_Property="_dXwzgLw1EeSpn78DYJKtkA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHDSaRhsEeewCs0lkpWskw" base_Property="_QVmjwLxAEeSpn78DYJKtkA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHDSahhsEeewCs0lkpWskw" base_Property="_z2aJ0LxAEeSpn78DYJKtkA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZABhsEeewCs0lkpWskw" base_Property="_khqLYMbMEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZARhsEeewCs0lkpWskw" base_Property="_mJof4PLsEeaAIfPpmDwI5Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZAhhsEeewCs0lkpWskw" base_Property="_-ePpMMbMEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZAxhsEeewCs0lkpWskw" base_Property="_ystxUNzEEeaMV83ubDcSig"/>
@@ -814,7 +781,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZBhhsEeewCs0lkpWskw" base_Property="_bsmIshP7EeepnPPr_BcZKg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZBxhsEeewCs0lkpWskw" base_Property="_1i30McbNEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHJZCBhsEeewCs0lkpWskw" base_Property="_qX1LIuxIEeaTUPmcu3rLwA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfoBhsEeewCs0lkpWskw" base_Property="_khqLYcbMEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfoRhsEeewCs0lkpWskw" base_Property="_1i6QcMbNEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfpBhsEeewCs0lkpWskw" base_Property="__n7gANzDEeaMV83ubDcSig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfphhsEeewCs0lkpWskw" base_Property="_qX7RwexIEeaTUPmcu3rLwA"/>
@@ -825,7 +791,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:StrictComposite xmi:id="_K2_yMEyeEeeBqfKxLidrUg" base_Association="_1i2mEMbNEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh4FqoEeexvMtO2oNM9g" base_Class="_CE0kkLwmEeSpn78DYJKtkA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh5lqoEeexvMtO2oNM9g" base_Class="_zR-agMbLEeaVKq30FmMykA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh51qoEeexvMtO2oNM9g" base_Class="_iE9fcMbMEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh6FqoEeexvMtO2oNM9g" base_Class="_k-OoENzEEeaMV83ubDcSig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh6VqoEeexvMtO2oNM9g" base_Class="_NgYmEOxFEeaTUPmcu3rLwA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh6lqoEeexvMtO2oNM9g" base_Class="_1qX4MOwNEealldJ4rm6P_g"/>
@@ -864,18 +829,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelAttribute xmi:id="_B9eEooHDEeeh4KO3PMo8Rw" base_StructuralFeature="_B9eEoIHDEeeh4KO3PMo8Rw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_DOXbMILIEeelF8AE_WZtHQ" base_StructuralFeature="_DOW0IILIEeelF8AE_WZtHQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DOYCQILIEeelF8AE_WZtHQ" base_Property="_DOW0IILIEeelF8AE_WZtHQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_6KfXwINHEeelF8AE_WZtHQ" base_StructuralFeature="_6Kews4NHEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6KfXwYNHEeelF8AE_WZtHQ" base_Property="_6Kews4NHEeelF8AE_WZtHQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_6Kgl4YNHEeelF8AE_WZtHQ" base_StructuralFeature="_6Kgl4INHEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6Kgl4oNHEeelF8AE_WZtHQ" base_Property="_6Kgl4INHEeelF8AE_WZtHQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_62-DQINHEeelF8AE_WZtHQ" base_StructuralFeature="_629cMoNHEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_62-DQYNHEeelF8AE_WZtHQ" base_Property="_629cMoNHEeelF8AE_WZtHQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_62-qUYNHEeelF8AE_WZtHQ" base_StructuralFeature="_62-qUINHEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_62-qUoNHEeelF8AE_WZtHQ" base_Property="_62-qUINHEeelF8AE_WZtHQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_AijQkINJEeelF8AE_WZtHQ" base_StructuralFeature="_Aiipg4NJEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AijQkYNJEeelF8AE_WZtHQ" base_Property="_Aiipg4NJEeelF8AE_WZtHQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Aij3oINJEeelF8AE_WZtHQ" base_StructuralFeature="_AijQkoNJEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Aij3oYNJEeelF8AE_WZtHQ" base_Property="_AijQkoNJEeelF8AE_WZtHQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_A0XLAZPsEeePQIrrJoWPZA" base_Property="_A0XLAJPsEeePQIrrJoWPZA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_A0dRoJPsEeePQIrrJoWPZA" base_StructuralFeature="_A0XLAJPsEeePQIrrJoWPZA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GTWJcD2kEeihCtCrhJZ45g" base_StructuralFeature="_GTViYD2kEeihCtCrhJZ45g"/>
@@ -1059,4 +1012,12 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelParameter xmi:id="_VJFbIZsZEeid4dfn4JFJZg" base_Parameter="_VJFbIJsZEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_bdSkIZsZEeid4dfn4JFJZg" base_Parameter="_bdSkIJsZEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_kgDlIZsZEeid4dfn4JFJZg" base_Parameter="_kgDlIJsZEeid4dfn4JFJZg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cXcaMcWVEeiWCKGKl1wb8w" base_Property="_cXcaMMWVEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cXcaMsWVEeiWCKGKl1wb8w" base_StructuralFeature="_cXcaMMWVEeiWCKGKl1wb8w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ft704cWVEeiWCKGKl1wb8w" base_Property="_ft704MWVEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ft704sWVEeiWCKGKl1wb8w" base_StructuralFeature="_ft704MWVEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Sz5VccWXEeiWCKGKl1wb8w" base_Parameter="_Sz5VcMWXEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_c_SyccWXEeiWCKGKl1wb8w" base_Parameter="_c_SycMWXEeiWCKGKl1wb8w"/>
+  <OpenModel_Profile:Experimental xmi:id="_Xp_JQMcZEeiSV9wVm02xsw" base_Element="_2-15sEI6EeiDweqmZm-ZXQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_eUiVsMcZEeiSV9wVm02xsw" base_Element="_bgGpwIUvEeiYFOBVMQg1QQ"/>
 </xmi:XMI>

--- a/YANG/tapi-eth@2018-08-31.tree
+++ b/YANG/tapi-eth@2018-08-31.tree
@@ -141,6 +141,8 @@ module: tapi-eth
           +--ro lm-tf-min?                uint64
   augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:meg/tapi-oam:mip:
     +--ro eth-mip-spec
+       +--ro mip-mac?       mac-address
+       +--ro is-full-mip?   boolean
   augment /tapi-common:context/tapi-oam:oam-context/tapi-oam:oam-job:
     +--rw eth-pro-active-2way-measurement-job
        +--rw pro-active-control-2way-source

--- a/YANG/tapi-eth@2018-08-31.yang
+++ b/YANG/tapi-eth@2018-08-31.yang
@@ -570,6 +570,16 @@ module tapi-eth {
             description "none";
         }
         grouping eth-mip-spec {
+            leaf mip-mac {
+                type mac-address;
+                config false;
+                description "This attribute contains the MAC address of the MIP instance.";
+            }
+            leaf is-full-mip {
+                type boolean;
+                config false;
+                description "This attribute indicates whether the MIP is a full MIP (true) or a down-half MIP (false).";
+            }
             description "none";
         }
         grouping eth-loopback-job {

--- a/YANG/tapi-oam@2018-08-31.tree
+++ b/YANG/tapi-oam@2018-08-31.tree
@@ -17,6 +17,8 @@ module: tapi-oam
        |  |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
        |  |  +--rw layer-protocol-name?              tapi-common:layer-protocol-name
        |  |  +--rw direction?                        tapi-common:port-direction
+       |  |  +--rw mep-identifier?                   string
+       |  |  +--rw peer-mep-identifier*              string
        |  |  +--rw local-id                          string
        |  |  +--rw name* [value-name]
        |  |  |  +--rw value-name    string
@@ -39,40 +41,20 @@ module: tapi-oam
        |  +--rw direction?              tapi-common:forwarding-direction
        |  +--rw meg-level?              uint64
        +--ro meg* [uuid]
-       |  +--ro me* [local-id]
-       |  |  +--ro mep* [meg-uuid mep-local-id]
-       |  |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-       |  |  |  +--ro mep-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
-       |  |  +--ro mip* [meg-uuid mip-local-id]
-       |  |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-       |  |  |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
-       |  |  +--ro connection-route
-       |  |  |  +--ro connection-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
-       |  |  |  +--ro route-local-id?    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/route/local-id
-       |  |  +--ro local-id            string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
        |  +--ro mep* [local-id]
-       |  |  +--ro oam-service-end-point
-       |  |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
-       |  |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
-       |  |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-       |  |  +--ro direction?               tapi-common:termination-direction
-       |  |  +--ro mep-identifier?          string
-       |  |  +--ro peer-mep-identifier*     string
-       |  |  +--ro local-id                 string
+       |  |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+       |  |  +--ro direction?             tapi-common:termination-direction
+       |  |  +--ro mep-identifier?        string
+       |  |  +--ro peer-mep-identifier*   string
+       |  |  +--ro local-id               string
        |  |  +--ro name* [value-name]
        |  |  |  +--ro value-name    string
        |  |  |  +--ro value?        string
-       |  |  +--ro operational-state?       operational-state
-       |  |  +--ro lifecycle-state?         lifecycle-state
+       |  |  +--ro operational-state?     operational-state
+       |  |  +--ro lifecycle-state?       lifecycle-state
        |  +--ro mip* [local-id]
-       |  |  +--ro oam-service-end-point
-       |  |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
-       |  |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
-       |  |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-       |  |  +--ro local-id                 string
+       |  |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+       |  |  +--ro local-id               string
        |  |  +--ro name* [value-name]
        |  |     +--ro value-name    string
        |  |     +--ro value?        string
@@ -176,6 +158,8 @@ module: tapi-oam
     |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
     |  |  |  +---w direction?                        tapi-common:port-direction
+    |  |  |  +---w mep-identifier?                   string
+    |  |  |  +---w peer-mep-identifier*              string
     |  |  |  +---w local-id?                         string
     |  |  |  +---w name* [value-name]
     |  |  |  |  +---w value-name    string
@@ -204,6 +188,8 @@ module: tapi-oam
     |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
+    |        |  +--ro mep-identifier?                   string
+    |        |  +--ro peer-mep-identifier*              string
     |        |  +--ro local-id                          string
     |        |  +--ro name* [value-name]
     |        |  |  +--ro value-name    string
@@ -247,6 +233,8 @@ module: tapi-oam
     |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
+    |        |  +--ro mep-identifier?                   string
+    |        |  +--ro peer-mep-identifier*              string
     |        |  +--ro local-id                          string
     |        |  +--ro name* [value-name]
     |        |  |  +--ro value-name    string
@@ -285,6 +273,8 @@ module: tapi-oam
     |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
     |  |  |  +---w direction?                        tapi-common:port-direction
+    |  |  |  +---w mep-identifier?                   string
+    |  |  |  +---w peer-mep-identifier*              string
     |  |  |  +---w local-id?                         string
     |  |  |  +---w name* [value-name]
     |  |  |  |  +---w value-name    string
@@ -422,6 +412,8 @@ module: tapi-oam
     |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
+    |        |  +--ro mep-identifier?                   string
+    |        |  +--ro peer-mep-identifier*              string
     |        |  +--ro local-id                          string
     |        |  +--ro name* [value-name]
     |        |  |  +--ro value-name    string
@@ -448,40 +440,20 @@ module: tapi-oam
     |  |  +---w service-id?   string
     |  +--ro output
     |     +--ro meg
-    |        +--ro me* [local-id]
-    |        |  +--ro mep* [meg-uuid mep-local-id]
-    |        |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-    |        |  |  +--ro mep-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
-    |        |  +--ro mip* [meg-uuid mip-local-id]
-    |        |  |  +--ro meg-uuid        -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-    |        |  |  +--ro mip-local-id    -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
-    |        |  +--ro connection-route
-    |        |  |  +--ro connection-uuid?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/uuid
-    |        |  |  +--ro route-local-id?    -> /tapi-common:context/tapi-connectivity:connectivity-context/connection/route/local-id
-    |        |  +--ro local-id            string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
     |        +--ro mep* [local-id]
-    |        |  +--ro oam-service-end-point
-    |        |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
-    |        |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
-    |        |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |        |  +--ro direction?               tapi-common:termination-direction
-    |        |  +--ro mep-identifier?          string
-    |        |  +--ro peer-mep-identifier*     string
-    |        |  +--ro local-id                 string
+    |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+    |        |  +--ro direction?             tapi-common:termination-direction
+    |        |  +--ro mep-identifier?        string
+    |        |  +--ro peer-mep-identifier*   string
+    |        |  +--ro local-id               string
     |        |  +--ro name* [value-name]
     |        |  |  +--ro value-name    string
     |        |  |  +--ro value?        string
-    |        |  +--ro operational-state?       operational-state
-    |        |  +--ro lifecycle-state?         lifecycle-state
+    |        |  +--ro operational-state?     operational-state
+    |        |  +--ro lifecycle-state?       lifecycle-state
     |        +--ro mip* [local-id]
-    |        |  +--ro oam-service-end-point
-    |        |  |  +--ro oam-service-uuid?                 -> /tapi-common:context/tapi-oam:oam-context/oam-service/uuid
-    |        |  |  +--ro oam-service-end-point-local-id?   -> /tapi-common:context/tapi-oam:oam-context/oam-service/end-point/local-id
-    |        |  +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |        |  +--ro local-id                 string
+    |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+    |        |  +--ro local-id               string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
@@ -512,6 +484,8 @@ module: tapi-oam
     |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
     |  |  |  +---w direction?                        tapi-common:port-direction
+    |  |  |  +---w mep-identifier?                   string
+    |  |  |  +---w peer-mep-identifier*              string
     |  |  |  +---w local-id?                         string
     |  |  |  +---w name* [value-name]
     |  |  |  |  +---w value-name    string
@@ -540,6 +514,8 @@ module: tapi-oam
     |        |  |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro direction?                        tapi-common:port-direction
+    |        |  +--ro mep-identifier?                   string
+    |        |  +--ro peer-mep-identifier*              string
     |        |  +--ro local-id                          string
     |        |  +--ro name* [value-name]
     |        |  |  +--ro value-name    string
@@ -636,12 +612,14 @@ module: tapi-oam
     |        +--ro lifecycle-state?         lifecycle-state
     +---x create-oam-service-end-point
     |  +---w input
-    |  |  +---w service-id?   string
-    |  |  +---w sip-id?       string
-    |  |  +---w c-sep-id?     string
-    |  |  +---w layer?        string
-    |  |  +---w direction?    string
-    |  |  +---w state?        string
+    |  |  +---w service-id?            string
+    |  |  +---w sip-id?                string
+    |  |  +---w c-sep-id?              string
+    |  |  +---w layer?                 string
+    |  |  +---w direction?             string
+    |  |  +---w state?                 string
+    |  |  +---w mep-identifier?        string
+    |  |  +---w peer-mep-identifier*   string
     |  +--ro output
     |     +--ro end-point
     |        +--ro service-interface-point
@@ -657,6 +635,8 @@ module: tapi-oam
     |        |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        +--ro direction?                        tapi-common:port-direction
+    |        +--ro mep-identifier?                   string
+    |        +--ro peer-mep-identifier*              string
     |        +--ro local-id?                         string
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -688,6 +668,8 @@ module: tapi-oam
     |        |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
     |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        +--ro direction?                        tapi-common:port-direction
+    |        +--ro mep-identifier?                   string
+    |        +--ro peer-mep-identifier*              string
     |        +--ro local-id?                         string
     |        +--ro name* [value-name]
     |        |  +--ro value-name    string
@@ -714,6 +696,8 @@ module: tapi-oam
              |  +--ro mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
              +--ro layer-protocol-name?              tapi-common:layer-protocol-name
              +--ro direction?                        tapi-common:port-direction
+             +--ro mep-identifier?                   string
+             +--ro peer-mep-identifier*              string
              +--ro local-id?                         string
              +--ro name* [value-name]
              |  +--ro value-name    string

--- a/YANG/tapi-oam@2018-08-31.yang
+++ b/YANG/tapi-oam@2018-08-31.yang
@@ -199,11 +199,6 @@ module tapi-oam {
     * package object-classes
     **********************/ 
         grouping mep {
-            container oam-service-end-point {
-                uses oam-service-end-point-ref;
-                config false;
-                description "none";
-            }
             leaf layer-protocol-name {
                 type tapi-common:layer-protocol-name;
                 config false;
@@ -233,8 +228,7 @@ module tapi-oam {
             list oam-service-end-point {
             	uses oam-service-end-point-ref;
             	key 'oam-service-uuid oam-service-end-point-local-id';
-                min-elements 1;
-                max-elements 2;
+            	min-elements 1;
                 description "none";
             }
             container oam-profile {
@@ -269,13 +263,6 @@ module tapi-oam {
             description "none";
         }
         grouping meg {
-            list me {
-                key 'local-id';
-                config false;
-                min-elements 1;
-                uses maintenance-entity;
-                description "none";
-            }
             list mep {
                 key 'local-id';
                 config false;
@@ -314,33 +301,7 @@ module tapi-oam {
             uses tapi-common:operational-state-pac;
             description "none";
         }
-        grouping maintenance-entity {
-            list mep {
-                uses mep-ref;
-                key 'meg-uuid mep-local-id';
-                config false;
-                max-elements 2;
-                description "none";
-            }
-            list mip {
-            	uses mip-ref;
-                key 'meg-uuid mip-local-id';
-                config false;
-                description "none";
-            }
-            container connection-route {
-                uses tapi-connectivity:route-ref;
-                config false;
-                description "none";
-            }
-            uses tapi-common:local-class;
-            description "none";
-        }
         grouping mip {
-            container oam-service-end-point {
-            	uses oam-service-end-point-ref;
-                description "none";
-            }
             leaf layer-protocol-name {
                 type tapi-common:layer-protocol-name;
                 config false;
@@ -352,7 +313,7 @@ module tapi-oam {
         grouping oam-service {
             list end-point {
                 key 'local-id';
-                min-elements 1;
+                min-elements 2;
                 uses oam-service-end-point;
                 description "none";
             }
@@ -420,6 +381,18 @@ module tapi-oam {
             leaf direction {
                 type tapi-common:port-direction;
                 description "none";
+            }
+            leaf mep-identifier {
+                type string;
+                description "This attribute contains the identifier of the MEP.
+                    This attribute is empty in case the OSEP relates to the provisioing of an MIP.
+                    ";
+            }
+            leaf-list peer-mep-identifier {
+                type string;
+                description "This attribute models the MI_PeerMEP_ID[i] defined in G.8021 and configured as specified in G.8051. It provides the identifiers of the MEPs which are peer to the subject MEP.
+                    This attribute is not specified in case the OSEP relates to the provisioing of an MIP.
+                    In case of P2P, there is only one peer";
             }
             uses tapi-common:local-class;
             uses tapi-common:admin-state-pac;
@@ -563,7 +536,7 @@ module tapi-oam {
             description "none";
             input {
                 list end-point {
-                    min-elements 1;
+                    min-elements 2;
                     uses oam-service-end-point;
                     description "none";
                 }
@@ -615,8 +588,7 @@ module tapi-oam {
                     description "none";
                 }
                 list oam-service-end-point {
-                    min-elements 1;
-                    max-elements 2;
+                    min-elements 2;
                     uses oam-service-end-point;
                     description "none";
                 }
@@ -766,6 +738,14 @@ module tapi-oam {
                     description "none";
                 }
                 leaf state {
+                    type string;
+                    description "none";
+                }
+                leaf mep-identifier {
+                    type string;
+                    description "none";
+                }
+                leaf-list peer-mep-identifier {
                     type string;
                     description "none";
                 }


### PR DESCRIPTION
Fixes #354 as per TAPI 10/02/2018 [discussions](https://wiki.opennetworking.org/display/OTCC/2018-10-02+TAPI+Meeting+Notes)
- Maintenance Entity has been removed
- OamService will specify at least 2 OSEPs which has provisioning info
for either
-- 2 MEPs (OamService represents an MEG wholly contained in the domain)
-- 1 MEP & 1 MIP (OamService represents a segment of a MEG in an edge
domain)
-- 2 MIPs (OamService represents a segment of a MEG in a transit domain)
- OamJob will specify at least 1 OSEP which points to an MEP
- OSEPRelatesToMEP/MIP association navigability changed to one-way from
OSEP to MEP/MIP
- Added mepIdentifier and peerMepIdentifier attributes to OSEP
- Added mipMac & isFullMip attributes to Eth augmentation of MIP