### PR TITLE
Resilience Update

### DIFF
--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -4434,6 +4434,14 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_jwuBuuryEeaeHOJw3lCT8A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_e2HOlfKiEeaAIfPpmDwI5Q"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_wA6FsAOyEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_UEoBIP-5EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wA6FsQOyEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wA8h8AOyEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_2mSo8P-6EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wA8h8QOyEemABdf1yJ9dlA"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_rSCMFOr0EeaeHOJw3lCT8A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_rSCMFer0EeaeHOJw3lCT8A"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_rSCMFur0EeaeHOJw3lCT8A"/>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -231,49 +231,57 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlMzBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0HHlNDBFEeam35bpdXJzEw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_QrZ4EKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIIk0AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nPhusKhLEeeAVfY3jqnvAA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrZ4EaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIIk0QHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrafIKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIJL4AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_6zHhEIoOEeivCevppATXng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrafIaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJL4QHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrafIqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrafI6SfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrafJKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hHoP4nIzEeeSiaQ95-6r9w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrafJaSfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrafJqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_EN4L8WJREeek3OrhDuslYQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrafJ6SfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrafKKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nJqIEUwFEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrafKaSfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrafKqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIJL4gHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTK2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrafK6SfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJL4wHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrbGMKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIJL5AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTJ2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrbGMaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJL5QHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrbGMqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIJL5gHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_207M8IfjEeet-8tHdGGp_w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrbGM6SfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJL5wHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrbGNKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIJL6AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nJqIEUwFEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJL6QHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GIJy8AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJy8QHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GIJy8gHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hHoP4nIzEeeSiaQ95-6r9w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJy8wHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GIJy9AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_EN4L8WJREeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJy9QHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GIJy9gHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Sk8zkP-4EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJy9wHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GIJy-AHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_6CRicP_MEeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJy-QHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GIJy-gHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrbGNaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIJy-wHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_QrbGNqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GIKaAAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_QrbGN6SfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GIKaAQHtEemABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0HHl3DBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0HHl3TBFEeam35bpdXJzEw"/>
@@ -293,7 +301,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHl6TBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="147" y="315" width="303" height="226"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="147" y="315" width="303" height="246"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HtYijBFEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0HtYizBFEeam35bpdXJzEw" showTitle="true"/>
@@ -802,57 +810,61 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__Y_oIYfVEeeirpBaj87qAw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__Y_oIofVEeeirpBaj87qAw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_l_p30NoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_SwaJYAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_0gCMcIfTEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_p30doHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwaJYQHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_p30toHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#__jB_0IfTEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_p309oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_qe4NoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_rgC9MIfUEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe4doHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_qe4toHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV4urzEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe49oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_qe5NoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV5erzEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe5doHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_qe5toHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV7OrzEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe59oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_qe6NoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_kKvJ4PKiEeaAIfPpmDwI5Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe6doHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_qe6toHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_zpUU8O4GEeaRONVEJOGI1g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe69oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_rF8NoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nuZ_TOryEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF8doHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_rF8toHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_k13kMIfUEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF89oHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_l_rF9NoHEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF9doHEeeYx-v40uoW_Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UU_YYP-5EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Swb-kAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_UEoBIP-5EeiABdf1yJ9dlA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UU_YYf-5EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Swb-kQHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_237LgP-6EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_SwcloAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#__jB_0IfTEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwcloQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwclogHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_rgC9MIfUEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwclowHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdMsAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV4urzEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdMsQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdMsgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV5erzEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdMswHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdMtAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV7OrzEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdMtQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdMtgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_kKvJ4PKiEeaAIfPpmDwI5Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdMtwHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdMuAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_zpUU8O4GEeaRONVEJOGI1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdMuQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdzwAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nuZ_TOryEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdzwQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SwdzwgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_k13kMIfUEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SwdzwwHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Swea0AHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Swea0QHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Swea0gHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_jwuBuuryEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Swea0wHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Swea1AHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_2mSo8P-6EeiABdf1yJ9dlA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_237Lgf-6EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Swea1QHsEemABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__Y_oI4fVEeeirpBaj87qAw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__Y_oJIfVEeeirpBaj87qAw"/>
@@ -872,7 +884,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_oMIfVEeeirpBaj87qAw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_BEYfVEeeirpBaj87qAw" x="-281" y="-60" height="237"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_BEYfVEeeirpBaj87qAw" x="-281" y="-80" height="257"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SCXpgIhDEeeOl5P_FBJSmA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_SCY3oIhDEeeOl5P_FBJSmA" type="Class_NameLabel"/>
@@ -880,53 +892,53 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_SCZesIhDEeeOl5P_FBJSmA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_SCZesYhDEeeOl5P_FBJSmA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_N4ymgKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_MrincAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N4ymgaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MrincQHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_N4z0oKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_MrjOgAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ypGF8IoOEeivCevppATXng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N4z0oaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MrjOgQHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_N4z0oqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N4z0o6SfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_N4z0pKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N4z0paSfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_N40bsqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4c1JUJ--EeiO_KvaRsULdw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N40bs6SfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_N40btKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N40btaSfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_N40btqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N40bt6SfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_N40buKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Mrj1kAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N40buaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mrj1kQHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_N41CwKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Mrj1kgHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutJ2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N41CwaSfEeiKJbr6a5Jjpg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mrj1kwHtEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_N41CwqSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N41Cw6SfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_N41CxKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_N41CxaSfEeiKJbr6a5Jjpg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_pwZt4P-1EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Mrj1lAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_pbi4MP-1EeiABdf1yJ9dlA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_pwZt4f-1EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mrj1lQHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Mrj1lgHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mrj1lwHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Mrj1mAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mrj1mQHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Mrj1mgHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4c1JUJ--EeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mrj1mwHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MrkcoAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MrkcoQHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MrkcogHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MrkcowHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MrkcpAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MrkcpQHtEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MrlDsAHtEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MrlDsQHtEemABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_SCZesohDEeeOl5P_FBJSmA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_SCZes4hDEeeOl5P_FBJSmA"/>
@@ -946,7 +958,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCZev4hDEeeOl5P_FBJSmA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCXpgYhDEeeOl5P_FBJSmA" x="715" y="-296" width="386" height="239"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCXpgYhDEeeOl5P_FBJSmA" x="715" y="-280" width="386" height="223"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__j-OAK1aEeiIjuV0HZnJAQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="__j-OAq1aEeiIjuV0HZnJAQ" type="Class_NameLabel"/>
@@ -1000,7 +1012,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OE61aEeiIjuV0HZnJAQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-280" y="-220" height="141"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-280" y="-240" width="321" height="141"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_42A5IPPjEeinaYo1FpF9OA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_42A5IfPjEeinaYo1FpF9OA"/>
@@ -1199,7 +1211,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lT2KsouQEeiu6boZkiJHCA" points="[222, 102, -643984, -643984]$[49, 65, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nlKtEIuQEeiu6boZkiJHCA" id="(0.0,0.40860215053763443)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oo4M0IuQEeiu6boZkiJHCA" id="(1.0,0.8438818565400844)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oo4M0IuQEeiu6boZkiJHCA" id="(1.0,0.8560311284046692)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xDbXQIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G91jDBFEeam35bpdXJzEw" target="_0G9yhzBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_xDb-UIuQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1429,7 +1441,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_S_bisouREeiu6boZkiJHCA" points="[719, 255, -643984, -643984]$[665, 255, -643984, -643984]$[665, -128, -643984, -643984]$[715, -142, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UKluQIuREeiu6boZkiJHCA" id="(0.0,0.12755102040816327)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UKluQYuREeiu6boZkiJHCA" id="(0.0,0.702928870292887)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UKluQYuREeiu6boZkiJHCA" id="(0.0,0.7174887892376681)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ZFXmMIuREeiu6boZkiJHCA" type="Association_Edge" source="_0HHioDBFEeam35bpdXJzEw" target="_0HHjqDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_ZFYNQIuREeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1476,7 +1488,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_cGt3UYuREeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cGt3UouREeiu6boZkiJHCA" points="[892, -90, -643984, -643984]$[877, 13, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dhRJwIuREeiu6boZkiJHCA" id="(0.42487046632124353,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dhRJwIuREeiu6boZkiJHCA" id="(0.4274611398963731,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dKx8YIuREeiu6boZkiJHCA" id="(0.5296052631578947,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_iiLsYKSfEeiKJbr6a5Jjpg" type="Association_Edge" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_SCXpgIhDEeeOl5P_FBJSmA" routing="Rectilinear">
@@ -1507,17 +1519,17 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_iiLsYaSfEeiKJbr6a5Jjpg"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Yh4IJ--EeiO_KvaRsULdw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iiLsYqSfEeiKJbr6a5Jjpg" points="[1101, -176, -643984, -643984]$[1179, -176, -643984, -643984]$[1179, -251, -643984, -643984]$[1101, -251, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lFunMKSfEeiKJbr6a5Jjpg" id="(1.0,0.502092050209205)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lFunMaSfEeiKJbr6a5Jjpg" id="(1.0,0.18828451882845187)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lFunMKSfEeiKJbr6a5Jjpg" id="(1.0,0.4484304932735426)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lFunMaSfEeiKJbr6a5Jjpg" id="(1.0,0.08968609865470852)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_W6DjoK1bEeiIjuV0HZnJAQ" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="__j-OAK1aEeiIjuV0HZnJAQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_W6Djo61bEeiIjuV0HZnJAQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zzraUK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6DjpK1bEeiIjuV0HZnJAQ" x="13" y="-11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6DjpK1bEeiIjuV0HZnJAQ" x="74" y="-41"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_W6Djpa1bEeiIjuV0HZnJAQ" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_z7zbkK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Djpq1bEeiIjuV0HZnJAQ" x="29" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Djpq1bEeiIjuV0HZnJAQ" x="94" y="-18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_W6Djp61bEeiIjuV0HZnJAQ" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0EMikK1bEeiIjuV0HZnJAQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1537,9 +1549,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_W6Djoa1bEeiIjuV0HZnJAQ"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W6Djoq1bEeiIjuV0HZnJAQ" points="[222, 51, -643984, -643984]$[132, 51, -643984, -643984]$[132, -100, -643984, -643984]$[16, -100, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W6Djoq1bEeiIjuV0HZnJAQ" points="[222, 80, -643984, -643984]$[140, 80, -643984, -643984]$[140, -200, -643984, -643984]$[41, -200, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAK1bEeiIjuV0HZnJAQ" id="(0.0,0.12903225806451613)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAa1bEeiIjuV0HZnJAQ" id="(1.0,0.5673758865248227)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAa1bEeiIjuV0HZnJAQ" id="(1.0,0.425531914893617)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_42A5JPPjEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_0G9yhzBFEeam35bpdXJzEw" target="_42A5IPPjEeinaYo1FpF9OA">
       <styles xmi:type="notation:FontStyle" xmi:id="_42A5JfPjEeinaYo1FpF9OA"/>
@@ -1749,8 +1761,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_SzjQQf-4EeiABdf1yJ9dlA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_SklnMP-4EeiABdf1yJ9dlA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SzjQQv-4EeiABdf1yJ9dlA" points="[147, 420, -643984, -643984]$[40, 420, -643984, -643984]$[40, 480, -643984, -643984]$[147, 480, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TK-RwP-4EeiABdf1yJ9dlA" id="(0.0,0.4646017699115044)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TK-Rwf-4EeiABdf1yJ9dlA" id="(0.0,0.7300884955752213)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TK-RwP-4EeiABdf1yJ9dlA" id="(0.0,0.4268292682926829)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TK-Rwf-4EeiABdf1yJ9dlA" id="(0.0,0.6707317073170732)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_6QtAAP_MEeiABdf1yJ9dlA" type="Association_Edge" source="_0HHlMDBFEeam35bpdXJzEw" target="_0HHlMDBFEeam35bpdXJzEw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_6QtnEP_MEeiABdf1yJ9dlA" type="Association_StereotypeLabel">
@@ -1780,8 +1792,33 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_6QtAAf_MEeiABdf1yJ9dlA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_6CPGMP_MEeiABdf1yJ9dlA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6QtAAv_MEeiABdf1yJ9dlA" points="[450, 480, -643984, -643984]$[540, 480, -643984, -643984]$[540, 420, -643984, -643984]$[450, 420, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6t_Y8P_MEeiABdf1yJ9dlA" id="(1.0,0.7300884955752213)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6uAnEP_MEeiABdf1yJ9dlA" id="(1.0,0.4646017699115044)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6t_Y8P_MEeiABdf1yJ9dlA" id="(1.0,0.6707317073170732)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6uAnEP_MEeiABdf1yJ9dlA" id="(1.0,0.4268292682926829)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__gq5wAN6EemABdf1yJ9dlA" type="Association_Edge" source="_0HHlMDBFEeam35bpdXJzEw" target="_0HHlMDBFEeam35bpdXJzEw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="__hOTYAN6EemABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__hQIkAN6EemABdf1yJ9dlA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__hQIkQN6EemABdf1yJ9dlA" type="Association_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__hQIkgN6EemABdf1yJ9dlA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__hQIkwN6EemABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__hQIlAN6EemABdf1yJ9dlA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__hQIlQN6EemABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__hQIlgN6EemABdf1yJ9dlA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__hQIlwN6EemABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__hQImAN6EemABdf1yJ9dlA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__hQvoAN6EemABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__hQvoQN6EemABdf1yJ9dlA" x="-15" y="56"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="__gq5wQN6EemABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_--c9gAN6EemABdf1yJ9dlA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__gq5wgN6EemABdf1yJ9dlA" points="[147, 540, -643984, -643984]$[200, 561, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AIFfEAN7EemABdf1yJ9dlA" id="(0.0,0.9146341463414634)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AIFfEQN7EemABdf1yJ9dlA" id="(0.17491749174917492,1.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityServiceSkeleton" measurementUnit="Pixel">
@@ -4623,49 +4660,57 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__j6ptOscEealN7CdLT_GPw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__j6ptescEealN7CdLT_GPw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_B6U0UIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6U0UYoPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6VbYIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ypGF8IoOEeivCevppATXng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6VbYYoPEeivCevppATXng"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_B6VbYooPEeivCevppATXng" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hHpeAHIzEeeSiaQ95-6r9w"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_B6VbY4oPEeivCevppATXng"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6VbZIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6VbZYoPEeivCevppATXng"/>
+        <children xmi:type="notation:Shape" xmi:id="_0JMTAAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JMTAQHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6VbZooPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6VbZ4oPEeivCevppATXng"/>
+        <children xmi:type="notation:Shape" xmi:id="_0JM6EAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ypGF8IoOEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JM6EQHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6WCcIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6WCcYoPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6WCcooPEeivCevppATXng" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6WCc4oPEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6WCdIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_0JM6EgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6WCdYoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JM6EwHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6WCdooPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_0JM6FAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutJ2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6WCd4oPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JM6FQHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6WpgIoPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_0JM6FgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_pbi4MP-1EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JM6FwHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0JM6GAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JM6GQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0JNhIAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JNhIQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0JNhIgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4c1JUJ--EeiO_KvaRsULdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JNhIwHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0JNhJAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JNhJQHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0JNhJgHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JNhJwHsEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0JNhKAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6WpgYoPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JNhKQHsEemABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_B6WpgooPEeivCevppATXng" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_0JOIMAHsEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_B6Wpg4oPEeivCevppATXng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0JOIMQHsEemABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__j6ptuscEealN7CdLT_GPw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__j6pt-scEealN7CdLT_GPw"/>
@@ -4685,7 +4730,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j6pw-scEealN7CdLT_GPw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j6psescEealN7CdLT_GPw" x="761" y="-77" width="395" height="208"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j6psescEealN7CdLT_GPw" x="761" y="-77" width="395" height="238"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_hU2_M-seEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_hU2_NOseEealN7CdLT_GPw" showTitle="true"/>
@@ -4967,7 +5012,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__1Uo0ouREeiu6boZkiJHCA" points="[490, -212, -643984, -643984]$[958, -212, -643984, -643984]$[958, -77, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A6orEIuSEeiu6boZkiJHCA" id="(1.0,0.4973544973544973)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A6orEYuSEeiu6boZkiJHCA" id="(0.49873417721518987,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A6orEYuSEeiu6boZkiJHCA" id="(0.5037974683544304,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DVHJcIuSEeiu6boZkiJHCA" type="Association_Edge" source="__j6psOscEealN7CdLT_GPw" target="_QjgYUOsSEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_DVHwgIuSEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -4997,7 +5042,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_DVHJcYuSEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DVHJcouSEeiu6boZkiJHCA" points="[761, -30, -643984, -643984]$[579, -30, -643984, -643984]$[579, -2, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKfWsIuSEeiu6boZkiJHCA" id="(0.0,0.22596153846153846)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKfWsIuSEeiu6boZkiJHCA" id="(0.0,0.23949579831932774)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKfWsYuSEeiu6boZkiJHCA" id="(0.4794520547945205,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_J7u4IIuSEeiu6boZkiJHCA" type="Association_Edge" source="_ryFlIOr0EeaeHOJw3lCT8A" target="__j6psOscEealN7CdLT_GPw">
@@ -5029,7 +5074,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hSkgMOseEealN7CdLT_GPw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J7u4IouSEeiu6boZkiJHCA" points="[722, 266, -643984, -643984]$[965, 266, -643984, -643984]$[965, 131, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LChhEIuSEeiu6boZkiJHCA" id="(1.0,0.5)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LCiIIIuSEeiu6boZkiJHCA" id="(0.5164556962025316,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LCiIIIuSEeiu6boZkiJHCA" id="(0.5037974683544304,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_NFTRIIuSEeiu6boZkiJHCA" type="Association_Edge" source="_s9Rl4Or0EeaeHOJw3lCT8A" target="_ryFlIOr0EeaeHOJw3lCT8A">
       <children xmi:type="notation:DecorationNode" xmi:id="_NFTRI4uSEeiu6boZkiJHCA" type="Association_StereotypeLabel">

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -293,7 +293,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHl6TBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="147" y="315" width="303" height="209"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="147" y="315" width="303" height="226"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HtYijBFEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0HtYizBFEeam35bpdXJzEw" showTitle="true"/>
@@ -846,6 +846,14 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF9doHEeeYx-v40uoW_Q"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_UU_YYP-5EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_UEoBIP-5EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UU_YYf-5EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_237LgP-6EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_2mSo8P-6EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_237Lgf-6EeiABdf1yJ9dlA"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__Y_oI4fVEeeirpBaj87qAw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__Y_oJIfVEeeirpBaj87qAw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="__Y_oJYfVEeeirpBaj87qAw"/>
@@ -864,7 +872,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_oMIfVEeeirpBaj87qAw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_BEYfVEeeirpBaj87qAw" x="-281" y="-28" height="205"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y_BEYfVEeeirpBaj87qAw" x="-281" y="-60" height="237"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SCXpgIhDEeeOl5P_FBJSmA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_SCY3oIhDEeeOl5P_FBJSmA" type="Class_NameLabel"/>
@@ -915,6 +923,10 @@
         <children xmi:type="notation:Shape" xmi:id="_N41CxKSfEeiKJbr6a5Jjpg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_N41CxaSfEeiKJbr6a5Jjpg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_pwZt4P-1EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_pbi4MP-1EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_pwZt4f-1EeiABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_SCZesohDEeeOl5P_FBJSmA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_SCZes4hDEeeOl5P_FBJSmA"/>
@@ -988,7 +1000,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OE61aEeiIjuV0HZnJAQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-282" y="-183" height="141"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-280" y="-220" height="141"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_42A5IPPjEeinaYo1FpF9OA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_42A5IfPjEeinaYo1FpF9OA"/>
@@ -1187,7 +1199,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lT2KsouQEeiu6boZkiJHCA" points="[222, 102, -643984, -643984]$[49, 65, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nlKtEIuQEeiu6boZkiJHCA" id="(0.0,0.40860215053763443)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oo4M0IuQEeiu6boZkiJHCA" id="(1.0,0.7804878048780488)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oo4M0IuQEeiu6boZkiJHCA" id="(1.0,0.8438818565400844)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xDbXQIuQEeiu6boZkiJHCA" type="Association_Edge" source="_0G91jDBFEeam35bpdXJzEw" target="_0G9yhzBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_xDb-UIuQEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1324,7 +1336,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DM_ksouREeiu6boZkiJHCA" points="[311, 242, -643984, -643984]$[277, 313, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EXtEUIuREeiu6boZkiJHCA" id="(0.2080536912751678,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EvkxwIuREeiu6boZkiJHCA" id="(0.4521452145214521,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EvkxwIuREeiu6boZkiJHCA" id="(0.4389438943894389,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_G3oqcIuREeiu6boZkiJHCA" type="Association_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="_0HHioDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_G3pRgIuREeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1526,8 +1538,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_W6Djoa1bEeiIjuV0HZnJAQ"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W6Djoq1bEeiIjuV0HZnJAQ" points="[222, 51, -643984, -643984]$[132, 51, -643984, -643984]$[132, -100, -643984, -643984]$[16, -100, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAK1bEeiIjuV0HZnJAQ" id="(0.0,0.1324200913242009)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAa1bEeiIjuV0HZnJAQ" id="(1.0,0.5886524822695035)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAK1bEeiIjuV0HZnJAQ" id="(0.0,0.12903225806451613)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLDNAa1bEeiIjuV0HZnJAQ" id="(1.0,0.5673758865248227)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_42A5JPPjEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_0G9yhzBFEeam35bpdXJzEw" target="_42A5IPPjEeinaYo1FpF9OA">
       <styles xmi:type="notation:FontStyle" xmi:id="_42A5JfPjEeinaYo1FpF9OA"/>
@@ -1708,6 +1720,68 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5IkoxvPjEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Ikox_PjEeinaYo1FpF9OA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5IkoyPPjEeinaYo1FpF9OA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SzjQQP-4EeiABdf1yJ9dlA" type="Association_Edge" source="_0HHlMDBFEeam35bpdXJzEw" target="_0HHlMDBFEeam35bpdXJzEw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SzlsgP-4EeiABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uCgioP-9EeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Szlsgf-4EeiABdf1yJ9dlA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Szlsgv-4EeiABdf1yJ9dlA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uOS74P-9EeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Szlsg_-4EeiABdf1yJ9dlA" x="-43" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SzlshP-4EeiABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uZvW4P-9EeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Szlshf-4EeiABdf1yJ9dlA" x="-2" y="-82"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Szlshv-4EeiABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ulJ8sP-9EeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Szlsh_-4EeiABdf1yJ9dlA" x="-77" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SzlsiP-4EeiABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uwOkQP-9EeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Szlsif-4EeiABdf1yJ9dlA" x="22" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Szlsiv-4EeiABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u8DZwP-9EeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Szlsi_-4EeiABdf1yJ9dlA" x="-16" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_SzjQQf-4EeiABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_SklnMP-4EeiABdf1yJ9dlA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SzjQQv-4EeiABdf1yJ9dlA" points="[147, 420, -643984, -643984]$[40, 420, -643984, -643984]$[40, 480, -643984, -643984]$[147, 480, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TK-RwP-4EeiABdf1yJ9dlA" id="(0.0,0.4646017699115044)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TK-Rwf-4EeiABdf1yJ9dlA" id="(0.0,0.7300884955752213)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6QtAAP_MEeiABdf1yJ9dlA" type="Association_Edge" source="_0HHlMDBFEeam35bpdXJzEw" target="_0HHlMDBFEeam35bpdXJzEw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6QtnEP_MEeiABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gCOrgP_NEeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6QtnEf_MEeiABdf1yJ9dlA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6QtnEv_MEeiABdf1yJ9dlA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gQAo0P_NEeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6QtnE__MEeiABdf1yJ9dlA" x="43" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6QtnFP_MEeiABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ghA5QP_NEeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6QtnFf_MEeiABdf1yJ9dlA" x="66" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6QtnFv_MEeiABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gtq1MP_NEeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6QtnF__MEeiABdf1yJ9dlA" x="-66" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6QtnGP_MEeiABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_g66nAP_NEeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6QtnGf_MEeiABdf1yJ9dlA" x="15" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6QtnGv_MEeiABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hJWEkP_NEeiABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6QtnG__MEeiABdf1yJ9dlA" x="-21" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_6QtAAf_MEeiABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_6CPGMP_MEeiABdf1yJ9dlA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6QtAAv_MEeiABdf1yJ9dlA" points="[450, 480, -643984, -643984]$[540, 480, -643984, -643984]$[540, 420, -643984, -643984]$[450, 420, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6t_Y8P_MEeiABdf1yJ9dlA" id="(1.0,0.7300884955752213)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6uAnEP_MEeiABdf1yJ9dlA" id="(1.0,0.4646017699115044)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityServiceSkeleton" measurementUnit="Pixel">
@@ -4319,6 +4393,10 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_p3I7tYhCEeeOl5P_FBJSmA"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_e2HOlPKiEeaAIfPpmDwI5Q" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_jwuBuuryEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_e2HOlfKiEeaAIfPpmDwI5Q"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_rSCMFOr0EeaeHOJw3lCT8A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_rSCMFer0EeaeHOJw3lCT8A"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_rSCMFur0EeaeHOJw3lCT8A"/>
@@ -4352,10 +4430,6 @@
         <children xmi:type="notation:Shape" xmi:id="_e2HOkvKiEeaAIfPpmDwI5Q" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_KnJbVPIoEea79czpMf3AVQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_e2HOk_KiEeaAIfPpmDwI5Q"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_e2HOlPKiEeaAIfPpmDwI5Q" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_jwuBuuryEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_e2HOlfKiEeaAIfPpmDwI5Q"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_e2HOlvKiEeaAIfPpmDwI5Q" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_jwuBwOryEeaeHOJw3lCT8A"/>
@@ -5336,6 +5410,36 @@
       </children>
       <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#__jPYUCmmEeeA7tvtQmACtQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IDDyoYhBEeeOl5P_FBJSmA" x="340" y="59"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dEdYAP-7EeiABdf1yJ9dlA" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dEd_EP-7EeiABdf1yJ9dlA" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dEd_Ef-7EeiABdf1yJ9dlA" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dEd_Ev-7EeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dEd_E_-7EeiABdf1yJ9dlA" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JFzmUP-9EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_nB4qcP-7EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JFzmUf-9EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JF0NYP-9EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_wMFwMP-7EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JF0NYf-9EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JF1bgP-9EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_ADwMcP-8EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JF1bgf-9EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JF2CkP-9EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_mwZcYP-8EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JF2Ckf-9EeiABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dEd_FP-7EeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dEd_Ff-7EeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dEd_Fv-7EeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEd_F_-7EeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_dEU1IP-7EeiABdf1yJ9dlA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEdYAf-7EeiABdf1yJ9dlA" x="520" y="220"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_W_wkgfItEea79czpMf3AVQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_W_wkgvItEea79czpMf3AVQ"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -346,6 +346,12 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_6CT-sf_MEeiABdf1yJ9dlA" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_6CPGMP_MEeiABdf1yJ9dlA"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_--c9gAN6EemABdf1yJ9dlA" name="CSEPIsProtectedByCSEP" memberEnd="__Ab6gAN6EemABdf1yJ9dlA __AwDkQN6EemABdf1yJ9dlA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__AXCAAN6EemABdf1yJ9dlA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__AXpEAN6EemABdf1yJ9dlA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="__AwDkQN6EemABdf1yJ9dlA" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_--c9gAN6EemABdf1yJ9dlA"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
@@ -519,26 +525,6 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ypGF8IoOEeivCevppATXng" name="layerProtocolQualifier" isReadOnly="true">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_B3Ln4EHCEeWqPKyD1j6LMg" name="_parentNodeEdgePoint" isReadOnly="true" association="_B3JLoEHCEeWqPKyD1j6LMg">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WeYVYEHCEeWqPKyD1j6LMg" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WeZjgEHCEeWqPKyD1j6LMg" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Zb_6UH5NEeWWkJKpap4S3A" name="_clientNodeEdgePoint" isReadOnly="true" aggregation="shared" association="_Zb5MoH5NEeWWkJKpap4S3A">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XMYckH5XEeWWkJKpap4S3A"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XNugYH5XEeWWkJKpap4S3A" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_4c1JUJ--EeiO_KvaRsULdw" name="_aggregatedConnectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" aggregation="shared" association="_4Yh4IJ--EeiO_KvaRsULdw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4c6B0J--EeiO_KvaRsULdw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4c6o4J--EeiO_KvaRsULdw" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_sGvxssZaEeeAD9H5zOiMUQ" name="_termination" aggregation="composite" association="_sGvKoMZaEeeAD9H5zOiMUQ">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_sIutK2h-EeWZEqTYAF8eqA" name="connectionPortDirection" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_sIutLGh-EeWZEqTYAF8eqA" annotatedElement="_sIutK2h-EeWZEqTYAF8eqA">
             <body>The orientation of defined flow at the EndPoint.</body>
@@ -558,6 +544,26 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_pbi4MP-1EeiABdf1yJ9dlA" name="protectionRole" type="_KtcbYCmxEeeA7tvtQmACtQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0I5ywP-1EeiABdf1yJ9dlA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0Jb-QP-1EeiABdf1yJ9dlA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_B3Ln4EHCEeWqPKyD1j6LMg" name="_parentNodeEdgePoint" isReadOnly="true" association="_B3JLoEHCEeWqPKyD1j6LMg">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WeYVYEHCEeWqPKyD1j6LMg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WeZjgEHCEeWqPKyD1j6LMg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Zb_6UH5NEeWWkJKpap4S3A" name="_clientNodeEdgePoint" isReadOnly="true" aggregation="shared" association="_Zb5MoH5NEeWWkJKpap4S3A">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XMYckH5XEeWWkJKpap4S3A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XNugYH5XEeWWkJKpap4S3A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4c1JUJ--EeiO_KvaRsULdw" name="_aggregatedConnectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" aggregation="shared" association="_4Yh4IJ--EeiO_KvaRsULdw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4c6B0J--EeiO_KvaRsULdw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4c6o4J--EeiO_KvaRsULdw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sGvxssZaEeeAD9H5zOiMUQ" name="_termination" aggregation="composite" association="_sGvKoMZaEeeAD9H5zOiMUQ">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
@@ -648,19 +654,6 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <ownedAttribute xmi:type="uml:Property" xmi:id="_6zHhEIoOEeivCevppATXng" name="layerProtocolQualifier">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_YyoyAmkJEeWZEqTYAF8eqA" name="_serviceInterfacePoint" association="_YyfoEGkJEeWZEqTYAF8eqA">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hHoP4nIzEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" association="_hF804HIzEeeSiaQ95-6r9w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X5h9EHI9EeeSiaQ95-6r9w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X5mOgHI9EeeSiaQ95-6r9w" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_EN4L8WJREeek3OrhDuslYQ" name="_state" aggregation="composite" association="_EN290GJREeek3OrhDuslYQ">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_nJqIEUwFEeewALXL7BvPYw" name="capacity" aggregation="composite" association="_nJo58EwFEeewALXL7BvPYw">
-          <type xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTK2h5EeWZEqTYAF8eqA" name="direction" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTLGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTK2h5EeWZEqTYAF8eqA">
             <body>The orientation of defined flow at the EndPoint.</body>
@@ -684,6 +677,19 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_B2jHUIfkEeet-8tHdGGp_w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_B2mxsIfkEeet-8tHdGGp_w" value="1"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nJqIEUwFEeewALXL7BvPYw" name="capacity" aggregation="composite" association="_nJo58EwFEeewALXL7BvPYw">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YyoyAmkJEeWZEqTYAF8eqA" name="_serviceInterfacePoint" association="_YyfoEGkJEeWZEqTYAF8eqA">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hHoP4nIzEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" association="_hF804HIzEeeSiaQ95-6r9w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X5h9EHI9EeeSiaQ95-6r9w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X5mOgHI9EeeSiaQ95-6r9w" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EN4L8WJREeek3OrhDuslYQ" name="_state" aggregation="composite" association="_EN290GJREeek3OrhDuslYQ">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Sk8zkP-4EeiABdf1yJ9dlA" name="_peerFwdConnectivityServiceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_SklnMP-4EeiABdf1yJ9dlA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Sk-owP-4EeiABdf1yJ9dlA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Sk_P0P-4EeiABdf1yJ9dlA" value="1"/>
@@ -691,6 +697,10 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <ownedAttribute xmi:type="uml:Property" xmi:id="_6CRicP_MEeiABdf1yJ9dlA" name="_serverConnectivityServiceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_6CPGMP_MEeiABdf1yJ9dlA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6CTXoP_MEeiABdf1yJ9dlA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6CT-sP_MEeiABdf1yJ9dlA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__Ab6gAN6EemABdf1yJ9dlA" name="_protectingConnectivityServiceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_--c9gAN6EemABdf1yJ9dlA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__AvcgAN6EemABdf1yJ9dlA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__AwDkAN6EemABdf1yJ9dlA" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Route" isLeaf="true">
@@ -867,7 +877,7 @@ All administrative controls of any aspect of protection are rejected.</body>
             <body>Degree of administrative control applied to the switch selection.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_2mSo8P-6EeiABdf1yJ9dlA" name="faultConditionDetermination"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2mSo8P-6EeiABdf1yJ9dlA" name="faultConditionDetermination" type="_dEU1IP-7EeiABdf1yJ9dlA"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_1ZroEHIYEeeSiaQ95-6r9w" name="CepList">
         <ownedAttribute xmi:type="uml:Property" xmi:id="__jiM8XIYEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" aggregation="composite" association="__jfwsHIYEeeSiaQ95-6r9w">
@@ -1375,4 +1385,8 @@ The determination of a fault condition on a serial compound link connection with
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6CSwkP_MEeiABdf1yJ9dlA" base_Property="_6CRicP_MEeiABdf1yJ9dlA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6CT-sv_MEeiABdf1yJ9dlA" base_StructuralFeature="_6CT-sf_MEeiABdf1yJ9dlA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6CT-s__MEeiABdf1yJ9dlA" base_Property="_6CT-sf_MEeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__AqkAAN6EemABdf1yJ9dlA" base_StructuralFeature="__Ab6gAN6EemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__AtnUAN6EemABdf1yJ9dlA" base_Property="__Ab6gAN6EemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__AwDkgN6EemABdf1yJ9dlA" base_StructuralFeature="__AwDkQN6EemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__AwDkwN6EemABdf1yJ9dlA" base_Property="__AwDkQN6EemABdf1yJ9dlA"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -332,8 +332,21 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_Wuyu161bEeiIjuV0HZnJAQ" name="connectivityservice" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_WumhkK1bEeiIjuV0HZnJAQ"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_SklnMP-4EeiABdf1yJ9dlA" name="CSEPHasForwardingPeerCSEP" memberEnd="_Sk8zkP-4EeiABdf1yJ9dlA _Sk_P0f-4EeiABdf1yJ9dlA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Sk5wQP-4EeiABdf1yJ9dlA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Sk6XUP-4EeiABdf1yJ9dlA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Sk_P0f-4EeiABdf1yJ9dlA" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_SklnMP-4EeiABdf1yJ9dlA"/>
+      </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_6CPGMP_MEeiABdf1yJ9dlA" name="CSEPHasServerCSEP" memberEnd="_6CRicP_MEeiABdf1yJ9dlA _6CT-sf_MEeiABdf1yJ9dlA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6CQ7YP_MEeiABdf1yJ9dlA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6CQ7Yf_MEeiABdf1yJ9dlA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_6CT-sf_MEeiABdf1yJ9dlA" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_6CPGMP_MEeiABdf1yJ9dlA"/>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -542,6 +555,10 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sIutKWh-EeWZEqTYAF8eqA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sIutKmh-EeWZEqTYAF8eqA" value="1"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pbi4MP-1EeiABdf1yJ9dlA" name="protectionRole" type="_KtcbYCmxEeeA7tvtQmACtQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0I5ywP-1EeiABdf1yJ9dlA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0Jb-QP-1EeiABdf1yJ9dlA" value="1"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Hk2vsK1lEeiqCPid09Hqfw" name="serviceLayer">
@@ -667,6 +684,14 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_B2jHUIfkEeet-8tHdGGp_w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_B2mxsIfkEeet-8tHdGGp_w" value="1"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Sk8zkP-4EeiABdf1yJ9dlA" name="_peerFwdConnectivityServiceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_SklnMP-4EeiABdf1yJ9dlA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Sk-owP-4EeiABdf1yJ9dlA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Sk_P0P-4EeiABdf1yJ9dlA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6CRicP_MEeiABdf1yJ9dlA" name="_serverConnectivityServiceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_6CPGMP_MEeiABdf1yJ9dlA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6CTXoP_MEeiABdf1yJ9dlA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6CT-sP_MEeiABdf1yJ9dlA" value="1"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Route" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_kkzTEUUbEeWKAbXi7_SowQ" annotatedElement="_kkzTEEUbEeWKAbXi7_SowQ">
@@ -719,11 +744,6 @@ This ability allows multiple alternate routes to be present that otherwise would
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aThNkPIoEea79czpMf3AVQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aTnUMPIoEea79czpMf3AVQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwuBuuryEeaeHOJw3lCT8A" name="selectionControl" type="_ya6IserzEeaeHOJw3lCT8A">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_jwuBu-ryEeaeHOJw3lCT8A" annotatedElement="_jwuBuuryEeaeHOJw3lCT8A">
-            <body>Degree of administrative control applied to the switch selection.</body>
-          </ownedComment>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jwuBwOryEeaeHOJw3lCT8A" name="selectionReason" type="_ya6Iu-rzEeaeHOJw3lCT8A" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_jwuBweryEeaeHOJw3lCT8A" annotatedElement="_jwuBwOryEeaeHOJw3lCT8A">
             <body>The reason for the current switch selection.</body>
@@ -760,8 +780,11 @@ This ability allows multiple alternate routes to be present that otherwise would
         <ownedComment xmi:type="uml:Comment" xmi:id="_MBqV4erzEeaeHOJw3lCT8A" annotatedElement="_MBqV4OrzEeaeHOJw3lCT8A">
           <body>A list of control parameters to apply to a switch.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_0gCMcIfTEeeirpBaj87qAw" name="resilienceType">
-          <type xmi:type="uml:DataType" href="TapiTopology.uml#_IQQS0IfNEeeirpBaj87qAw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0gCMcIfTEeeirpBaj87qAw" name="protectionType">
+          <type xmi:type="uml:Enumeration" href="TapiTopology.uml#_9bzYYOr1EeaeHOJw3lCT8A"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UEoBIP-5EeiABdf1yJ9dlA" name="restorationPolicy">
+          <type xmi:type="uml:Enumeration" href="TapiTopology.uml#_5PZ_AEthEeet_JEg2fof-A"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__jB_0IfTEeeirpBaj87qAw" name="restorationCoordinateType" type="__jPYUCmmEeeA7tvtQmACtQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_L2ECQIfVEeeirpBaj87qAw" annotatedElement="__jB_0IfTEeeirpBaj87qAw">
@@ -839,6 +862,12 @@ All administrative controls of any aspect of protection are rejected.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oHM_EIoPEeivCevppATXng"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oHONMIoPEeivCevppATXng" value="*"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwuBuuryEeaeHOJw3lCT8A" name="selectionControl" type="_ya6IserzEeaeHOJw3lCT8A">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jwuBu-ryEeaeHOJw3lCT8A" annotatedElement="_jwuBuuryEeaeHOJw3lCT8A">
+            <body>Degree of administrative control applied to the switch selection.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2mSo8P-6EeiABdf1yJ9dlA" name="faultConditionDetermination"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_1ZroEHIYEeeSiaQ95-6r9w" name="CepList">
         <ownedAttribute xmi:type="uml:Property" xmi:id="__jiM8XIYEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" aggregation="composite" association="__jfwsHIYEeeSiaQ95-6r9w">
@@ -914,6 +943,36 @@ Note: Only relevant when part of a protection scheme.</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_UrO6MCmxEeeA7tvtQmACtQ" name="NA"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2HxMYGrhEeezaeKmbo_0Qw" name="WORK_RESTORE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_3OZdQGrhEeezaeKmbo_0Qw" name="PROTECT_RESTORE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_dEU1IP-7EeiABdf1yJ9dlA" name="FaultConditionDetermination">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_aHxvAP-8EeiABdf1yJ9dlA" annotatedElement="_dEU1IP-7EeiABdf1yJ9dlA">
+          <body>ITU-T G.808-201611&#xD;
+3.2.6.8 subnetwork connection protection&#xD;
+Transport entity protection for the case where the transport entity is a subnetwork connection.&#xD;
+The serial compound link connection within the subnetwork connection is protected by adding bridges and selectors&#xD;
+in the connection functions at the edges of the protected domain and an additional serial compound link connection between these connection functions.&#xD;
+The determination of a fault condition on a serial compound link connection within the protected domain can be performed as follows: see enum.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nB4qcP-7EeiABdf1yJ9dlA" name="INHERENT">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_srycwP-8EeiABdf1yJ9dlA" annotatedElement="_nB4qcP-7EeiABdf1yJ9dlA">
+            <body>Inherent monitored (/I): The fault condition status of each link connection is derived from the status of the underlying server layer trail.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wMFwMP-7EeiABdf1yJ9dlA" name="NON_INTRUSIVE">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wk6qcP-8EeiABdf1yJ9dlA" annotatedElement="_wMFwMP-7EeiABdf1yJ9dlA">
+            <body>Non-intrusive monitored (/N): Each serial compound link connection is extended with a non-intrusive monitoring termination sink function to derive the fault condition status from the traffic signal that is present.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ADwMcP-8EeiABdf1yJ9dlA" name="SUBLAYER">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ADwMcf-8EeiABdf1yJ9dlA" annotatedElement="_ADwMcP-8EeiABdf1yJ9dlA">
+            <body>Sublayer monitored (/S): Each serial compound link connection is extended with tandem connection monitoring or segment termination/adaptation functions to derive the fault condition status independent of the traffic signal present.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mwZcYP-8EeiABdf1yJ9dlA" name="TEST">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mwZcYf-8EeiABdf1yJ9dlA" annotatedElement="_mwZcYP-8EeiABdf1yJ9dlA">
+            <body>Test monitored (/T): Each serial compound link connection's fault condition status is derived from an additional monitored serial compound link connection transported via the same serial compound link.</body>
+          </ownedComment>
+        </ownedLiteral>
       </packagedElement>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_L5hlgBMfEee0L_IMWjydgQ">
@@ -1302,4 +1361,18 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelParameter xmi:id="_N1bSUPPkEeinaYo1FpF9OA" base_Parameter="_N1arQPPkEeinaYo1FpF9OA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_QgLBUfPkEeinaYo1FpF9OA" base_Parameter="_QgLBUPPkEeinaYo1FpF9OA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_U_XwgfPkEeinaYo1FpF9OA" base_Parameter="_U_XwgPPkEeinaYo1FpF9OA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pbkGUP-1EeiABdf1yJ9dlA" base_StructuralFeature="_pbi4MP-1EeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_pbktYP-1EeiABdf1yJ9dlA" base_Property="_pbi4MP-1EeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Sk8zkf-4EeiABdf1yJ9dlA" base_StructuralFeature="_Sk8zkP-4EeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Sk-BsP-4EeiABdf1yJ9dlA" base_Property="_Sk8zkP-4EeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Sk_24P-4EeiABdf1yJ9dlA" base_StructuralFeature="_Sk_P0f-4EeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Sk_24f-4EeiABdf1yJ9dlA" base_Property="_Sk_P0f-4EeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UEoBIf-5EeiABdf1yJ9dlA" base_StructuralFeature="_UEoBIP-5EeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UEoBIv-5EeiABdf1yJ9dlA" base_Property="_UEoBIP-5EeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2mSo8f-6EeiABdf1yJ9dlA" base_StructuralFeature="_2mSo8P-6EeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2mTQAP-6EeiABdf1yJ9dlA" base_Property="_2mSo8P-6EeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6CSJgP_MEeiABdf1yJ9dlA" base_StructuralFeature="_6CRicP_MEeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6CSwkP_MEeiABdf1yJ9dlA" base_Property="_6CRicP_MEeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6CT-sv_MEeiABdf1yJ9dlA" base_StructuralFeature="_6CT-sf_MEeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6CT-s__MEeiABdf1yJ9dlA" base_Property="_6CT-sf_MEeiABdf1yJ9dlA"/>
 </xmi:XMI>

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -1311,7 +1311,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arsiJ16fEeitO-Stqhyn1g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_nTcS8FRxEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nT0GYVRxEeitkMFXBYQFcg" x="177" y="195" width="219" height="157"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nT0GYVRxEeitkMFXBYQFcg" x="205" y="198" width="219" height="157"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F-r4QFRyEeitkMFXBYQFcg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_F-r4QlRyEeitkMFXBYQFcg" type="Class_NameLabel"/>
@@ -1356,7 +1356,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-sfXlRyEeitkMFXBYQFcg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_F-hgMFRyEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-r4QVRyEeitkMFXBYQFcg" x="-183" y="204" width="232" height="117"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-r4QVRyEeitkMFXBYQFcg" x="54" y="405" width="232" height="117"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_VUtAAFRyEeitkMFXBYQFcg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_VUtAAlRyEeitkMFXBYQFcg" type="Class_NameLabel"/>
@@ -1443,7 +1443,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUtAE1RyEeitkMFXBYQFcg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_VUpVoFRyEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUtAAVRyEeitkMFXBYQFcg" x="356" y="188" width="252" height="210"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUtAAVRyEeitkMFXBYQFcg" x="481" y="199" width="252" height="235"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_3JXW21VCEeitkMFXBYQFcg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_3JXW3FVCEeitkMFXBYQFcg" showTitle="true"/>
@@ -2572,6 +2572,310 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PsrKgvK1EeiTnqcAgKK24Q" x="556" y="188"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7EHVkP-uEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7EHVkf-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7EHVk_-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7EHVkv-uEeiABdf1yJ9dlA" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7L2VQP-uEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7L2VQf-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7L2VQ_-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7L2VQv-uEeiABdf1yJ9dlA" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FKizAP-vEeiABdf1yJ9dlA" type="Class_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jiNj8ASwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jiNj8QSwEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jiNj8gSwEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jiNj8wSwEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FKqu0P-vEeiABdf1yJ9dlA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FKrV4P-vEeiABdf1yJ9dlA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FKrV4f-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FKr88P-vEeiABdf1yJ9dlA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_asQP4ASwEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_s-rI4NYBEeidMu8ST4Ma3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_asQP4QSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_asReAASwEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Ju0EsNYIEeidMu8ST4Ma3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_asReAQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_asReAgSwEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_VfiUYNZCEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_asReAwSwEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FKr88f-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FKr88v-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FKr88_-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKr89P-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FKr89f-vEeiABdf1yJ9dlA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FKr89v-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FKr89_-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FKr8-P-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKr8-f-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FKr8-v-vEeiABdf1yJ9dlA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FKr8-_-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FKr8_P-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FKr8_f-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKr8_v-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_nkE94NYAEeidMu8ST4Ma3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKizAf-vEeiABdf1yJ9dlA" x="-444" y="189" height="80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FLTA8P-vEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FLTA8f-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FLToAf-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_nkE94NYAEeidMu8ST4Ma3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FLToAP-vEeiABdf1yJ9dlA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F_PmYP-vEeiABdf1yJ9dlA" type="Class_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1NLIASwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1OZQASwEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1PnYASwEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1Q1gQSwEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F_Q0gP-vEeiABdf1yJ9dlA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_F_RbkP-vEeiABdf1yJ9dlA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_F_Rbkf-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F_Rbkv-vEeiABdf1yJ9dlA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_eECEAASwEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Bk0N8NboEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eECEAQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eECrEASwEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Cck8YNboEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eECrEQSwEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F_Rbk_-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F_RblP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F_Rblf-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_Rblv-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F_Rbl_-vEeiABdf1yJ9dlA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F_RbmP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F_Rbmf-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F_Rbmv-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_Rbm_-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_F_SCoP-vEeiABdf1yJ9dlA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_F_SCof-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_F_SCov-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_F_SCo_-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_SCpP-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_-vckINa3EeidLb5WEUMFmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_PmYf-vEeiABdf1yJ9dlA" x="-363" y="357" height="66"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_F_pPA_-vEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_F_p2EP-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F_p2Ev-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_-vckINa3EeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_p2Ef-vEeiABdf1yJ9dlA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SavdwP-vEeiABdf1yJ9dlA" type="Enumeration_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1PAUASwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1PAUQSwEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1QOcQSwEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1Q1gwSwEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SawE0P-vEeiABdf1yJ9dlA" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SawE0f-vEeiABdf1yJ9dlA" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SawE0v-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SawE0_-vEeiABdf1yJ9dlA" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_eEDSIgSwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_woFiwNYFEeidMu8ST4Ma3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEDSIwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEDSJASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_DbMccNYGEeidMu8ST4Ma3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEDSJQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEDSJgSwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_dzPuQNYGEeidMu8ST4Ma3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEDSJwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eED5MASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_hieZENYGEeidMu8ST4Ma3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eED5MQSwEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SawE1P-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SawE1f-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SawE1v-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SawE1_-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiEth.uml#_15PQINYBEeidMu8ST4Ma3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Savdwf-vEeiABdf1yJ9dlA" x="-291" y="545"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TEUmQP-vEeiABdf1yJ9dlA" type="Enumeration_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1PAVASwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1PAVQSwEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1Q1gASwEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1Q1hQSwEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TEVNUP-vEeiABdf1yJ9dlA" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TEVNUf-vEeiABdf1yJ9dlA" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TEVNUv-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TEVNU_-vEeiABdf1yJ9dlA" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_eEEgQgSwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_emPIQNZEEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEEgQwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEEgRASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#__gQ5UNZEEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEEgRQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEEgRgSwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_GBGwINZFEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEEgRwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEFHUASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_N0RKcNZFEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEFHUQSwEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TEVNVP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TEVNVf-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TEVNVv-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TEVNV_-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiEth.uml#_UStqANZEEeidLb5WEUMFmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TEUmQf-vEeiABdf1yJ9dlA" x="-58" y="548"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TtthgP-vEeiABdf1yJ9dlA" type="Enumeration_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1OZQQSwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1OZQgSwEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1QOcASwEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1Q1ggSwEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ttthgv-vEeiABdf1yJ9dlA" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ttthg_-vEeiABdf1yJ9dlA" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TtthhP-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Ttthhf-vEeiABdf1yJ9dlA" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_eECrEgSwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_oezWUNboEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eECrEwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eECrFASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_emPIQNZEEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eECrFQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eECrFgSwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#__gQ5UNZEEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eECrFwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eECrGASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_GBGwINZFEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eECrGQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEDSIASwEemABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_N0RKcNZFEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEDSIQSwEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Ttthhv-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TtuIkP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TtuIkf-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TtuIkv-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiEth.uml#_NAYSUNboEeidLb5WEUMFmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ttthgf-vEeiABdf1yJ9dlA" x="477" y="546"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VDGnIP-vEeiABdf1yJ9dlA" type="DataType_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1PAUgSwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1PAUwSwEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1QOcgSwEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g1Q1hASwEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VDHOMP-vEeiABdf1yJ9dlA" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VDHOMf-vEeiABdf1yJ9dlA" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VDHOMv-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VDHOM_-vEeiABdf1yJ9dlA" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_eED5MgSwEemABdf1yJ9dlA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_lY6rANcKEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eED5MwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eED5NASwEemABdf1yJ9dlA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_9x0IgNcKEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eED5NQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eED5NgSwEemABdf1yJ9dlA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_EVOVsNcMEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eED5NwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eED5OASwEemABdf1yJ9dlA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_zPcrENcMEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eED5OQSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eED5OgSwEemABdf1yJ9dlA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_diqOgNcMEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eED5OwSwEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eEEgQASwEemABdf1yJ9dlA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_nRnnINcMEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eEEgQQSwEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VDHONP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VDHONf-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VDHONv-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDHON_-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VDHOOP-vEeiABdf1yJ9dlA" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VDHOOf-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VDHOOv-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VDHOO_-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDHOPP-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiEth.uml#_V7D14NcKEeidLb5WEUMFmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDGnIf-vEeiABdf1yJ9dlA" x="257" y="547"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Hp6nYASwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Hp6nYQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hp7OcASwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Hp6nYgSwEemABdf1yJ9dlA" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Hx43oASwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Hx43oQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hx43owSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Hx43ogSwEemABdf1yJ9dlA" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-zxQoASwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-zxQoQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-zxQowSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_RLGcANZIEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-zxQogSwEemABdf1yJ9dlA" x="-57" y="-102"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__edzcwSwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__edzdASwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__edzdgSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_2_a7wNcXEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__edzdQSwEemABdf1yJ9dlA" x="-57" y="-102"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_--vAkU-wEeitY7qZgkO_XQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_--vAkk-wEeitY7qZgkO_XQ"/>
@@ -3749,11 +4053,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_m_RGUItyEeik7I8D544C6Q" type="Association_Edge" source="_jrxwQ0-xEeitY7qZgkO_XQ" target="_F-r4QFRyEeitkMFXBYQFcg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_m_RGU4tyEeik7I8D544C6Q" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pchL4ItyEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_m_RGVItyEeik7I8D544C6Q" x="60" y="-58"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m_RGVItyEeik7I8D544C6Q" x="146" y="-70"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_m_RtYItyEeik7I8D544C6Q" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pfXrkItyEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_m_RtYYtyEeik7I8D544C6Q" x="82" y="-85"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m_RtYYtyEeik7I8D544C6Q" x="127" y="-76"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_m_RtYotyEeik7I8D544C6Q" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_piROkItyEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -3773,9 +4077,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_m_RGUYtyEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_I55FIFRyEeitkMFXBYQFcg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_m_RGUotyEeik7I8D544C6Q" points="[49, 92, -643984, -643984]$[49, 151, -643984, -643984]$[-67, 151, -643984, -643984]$[-67, 204, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pZftEItyEeik7I8D544C6Q" id="(0.07333333333333333,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pZgUIItyEeik7I8D544C6Q" id="(0.4827586206896552,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_m_RGUotyEeik7I8D544C6Q" points="[91, 92, -643984, -643984]$[91, 405, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pZftEItyEeik7I8D544C6Q" id="(0.21,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pZgUIItyEeik7I8D544C6Q" id="(0.15517241379310345,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_06Y9YItyEeik7I8D544C6Q" type="Association_Edge" source="_jrxwQ0-xEeitY7qZgkO_XQ" target="_nT0GYFRxEeitkMFXBYQFcg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_06Y9Y4tyEeik7I8D544C6Q" type="Association_StereotypeLabel">
@@ -3804,9 +4108,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_06Y9YYtyEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_zNY8cFRxEeitkMFXBYQFcg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_06Y9YotyEeik7I8D544C6Q" points="[189, 92, -643984, -643984]$[189, 197, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3v2HkItyEeik7I8D544C6Q" id="(0.54,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3v2HkYtyEeik7I8D544C6Q" id="(0.5205479452054794,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_06Y9YotyEeik7I8D544C6Q" points="[231, 92, -643984, -643984]$[231, 198, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3v2HkItyEeik7I8D544C6Q" id="(0.68,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3v2HkYtyEeik7I8D544C6Q" id="(0.1187214611872146,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_6f074ItyEeik7I8D544C6Q" type="Association_Edge" source="_jrxwQ0-xEeitY7qZgkO_XQ" target="_VUtAAFRyEeitkMFXBYQFcg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_6f1i8ItyEeik7I8D544C6Q" type="Association_StereotypeLabel">
@@ -4148,6 +4452,148 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PsrKhvK1EeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PsrKh_K1EeiTnqcAgKK24Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PsrKiPK1EeiTnqcAgKK24Q"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7EHVlP-uEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_7EHVkP-uEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7EHVlf-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7EHVmf-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7EHVlv-uEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7EHVl_-uEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7EHVmP-uEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7L28UP-uEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_7L2VQP-uEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7L28Uf-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7L28Vf-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7L28Uv-uEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7L28U_-uEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7L28VP-uEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FLToAv-vEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_FKizAP-vEeiABdf1yJ9dlA" target="_FLTA8P-vEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FLToA_-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FLX5cP-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_nkE94NYAEeidMu8ST4Ma3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FLToBP-vEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FLToBf-vEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FLUPEP-vEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F_qdIP-vEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_F_PmYP-vEeiABdf1yJ9dlA" target="_F_pPA_-vEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F_qdIf-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F_qdJf-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_-vckINa3EeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F_qdIv-vEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F_qdI_-vEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F_qdJP-vEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Hp7OcQSwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_Hp6nYASwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Hp7OcgSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hp7OdgSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hp7OcwSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hp7OdASwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hp7OdQSwEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Hx43pASwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_Hx43oASwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Hx43pQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hx5esgSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hx43pgSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hx5esASwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hx5esQSwEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-xFwEASwEemABdf1yJ9dlA" type="Association_Edge" source="_iN-8kE-xEeitY7qZgkO_XQ" target="_FKizAP-vEeiABdf1yJ9dlA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xGXIASwEemABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CNmTMASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXIQSwEemABdf1yJ9dlA" x="19" y="67"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xGXIgSwEemABdf1yJ9dlA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CWcGIASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXIwSwEemABdf1yJ9dlA" x="-1" y="90"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xGXJASwEemABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CeOwMASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXJQSwEemABdf1yJ9dlA" x="14" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xGXJgSwEemABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CmCoYASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXJwSwEemABdf1yJ9dlA" x="-14" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xG-MASwEemABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ct480ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xG-MQSwEemABdf1yJ9dlA" x="14" y="-21"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xG-MgSwEemABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_C2NyYASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xG-MwSwEemABdf1yJ9dlA" x="-14" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_-xFwEQSwEemABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_RLGcANZIEeidLb5WEUMFmw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-xFwEgSwEemABdf1yJ9dlA" points="[-246, 98, -643984, -643984]$[-246, 189, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIASxEemABdf1yJ9dlA" id="(0.04150943396226415,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIQSxEemABdf1yJ9dlA" id="(0.5,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-zxQpASwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_-xFwEASwEemABdf1yJ9dlA" target="_-zxQoASwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-zxQpQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-zxQqQSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_RLGcANZIEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-zxQpgSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-zxQpwSwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-zxQqASwEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__b3ycASwEemABdf1yJ9dlA" type="Association_Edge" source="_iN-8kE-xEeitY7qZgkO_XQ" target="_F_PmYP-vEeiABdf1yJ9dlA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="__b4ZgASwEemABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_E_Uz8ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZgQSwEemABdf1yJ9dlA" x="115" y="59"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__b4ZggSwEemABdf1yJ9dlA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FHPZ0ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZgwSwEemABdf1yJ9dlA" x="96" y="134"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__b4ZhASwEemABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FPGVUASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZhQSwEemABdf1yJ9dlA" x="55" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__b4ZhgSwEemABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FXdAEASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZhwSwEemABdf1yJ9dlA" x="-55" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__b4ZiASwEemABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FfVJsASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZiQSwEemABdf1yJ9dlA" x="18" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__b4ZigSwEemABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FnMsQASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZiwSwEemABdf1yJ9dlA" x="-17" y="-22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="__b3ycQSwEemABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_2_a7wNcXEeidLb5WEUMFmw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__b3ycgSwEemABdf1yJ9dlA" points="[-14, 98, -643984, -643984]$[-14, 357, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E1CPgASxEemABdf1yJ9dlA" id="(0.9169811320754717,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E1C2kASxEemABdf1yJ9dlA" id="(0.9136125654450262,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__edzdwSwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="__b3ycASwEemABdf1yJ9dlA" target="__edzcwSwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="__edzeASwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__eeaggSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_2_a7wNcXEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__edzeQSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__eeagASwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__eeagQSwEemABdf1yJ9dlA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_ODB7UFhmEeiYiLRYKaTpTw" type="PapyrusUMLClassDiagram" name="EthProActiveJobs" measurementUnit="Pixel">
@@ -6015,6 +6461,38 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dQiUgsc5EeiSV9wVm02xsw" x="560" y="-140"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_3dwS4P-uEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3dwS4f-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3dwS4_-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3dwS4v-uEeiABdf1yJ9dlA" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3htl0P-uEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3htl0f-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3htl0_-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3htl0v-uEeiABdf1yJ9dlA" x="560" y="-140"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_IJL9UASwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_IJL9UQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IJL9UwSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IJL9UgSwEemABdf1yJ9dlA" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_INDwsASwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_INDwsQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_INDwswSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_INDwsgSwEemABdf1yJ9dlA" x="560" y="-140"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_ODB7UVhmEeiYiLRYKaTpTw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_ODB7UlhmEeiYiLRYKaTpTw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_brdm8IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -7536,6 +8014,46 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dQiUhsc5EeiSV9wVm02xsw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dQiUh8c5EeiSV9wVm02xsw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dQiUiMc5EeiSV9wVm02xsw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3dwS5P-uEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_3dwS4P-uEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3dwS5f-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3dw58v-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3dwS5v-uEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3dw58P-uEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3dw58f-uEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3htl1P-uEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_3htl0P-uEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3htl1f-uEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3huM4v-uEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3htl1v-uEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3huM4P-uEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3huM4f-uEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_IJL9VASwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_IJL9UASwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_IJL9VQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IJL9WQSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IJL9VgSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IJL9VwSwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IJL9WASwEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_INDwtASwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_INDwsASwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_INDwtQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_INDwuQSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_INDwtgSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_INDwtwSwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_INDwuASwEemABdf1yJ9dlA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_tC4KUGBLEei7_-Uhq6CryQ" type="PapyrusUMLClassDiagram" name="EthOnDemandJobs" measurementUnit="Pixel">
@@ -9228,7 +9746,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K4zFsWBWEeiBxvDM8HEDKw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_HfynMFSJEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K4s_AWBWEeiBxvDM8HEDKw" x="570" y="221" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K4s_AWBWEeiBxvDM8HEDKw" x="570" y="221" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_bIDloIqfEeiT7s5en7ligw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_bIEMsIqfEeiT7s5en7ligw" type="Class_NameLabel"/>
@@ -9664,6 +10182,164 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5S0sQvK3EeiTnqcAgKK24Q" x="1234" y="59"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_LOpqgP-vEeiABdf1yJ9dlA" type="Class_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OZTbEgSxEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OZTbEwSxEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OZTbFQSxEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OZUCIQSxEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LOpqgv-vEeiABdf1yJ9dlA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LOpqg_-vEeiABdf1yJ9dlA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LOqRkP-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LOqRkf-vEeiABdf1yJ9dlA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_PWHBkASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_cYsmQNePEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWHBkQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWHBkgSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_aTjCMNeQEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWHBkwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWHBlASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_lPsKMNeREeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWHBlQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWHooASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_ckfNQNeUEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWHooQSxEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LOqRkv-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LOqRk_-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LOqRlP-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LOqRlf-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LOqRlv-vEeiABdf1yJ9dlA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LOqRl_-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LOqRmP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LOqRmf-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LOqRmv-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LOqRm_-vEeiABdf1yJ9dlA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LOqRnP-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LOqRnf-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LOqRnv-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LOqRn_-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LOpqgf-vEeiABdf1yJ9dlA" x="1033" y="330"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LO5iI_-vEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LO5iJP-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LO5iJv-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LO5iJf-vEeiABdf1yJ9dlA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_L-Tl0P-vEeiABdf1yJ9dlA" type="Class_Shape" fontColor="255" fontName="Segoe UI">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OZTbEASxEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OZTbEQSxEemABdf1yJ9dlA" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OZTbFASxEemABdf1yJ9dlA" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OZUCIASxEemABdf1yJ9dlA" key="italic" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L-UM4P-vEeiABdf1yJ9dlA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L-UM4f-vEeiABdf1yJ9dlA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L-UM4v-vEeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_L-UM4_-vEeiABdf1yJ9dlA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_PWD-QASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_xM0hYNpAEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWD-QQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWElUASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_yIQ18NpAEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWElUQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFMYASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_dInWYNn3EeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFMYQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFMYgSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_SoGHgNoDEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFMYwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFMZASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_TR4EUNoDEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFMZQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFMZgSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_T3c2kNoDEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFMZwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFzcASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_VFIKoNoDEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFzcQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFzcgSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_VrlGoNoDEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFzcwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFzdASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_WRcMwNoDEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFzdQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFzdgSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_TkloINoHEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFzdwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWFzeASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_UNFykNoHEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWFzeQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWGagASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_U1BVQNoHEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWGagQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWGaggSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_WZR9UNoHEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWGagwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWGahASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_8YO_0NoSEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWGahQSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWGahgSxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_NhZlkNomEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWGahwSxEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PWGaiASxEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_OjzdwNomEeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PWGaiQSxEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_L-UM5P-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_L-UM5f-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_L-UM5v-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L-UM5_-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_L-UM6P-vEeiABdf1yJ9dlA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_L-UM6f-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_L-UM6v-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_L-UM6_-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L-UM7P-vEeiABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_L-UM7f-vEeiABdf1yJ9dlA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_L-UM7v-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_L-UM7_-vEeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_L-UM8P-vEeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L-UM8f-vEeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L-Tl0f-vEeiABdf1yJ9dlA" x="888" y="479" height="285"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_L-o9AP-vEeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_L-o9Af-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L-o9A_-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L-o9Av-vEeiABdf1yJ9dlA" x="200"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_uH_zwWBVEeiBxvDM8HEDKw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_uH_zwmBVEeiBxvDM8HEDKw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_b1RqQIqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -9730,7 +10406,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_K5XtYWBWEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_YRB34FUaEeitkMFXBYQFcg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K5XtYmBWEeiBxvDM8HEDKw" points="[570, 240, -643984, -643984]$[454, 240, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5XtZ2BWEeiBxvDM8HEDKw" id="(0.0,0.2835820895522388)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5XtZ2BWEeiBxvDM8HEDKw" id="(0.0,0.24358974358974358)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5XtaGBWEeiBxvDM8HEDKw" id="(1.0,0.8735632183908046)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_-m5-sIqxEeiT7s5en7ligw" type="Abstraction_Edge" source="_3iTTgIqxEeiT7s5en7ligw" target="_bIDloIqfEeiT7s5en7ligw" routing="Rectilinear">
@@ -9803,7 +10479,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZGGYQJyjEeihoemEj9HqGA" id="(0.46258503401360546,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8ptXgJyfEeihoemEj9HqGA" id="(0.5172413793103449,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_uq6A0LEYEeiB1L1dQuD1kw" type="Association_Edge" source="_K4s_AGBWEeiBxvDM8HEDKw" target="_rIyaYLEXEeiB1L1dQuD1kw">
+    <edges xmi:type="notation:Connector" xmi:id="_uq6A0LEYEeiB1L1dQuD1kw" type="Association_Edge" source="_K4s_AGBWEeiBxvDM8HEDKw" target="_rIyaYLEXEeiB1L1dQuD1kw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_uq6n4LEYEeiB1L1dQuD1kw" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UwTqkLEZEeiB1L1dQuD1kw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_uq6n4bEYEeiB1L1dQuD1kw" x="-4" y="8"/>
@@ -9830,9 +10506,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_uq6A0bEYEeiB1L1dQuD1kw"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_umHAYLEYEeiB1L1dQuD1kw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uq6A0rEYEeiB1L1dQuD1kw" points="[745, 277, -643984, -643984]$[881, 279, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u1SE0LEYEeiB1L1dQuD1kw" id="(1.0,0.39622641509433965)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u1SE0bEYEeiB1L1dQuD1kw" id="(0.0,0.47692307692307695)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uq6A0rEYEeiB1L1dQuD1kw" points="[863, 248, -643984, -643984]$[1031, 248, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u1SE0LEYEeiB1L1dQuD1kw" id="(1.0,0.3333333333333333)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u1SE0bEYEeiB1L1dQuD1kw" id="(0.0,0.3384615384615385)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_A3a0kLEZEeiB1L1dQuD1kw" type="Association_Edge" source="_69WVkGBVEeiBxvDM8HEDKw" target="_XeRiILEYEeiB1L1dQuD1kw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_A3bborEZEeiB1L1dQuD1kw" type="Association_StereotypeLabel">
@@ -9892,8 +10568,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BvDnMbEZEeiB1L1dQuD1kw"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_BrbEYLEZEeiB1L1dQuD1kw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BvDnMrEZEeiB1L1dQuD1kw" points="[860, 94, -643984, -643984]$[1034, 94, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B3JMMLEZEeiB1L1dQuD1kw" id="(1.0,0.45614035087719296)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BvDnMrEZEeiB1L1dQuD1kw" points="[860, 93, -643984, -643984]$[1034, 93, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B3JMMLEZEeiB1L1dQuD1kw" id="(1.0,0.43859649122807015)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B3JMMbEZEeiB1L1dQuD1kw" id="(0.0,0.2323943661971831)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_5GybZPK3EeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_wQYckGBVEeiBxvDM8HEDKw" target="_5GybYPK3EeiTnqcAgKK24Q">
@@ -10115,6 +10791,88 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5S0sRvK3EeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5S0sR_K3EeiTnqcAgKK24Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5S0sSPK3EeiTnqcAgKK24Q"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LO5iJ_-vEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_LOpqgP-vEeiABdf1yJ9dlA" target="_LO5iI_-vEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LO5iKP-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LO6JMP-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LO5iKf-vEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LO5iKv-vEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LO5iK_-vEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_L-o9BP-vEeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_L-Tl0P-vEeiABdf1yJ9dlA" target="_L-o9AP-vEeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_L-o9Bf-vEeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L-o9Cf-vEeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L-o9Bv-vEeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L-o9B_-vEeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L-o9CP-vEeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UKuAEASxEemABdf1yJ9dlA" type="Association_Edge" source="_K4s_AGBWEeiBxvDM8HEDKw" target="_LOpqgP-vEeiABdf1yJ9dlA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UKuAEwSxEemABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Z1Fh4ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UKuAFASxEemABdf1yJ9dlA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UKunIASxEemABdf1yJ9dlA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Z-riwASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UKunIQSxEemABdf1yJ9dlA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UKunIgSxEemABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_aIhbQASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UKunIwSxEemABdf1yJ9dlA" x="32" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UKunJASxEemABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_aQo1cASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UKunJQSxEemABdf1yJ9dlA" x="-32" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UKunJgSxEemABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_aYuacASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UKunJwSxEemABdf1yJ9dlA" x="32" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UKunKASxEemABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ahgjAASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UKunKQSxEemABdf1yJ9dlA" x="-32" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UKuAEQSxEemABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_i9c3QNeQEeidLb5WEUMFmw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UKuAEgSxEemABdf1yJ9dlA" points="[837, 288, -643984, -643984]$[837, 373, -643984, -643984]$[967, 373, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZtCZIASxEemABdf1yJ9dlA" id="(0.9112627986348123,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZtCZIQSxEemABdf1yJ9dlA" id="(0.0,0.09230769230769231)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Utt_cASxEemABdf1yJ9dlA" type="Association_Edge" source="_3iTTgIqxEeiT7s5en7ligw" target="_L-Tl0P-vEeiABdf1yJ9dlA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UtumgASxEemABdf1yJ9dlA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_he7oIASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UtumgQSxEemABdf1yJ9dlA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UtumggSxEemABdf1yJ9dlA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hofMwASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UtumgwSxEemABdf1yJ9dlA" x="-92" y="21"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UtumhASxEemABdf1yJ9dlA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hwkKsASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UtumhQSxEemABdf1yJ9dlA" x="23" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UtumhgSxEemABdf1yJ9dlA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_h4hM0ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UtumhwSxEemABdf1yJ9dlA" x="-23" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UtumiASxEemABdf1yJ9dlA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iAtfgASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UtumiQSxEemABdf1yJ9dlA" x="15" y="-16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UtumigSxEemABdf1yJ9dlA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_iIjz8ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UtumiwSxEemABdf1yJ9dlA" x="-12" y="-14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Utt_cQSxEemABdf1yJ9dlA"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_0jzpINoxEeidLb5WEUMFmw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Utt_cgSxEemABdf1yJ9dlA" points="[781, 626, -643984, -643984]$[888, 626, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iQ8T4ASxEemABdf1yJ9dlA" id="(1.0,0.7758620689655172)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iQ8T4QSxEemABdf1yJ9dlA" id="(0.0,0.512280701754386)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_e0rQkIbqEeil5oKL3Vgl-g" type="PapyrusUMLClassDiagram" name="EthThresholdSpec" measurementUnit="Pixel">
@@ -10560,6 +11318,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D1yvssWdEeiWCKGKl1wb8w" x="557" y="13"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_JXxQUASwEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JXxQUQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXxQUwSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXxQUgSwEemABdf1yJ9dlA" x="557" y="13"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_e0rQkYbqEeil5oKL3Vgl-g" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_e0rQkobqEeil5oKL3Vgl-g"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_b6T7QIqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -10899,6 +11665,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D1yvtsWdEeiWCKGKl1wb8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D1yvt8WdEeiWCKGKl1wb8w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D1yvuMWdEeiWCKGKl1wb8w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JXx3YASwEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_JXxQUASwEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JXx3YQSwEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXx3ZQSwEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXx3YgSwEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXx3YwSwEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXx3ZASwEemABdf1yJ9dlA"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -4101,6 +4101,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lCa4gqvGEei1V6VHLzh4gA" x="-42" y="-54"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_T1KPgP--EeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T1KPgf--EeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1MEsP--EeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T1KPgv--EeiABdf1yJ9dlA" x="208" y="-68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_T56zsP--EeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T56zsf--EeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T56zs_--EeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T56zsv--EeiABdf1yJ9dlA" x="-42" y="-54"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Y9l7gIuXEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -6475,6 +6491,26 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lCa4h6vGEei1V6VHLzh4gA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lCa4iKvGEei1V6VHLzh4gA"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_T1MrwP--EeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_T1KPgP--EeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T1Mrwf--EeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1Mrxf--EeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T1Mrwv--EeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1Mrw_--EeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1MrxP--EeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_T56ztP--EeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_T56zsP--EeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T56ztf--EeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T57awP--EeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T56ztv--EeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T56zt_--EeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T56zuP--EeiABdf1yJ9dlA"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_lW6NAJQPEeebLvYqX3NA2Q" type="PapyrusUMLClassDiagram" name="OduOamSpec" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_YM5NUJQQEeebLvYqX3NA2Q" type="Class_Shape">
@@ -8306,7 +8342,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jM4Jrqu6Eei1V6VHLzh4gA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiOdu.uml#_WKC-0JSfEeeTcuZP_vjYKw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jM4Joau6Eei1V6VHLzh4gA" x="852" y="232"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jM4Joau6Eei1V6VHLzh4gA" x="860" y="240"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_khikkKu8Eei1V6VHLzh4gA" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_khikkqu8Eei1V6VHLzh4gA" type="Enumeration_NameLabel"/>
@@ -8337,6 +8373,70 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPqhau9Eei1V6VHLzh4gA" x="258" y="128"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pPBJAP--EeiABdf1yJ9dlA" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pPBwEP--EeiABdf1yJ9dlA" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pPBwEf--EeiABdf1yJ9dlA" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pPBwEv--EeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pPBwE_--EeiABdf1yJ9dlA" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_tuBD4P--EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_nB4qcP-7EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tuBD4f--EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tuBq8P--EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_wMFwMP-7EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tuBq8f--EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tuCSAP--EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_ADwMcP-8EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tuCSAf--EeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tuCSAv--EeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiConnectivity.uml#_mwZcYP-8EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tuCSA_--EeiABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pPBwFP--EeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pPBwFf--EeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pPBwFv--EeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pPBwF_--EeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_dEU1IP-7EeiABdf1yJ9dlA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pPBJAf--EeiABdf1yJ9dlA" x="1100" y="80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_wnr_sP--EeiABdf1yJ9dlA" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_wnr_sv--EeiABdf1yJ9dlA" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_wnr_s_--EeiABdf1yJ9dlA" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wnr_tP--EeiABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_wnr_tf--EeiABdf1yJ9dlA" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_mSEk0P_AEeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOdu.uml#_YJWMEP-_EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mSEk0f_AEeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_mSFy8P_AEeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOdu.uml#_ckF5EP-_EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mSFy8f_AEeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_mSFy8v_AEeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOdu.uml#_hsWzYP-_EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mSFy8__AEeiABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_wnr_tv--EeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_wnsmwP--EeiABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_wnsmwf--EeiABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wnsmwv--EeiABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOdu.uml#_wnqKgP--EeiABdf1yJ9dlA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wnr_sf--EeiABdf1yJ9dlA" x="1100" y="260"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EX5a0P-_EeiABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EX5a0f-_EeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EX5a0_-_EeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_C0j_0P-_EeiABdf1yJ9dlA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EX5a0v-_EeiABdf1yJ9dlA" x="1300" y="160"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_b2XPEau6Eei1V6VHLzh4gA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_b2XPEqu6Eei1V6VHLzh4gA"/>
@@ -8408,6 +8508,29 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDPqiau9Eei1V6VHLzh4gA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BDPqiqu9Eei1V6VHLzh4gA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BDPqi6u9Eei1V6VHLzh4gA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_C0pfYP-_EeiABdf1yJ9dlA" type="Abstraction_Edge" source="_wnr_sP--EeiABdf1yJ9dlA" target="_pPBJAP--EeiABdf1yJ9dlA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_C0qGcP-_EeiABdf1yJ9dlA" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_C0qGcf-_EeiABdf1yJ9dlA" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_C0qGcv-_EeiABdf1yJ9dlA" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_C0qGc_-_EeiABdf1yJ9dlA" x="-20" y="-62"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_C0pfYf-_EeiABdf1yJ9dlA"/>
+      <element xmi:type="uml:Abstraction" href="TapiOdu.uml#_C0j_0P-_EeiABdf1yJ9dlA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_C0pfYv-_EeiABdf1yJ9dlA" points="[1200, 260, -643984, -643984]$[1200, 195, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C4XhwP-_EeiABdf1yJ9dlA" id="(0.4854368932038835,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C4Xhwf-_EeiABdf1yJ9dlA" id="(0.5376344086021505,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EX5a1P-_EeiABdf1yJ9dlA" type="StereotypeCommentLink" source="_C0pfYP-_EeiABdf1yJ9dlA" target="_EX5a0P-_EeiABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EX5a1f-_EeiABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EX5a2f-_EeiABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_C0j_0P-_EeiABdf1yJ9dlA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EX5a1v-_EeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EX5a1_-_EeiABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EX5a2P-_EeiABdf1yJ9dlA"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -4117,6 +4117,122 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T56zsv--EeiABdf1yJ9dlA" x="-42" y="-54"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_4me0YAOyEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4me0YQOyEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4me0YwOyEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4me0YgOyEemABdf1yJ9dlA" x="208" y="-68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_41gu4AOyEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_41gu4QOyEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_41gu4wOyEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_41gu4gOyEemABdf1yJ9dlA" x="-42" y="-54"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gvMxwARYEemABdf1yJ9dlA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gvUtkARYEemABdf1yJ9dlA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gvVUoARYEemABdf1yJ9dlA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gvV7sARYEemABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gvWiwARYEemABdf1yJ9dlA" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gvWiwQRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gvWiwgRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gvWiwwRYEemABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gvWixARYEemABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gvXJ0ARYEemABdf1yJ9dlA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gvXJ0QRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gvXJ0gRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gvXJ0wRYEemABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gvXJ1ARYEemABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gvXJ1QRYEemABdf1yJ9dlA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gvXJ1gRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gvXJ1wRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gvXJ2ARYEemABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gvXJ2QRYEemABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gvNY0ARYEemABdf1yJ9dlA" x="720" y="-460" width="341" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gwvp4ARYEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gwvp4QRYEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gwvp4wRYEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gwvp4gRYEemABdf1yJ9dlA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_r8dUYARYEemABdf1yJ9dlA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_r8fJkARYEemABdf1yJ9dlA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r8fJkQRYEemABdf1yJ9dlA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r8fJkgRYEemABdf1yJ9dlA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_r8gXsARYEemABdf1yJ9dlA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_GmppoARaEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_GmPZ8ARaEemABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GmppoQRaEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UASkQARaEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_UAKBYARaEemABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UASkQQRaEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_XOKOcARaEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_XOC5sARaEemABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XOKOcQRaEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cIOUsARaEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_cIBgYARaEemABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cIOUsQRaEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jt7h0ARaEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_jtxw0ARaEemABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jt7h0QRaEemABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wtfvkARaEemABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_wtbeIARaEemABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wtfvkQRaEemABdf1yJ9dlA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_r8gXsQRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_r8gXsgRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_r8gXswRYEemABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r8gXtARYEemABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_r8g-wARYEemABdf1yJ9dlA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_r8g-wQRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_r8g-wgRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_r8g-wwRYEemABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r8g-xARYEemABdf1yJ9dlA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_r8hl0ARYEemABdf1yJ9dlA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_r8hl0QRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_r8hl0gRYEemABdf1yJ9dlA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_r8hl0wRYEemABdf1yJ9dlA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r8hl1ARYEemABdf1yJ9dlA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOdu.uml#_r8OD0ARYEemABdf1yJ9dlA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r8dUYQRYEemABdf1yJ9dlA" x="720" y="-340" height="141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_r9JQ4ARYEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r9JQ4QRYEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9JQ4wRYEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_r8OD0ARYEemABdf1yJ9dlA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r9JQ4gRYEemABdf1yJ9dlA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bi1VAARbEemABdf1yJ9dlA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bi1VAQRbEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bi1VAwRbEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_3XrIkARaEemABdf1yJ9dlA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bi1VAgRbEemABdf1yJ9dlA" x="920" y="-460"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Y9l7gIuXEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -6510,6 +6626,71 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T56ztv--EeiABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T56zt_--EeiABdf1yJ9dlA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T56zuP--EeiABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4me0ZAOyEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_4me0YAOyEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4me0ZQOyEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4me0aQOyEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4me0ZgOyEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4me0ZwOyEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4me0aAOyEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_41gu5AOyEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_41gu4AOyEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_41hV8AOyEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_41hV9AOyEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_41hV8QOyEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_41hV8gOyEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_41hV8wOyEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gwxfEARYEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_gvMxwARYEemABdf1yJ9dlA" target="_gwvp4ARYEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gwxfEQRYEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gwzUQARYEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gwxfEgRYEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gwyGIARYEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gwytMARYEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r9J38ARYEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_r8dUYARYEemABdf1yJ9dlA" target="_r9JQ4ARYEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r9J38QRYEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9J39QRYEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_r8OD0ARYEemABdf1yJ9dlA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r9J38gRYEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9J38wRYEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9J39ARYEemABdf1yJ9dlA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3XxPMARaEemABdf1yJ9dlA" type="Abstraction_Edge" source="_r8dUYARYEemABdf1yJ9dlA" target="_gvMxwARYEemABdf1yJ9dlA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3XxPMwRaEemABdf1yJ9dlA" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BWP_oARdEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3XxPNARaEemABdf1yJ9dlA" x="3" y="-79"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3Xx2QARaEemABdf1yJ9dlA" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Bd4RoARdEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Xx2QQRaEemABdf1yJ9dlA" x="-17" y="-62"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_3XxPMQRaEemABdf1yJ9dlA"/>
+      <element xmi:type="uml:Abstraction" href="TapiOdu.uml#_3XrIkARaEemABdf1yJ9dlA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3XxPMgRaEemABdf1yJ9dlA" points="[900, -360, -643984, -643984]$[900, -399, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3oM34ARaEemABdf1yJ9dlA" id="(0.5172413793103449,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3oM34QRaEemABdf1yJ9dlA" id="(0.5278592375366569,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Bi1VBARbEemABdf1yJ9dlA" type="StereotypeCommentLink" source="_3XxPMARaEemABdf1yJ9dlA" target="_Bi1VAARbEemABdf1yJ9dlA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Bi1VBQRbEemABdf1yJ9dlA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bi18EgRbEemABdf1yJ9dlA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_3XrIkARaEemABdf1yJ9dlA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bi1VBgRbEemABdf1yJ9dlA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bi18EARbEemABdf1yJ9dlA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bi18EQRbEemABdf1yJ9dlA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_lW6NAJQPEeebLvYqX3NA2Q" type="PapyrusUMLClassDiagram" name="OduOamSpec" measurementUnit="Pixel">

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -117,7 +117,32 @@ License: This module is distributed under the Apache License 2.0</body>
         <supplier xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_sYw7vx3BEea2UIYIpgn3Zw" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_sYw7vx3BEea2UIYIpgn3Zw" name="Diagrams">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_wnqKgP--EeiABdf1yJ9dlA" name="OtnFaultConditionDetermination">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_6xs8oP--EeiABdf1yJ9dlA" annotatedElement="_wnqKgP--EeiABdf1yJ9dlA">
+          <body>T-REC-G.873.1-201710&#xD;
+Optical transport network: Linear protection</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YJWMEP-_EeiABdf1yJ9dlA" name="NON_INTRUSIVE_CLIENT">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_YJWMEf-_EeiABdf1yJ9dlA" annotatedElement="_YJWMEP-_EeiABdf1yJ9dlA">
+            <body>Non-intrusive monitoring of Client signal fail</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ckF5EP-_EeiABdf1yJ9dlA" name="NON_INTRUSIVE_E2E">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ckF5Ef-_EeiABdf1yJ9dlA" annotatedElement="_ckF5EP-_EeiABdf1yJ9dlA">
+            <body>Non-intrusive end-to-end monitoring</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_hsWzYP-_EeiABdf1yJ9dlA" name="NON_INTRUSIVE_SUBLAYER">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hsWzYf-_EeiABdf1yJ9dlA" annotatedElement="_hsWzYP-_EeiABdf1yJ9dlA">
+            <body>Non-intrusive Sublayer monitoring</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_C0j_0P-_EeiABdf1yJ9dlA" name="OtnFaultConditionDeterminationAugmentsFaultConditionDetermination" client="_wnqKgP--EeiABdf1yJ9dlA">
+        <supplier xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_dEU1IP-7EeiABdf1yJ9dlA"/>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_sYxiwB3BEea2UIYIpgn3Zw" name="ObjectClasses">
       <packagedElement xmi:type="uml:Class" xmi:id="_sYxiwR3BEea2UIYIpgn3Zw" name="OduTerminationAndClientAdaptationPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_TmyDEEeLEeetffGEmR5xrg" annotatedElement="_sYxiwR3BEea2UIYIpgn3Zw">
@@ -1019,4 +1044,5 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenModel_Profile:StrictComposite xmi:id="_gxcX8BNqEeiod932A6hg3A" base_Association="_24Bd4JQQEeebLvYqX3NA2Q"/>
   <OpenModel_Profile:OpenModelStatement xmi:id="_cz1tUGm2EeiLh_06MH5Rjg" base_Model="_LTrOcBwyEea2UIYIpgn3Zw"/>
   <OpenModel_Profile:Specify xmi:id="_BB5msKu9Eei1V6VHLzh4gA" base_Abstraction="_mymoQKu8Eei1V6VHLzh4gA"/>
+  <OpenModel_Profile:Specify xmi:id="_EVpYEP-_EeiABdf1yJ9dlA" base_Abstraction="_C0j_0P-_EeiABdf1yJ9dlA"/>
 </xmi:XMI>

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -142,6 +142,54 @@ Optical transport network: Linear protection</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_C0j_0P-_EeiABdf1yJ9dlA" name="OtnFaultConditionDeterminationAugmentsFaultConditionDetermination" client="_wnqKgP--EeiABdf1yJ9dlA">
         <supplier xmi:type="uml:Enumeration" href="TapiConnectivity.uml#_dEU1IP-7EeiABdf1yJ9dlA"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_r8OD0ARYEemABdf1yJ9dlA" name="OduConnectivityServiceEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GmPZ8ARaEemABdf1yJ9dlA" name="oduType" visibility="public" type="_QRjOYITEEea405q5sHuNGg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GmPZ8QRaEemABdf1yJ9dlA" annotatedElement="_GmPZ8ARaEemABdf1yJ9dlA">
+            <body>This attribute specifies the type of the ODU termination point.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GmPZ8gRaEemABdf1yJ9dlA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GmPZ8wRaEemABdf1yJ9dlA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UAKBYARaEemABdf1yJ9dlA" name="tributarySlotList" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_UAKBYQRaEemABdf1yJ9dlA" annotatedElement="_UAKBYARaEemABdf1yJ9dlA">
+            <body>This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). &#xD;
+This attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. &#xD;
+It will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). &#xD;
+The upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). &#xD;
+Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UAKBYgRaEemABdf1yJ9dlA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UAKBYwRaEemABdf1yJ9dlA" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XOC5sARaEemABdf1yJ9dlA" name="tributaryPortNumber" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_XOC5sQRaEemABdf1yJ9dlA" annotatedElement="_XOC5sARaEemABdf1yJ9dlA">
+            <body>This attribute identifies the tributary port number that is associated with the ODU CTP.&#xD;
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cIBgYARaEemABdf1yJ9dlA" name="opuTributarySlotSize" type="_2ChJIITYEea405q5sHuNGg" isReadOnly="true" isDerivedUnion="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_cIBgYQRaEemABdf1yJ9dlA" annotatedElement="_cIBgYARaEemABdf1yJ9dlA">
+            <body>This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jtxw0ARaEemABdf1yJ9dlA" name="configuredMappingType" type="_xwDcIITdEea405q5sHuNGg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jtxw0QRaEemABdf1yJ9dlA" annotatedElement="_jtxw0ARaEemABdf1yJ9dlA">
+            <body>This attributes indicates the configured mapping type.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wtbeIARaEemABdf1yJ9dlA" name="acceptedPayloadType" visibility="public" type="_lSSWAGZMEeeGDK6oTuc93w" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wtbeIQRaEemABdf1yJ9dlA" annotatedElement="_wtbeIARaEemABdf1yJ9dlA">
+            <body>This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. &#xD;
+This attribute is a 2-digit Hex code that indicates the new accepted payload type.&#xD;
+Valid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_3XrIkARaEemABdf1yJ9dlA" name="OduCsepSpecAugmentsCsep" client="_r8OD0ARYEemABdf1yJ9dlA">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_sYxiwB3BEea2UIYIpgn3Zw" name="ObjectClasses">
       <packagedElement xmi:type="uml:Class" xmi:id="_sYxiwR3BEea2UIYIpgn3Zw" name="OduTerminationAndClientAdaptationPac">
@@ -149,7 +197,7 @@ Optical transport network: Linear protection</body>
           <body>This Pac contains the attributes associated with the client adaptation function of the server layer TTP&#xD;
 It is present only if the CEP contains a TTP</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_1oOPQITXEea405q5sHuNGg" name="opuTributarySlotSize" type="_2ChJIITYEea405q5sHuNGg" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1oOPQITXEea405q5sHuNGg" name="opuTributarySlotSize" type="_2ChJIITYEea405q5sHuNGg" isReadOnly="true" isDerivedUnion="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_qkULAITZEea405q5sHuNGg" annotatedElement="_1oOPQITXEea405q5sHuNGg">
             <body>This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP.</body>
           </ownedComment>
@@ -1045,4 +1093,28 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenModel_Profile:OpenModelStatement xmi:id="_cz1tUGm2EeiLh_06MH5Rjg" base_Model="_LTrOcBwyEea2UIYIpgn3Zw"/>
   <OpenModel_Profile:Specify xmi:id="_BB5msKu9Eei1V6VHLzh4gA" base_Abstraction="_mymoQKu8Eei1V6VHLzh4gA"/>
   <OpenModel_Profile:Specify xmi:id="_EVpYEP-_EeiABdf1yJ9dlA" base_Abstraction="_C0j_0P-_EeiABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_r8P5AARYEemABdf1yJ9dlA" base_Class="_r8OD0ARYEemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_r8S8UARYEemABdf1yJ9dlA" base_Class="_r8OD0ARYEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:Experimental xmi:id="_-d29kARZEemABdf1yJ9dlA" base_Element="_r8OD0ARYEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GmQBAARaEemABdf1yJ9dlA" base_StructuralFeature="_GmPZ8ARaEemABdf1yJ9dlA" isInvariant="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_GmQoEARaEemABdf1yJ9dlA" base_Property="_GmPZ8ARaEemABdf1yJ9dlA" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Preliminary xmi:id="_GnYCYARaEemABdf1yJ9dlA" base_Element="_GmPZ8ARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UAKocARaEemABdf1yJ9dlA" base_StructuralFeature="_UAKBYARaEemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UALPgARaEemABdf1yJ9dlA" base_Property="_UAKBYARaEemABdf1yJ9dlA" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Preliminary xmi:id="_UAVnkARaEemABdf1yJ9dlA" base_Element="_UAKBYARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XODgwARaEemABdf1yJ9dlA" base_StructuralFeature="_XOC5sARaEemABdf1yJ9dlA" valueRange="The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.&#xD;&#xA;&#xD;&#xA;In case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.&#xD;&#xA;&#xD;&#xA;In case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.&#xD;&#xA;&#xD;&#xA;In case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.&#xD;&#xA;&#xD;&#xA;In case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.&#xD;&#xA;"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_XODgwQRaEemABdf1yJ9dlA" base_Property="_XOC5sARaEemABdf1yJ9dlA" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Preliminary xmi:id="_XOMqsARaEemABdf1yJ9dlA" base_Element="_XOC5sARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cIBgYgRaEemABdf1yJ9dlA" base_StructuralFeature="_cIBgYARaEemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cICugARaEemABdf1yJ9dlA" base_Property="_cIBgYARaEemABdf1yJ9dlA" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Experimental xmi:id="_cIRYAARaEemABdf1yJ9dlA" base_Element="_cIBgYARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jtxw0gRaEemABdf1yJ9dlA" base_StructuralFeature="_jtxw0ARaEemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jtyX4ARaEemABdf1yJ9dlA" base_Property="_jtxw0ARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:Experimental xmi:id="_jt9XAARaEemABdf1yJ9dlA" base_Element="_jtxw0ARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wtbeIgRaEemABdf1yJ9dlA" base_StructuralFeature="_wtbeIARaEemABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_wtcFMARaEemABdf1yJ9dlA" base_Property="_wtbeIARaEemABdf1yJ9dlA" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Experimental xmi:id="_wthkwARaEemABdf1yJ9dlA" base_Element="_wtbeIARaEemABdf1yJ9dlA"/>
+  <OpenModel_Profile:Specify xmi:id="_BaLIQARbEemABdf1yJ9dlA" base_Abstraction="_3XrIkARaEemABdf1yJ9dlA">
+    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
+  </OpenModel_Profile:Specify>
 </xmi:XMI>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -269,34 +269,6 @@
       <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_5Mca0Bk-EeeV4o0osG5stg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gUZAwUwCEeewALXL7BvPYw" x="223" y="283"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7nzkIIhGEeeOl5P_FBJSmA" type="DataType_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_7nzkIohGEeeOl5P_FBJSmA" type="DataType_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_7n0LMIhGEeeOl5P_FBJSmA" type="DataType_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7n0LMYhGEeeOl5P_FBJSmA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_7n0LMohGEeeOl5P_FBJSmA" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_8jCdUIhGEeeOl5P_FBJSmA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_BSey8IfOEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8jCdUYhGEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_8jCdUohGEeeOl5P_FBJSmA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_D8PDcIfOEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8jCdU4hGEeeOl5P_FBJSmA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_7n0LM4hGEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_7n0LNIhGEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_7n0LNYhGEeeOl5P_FBJSmA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7n0LNohGEeeOl5P_FBJSmA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_7n0LN4hGEeeOl5P_FBJSmA" type="DataType_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_7n0LOIhGEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_7n0LOYhGEeeOl5P_FBJSmA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_7n0LOohGEeeOl5P_FBJSmA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7n0LO4hGEeeOl5P_FBJSmA"/>
-      </children>
-      <element xmi:type="uml:DataType" href="TapiTopology.uml#_IQQS0IfNEeeirpBaj87qAw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7nzkIYhGEeeOl5P_FBJSmA" x="560" y="16"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_9VhqMIhGEeeOl5P_FBJSmA" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_9VhqMohGEeeOl5P_FBJSmA" type="Enumeration_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_9VhqM4hGEeeOl5P_FBJSmA" type="Enumeration_FloatingNameLabel">
@@ -314,6 +286,14 @@
         <children xmi:type="notation:Shape" xmi:id="_-eW6gIhGEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_jbZjMHjfEee9bcuk4UnRkg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_-eW6gYhGEeeOl5P_FBJSmA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AYg6GIhHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_1JljsEtiEeet_JEg2fof-A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AYg6GYhHEeeOl5P_FBJSmA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AYhhIIhHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_1_9LAEtiEeet_JEg2fof-A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AYhhIYhHEeeOl5P_FBJSmA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_9VhqNohGEeeOl5P_FBJSmA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_9VhqN4hGEeeOl5P_FBJSmA"/>
@@ -337,25 +317,21 @@
           <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_ojEIEEtiEeet_JEg2fof-A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_AYg6EYhHEeeOl5P_FBJSmA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_AYg6EohHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_uyuvUEtiEeet_JEg2fof-A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AYg6E4hHEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_AYg6FIhHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_xTUcwEtiEeet_JEg2fof-A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AYg6FYhHEeeOl5P_FBJSmA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_AYg6FohHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_zdJ3EEtiEeet_JEg2fof-A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_AYg6F4hHEeeOl5P_FBJSmA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_AYg6GIhHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_1JljsEtiEeet_JEg2fof-A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AYg6GYhHEeeOl5P_FBJSmA"/>
+        <children xmi:type="notation:Shape" xmi:id="_3gyeIP_BEeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_pvkxAP_BEeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_3gyeIf_BEeiABdf1yJ9dlA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_AYhhIIhHEeeOl5P_FBJSmA" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_1_9LAEtiEeet_JEg2fof-A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AYhhIYhHEeeOl5P_FBJSmA"/>
+        <children xmi:type="notation:Shape" xmi:id="_t1ENcP_GEeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_iVvqcP_GEeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_t1ENcf_GEeiABdf1yJ9dlA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_t1JF8P_GEeiABdf1yJ9dlA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_p-jO4P_GEeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_t1JF8f_GEeiABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__jG8EohGEeeOl5P_FBJSmA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__jG8E4hGEeeOl5P_FBJSmA"/>
@@ -363,7 +339,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__jG8FYhGEeeOl5P_FBJSmA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_9bzYYOr1EeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__jGVAYhGEeeOl5P_FBJSmA" x="549" y="242"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__jGVAYhGEeeOl5P_FBJSmA" x="540" y="300"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_717IwTBCEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_717IwjBCEea4fKwSGMr6CA"/>
@@ -1391,6 +1367,10 @@
         <children xmi:type="notation:Shape" xmi:id="_41iOJtoGEeeYx-v40uoW_Q" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_41iOJ9oGEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EOnxwP-5EeiABdf1yJ9dlA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiTopology.uml#_EFvikP-5EeiABdf1yJ9dlA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EOnxwf-5EeiABdf1yJ9dlA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_WvbkHTBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_WvbkHjBDEea4fKwSGMr6CA"/>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -421,7 +421,8 @@ Is not present in more complex cases.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QpQJIoNtEeW35P6IpRw6Dg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QpQJI4NtEeW35P6IpRw6Dg" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_6TXH4IfREeeirpBaj87qAw" name="resilienceType" type="_IQQS0IfNEeeirpBaj87qAw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6TXH4IfREeeirpBaj87qAw" name="protectionType" type="_9bzYYOr1EeaeHOJw3lCT8A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EFvikP-5EeiABdf1yJ9dlA" name="restorationPolicy" type="_5PZ_AEthEeet_JEg2fof-A"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_xImb0OK4EeSq5fATALSQkQ" name="Node" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_xImb0eK4EeSq5fATALSQkQ" annotatedElement="_xImb0OK4EeSq5fATALSQkQ">
@@ -936,23 +937,20 @@ Depending upon the importance of the traffic being routed different risk charact
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_3SEY0Bk-EeeV4o0osG5stg" name="RISK"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nR7FcBl_EeeV4o0osG5stg" name="GROUPING"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_IQQS0IfNEeeirpBaj87qAw" name="ResilienceType">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_BSey8IfOEeeirpBaj87qAw" name="restorationPolicy" type="_5PZ_AEthEeet_JEg2fof-A"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_D8PDcIfOEeeirpBaj87qAw" name="protectionType" type="_9bzYYOr1EeaeHOJw3lCT8A"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_5PZ_AEthEeet_JEg2fof-A" name="RestorationPolicy" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_9YG5wEthEeet_JEg2fof-A" name="PER_DOMAIN_RESTORATION"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__V-7sEthEeet_JEg2fof-A" name="END_TO_END_RESTORATION"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jbZjMHjfEee9bcuk4UnRkg" name="NA"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_9bzYYOr1EeaeHOJw3lCT8A" name="ProtectionType" isLeaf="true">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nuQnAEtiEeet_JEg2fof-A" name="NO_PROTECTON"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ojEIEEtiEeet_JEg2fof-A" name="ONE_PLUS_ONE_PROTECTION"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_uyuvUEtiEeet_JEg2fof-A" name="ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_xTUcwEtiEeet_JEg2fof-A" name="PERMANENT_ONE_PLUS_ONE_PROTECTION"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_zdJ3EEtiEeet_JEg2fof-A" name="ONE_FOR_ONE_PROTECTION"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1JljsEtiEeet_JEg2fof-A" name="DYNAMIC_RESTORATION"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1_9LAEtiEeet_JEg2fof-A" name="PRE_COMPUTED_RESTORATION"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_9bzYYOr1EeaeHOJw3lCT8A" name="ProtectionType" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nuQnAEtiEeet_JEg2fof-A" name="NO_PROTECTION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ojEIEEtiEeet_JEg2fof-A" name="ONE_PLUS_ONE_PROTECTION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_zdJ3EEtiEeet_JEg2fof-A" name="ONE_FOR_ONE_PROTECTION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_pvkxAP_BEeiABdf1yJ9dlA" name="ONE_FOR_N_PROTECTION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iVvqcP_GEeiABdf1yJ9dlA" name="M_FOR_N_PROTECTION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_p-jO4P_GEeiABdf1yJ9dlA" name="ONE_FOR_ONE_BY_N"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_FKJUsNk_EeidLb5WEUMFmw" name="NepLayerProtocolCapability">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_6wFUINk_EeidLb5WEUMFmw" name="layerProtocolQualifier">
@@ -1322,10 +1320,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_AvAR9FqpEeexvMtO2oNM9g" base_Class="_JCwTkBk8EeeV4o0osG5stg"/>
   <OpenModel_Profile:LifecycleAggregate xmi:id="_3gKIsFroEeexvMtO2oNM9g" base_Association="_T7gvkD_LEeWNAdBR30aJhw"/>
   <OpenModel_Profile:LifecycleAggregate xmi:id="_8sWgwFroEeexvMtO2oNM9g" base_Association="_v4NNUETtEead1bezhJG4aw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_BSfaAIfOEeeirpBaj87qAw" base_StructuralFeature="_BSey8IfOEeeirpBaj87qAw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BSkSgIfOEeeirpBaj87qAw" base_Property="_BSey8IfOEeeirpBaj87qAw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_D8PDcYfOEeeirpBaj87qAw" base_StructuralFeature="_D8PDcIfOEeeirpBaj87qAw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_D8PqgIfOEeeirpBaj87qAw" base_Property="_D8PDcIfOEeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6TXH4YfREeeirpBaj87qAw" base_StructuralFeature="_6TXH4IfREeeirpBaj87qAw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6TXu8IfREeeirpBaj87qAw" base_Property="_6TXH4IfREeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_qpAjEag3EeeAVfY3jqnvAA" base_StructuralFeature="_qpAjEKg3EeeAVfY3jqnvAA"/>
@@ -1347,4 +1341,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6wGiQNk_EeidLb5WEUMFmw" base_StructuralFeature="_6wFUINk_EeidLb5WEUMFmw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BM6NodlAEeidLb5WEUMFmw" base_Property="_BM6NoNlAEeidLb5WEUMFmw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_BM60sNlAEeidLb5WEUMFmw" base_StructuralFeature="_BM6NoNlAEeidLb5WEUMFmw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_EFvikf-5EeiABdf1yJ9dlA" base_StructuralFeature="_EFvikP-5EeiABdf1yJ9dlA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_EFvikv-5EeiABdf1yJ9dlA" base_Property="_EFvikP-5EeiABdf1yJ9dlA"/>
 </xmi:XMI>


### PR DESCRIPTION
- Split the ResilienceType into two distinct attributes: ProtectionType and RestorationPolicy.
- Updated ProtectionType according to G.808.
- Added reference from CSEP to peer-forwarding CSEP (multi-point protection schemes)
- Added CSEPIsProtectedByCSEP for multi-point protection schemes
- Added faultConditionDetermination attribute to ResilienceConstraint class according to G.808.
- Missing type from faultConditionDetermination attribute
- Added OTN specific fault condition determination (G.873.1)
- Introduced experimental ODU CSEP (not related to Resilience, rather to "asymmetric" connectivity case.
- Added reference from CSEP to server CSEP (for multi-layer constraints and "asymmetric connectivity case).