### PR TITLE
LLDP Modeling added to the TapiOam model

### DIFF
--- a/UML/ImplementationCommonDataTypes.di
+++ b/UML/ImplementationCommonDataTypes.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>

--- a/UML/ImplementationCommonDataTypes.notation
+++ b/UML/ImplementationCommonDataTypes.notation
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:css="http://www.eclipse.org/papyrus/infra/gmfdiag/css" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <notation:Diagram xmi:id="_fXz48FDQEeWpFusmeDrF3w" type="PapyrusUMLClassDiagram" name="ietf-inet-types ClassDiagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_n1czoFDQEeWpFusmeDrF3w" type="2010">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_t06bsFDQEeWpFusmeDrF3w" source="Stereotype_Annotation">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_t07CwFDQEeWpFusmeDrF3w" key="StereotypeWithQualifiedNameList" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_t07CwVDQEeWpFusmeDrF3w" key="StereotypeList" value="OpenModel_Profile::Choice"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_t07CwlDQEeWpFusmeDrF3w" key="Stereotype_Presentation_Kind" value="HorizontalStereo"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_t07Cw1DQEeWpFusmeDrF3w" key="PropStereoDisplay" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_t07CxFDQEeWpFusmeDrF3w" key="StereotypePropertyLocation" value="Compartment"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_n1eo0FDQEeWpFusmeDrF3w" type="5035">
+        <element xmi:type="uml:DataType" href="ImplementationCommonDataTypes.uml#_lMSD-FDOEeWpFusmeDrF3w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n1eo0VDQEeWpFusmeDrF3w" type="7020">
+        <children xmi:type="notation:Shape" xmi:id="_qiN74FDQEeWpFusmeDrF3w" type="3018">
+          <element xmi:type="uml:Property" href="ImplementationCommonDataTypes.uml#_lMSD_FDOEeWpFusmeDrF3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_qiN74VDQEeWpFusmeDrF3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_qiOi8FDQEeWpFusmeDrF3w" type="3018">
+          <element xmi:type="uml:Property" href="ImplementationCommonDataTypes.uml#_lMSD_1DOEeWpFusmeDrF3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_qiOi8VDQEeWpFusmeDrF3w"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n1eo0lDQEeWpFusmeDrF3w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n1eo01DQEeWpFusmeDrF3w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n1eo1FDQEeWpFusmeDrF3w"/>
+        <element xmi:type="uml:DataType" href="ImplementationCommonDataTypes.uml#_lMSD-FDOEeWpFusmeDrF3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1eo1VDQEeWpFusmeDrF3w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n1eo1lDQEeWpFusmeDrF3w" visible="false" type="7021">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n1eo11DQEeWpFusmeDrF3w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n1eo2FDQEeWpFusmeDrF3w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n1eo2VDQEeWpFusmeDrF3w"/>
+        <element xmi:type="uml:DataType" href="ImplementationCommonDataTypes.uml#_lMSD-FDOEeWpFusmeDrF3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1eo2lDQEeWpFusmeDrF3w"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ImplementationCommonDataTypes.uml#_lMSD-FDOEeWpFusmeDrF3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1czoVDQEeWpFusmeDrF3w" x="166" y="102"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5hMKsFDSEeWkF-fUd7ZbEw" type="2009">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hP1EFDSEeWkF-fUd7ZbEw" type="5032">
+        <element xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMSEAlDOEeWpFusmeDrF3w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5hQcIFDSEeWkF-fUd7ZbEw" visible="false" type="7039">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5hQcIVDSEeWkF-fUd7ZbEw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5hQcIlDSEeWkF-fUd7ZbEw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5hQcI1DSEeWkF-fUd7ZbEw"/>
+        <element xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMSEAlDOEeWpFusmeDrF3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5hQcJFDSEeWkF-fUd7ZbEw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5hQcJVDSEeWkF-fUd7ZbEw" visible="false" type="7040">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5hQcJlDSEeWkF-fUd7ZbEw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5hQcJ1DSEeWkF-fUd7ZbEw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5hQcKFDSEeWkF-fUd7ZbEw"/>
+        <element xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMSEAlDOEeWpFusmeDrF3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5hQcKVDSEeWkF-fUd7ZbEw"/>
+      </children>
+      <element xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMSEAlDOEeWpFusmeDrF3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5hMKsVDSEeWkF-fUd7ZbEw" x="452" y="106"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_fX0gAFDQEeWpFusmeDrF3w" name="diagram_compatibility_version" stringValue="1.0.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_fX0gAVDQEeWpFusmeDrF3w"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_fX0gAlDQEeWpFusmeDrF3w">
+      <owner xmi:type="uml:Package" href="ImplementationCommonDataTypes.uml#_lMSD4FDOEeWpFusmeDrF3w"/>
+    </styles>
+    <element xmi:type="uml:Package" href="ImplementationCommonDataTypes.uml#_lMSD4FDOEeWpFusmeDrF3w"/>
+  </notation:Diagram>
+  <css:ModelStyleSheets xmi:id="_j4-XAFDQEeWpFusmeDrF3w"/>
+</xmi:XMI>

--- a/UML/ImplementationCommonDataTypes.uml
+++ b/UML/ImplementationCommonDataTypes.uml
@@ -1,0 +1,3880 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:standard="http://www.eclipse.org/uml2/5.0.0/UML/Profile/Standard" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <uml:Model xmi:id="_-lRh4FDNEeWpFusmeDrF3w" name="ImplementationCommonDataTypes">
+    <packagedElement xmi:type="uml:Package" xmi:id="_iP7WAPZaEeWhRf3FikFX5w" name="IdentifierRelatedTypes">
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP7WAfZaEeWhRf3FikFX5w" name="ObjectIdentifier">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP7WAvZaEeWhRf3FikFX5w" annotatedElement="_iP7WAfZaEeWhRf3FikFX5w">
+          <body>type string {pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))(\.(0|([1-9]\d*)))*';}&#xD;
+&#xD;
+ The object-identifier type represents administratively assigned names in a registration-hierarchical-name tree.&#xD;
+&#xD;
+Values of this type are denoted as a sequence of numerical non-negative sub-identifier values.  Each sub-identifier value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers are separated by single dots and without any intermediate whitespace.&#xD;
+&#xD;
+The ASN.1 standard restricts the value space of the first sub-identifier to 0, 1, or 2.  Furthermore, the value space of the second sub-identifier is restricted to the range 0 to 39 if the first sub-identifier is 0 or 1.  Finally, the ASN.1 standard requires that an object identifier has always at least two sub-identifiers.  The pattern captures these restrictions.&#xD;
+&#xD;
+Although the number of sub-identifiers is not limited, module designers should realize that there may be implementations that stick with the SMIv2 limit of 128 sub-identifiers.&#xD;
+&#xD;
+This type is a superset of the SMIv2 OBJECT IDENTIFIER type since it is not restricted to 128 sub-identifiers.  Hence, this type SHOULD NOT be used to represent the SMIv2 OBJECT IDENTIFIER type; the object-identifier-128 type SHOULD be used instead.&quot;;&#xD;
+      reference&#xD;
+        &quot;ISO9834-1: Information technology -- Open Systems Interconnection -- Procedures for the operation of OSI Registration Authorities: General procedures and top arcs of the ASN.1 Object Identifier tree&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP7WA_ZaEeWhRf3FikFX5w" name="YangIdentifier">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP7WBPZaEeWhRf3FikFX5w" annotatedElement="_iP7WA_ZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+        length &quot;1..max&quot;;&#xD;
+        pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';&#xD;
+        pattern&#xD;
+          '.|..|[^xX].*|.[^mM].*|..[^lL].*'; }&#xD;
+&#xD;
+A YANG identifier string as defined by the 'identifier' rule in Section 12 of RFC 6020.  An identifier must start with an alphabetic character or an underscore followed by an arbitrary sequence of alphabetic or numeric characters, underscores, hyphens, or dots.&#xD;
+&#xD;
+A YANG identifier MUST NOT start with any possible combination of the lowercase or uppercase character sequence 'xml'.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 6020: YANG - A Data Modeling Language for the Network Configuration Protocol (NETCONF)&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP7WBfZaEeWhRf3FikFX5w" name="ObjectIdentifier128">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP7WBvZaEeWhRf3FikFX5w" annotatedElement="_iP7WBfZaEeWhRf3FikFX5w">
+          <body>type object-identifier {pattern '\d*(\.\d*){1,127}';}&#xD;
+&#xD;
+This type represents object-identifiers restricted to 128 sub-identifiers.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the OBJECT IDENTIFIER type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;</body>
+        </ownedComment>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_iP8kIPZaEeWhRf3FikFX5w" name="DateAndTimeRelatedTypes">
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP8kIfZaEeWhRf3FikFX5w" name="Timeticks">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP8kIvZaEeWhRf3FikFX5w" annotatedElement="_iP8kIfZaEeWhRf3FikFX5w">
+          <body>type uint32;&#xD;
+&#xD;
+The timeticks type represents a non-negative integer that represents the time, modulo 2^32 (4294967296 decimal), in hundredths of a second between two epochs.  When a schema node is defined that uses this type, the description of  the schema node identifies both of the reference epochs.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the TimeTicks type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP8kI_ZaEeWhRf3FikFX5w" name="Timestamp">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP8kJPZaEeWhRf3FikFX5w" annotatedElement="_iP8kI_ZaEeWhRf3FikFX5w">
+          <body>type timeticks;&#xD;
+&#xD;
+The timestamp type represents the value of an associated timeticks schema node at which a specific occurrence happened.  The specific occurrence must be defined in the description of any schema node defined using this type.  When the specific occurrence occurred prior to the last time the associated timeticks attribute was zero, then the timestamp value is zero.  Note that this requires all timestamp values to be reset to zero when the value of the associated timeticks attribute reaches 497+ days and wraps around to zero.&#xD;
+&#xD;
+The associated timeticks schema node must be specified in the description of any schema node using this type.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the TimeStamp textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2579: Textual Conventions for SMIv2&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP8kJfZaEeWhRf3FikFX5w" name="DateTime">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP8kJvZaEeWhRf3FikFX5w" annotatedElement="_iP8kJfZaEeWhRf3FikFX5w">
+          <body> type string {&#xD;
+        pattern&#xD;
+          '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})'; }&#xD;
+&#xD;
+The date-and-time type is a profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.  The profile is defined by the date-time production in Section 5.6 of RFC 3339.&#xD;
+&#xD;
+The date-and-time type is compatible with the dateTime XML schema type with the following notable exceptions:&#xD;
+&#xD;
+(a) The date-and-time type does not allow negative years.&#xD;
+&#xD;
+(b) The date-and-time time-offset -00:00 indicates an unknown time zone (see RFC 3339) while -00:00 and +00:00 and Z all represent the same time zone in dateTime.&#xD;
+&#xD;
+(c) The canonical format (see below) of data-and-time values differs from the canonical format used by the dateTime XML schema type, which requires all times to be in UTC using the time-offset 'Z'.&#xD;
+&#xD;
+This type is not equivalent to the DateAndTime textual convention of the SMIv2 since RFC 3339 uses a different separator between full-date and full-time and provides higher resolution of time-secfrac.&#xD;
+&#xD;
+The canonical format for date-and-time values with a known time zone uses a numeric time zone offset that is calculated using the device's configured known offset to UTC time.  A change of the device's offset to UTC time will cause date-and-time values to change accordingly.  Such changes might happen periodically in case a server follows automatically daylight saving time (DST) time zone offset changes.  The canonical format for date-and-time values with an unknown time zone (usually referring to the notion of local time) uses the time-offset -00:00.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 3339: Date and Time on the Internet: Timestamps&#xD;
+         RFC 2579: Textual Conventions for SMIv2&#xD;
+        XSD-TYPES: XML Schema Part 2: Datatypes Second Edition&quot;</body>
+        </ownedComment>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_iP9yQPZaEeWhRf3FikFX5w" name="AddressRelatedTypes">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_3VHAAvZaEeWhRf3FikFX5w" name="IpAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHAA_ZaEeWhRf3FikFX5w" annotatedElement="_3VHAAvZaEeWhRf3FikFX5w">
+          <body>The ip-address type represents an IP address and is IP version neutral.  The format of the textual representation implies the IP version.  This type supports scoped addresses by allowing zone identifiers in the address format.&#xD;
+    reference&#xD;
+     &quot;RFC 4007: IPv6 Scoped Address Architecture&quot;</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3VHABPZaEeWhRf3FikFX5w" name="ipv4Address" visibility="public" type="_3VHACvZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3VHABfZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3VHABvZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3VHAB_ZaEeWhRf3FikFX5w" name="ipv6Address" visibility="public" type="_3VHADPZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3VHACPZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3VHACfZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_3VHACvZaEeWhRf3FikFX5w" name="Ipv4Address">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHAC_ZaEeWhRf3FikFX5w" annotatedElement="_3VHACvZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+      pattern&#xD;
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'&#xD;
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'&#xD;
+      + '(%[\p{N}\p{L}]+)?'; }&#xD;
+&#xD;
+The ipv4-address type represents an IPv4 address in dotted-quad notation.  The IPv4 address may include a zone index, separated by a % sign.&#xD;
+&#xD;
+The zone index is used to disambiguate identical address values.  For link-local addresses, the zone index will typically be the interface index number or the name of an interface.  If the zone index is not present, the default zone of the device will be used.&#xD;
+&#xD;
+The canonical format for the zone index is the numerical format.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_3VHADPZaEeWhRf3FikFX5w" name="Ipv6Address">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHADfZaEeWhRf3FikFX5w" annotatedElement="_3VHADPZaEeWhRf3FikFX5w">
+          <body> type string {&#xD;
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'&#xD;
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'&#xD;
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'&#xD;
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'&#xD;
+            + '(%[\p{N}\p{L}]+)?';&#xD;
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'&#xD;
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'&#xD;
+            + '(%.+)?'; }&#xD;
+&#xD;
+The ipv6-address type represents an IPv6 address in full, mixed, shortened, and shortened-mixed notation.  The IPv6 address may include a zone index, separated by a % sign.&#xD;
+&#xD;
+The zone index is used to disambiguate identical address values.  For link-local addresses, the zone index will typically be the interface index number or the name of an interface.  If the zone index is not present, the default zone of the device will be used.&#xD;
+&#xD;
+The canonical format of IPv6 addresses uses the textual representation defined in Section 4 of RFC 5952.  The canonical format for the zone index is the numerical format as described in Section 11.2 of RFC 4007.&#xD;
+    reference&#xD;
+     &quot;RFC 4291: IP Version 6 Addressing Architecture&#xD;
+      RFC 4007: IPv6 Scoped Address Architecture&#xD;
+      RFC 5952: A Recommendation for IPv6 Address Text Representation&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_3VHADvZaEeWhRf3FikFX5w" name="IpAddressNoZone">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHAD_ZaEeWhRf3FikFX5w" annotatedElement="_3VHADvZaEeWhRf3FikFX5w">
+          <body>The ip-address-no-zone type represents an IP address and is IP version neutral.  The format of the textual representation implies the IP version.  This type does not support scoped addresses since it does not allow zone identifiers in the  address format.&#xD;
+    reference&#xD;
+     &quot;RFC 4007: IPv6 Scoped Address Architecture&quot;</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3VHAEPZaEeWhRf3FikFX5w" name="ipv4AddressNoZone" visibility="public" type="_3VHAFvZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3VHAEfZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3VHAEvZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3VHAE_ZaEeWhRf3FikFX5w" name="ipv6AddressNoZone" visibility="public" type="_3VHAGPZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3VHAFPZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3VHAFfZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_3VHAFvZaEeWhRf3FikFX5w" name="Ipv4AddressNoZone">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHAF_ZaEeWhRf3FikFX5w" annotatedElement="_3VHAFvZaEeWhRf3FikFX5w">
+          <body>type inet:ipv4-address {&#xD;
+      pattern '[0-9\.]*'; }&#xD;
+&#xD;
+An IPv4 address without a zone index.  This type, derived from ipv4-address, may be used in situations where the zone is known from the context and hence no zone index is needed.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_3VHAGPZaEeWhRf3FikFX5w" name="Ipv6AddressNoZone">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHAGfZaEeWhRf3FikFX5w" annotatedElement="_3VHAGPZaEeWhRf3FikFX5w">
+          <body>type inet:ipv6-address {&#xD;
+      pattern '[0-9a-fA-F:\.]*'; }&#xD;
+&#xD;
+An IPv6 address without a zone index.  This type, derived from ipv6-address, may be used in situations where the zone is known from the context and hence no zone index is needed.&#xD;
+    reference&#xD;
+     &quot;RFC 4291: IP Version 6 Addressing Architecture&#xD;
+      RFC 4007: IPv6 Scoped Address Architecture&#xD;
+      RFC 5952: A Recommendation for IPv6 Address Text Representation&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_3VHAGvZaEeWhRf3FikFX5w" name="Ipv4Prefix">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHAG_ZaEeWhRf3FikFX5w" annotatedElement="_3VHAGvZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+      pattern&#xD;
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'&#xD;
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'&#xD;
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))'; }&#xD;
+&#xD;
+The ipv4-prefix type represents an IPv4 address prefix. The prefix length is given by the number following the slash character and must be less than or equal to 32.&#xD;
+&#xD;
+A prefix length value of n corresponds to an IP address mask that has n contiguous 1-bits from the most significant bit (MSB) and all other bits set to 0.&#xD;
+&#xD;
+The canonical format of an IPv4 prefix has all bits of the IPv4 address set to zero that are not part of the IPv4 prefix.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_3VHnEPZaEeWhRf3FikFX5w" name="Ipv6Prefix">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHnEfZaEeWhRf3FikFX5w" annotatedElement="_3VHnEPZaEeWhRf3FikFX5w">
+          <body> type string {&#xD;
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'&#xD;
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'&#xD;
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'&#xD;
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'&#xD;
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';&#xD;
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'&#xD;
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'&#xD;
+            + '(/.+)'; }&#xD;
+&#xD;
+The ipv6-prefix type represents an IPv6 address prefix. The prefix length is given by the number following the slash character and must be less than or equal to 128.&#xD;
+&#xD;
+A prefix length value of n corresponds to an IP address mask that has n contiguous 1-bits from the most significant bit (MSB) and all other bits set to 0.&#xD;
+&#xD;
+The IPv6 address should have all bits that do not belong to the prefix set to zero.&#xD;
+&#xD;
+The canonical format of an IPv6 prefix has all bits of the IPv6 address set to zero that are not part of the IPv6 prefix.  Furthermore, the IPv6 address is represented as defined in Section 4 of RFC 5952.&#xD;
+    reference&#xD;
+     &quot;RFC 5952: A Recommendation for IPv6 Address Text Representation&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_3VHnEvZaEeWhRf3FikFX5w" name="IpPrefix">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3VHnE_ZaEeWhRf3FikFX5w" annotatedElement="_3VHnEvZaEeWhRf3FikFX5w">
+          <body>The ip-prefix type represents an IP prefix and is IP version neutral.  The format of the textual representations implies the IP version.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3VHnFPZaEeWhRf3FikFX5w" name="ipv4Prefix" visibility="public" type="_3VHAGvZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3VHnFfZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3VHnFvZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3VHnF_ZaEeWhRf3FikFX5w" name="ipv6Prefix" visibility="public" type="_3VHnEPZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3VHnGPZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3VHnGfZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP9yQ_ZaEeWhRf3FikFX5w" name="MacAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP9yRPZaEeWhRf3FikFX5w" annotatedElement="_iP9yQ_ZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+        pattern&#xD;
+          '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'; }&#xD;
+&#xD;
+The mac-address type represents an IEEE 802 MAC address. The canonical representation uses lowercase characters.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the MacAddress textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;IEEE 802: IEEE Standard for Local and Metropolitan Area Networks: Overview and Architecture&#xD;
+         RFC 2579: Textual Conventions for SMIv2&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iP9yQfZaEeWhRf3FikFX5w" name="PhysAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iP9yQvZaEeWhRf3FikFX5w" annotatedElement="_iP9yQfZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+        pattern&#xD;
+          '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?'; }&#xD;
+&#xD;
+Represents media- or physical-level addresses represented as a sequence octets, each octet represented by two hexadecimal numbers.  Octets are separated by colons.  The canonical representation uses lowercase characters.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the PhysAddress textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2579: Textual Conventions for SMIv2&quot;</body>
+        </ownedComment>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_iQBcoPZaEeWhRf3FikFX5w" name="StringRelatedTypes">
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iQBco_ZaEeWhRf3FikFX5w" name="Uuid">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iQBcpPZaEeWhRf3FikFX5w" annotatedElement="_iQBco_ZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+        pattern&#xD;
+          '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'; }&#xD;
+&#xD;
+A Universally Unique IDentifier in the string representation defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+&#xD;
+The following is an example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6 &quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 4122: A Universally Unique IDentifier (UUID) URN Namespace&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_iQBcpfZaEeWhRf3FikFX5w" name="DottedQuad">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iQBcpvZaEeWhRf3FikFX5w" annotatedElement="_iQBcpfZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+        pattern&#xD;
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'; }&#xD;
+&#xD;
+An unsigned 32-bit number expressed in the dotted-quad notation, i.e., four octets written as decimal numbers and separated with the '.' (full stop) character.&quot;</body>
+        </ownedComment>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_14yzAPZaEeWhRf3FikFX5w" name="ProtocolFieldRelatedTypes">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_14yzAfZaEeWhRf3FikFX5w" source="uml2.diagrams"/>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_14yzAvZaEeWhRf3FikFX5w" name="IpVersion">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_14yzA_ZaEeWhRf3FikFX5w" annotatedElement="_14yzAvZaEeWhRf3FikFX5w">
+          <body>This value represents the version of the IP protocol.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the InetVersion textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC  791: Internet Protocol&#xD;
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification&#xD;
+      RFC 4001: Textual Conventions for Internet Network Addresses&quot;</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_14yzBPZaEeWhRf3FikFX5w" name="UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_14zaEPZaEeWhRf3FikFX5w" annotatedElement="_14yzBPZaEeWhRf3FikFX5w">
+            <body>An unknown or unspecified version of the Internet protocol.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_14zaEfZaEeWhRf3FikFX5w"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_14zaEvZaEeWhRf3FikFX5w" name="IP_V4">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_14zaE_ZaEeWhRf3FikFX5w" annotatedElement="_14zaEvZaEeWhRf3FikFX5w">
+            <body>The IPv4 protocol as defined in RFC 791.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_14zaFPZaEeWhRf3FikFX5w" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_14zaFfZaEeWhRf3FikFX5w" name="IP_V6">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_14zaFvZaEeWhRf3FikFX5w" annotatedElement="_14zaFfZaEeWhRf3FikFX5w">
+            <body>The IPv6 protocol as defined in RFC 2460.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_14zaF_ZaEeWhRf3FikFX5w" value="2"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_14zaGPZaEeWhRf3FikFX5w" name="Dscp">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_14zaGfZaEeWhRf3FikFX5w" annotatedElement="_14zaGPZaEeWhRf3FikFX5w">
+          <body>type uint8 {&#xD;
+      range &quot;0..63&quot;; }&#xD;
+&#xD;
+The dscp type represents a Differentiated Services Code Point that may be used for marking packets in a traffic stream.&#xD;
+In the value set and its semantics, this type is equivalent to the Dscp textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC 3289: Management Information Base for the Differentiated Services Architecture&#xD;
+      RFC 2474: Definition of the Differentiated Services Field (DS Field) in the IPv4 and IPv6 Headers&#xD;
+      RFC 2780: IANA Allocation Guidelines For Values In the Internet Protocol and Related Headers&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_14zaGvZaEeWhRf3FikFX5w" name="IpV6FlowLabel">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_14zaG_ZaEeWhRf3FikFX5w" annotatedElement="_14zaGvZaEeWhRf3FikFX5w">
+          <body> type uint32 {&#xD;
+      range &quot;0..1048575&quot;; }&#xD;
+&#xD;
+The ipv6-flow-label type represents the flow identifier or Flow Label in an IPv6 packet header that may be used to discriminate traffic flows.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the IPv6FlowLabel textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC 3595: Textual Conventions for IPv6 Flow Label&#xD;
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification&quot;&#xD;
+</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_14zaHPZaEeWhRf3FikFX5w" name="PortNumber">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_14zaHfZaEeWhRf3FikFX5w" annotatedElement="_14zaHPZaEeWhRf3FikFX5w">
+          <body>type uint16 {&#xD;
+      range &quot;0..65535&quot;; }&#xD;
+&#xD;
+The port-number type represents a 16-bit port number of an Internet transport-layer protocol such as UDP, TCP, DCCP, or SCTP.  Port numbers are assigned by IANA.  A current list of all assignments is available from &lt;http://www.iana.org/>.&#xD;
+&#xD;
+Note that the port number value zero is reserved by IANA.  In situations where the value zero does not make sense, it can be excluded by subtyping the port-number type.&#xD;
+In the value set and its semantics, this type is equivalent to the InetPortNumber textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC  768: User Datagram Protocol&#xD;
+      RFC  793: Transmission Control Protocol&#xD;
+      RFC 4960: Stream Control Transmission Protocol&#xD;
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)&#xD;
+      RFC 4001: Textual Conventions for Internet Network Addresses&quot;</body>
+        </ownedComment>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_4m-3kPZaEeWhRf3FikFX5w" name="DomainNameAndUriRelatedTypes">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4m-3kfZaEeWhRf3FikFX5w" source="uml2.diagrams"/>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_4m-3kvZaEeWhRf3FikFX5w" name="DomainName">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_4m-3k_ZaEeWhRf3FikFX5w" annotatedElement="_4m-3kvZaEeWhRf3FikFX5w">
+          <body>type string {&#xD;
+      pattern&#xD;
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'&#xD;
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'&#xD;
+      + '|\.';&#xD;
+      length &quot;1..253&quot;; }&#xD;
+&#xD;
+The domain-name type represents a DNS domain name.  The name SHOULD be fully qualified whenever possible.&#xD;
+&#xD;
+Internet domain names are only loosely specified.  Section 3.5 of RFC 1034 recommends a syntax (modified in Section 2.1 of RFC 1123).  The pattern above is intended to allow for current practice in domain name use, and some possible  future expansion.  It is designed to hold various types of domain names, including names used for A or AAAA records (host names) and other records, such as SRV records.  Note that Internet host names have a stricter syntax (described in RFC 952) than the DNS recommendations in RFCs 1034 and 1123, and that systems that want to store host names in schema nodes using the domain-name type are recommended to adhere to this stricter standard to ensure interoperability.&#xD;
+&#xD;
+The encoding of DNS names in the DNS protocol is limited to 255 characters.  Since the encoding consists of labels prefixed by a length bytes and there is a trailing NULL byte, only 253 characters can appear in the textual dotted notation.&#xD;
+&#xD;
+The description clause of schema nodes using the domain-name type MUST describe when and how these names are resolved to IP addresses.  Note that the resolution of a domain-name value may require to query multiple DNS records (e.g., A for IPv4 and AAAA for IPv6).  The order of the resolution process and which DNS record takes precedence can either be defined explicitly or may depend on the configuration of the resolver.&#xD;
+&#xD;
+Domain-name values use the US-ASCII encoding. Their canonical format uses lowercase US-ASCII characters.  Internationalized domain names MUST be A-labels as per RFC 5890.&#xD;
+    reference&#xD;
+     &quot;RFC  952: DoD Internet Host Table Specification&#xD;
+      RFC 1034: Domain Names - Concepts and Facilities&#xD;
+      RFC 1123: Requirements for Internet Hosts -- Application and Support&#xD;
+      RFC 2782: A DNS RR for specifying the location of services (DNS SRV)&#xD;
+      RFC 5890: Internationalized Domain Names in Applications (IDNA): Definitions and Document Framework&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_4m-3lPZaEeWhRf3FikFX5w" name="Host">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4m-3lfZaEeWhRf3FikFX5w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4m-3lvZaEeWhRf3FikFX5w" key="Union"/>
+        </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_4m-3l_ZaEeWhRf3FikFX5w" annotatedElement="_4m-3lPZaEeWhRf3FikFX5w">
+          <body>The host type represents either an IP address or a DNS domain name.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4m-3mPZaEeWhRf3FikFX5w" name="ipAddress" visibility="public" type="_lMSD-FDOEeWpFusmeDrF3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4m-3mfZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4m-3mvZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4m-3m_ZaEeWhRf3FikFX5w" name="domainName" visibility="public" type="_4m-3kvZaEeWhRf3FikFX5w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4m-3nPZaEeWhRf3FikFX5w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4m-3nfZaEeWhRf3FikFX5w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_4m-3nvZaEeWhRf3FikFX5w" name="Uri">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_4m-3n_ZaEeWhRf3FikFX5w" annotatedElement="_4m-3nvZaEeWhRf3FikFX5w">
+          <body>type string;&#xD;
+&#xD;
+The uri type represents a Uniform Resource Identifier (URI) as defined by STD 66.&#xD;
+&#xD;
+Objects using the uri type MUST be in US-ASCII encoding, and MUST be normalized as described by RFC 3986 Sections 6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary percent-encoding is removed, and all case-insensitive characters are set to lowercase except for hexadecimal digits, which are normalized to uppercase as described in Section 6.2.2.1.&#xD;
+&#xD;
+The purpose of this normalization is to help provide unique URIs.  Note that this normalization is not sufficient to provide uniqueness.  Two URIs that are textually distinct after this normalization may still be equivalent.&#xD;
+&#xD;
+Objects using the uri type may restrict the schemes that they permit.  For example, 'data:' and 'urn:' schemes might not be appropriate.&#xD;
+&#xD;
+A zero-length URI is not a valid URI.  This can be used to express 'URI absent' where required.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the Uri SMIv2 textual convention defined in RFC 5017.&#xD;
+    reference&#xD;
+     &quot;RFC 3986: Uniform Resource Identifier (URI): Generic Syntax&#xD;
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest Group: Uniform Resource Identifiers (URIs), URLs, and Uniform Resource Names (URNs): Clarifications and Recommendations&#xD;
+      RFC 5017: MIB Textual Conventions for Uniform Resource Identifiers (URIs)&quot;</body>
+        </ownedComment>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_oSFFsPZaEeWhRf3FikFX5w" name="OtherStandardisedDataTypes">
+      <packagedElement xmi:type="uml:Package" xmi:id="_gxc3UFDOEeWpFusmeDrF3w" name="ietf-yang-types">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gxc3UVDOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3UlDOEeWpFusmeDrF3w" annotatedElement="_gxc3UFDOEeWpFusmeDrF3w">
+          <body>This module contains a collection of generally useful derived YANG data types.&#xD;
+Copyright (c) 2013 IETF Trust and the persons identified as authors of the code.  All rights reserved.&#xD;
+Redistribution and use in source and binary forms, with or without modification, is permitted pursuant to, and subject to the license terms contained in, the Simplified BSD License set forth in Section 4.c of the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info).&#xD;
+This version of this YANG module is part of RFC 6991; see the RFC itself for full legal notices.&quot;&#xD;
+&#xD;
+revision 2013-07-15 {&#xD;
+    description&#xD;
+    &quot;This revision adds the following new data types:&#xD;
+      - yang-identifier&#xD;
+      - hex-string&#xD;
+      - uuid&#xD;
+      - dotted-quad&quot;;&#xD;
+    reference&#xD;
+        &quot;RFC 6991: Common YANG Data Types&quot;&#xD;
+&#xD;
+revision &quot;2010-09-24&quot; {&#xD;
+      description &quot;Initial revision.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 6021: Common YANG Data Types&quot;</body>
+        </ownedComment>
+        <packagedElement xmi:type="uml:Package" xmi:id="_v1APYN_DEeWR__mujpnT9g" name="counter and gauge types">
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3U1DOEeWpFusmeDrF3w" name="Counter32">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3VFDOEeWpFusmeDrF3w" annotatedElement="_gxc3U1DOEeWpFusmeDrF3w">
+              <body>The counter32 type represents a non-negative integer that monotonically increases until it reaches a maximum value of 2^32-1 (4294967295 decimal), when it wraps around and starts increasing again from zero.&#xD;
+&#xD;
+Counters have no defined 'initial' value, and thus, a single value of a counter has (in general) no information content.  Discontinuities in the monotonically increasing value normally occur at re-initialization of the management system, and at other times as specified in the description of a schema node using this type.  If such other times can occur, for example, the creation of a schema node of type counter32 at times other than re-initialization, then a corresponding schema node should be defined, with an appropriate type, to indicate the last discontinuity.&#xD;
+&#xD;
+The counter32 type should not be used for configuration schema nodes.  A default statement SHOULD NOT be used in combination with the type counter32.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the Counter32 type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3V1DOEeWpFusmeDrF3w" name="Counter64">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3WFDOEeWpFusmeDrF3w" annotatedElement="_gxc3V1DOEeWpFusmeDrF3w">
+              <body>The counter64 type represents a non-negative integer that monotonically increases until it reaches a maximum value of 2^64-1 (18446744073709551615 decimal), when it wraps around and starts increasing again from zero.&#xD;
+&#xD;
+Counters have no defined 'initial' value, and thus, a single value of a counter has (in general) no information content.  Discontinuities in the monotonically increasing value normally occur at re-initialization of the management system, and at other times as specified in the description of a schema node using this type.  If such other times can occur, for example, the creation of a schema node of type counter64 at times other than re-initialization, then a corresponding schema node should be defined, with an appropriate type, to indicate the last discontinuity.&#xD;
+&#xD;
+The counter64 type should not be used for configuration schema nodes.  A default statement SHOULD NOT be used in combination with the type counter64.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the Counter64 type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3W1DOEeWpFusmeDrF3w" name="Gauge32">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3XFDOEeWpFusmeDrF3w" annotatedElement="_gxc3W1DOEeWpFusmeDrF3w">
+              <body>The gauge32 type represents a non-negative integer, which may increase or decrease, but shall never exceed a maximum value, nor fall below a minimum value.  The maximum value cannot be greater than 2^32-1 (4294967295 decimal), and the minimum value cannot be smaller than 0.  The value of a gauge32 has its maximum value whenever the information being modeled is greater than or equal to its maximum value, and has its minimum value whenever the information being modeled is smaller than or equal to its minimum value. If the information being modeled subsequently decreases below (increases above) the maximum (minimum) value, the gauge32 also decreases (increases).&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the Gauge32 type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3XVDOEeWpFusmeDrF3w" name="Gauge64">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3XlDOEeWpFusmeDrF3w" annotatedElement="_gxc3XVDOEeWpFusmeDrF3w">
+              <body>The gauge64 type represents a non-negative integer, which may increase or decrease, but shall never exceed a maximum value, nor fall below a minimum value.  The maximum value cannot be greater than 2^64-1 (18446744073709551615), and the minimum value cannot be smaller than 0.  The value of a gauge64 has its maximum value whenever the information being modeled is greater than or equal to its maximum value, and has its minimum value whenever the information being modeled is smaller than or equal to its minimum value. If the information being modeled subsequently decreases below (increases above) the maximum (minimum) value, the gauge64 also decreases (increases).&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the CounterBasedGauge64 SMIv2 textual convention defined in RFC 2856&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2856: Textual Conventions for Additional High Capacity Data Types&quot;;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3VVDOEeWpFusmeDrF3w" name="ZeroBasedCounter32">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3VlDOEeWpFusmeDrF3w" annotatedElement="_gxc3VVDOEeWpFusmeDrF3w">
+              <body>The zero-based-counter32 type represents a counter32 that has the defined 'initial' value zero.&#xD;
+&#xD;
+A schema node of this type will be set to zero (0) on creation and will thereafter increase monotonically until it reaches a maximum value of 2^32-1 (4294967295 decimal), when it wraps around and starts increasing again from zero.&#xD;
+&#xD;
+Provided that an application discovers a new schema node of this type within the minimum time to wrap, it can use the 'initial' value as a delta.  It is important for a management station to be aware of this minimum time and the actual time  between polls, and to discard data if the actual time is too long or there is no defined minimum time.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the ZeroBasedCounter32 textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 4502: Remote Network Monitoring Management Information Base Version 2&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3WVDOEeWpFusmeDrF3w" name="ZeroBasedCounter64">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3WlDOEeWpFusmeDrF3w" annotatedElement="_gxc3WVDOEeWpFusmeDrF3w">
+              <body>The zero-based-counter64 type represents a counter64 that has the defined 'initial' value zero.&#xD;
+&#xD;
+A schema node of this type will be set to zero (0) on creation and will thereafter increase monotonically until it reaches a maximum value of 2^64-1 (18446744073709551615 decimal), when it wraps around and starts increasing again from zero.&#xD;
+&#xD;
+Provided that an application discovers a new schema node of this type within the minimum time to wrap, it can use the 'initial' value as a delta.  It is important for a management station to be aware of this minimum time and the actual time  between polls, and to discard data if the actual time is too long or there is no defined minimum time.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the ZeroBasedCounter64 textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2856: Textual Conventions for Additional High Capacity Data Types&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_xcpioN_DEeWR__mujpnT9g" name="identifier-related types">
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3X1DOEeWpFusmeDrF3w" name="ObjectIdentifier">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3YFDOEeWpFusmeDrF3w" annotatedElement="_gxc3X1DOEeWpFusmeDrF3w">
+              <body>type string {pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))(\.(0|([1-9]\d*)))*';}&#xD;
+&#xD;
+ The object-identifier type represents administratively assigned names in a registration-hierarchical-name tree.&#xD;
+&#xD;
+Values of this type are denoted as a sequence of numerical non-negative sub-identifier values.  Each sub-identifier value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers are separated by single dots and without any intermediate whitespace.&#xD;
+&#xD;
+The ASN.1 standard restricts the value space of the first sub-identifier to 0, 1, or 2.  Furthermore, the value space of the second sub-identifier is restricted to the range 0 to 39 if the first sub-identifier is 0 or 1.  Finally, the ASN.1 standard requires that an object identifier has always at least two sub-identifiers.  The pattern captures these restrictions.&#xD;
+&#xD;
+Although the number of sub-identifiers is not limited, module designers should realize that there may be implementations that stick with the SMIv2 limit of 128 sub-identifiers.&#xD;
+&#xD;
+This type is a superset of the SMIv2 OBJECT IDENTIFIER type since it is not restricted to 128 sub-identifiers.  Hence, this type SHOULD NOT be used to represent the SMIv2 OBJECT IDENTIFIER type; the object-identifier-128 type SHOULD be used instead.&quot;;&#xD;
+      reference&#xD;
+        &quot;ISO9834-1: Information technology -- Open Systems Interconnection -- Procedures for the operation of OSI Registration Authorities: General procedures and top arcs of the ASN.1 Object Identifier tree&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3Y1DOEeWpFusmeDrF3w" name="YangIdentifier">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3ZFDOEeWpFusmeDrF3w" annotatedElement="_gxc3Y1DOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+        length &quot;1..max&quot;;&#xD;
+        pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';&#xD;
+        pattern&#xD;
+          '.|..|[^xX].*|.[^mM].*|..[^lL].*'; }&#xD;
+&#xD;
+A YANG identifier string as defined by the 'identifier' rule in Section 12 of RFC 6020.  An identifier must start with an alphabetic character or an underscore followed by an arbitrary sequence of alphabetic or numeric characters, underscores, hyphens, or dots.&#xD;
+&#xD;
+A YANG identifier MUST NOT start with any possible combination of the lowercase or uppercase character sequence 'xml'.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 6020: YANG - A Data Modeling Language for the Network Configuration Protocol (NETCONF)&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3YVDOEeWpFusmeDrF3w" name="ObjectIdentifier128">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3YlDOEeWpFusmeDrF3w" annotatedElement="_gxc3YVDOEeWpFusmeDrF3w">
+              <body>type object-identifier {pattern '\d*(\.\d*){1,127}';}&#xD;
+&#xD;
+This type represents object-identifiers restricted to 128 sub-identifiers.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the OBJECT IDENTIFIER type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_Kgid4N_EEeWR__mujpnT9g" name="types related to date and time">
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3Z1DOEeWpFusmeDrF3w" name="Timeticks">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3aFDOEeWpFusmeDrF3w" annotatedElement="_gxc3Z1DOEeWpFusmeDrF3w">
+              <body>type uint32;&#xD;
+&#xD;
+The timeticks type represents a non-negative integer that represents the time, modulo 2^32 (4294967296 decimal), in hundredths of a second between two epochs.  When a schema node is defined that uses this type, the description of  the schema node identifies both of the reference epochs.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the TimeTicks type of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2578: Structure of Management Information Version 2 (SMIv2)&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3aVDOEeWpFusmeDrF3w" name="Timestamp">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3alDOEeWpFusmeDrF3w" annotatedElement="_gxc3aVDOEeWpFusmeDrF3w">
+              <body>type timeticks;&#xD;
+&#xD;
+The timestamp type represents the value of an associated timeticks schema node at which a specific occurrence happened.  The specific occurrence must be defined in the description of any schema node defined using this type.  When the specific occurrence occurred prior to the last time the associated timeticks attribute was zero, then the timestamp value is zero.  Note that this requires all timestamp values to be reset to zero when the value of the associated timeticks attribute reaches 497+ days and wraps around to zero.&#xD;
+&#xD;
+The associated timeticks schema node must be specified in the description of any schema node using this type.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the TimeStamp textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2579: Textual Conventions for SMIv2&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3ZVDOEeWpFusmeDrF3w" name="DateAndTime">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3ZlDOEeWpFusmeDrF3w" annotatedElement="_gxc3ZVDOEeWpFusmeDrF3w">
+              <body> type string {&#xD;
+        pattern&#xD;
+          '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})'; }&#xD;
+&#xD;
+The date-and-time type is a profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.  The profile is defined by the date-time production in Section 5.6 of RFC 3339.&#xD;
+&#xD;
+The date-and-time type is compatible with the dateTime XML schema type with the following notable exceptions:&#xD;
+&#xD;
+(a) The date-and-time type does not allow negative years.&#xD;
+&#xD;
+(b) The date-and-time time-offset -00:00 indicates an unknown time zone (see RFC 3339) while -00:00 and +00:00 and Z all represent the same time zone in dateTime.&#xD;
+&#xD;
+(c) The canonical format (see below) of data-and-time values differs from the canonical format used by the dateTime XML schema type, which requires all times to be in UTC using the time-offset 'Z'.&#xD;
+&#xD;
+This type is not equivalent to the DateAndTime textual convention of the SMIv2 since RFC 3339 uses a different separator between full-date and full-time and provides higher resolution of time-secfrac.&#xD;
+&#xD;
+The canonical format for date-and-time values with a known time zone uses a numeric time zone offset that is calculated using the device's configured known offset to UTC time.  A change of the device's offset to UTC time will cause date-and-time values to change accordingly.  Such changes might happen periodically in case a server follows automatically daylight saving time (DST) time zone offset changes.  The canonical format for date-and-time values with an unknown time zone (usually referring to the notion of local time) uses the time-offset -00:00.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 3339: Date and Time on the Internet: Timestamps&#xD;
+         RFC 2579: Textual Conventions for SMIv2&#xD;
+        XSD-TYPES: XML Schema Part 2: Datatypes Second Edition&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_SPWjsN_EEeWR__mujpnT9g" name="generic address types">
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3a1DOEeWpFusmeDrF3w" name="PhysAddress">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3bFDOEeWpFusmeDrF3w" annotatedElement="_gxc3a1DOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+        pattern&#xD;
+          '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?'; }&#xD;
+&#xD;
+Represents media- or physical-level addresses represented as a sequence octets, each octet represented by two hexadecimal numbers.  Octets are separated by colons.  The canonical representation uses lowercase characters.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the PhysAddress textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 2579: Textual Conventions for SMIv2&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3bVDOEeWpFusmeDrF3w" name="MacAddress">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3blDOEeWpFusmeDrF3w" annotatedElement="_gxc3bVDOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+        pattern&#xD;
+          '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'; }&#xD;
+&#xD;
+The mac-address type represents an IEEE 802 MAC address. The canonical representation uses lowercase characters.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the MacAddress textual convention of the SMIv2.&quot;;&#xD;
+      reference&#xD;
+        &quot;IEEE 802: IEEE Standard for Local and Metropolitan Area Networks: Overview and Architecture&#xD;
+         RFC 2579: Textual Conventions for SMIv2&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_cNAfoN_EEeWR__mujpnT9g" name="XML-specific types">
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3b1DOEeWpFusmeDrF3w" name="Xpath1.0">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3cFDOEeWpFusmeDrF3w" annotatedElement="_gxc3b1DOEeWpFusmeDrF3w">
+              <body>type string;&#xD;
+&#xD;
+This type represents an XPATH 1.0 expression.&#xD;
+&#xD;
+When a schema node is defined that uses this type, the description of the schema node MUST specify the XPath context in which the XPath expression is evaluated.&quot;;&#xD;
+      reference&#xD;
+        &quot;XPATH: XML Path Language (XPath) Version 1.0&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_hiO34N_EEeWR__mujpnT9g" name="string types">
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3cVDOEeWpFusmeDrF3w" name="HexString">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3clDOEeWpFusmeDrF3w" annotatedElement="_gxc3cVDOEeWpFusmeDrF3w">
+              <body> type string {&#xD;
+        pattern&#xD;
+          '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?'; }&#xD;
+&#xD;
+A hexadecimal string with octets represented as hex digits separated by colons.  The canonical representation uses lowercase characters.&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3c1DOEeWpFusmeDrF3w" name="Uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3dFDOEeWpFusmeDrF3w" annotatedElement="_gxc3c1DOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+        pattern&#xD;
+          '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'; }&#xD;
+&#xD;
+A Universally Unique IDentifier in the string representation defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+&#xD;
+The following is an example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6 &quot;;&#xD;
+      reference&#xD;
+        &quot;RFC 4122: A Universally Unique IDentifier (UUID) URN Namespace&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_gxc3dVDOEeWpFusmeDrF3w" name="DottedQuad">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gxc3dlDOEeWpFusmeDrF3w" annotatedElement="_gxc3dVDOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+        pattern&#xD;
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'; }&#xD;
+&#xD;
+An unsigned 32-bit number expressed in the dotted-quad notation, i.e., four octets written as decimal numbers and separated with the '.' (full stop) character.&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_lMSD4FDOEeWpFusmeDrF3w" name="ietf-inet-types">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lMSD4VDOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD4lDOEeWpFusmeDrF3w" annotatedElement="_lMSD4FDOEeWpFusmeDrF3w">
+          <body>This module contains a collection of generally useful derived YANG data types for Internet addresses and related things.&#xD;
+Copyright (c) 2013 IETF Trust and the persons identified as authors of the code.  All rights reserved.&#xD;
+Redistribution and use in source and binary forms, with or without modification, is permitted pursuant to, and subject to the license terms contained in, the Simplified BSD License set forth in Section 4.c of the IETF Trust's Legal Provisions  Relating to IETF Documents (http://trustee.ietf.org/license-info).&#xD;
+This version of this YANG module is part of RFC 6991; see the RFC itself for full legal notices.&quot;&#xD;
+&#xD;
+revision 2010-09-24 {&#xD;
+    description&#xD;
+     &quot;Initial revision.&quot;;&#xD;
+    reference&#xD;
+     &quot;RFC 6021: Common YANG Data Types&quot;</body>
+        </ownedComment>
+        <packagedElement xmi:type="uml:Package" xmi:id="_lMSD41DOEeWpFusmeDrF3w" name="types related to protocol fields">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lMSD5FDOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+          <packagedElement xmi:type="uml:Enumeration" xmi:id="_lMSD5VDOEeWpFusmeDrF3w" name="IpVersion">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD5lDOEeWpFusmeDrF3w" annotatedElement="_lMSD5VDOEeWpFusmeDrF3w">
+              <body>This value represents the version of the IP protocol.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the InetVersion textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC  791: Internet Protocol&#xD;
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification&#xD;
+      RFC 4001: Textual Conventions for Internet Network Addresses&quot;</body>
+            </ownedComment>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_lMSD51DOEeWpFusmeDrF3w" name="UNKNOWN">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD6FDOEeWpFusmeDrF3w" annotatedElement="_lMSD51DOEeWpFusmeDrF3w">
+                <body>An unknown or unspecified version of the Internet protocol.</body>
+              </ownedComment>
+              <specification xmi:type="uml:LiteralInteger" xmi:id="_lMSD6VDOEeWpFusmeDrF3w"/>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_lMSD6lDOEeWpFusmeDrF3w" name="IP_V4">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD61DOEeWpFusmeDrF3w" annotatedElement="_lMSD6lDOEeWpFusmeDrF3w">
+                <body>The IPv4 protocol as defined in RFC 791.</body>
+              </ownedComment>
+              <specification xmi:type="uml:LiteralInteger" xmi:id="_lMSD7FDOEeWpFusmeDrF3w" value="1"/>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_lMSD7VDOEeWpFusmeDrF3w" name="IP_V6">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD7lDOEeWpFusmeDrF3w" annotatedElement="_lMSD7VDOEeWpFusmeDrF3w">
+                <body>The IPv6 protocol as defined in RFC 2460.</body>
+              </ownedComment>
+              <specification xmi:type="uml:LiteralInteger" xmi:id="_lMSD71DOEeWpFusmeDrF3w" value="2"/>
+            </ownedLiteral>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSD8FDOEeWpFusmeDrF3w" name="DSCP">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD8VDOEeWpFusmeDrF3w" annotatedElement="_lMSD8FDOEeWpFusmeDrF3w">
+              <body>type uint8 {&#xD;
+      range &quot;0..63&quot;; }&#xD;
+&#xD;
+The dscp type represents a Differentiated Services Code Point that may be used for marking packets in a traffic stream.&#xD;
+In the value set and its semantics, this type is equivalent to the Dscp textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC 3289: Management Information Base for the Differentiated Services Architecture&#xD;
+      RFC 2474: Definition of the Differentiated Services Field (DS Field) in the IPv4 and IPv6 Headers&#xD;
+      RFC 2780: IANA Allocation Guidelines For Values In the Internet Protocol and Related Headers&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSD8lDOEeWpFusmeDrF3w" name="IpV6FlowLabel">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD81DOEeWpFusmeDrF3w" annotatedElement="_lMSD8lDOEeWpFusmeDrF3w">
+              <body> type uint32 {&#xD;
+      range &quot;0..1048575&quot;; }&#xD;
+&#xD;
+The ipv6-flow-label type represents the flow identifier or Flow Label in an IPv6 packet header that may be used to discriminate traffic flows.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the IPv6FlowLabel textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC 3595: Textual Conventions for IPv6 Flow Label&#xD;
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification&quot;&#xD;
+</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSD9FDOEeWpFusmeDrF3w" name="PortNumber">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD9VDOEeWpFusmeDrF3w" annotatedElement="_lMSD9FDOEeWpFusmeDrF3w">
+              <body>type uint16 {&#xD;
+      range &quot;0..65535&quot;; }&#xD;
+&#xD;
+The port-number type represents a 16-bit port number of an Internet transport-layer protocol such as UDP, TCP, DCCP, or SCTP.  Port numbers are assigned by IANA.  A current list of all assignments is available from &lt;http://www.iana.org/>.&#xD;
+&#xD;
+Note that the port number value zero is reserved by IANA.  In situations where the value zero does not make sense, it can be excluded by subtyping the port-number type.&#xD;
+In the value set and its semantics, this type is equivalent to the InetPortNumber textual convention of the SMIv2.&#xD;
+    reference&#xD;
+     &quot;RFC  768: User Datagram Protocol&#xD;
+      RFC  793: Transmission Control Protocol&#xD;
+      RFC 4960: Stream Control Transmission Protocol&#xD;
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)&#xD;
+      RFC 4001: Textual Conventions for Internet Network Addresses&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_lMSD9lDOEeWpFusmeDrF3w" name="types related to IP addresses and hostnames">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lMSD91DOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_lMSD-FDOEeWpFusmeDrF3w" name="IpAddress">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSD-1DOEeWpFusmeDrF3w" annotatedElement="_lMSD-FDOEeWpFusmeDrF3w">
+              <body>The ip-address type represents an IP address and is IP version neutral.  The format of the textual representation implies the IP version.  This type supports scoped addresses by allowing zone identifiers in the address format.&#xD;
+    reference&#xD;
+     &quot;RFC 4007: IPv6 Scoped Address Architecture&quot;</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSD_FDOEeWpFusmeDrF3w" name="ipv4Address" visibility="public" type="_lMSEAlDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSD_VDOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSD_lDOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSD_1DOEeWpFusmeDrF3w" name="ipv6Address" visibility="public" type="_lMSEBFDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSEAFDOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSEAVDOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEAlDOEeWpFusmeDrF3w" name="Ipv4Address">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEA1DOEeWpFusmeDrF3w" annotatedElement="_lMSEAlDOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+      pattern&#xD;
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'&#xD;
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'&#xD;
+      + '(%[\p{N}\p{L}]+)?'; }&#xD;
+&#xD;
+The ipv4-address type represents an IPv4 address in dotted-quad notation.  The IPv4 address may include a zone index, separated by a % sign.&#xD;
+&#xD;
+The zone index is used to disambiguate identical address values.  For link-local addresses, the zone index will typically be the interface index number or the name of an interface.  If the zone index is not present, the default zone of the device will be used.&#xD;
+&#xD;
+The canonical format for the zone index is the numerical format.</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEBFDOEeWpFusmeDrF3w" name="Ipv6Address">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEBVDOEeWpFusmeDrF3w" annotatedElement="_lMSEBFDOEeWpFusmeDrF3w">
+              <body> type string {&#xD;
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'&#xD;
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'&#xD;
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'&#xD;
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'&#xD;
+            + '(%[\p{N}\p{L}]+)?';&#xD;
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'&#xD;
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'&#xD;
+            + '(%.+)?'; }&#xD;
+&#xD;
+The ipv6-address type represents an IPv6 address in full, mixed, shortened, and shortened-mixed notation.  The IPv6 address may include a zone index, separated by a % sign.&#xD;
+&#xD;
+The zone index is used to disambiguate identical address values.  For link-local addresses, the zone index will typically be the interface index number or the name of an interface.  If the zone index is not present, the default zone of the device will be used.&#xD;
+&#xD;
+The canonical format of IPv6 addresses uses the textual representation defined in Section 4 of RFC 5952.  The canonical format for the zone index is the numerical format as described in Section 11.2 of RFC 4007.&#xD;
+    reference&#xD;
+     &quot;RFC 4291: IP Version 6 Addressing Architecture&#xD;
+      RFC 4007: IPv6 Scoped Address Architecture&#xD;
+      RFC 5952: A Recommendation for IPv6 Address Text Representation&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_lMSEBlDOEeWpFusmeDrF3w" name="IpAddressNoZone">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSECVDOEeWpFusmeDrF3w" annotatedElement="_lMSEBlDOEeWpFusmeDrF3w">
+              <body>The ip-address-no-zone type represents an IP address and is IP version neutral.  The format of the textual representation implies the IP version.  This type does not support scoped addresses since it does not allow zone identifiers in the  address format.&#xD;
+    reference&#xD;
+     &quot;RFC 4007: IPv6 Scoped Address Architecture&quot;</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSEClDOEeWpFusmeDrF3w" name="ipv4AddressNoZone" visibility="public" type="_lMSEEFDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSEC1DOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSEDFDOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSEDVDOEeWpFusmeDrF3w" name="ipv6AddressNoZone" visibility="public" type="_lMSEElDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSEDlDOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSED1DOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEEFDOEeWpFusmeDrF3w" name="Ipv4AddressNoZone">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEEVDOEeWpFusmeDrF3w" annotatedElement="_lMSEEFDOEeWpFusmeDrF3w">
+              <body>type inet:ipv4-address {&#xD;
+      pattern '[0-9\.]*'; }&#xD;
+&#xD;
+An IPv4 address without a zone index.  This type, derived from ipv4-address, may be used in situations where the zone is known from the context and hence no zone index is needed.</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEElDOEeWpFusmeDrF3w" name="Ipv6AddressNoZone">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEE1DOEeWpFusmeDrF3w" annotatedElement="_lMSEElDOEeWpFusmeDrF3w">
+              <body>type inet:ipv6-address {&#xD;
+      pattern '[0-9a-fA-F:\.]*'; }&#xD;
+&#xD;
+An IPv6 address without a zone index.  This type, derived from ipv6-address, may be used in situations where the zone is known from the context and hence no zone index is needed.&#xD;
+    reference&#xD;
+     &quot;RFC 4291: IP Version 6 Addressing Architecture&#xD;
+      RFC 4007: IPv6 Scoped Address Architecture&#xD;
+      RFC 5952: A Recommendation for IPv6 Address Text Representation&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEFFDOEeWpFusmeDrF3w" name="Ipv4Prefix">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEFVDOEeWpFusmeDrF3w" annotatedElement="_lMSEFFDOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+      pattern&#xD;
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'&#xD;
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'&#xD;
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))'; }&#xD;
+&#xD;
+The ipv4-prefix type represents an IPv4 address prefix. The prefix length is given by the number following the slash character and must be less than or equal to 32.&#xD;
+&#xD;
+A prefix length value of n corresponds to an IP address mask that has n contiguous 1-bits from the most significant bit (MSB) and all other bits set to 0.&#xD;
+&#xD;
+The canonical format of an IPv4 prefix has all bits of the IPv4 address set to zero that are not part of the IPv4 prefix.</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEFlDOEeWpFusmeDrF3w" name="Ipv6Prefix">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEF1DOEeWpFusmeDrF3w" annotatedElement="_lMSEFlDOEeWpFusmeDrF3w">
+              <body> type string {&#xD;
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'&#xD;
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'&#xD;
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'&#xD;
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'&#xD;
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';&#xD;
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'&#xD;
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'&#xD;
+            + '(/.+)'; }&#xD;
+&#xD;
+The ipv6-prefix type represents an IPv6 address prefix. The prefix length is given by the number following the slash character and must be less than or equal to 128.&#xD;
+&#xD;
+A prefix length value of n corresponds to an IP address mask that has n contiguous 1-bits from the most significant bit (MSB) and all other bits set to 0.&#xD;
+&#xD;
+The IPv6 address should have all bits that do not belong to the prefix set to zero.&#xD;
+&#xD;
+The canonical format of an IPv6 prefix has all bits of the IPv6 address set to zero that are not part of the IPv6 prefix.  Furthermore, the IPv6 address is represented as defined in Section 4 of RFC 5952.&#xD;
+    reference&#xD;
+     &quot;RFC 5952: A Recommendation for IPv6 Address Text Representation&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_lMSEGFDOEeWpFusmeDrF3w" name="IpPrefix">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEG1DOEeWpFusmeDrF3w" annotatedElement="_lMSEGFDOEeWpFusmeDrF3w">
+              <body>The ip-prefix type represents an IP prefix and is IP version neutral.  The format of the textual representations implies the IP version.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSEHFDOEeWpFusmeDrF3w" name="ipv4Prefix" visibility="public" type="_lMSEFFDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSEHVDOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSEHlDOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSEH1DOEeWpFusmeDrF3w" name="ipv6Prefix" visibility="public" type="_lMSEFlDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSEIFDOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSEIVDOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_lMSEIlDOEeWpFusmeDrF3w" name="domain name and URI types">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lMSEI1DOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEJFDOEeWpFusmeDrF3w" name="DomainName">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEJVDOEeWpFusmeDrF3w" annotatedElement="_lMSEJFDOEeWpFusmeDrF3w">
+              <body>type string {&#xD;
+      pattern&#xD;
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'&#xD;
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'&#xD;
+      + '|\.';&#xD;
+      length &quot;1..253&quot;; }&#xD;
+&#xD;
+The domain-name type represents a DNS domain name.  The name SHOULD be fully qualified whenever possible.&#xD;
+&#xD;
+Internet domain names are only loosely specified.  Section 3.5 of RFC 1034 recommends a syntax (modified in Section 2.1 of RFC 1123).  The pattern above is intended to allow for current practice in domain name use, and some possible  future expansion.  It is designed to hold various types of domain names, including names used for A or AAAA records (host names) and other records, such as SRV records.  Note that Internet host names have a stricter syntax (described in RFC 952) than the DNS recommendations in RFCs 1034 and 1123, and that systems that want to store host names in schema nodes using the domain-name type are recommended to adhere to this stricter standard to ensure interoperability.&#xD;
+&#xD;
+The encoding of DNS names in the DNS protocol is limited to 255 characters.  Since the encoding consists of labels prefixed by a length bytes and there is a trailing NULL byte, only 253 characters can appear in the textual dotted notation.&#xD;
+&#xD;
+The description clause of schema nodes using the domain-name type MUST describe when and how these names are resolved to IP addresses.  Note that the resolution of a domain-name value may require to query multiple DNS records (e.g., A for IPv4 and AAAA for IPv6).  The order of the resolution process and which DNS record takes precedence can either be defined explicitly or may depend on the configuration of the resolver.&#xD;
+&#xD;
+Domain-name values use the US-ASCII encoding. Their canonical format uses lowercase US-ASCII characters.  Internationalized domain names MUST be A-labels as per RFC 5890.&#xD;
+    reference&#xD;
+     &quot;RFC  952: DoD Internet Host Table Specification&#xD;
+      RFC 1034: Domain Names - Concepts and Facilities&#xD;
+      RFC 1123: Requirements for Internet Hosts -- Application and Support&#xD;
+      RFC 2782: A DNS RR for specifying the location of services (DNS SRV)&#xD;
+      RFC 5890: Internationalized Domain Names in Applications (IDNA): Definitions and Document Framework&quot;</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_lMSEJlDOEeWpFusmeDrF3w" name="Host">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lMSEJ1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_lMSEKFDOEeWpFusmeDrF3w" key="Union"/>
+            </eAnnotations>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEKVDOEeWpFusmeDrF3w" annotatedElement="_lMSEJlDOEeWpFusmeDrF3w">
+              <body>The host type represents either an IP address or a DNS domain name.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSEKlDOEeWpFusmeDrF3w" name="ipAddress" visibility="public" type="_lMSD-FDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSEK1DOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSELFDOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_lMSELVDOEeWpFusmeDrF3w" name="domainName" visibility="public" type="_lMSEJFDOEeWpFusmeDrF3w">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lMSELlDOEeWpFusmeDrF3w"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lMSEL1DOEeWpFusmeDrF3w" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMSEMFDOEeWpFusmeDrF3w" name="Uri">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lMSEMVDOEeWpFusmeDrF3w" annotatedElement="_lMSEMFDOEeWpFusmeDrF3w">
+              <body>type string;&#xD;
+&#xD;
+The uri type represents a Uniform Resource Identifier (URI) as defined by STD 66.&#xD;
+&#xD;
+Objects using the uri type MUST be in US-ASCII encoding, and MUST be normalized as described by RFC 3986 Sections 6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary percent-encoding is removed, and all case-insensitive characters are set to lowercase except for hexadecimal digits, which are normalized to uppercase as described in Section 6.2.2.1.&#xD;
+&#xD;
+The purpose of this normalization is to help provide unique URIs.  Note that this normalization is not sufficient to provide uniqueness.  Two URIs that are textually distinct after this normalization may still be equivalent.&#xD;
+&#xD;
+Objects using the uri type may restrict the schemes that they permit.  For example, 'data:' and 'urn:' schemes might not be appropriate.&#xD;
+&#xD;
+A zero-length URI is not a valid URI.  This can be used to express 'URI absent' where required.&#xD;
+&#xD;
+In the value set and its semantics, this type is equivalent to the Uri SMIv2 textual convention defined in RFC 5017.&#xD;
+    reference&#xD;
+     &quot;RFC 3986: Uniform Resource Identifier (URI): Generic Syntax&#xD;
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest Group: Uniform Resource Identifiers (URIs), URLs, and Uniform Resource Names (URNs): Clarifications and Recommendations&#xD;
+      RFC 5017: MIB Textual Conventions for Uniform Resource Identifiers (URIs)&quot;</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_lMTSAFDOEeWpFusmeDrF3w" name="YANG Built-In Types">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lMTSAVDOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSA1DOEeWpFusmeDrF3w" name="binary"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSBFDOEeWpFusmeDrF3w" name="bits"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_ijC7wPZZEeWhRf3FikFX5w" name="boolean"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSDFDOEeWpFusmeDrF3w" name="decimal64"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSEFDOEeWpFusmeDrF3w" name="empty"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_tI_mwPZZEeWhRf3FikFX5w" name="enumeration"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSDlDOEeWpFusmeDrF3w" name="identityref"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSD1DOEeWpFusmeDrF3w" name="instance-identifier"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSCVDOEeWpFusmeDrF3w" name="int8"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSClDOEeWpFusmeDrF3w" name="int16"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSBlDOEeWpFusmeDrF3w" name="int32"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSC1DOEeWpFusmeDrF3w" name="int64"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSDVDOEeWpFusmeDrF3w" name="leafref"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_-CnPQPZZEeWhRf3FikFX5w" name="string"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSBVDOEeWpFusmeDrF3w" name="uint8"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSB1DOEeWpFusmeDrF3w" name="uint16"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSCFDOEeWpFusmeDrF3w" name="uint32"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_lMTSAlDOEeWpFusmeDrF3w" name="uint64"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_FasQEPZaEeWhRf3FikFX5w" name="union"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_vgEA0FDOEeWpFusmeDrF3w" name="MEF SOAM CFM Types">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEA0VDOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEA0lDOEeWpFusmeDrF3w" name="MepIdType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA01DOEeWpFusmeDrF3w" annotatedElement="_vgEA0lDOEeWpFusmeDrF3w">
+            <body>type uint16 {&#xD;
+range &quot;1..8191&quot;; }&#xD;
+&#xD;
+Maintenance association End Point Identifier (MEPID): A small integer, unique over a given Maintenance Association, identifying a specific MEP.&#xD;
+reference&#xD;
+&quot;[802.1q] 3.19 and 19.2.1&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEA1FDOEeWpFusmeDrF3w" name="VlanIdType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA1VDOEeWpFusmeDrF3w" annotatedElement="_vgEA1FDOEeWpFusmeDrF3w">
+            <body>type uint16 {&#xD;
+range &quot;1..4094&quot;; }&#xD;
+&#xD;
+The VLAN-ID that uniquely identifies a VLAN. This is the 12-bit VLAN-ID used in the VLAN Tag header.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 9.6&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEA1lDOEeWpFusmeDrF3w" name="PortStatusType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA11DOEeWpFusmeDrF3w" annotatedElement="_vgEA1lDOEeWpFusmeDrF3w">
+            <body>The set of values available from the Port Status TLV in CCM PDUs including the default no-status-tlv.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 20.19.3, 12.14.7.6.3:f&#xD;
+IEEE8021-CFM-MIB.Dot1agCfmPortStatus&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA2FDOEeWpFusmeDrF3w" name="NO_STATUS_TLV">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA2VDOEeWpFusmeDrF3w" annotatedElement="_vgEA2FDOEeWpFusmeDrF3w">
+              <body>Indicates either that no CCM has been received or that no port status TLV was present in the last CCM received.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA2lDOEeWpFusmeDrF3w" name="BLOCKED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA21DOEeWpFusmeDrF3w" annotatedElement="_vgEA2lDOEeWpFusmeDrF3w">
+              <body>Ordinary data cannot pass freely through the port on which the remote MEP resides. Value of enableRmepDefect is equal to false.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA3FDOEeWpFusmeDrF3w" name="UP">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA3VDOEeWpFusmeDrF3w" annotatedElement="_vgEA3FDOEeWpFusmeDrF3w">
+              <body>Ordinary data can pass freely through the port on which the remote MEP resides. Value of enableRmepDefect is equal to true.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEA3lDOEeWpFusmeDrF3w" name="InterfaceStatusType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA31DOEeWpFusmeDrF3w" annotatedElement="_vgEA3lDOEeWpFusmeDrF3w">
+            <body>The set of values available from the Interface Status TLV in CCM PDUs including the default no-status-tlv.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 20.19.4, 12.14.7.6.3:g&#xD;
+IEEE8021-CFM-MIB.Dot1agCfmInterfaceStatus&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA4FDOEeWpFusmeDrF3w" name="NO_STATUS_TLV">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA4VDOEeWpFusmeDrF3w" annotatedElement="_vgEA4FDOEeWpFusmeDrF3w">
+              <body>Indicates either that no CCM has been received or that no interface status TLV was present in the last CCM received.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA4lDOEeWpFusmeDrF3w" name="UP">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA41DOEeWpFusmeDrF3w" annotatedElement="_vgEA4lDOEeWpFusmeDrF3w">
+              <body>The interface is ready to pass packets.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA5FDOEeWpFusmeDrF3w" name="DOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA5VDOEeWpFusmeDrF3w" annotatedElement="_vgEA5FDOEeWpFusmeDrF3w">
+              <body>The interface cannot pass packets.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA5lDOEeWpFusmeDrF3w" name="TESTING">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA51DOEeWpFusmeDrF3w" annotatedElement="_vgEA5lDOEeWpFusmeDrF3w">
+              <body>The interface is in some test mode.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA6FDOEeWpFusmeDrF3w" name="UNKNOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA6VDOEeWpFusmeDrF3w" annotatedElement="_vgEA6FDOEeWpFusmeDrF3w">
+              <body>The interface status cannot be determined for some reason.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA6lDOEeWpFusmeDrF3w" name="DORMANT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA61DOEeWpFusmeDrF3w" annotatedElement="_vgEA6lDOEeWpFusmeDrF3w">
+              <body>The interface is not in a state to pass packets but is in a pending state, waiting for some external event.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA7FDOEeWpFusmeDrF3w" name="NOT_PRESENT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA7VDOEeWpFusmeDrF3w" annotatedElement="_vgEA7FDOEeWpFusmeDrF3w">
+              <body>Some component of the interface is missing.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA7lDOEeWpFusmeDrF3w" name="LOWER_LAYER_DOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA71DOEeWpFusmeDrF3w" annotatedElement="_vgEA7lDOEeWpFusmeDrF3w">
+              <body>The interface is down due to state of the lower layer interfaces.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEA8FDOEeWpFusmeDrF3w" name="MhfCreationType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA8VDOEeWpFusmeDrF3w" annotatedElement="_vgEA8FDOEeWpFusmeDrF3w">
+            <body>An enumerated value indicating whether the management entity can create MHFs for this VID(s).&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 22.2.3, 12.14.3.1.3:d&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA8lDOEeWpFusmeDrF3w" name="NONE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA81DOEeWpFusmeDrF3w" annotatedElement="_vgEA8lDOEeWpFusmeDrF3w">
+              <body>No MHFs can be created for this VID(s).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA9FDOEeWpFusmeDrF3w" name="DEFAULT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA9VDOEeWpFusmeDrF3w" annotatedElement="_vgEA9FDOEeWpFusmeDrF3w">
+              <body>MHFs can be created for this VID(s) on any Bridge Port through which the VID(s) can pass where:&#xD;
+- There are no lower active MD levels; or&#xD;
+- There is a MEP at the next lower active MD-level on the port.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA9lDOEeWpFusmeDrF3w" name="EXPLICIT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA91DOEeWpFusmeDrF3w" annotatedElement="_vgEA9lDOEeWpFusmeDrF3w">
+              <body>MHFs can be created for this VID(s) only on Bridge Ports through which this VID(s) can pass, and only if there is a MEP at the next lower active MD-level on the port.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA-FDOEeWpFusmeDrF3w" name="DEFER">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA-VDOEeWpFusmeDrF3w" annotatedElement="_vgEA-FDOEeWpFusmeDrF3w">
+              <body>In the Maintenance Association managed object only, the control of MHF creation is deferred to the corresponding variable in the enclosing Maintenance Domain.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEA-lDOEeWpFusmeDrF3w" name="IdPermissionType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA-1DOEeWpFusmeDrF3w" annotatedElement="_vgEA-lDOEeWpFusmeDrF3w">
+            <body>An enumerated value indicating what, if anything, is to be included in the Sender ID TLV transmitted by maintenance-points configured in the default Maintenance Domain.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 21.5.3, 12.14.3.1.3:e&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA_FDOEeWpFusmeDrF3w" name="NONE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA_VDOEeWpFusmeDrF3w" annotatedElement="_vgEA_FDOEeWpFusmeDrF3w">
+              <body>The Sender ID TLV is not to be sent.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEA_lDOEeWpFusmeDrF3w" name="CHASSIS">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEA_1DOEeWpFusmeDrF3w" annotatedElement="_vgEA_lDOEeWpFusmeDrF3w">
+              <body>The Chassis ID Length, Chassis ID Subtype, and Chassis ID fields of the Sender ID TLV are to be sent, but not the Management Address Length or Management Address fields.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBAFDOEeWpFusmeDrF3w" name="MANAGE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBAVDOEeWpFusmeDrF3w" annotatedElement="_vgEBAFDOEeWpFusmeDrF3w">
+              <body>The Management Address Length and Management Address of the Sender ID TLV are to be sent, but the Chassis ID Length is to be transmitted with a 0 value, and the Chassis ID Subtype and Chassis ID fields not sent.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBAlDOEeWpFusmeDrF3w" name="CHASSIS_MANAGE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBA1DOEeWpFusmeDrF3w" annotatedElement="_vgEBAlDOEeWpFusmeDrF3w">
+              <body>The Chassis ID Length, Chassis ID Subtype, Chassis ID, Management Address Length, and Management Address fields are all to be sent.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBBFDOEeWpFusmeDrF3w" name="DEFER">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBBVDOEeWpFusmeDrF3w" annotatedElement="_vgEBBFDOEeWpFusmeDrF3w">
+              <body>The contents of the Sender ID TLV are determined by the Maintenance Domain managed object.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBBlDOEeWpFusmeDrF3w" name="MacAddressAndUintType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBB1DOEeWpFusmeDrF3w" annotatedElement="_vgEBBlDOEeWpFusmeDrF3w">
+            <body>type binary {&#xD;
+length &quot;8&quot;; }&#xD;
+&#xD;
+A MAC address and a two-octet unsigned integer.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] IEEE8021-CFM-MIB.Dot1agCfmMaintDomainNameType&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEBCFDOEeWpFusmeDrF3w" name="FaultAlarmDefectType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBCVDOEeWpFusmeDrF3w" annotatedElement="_vgEBCFDOEeWpFusmeDrF3w">
+            <body>An enumerated value indicating the highest priority defect.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 20.33.9&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBClDOEeWpFusmeDrF3w" name="REMOTE_RDI">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBC1DOEeWpFusmeDrF3w" annotatedElement="_vgEBClDOEeWpFusmeDrF3w">
+              <body>Indicates the aggregate health of the remote MEPs.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBDFDOEeWpFusmeDrF3w" name="REMOTE_MAC_ERROR">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBDVDOEeWpFusmeDrF3w" annotatedElement="_vgEBDFDOEeWpFusmeDrF3w">
+              <body>Indicates that one or more of the remote MEPs is reporting a failure in its Port Status TLV or Interface Status TLV.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBDlDOEeWpFusmeDrF3w" name="REMOTE_INVALID_CCM">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBD1DOEeWpFusmeDrF3w" annotatedElement="_vgEBDlDOEeWpFusmeDrF3w">
+              <body>Indicates that at least one of the Remote MEP state machines is not receiving valid CCMs from its remote MEP.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBEFDOEeWpFusmeDrF3w" name="INVALID_CCM">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBEVDOEeWpFusmeDrF3w" annotatedElement="_vgEBEFDOEeWpFusmeDrF3w">
+              <body>Indicates that one or more invalid CCMs has been received and that 3.5 times that CCMs transmission interval has not yet expired.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBElDOEeWpFusmeDrF3w" name="CROSS_CONNECT_CCM">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBE1DOEeWpFusmeDrF3w" annotatedElement="_vgEBElDOEeWpFusmeDrF3w">
+              <body>Indicates that one or more cross connect CCMs has been received and that 3.5 times of at least one of those CCMs transmission interval has not yet expired.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBFFDOEeWpFusmeDrF3w" name="FaultAlarmDefectBitsType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBFVDOEeWpFusmeDrF3w" annotatedElement="_vgEBFFDOEeWpFusmeDrF3w">
+            <body>type bits {&#xD;
+bit remote-rdi;&#xD;
+bit remote-mac-error;&#xD;
+bit remote-invalid-ccm;&#xD;
+bit invalid-ccm;&#xD;
+bit cross-connect-ccm; }&#xD;
+&#xD;
+A set of bits indicating the the current defects:&#xD;
+- cross-connect-ccm One or more cross connect CCMs has been received&#xD;
+- invalid-ccm One or more invalid CCMs has been received&#xD;
+- remote-invalid-ccm At least one of the Remote MEP state machines is not receiving valid CCMs from its remote MEP&#xD;
+- remote-mac-error One or more of the remote MEPs is reporting a failure in its Port Status TLV or Interface Status&#xD;
+- remote-rdi Indicates that at least one of the Remote MEP state machines is receiving valid CCMs from its remote MEP that has the RDI bit set.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 20.33.9&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBFlDOEeWpFusmeDrF3w" name="LbmTransactionIdType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBF1DOEeWpFusmeDrF3w" annotatedElement="_vgEBFlDOEeWpFusmeDrF3w">
+            <body>type uint32;&#xD;
+&#xD;
+A loopback transaction identifier.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 21.7.3&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBGFDOEeWpFusmeDrF3w" name="LtmTransactionIdType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBGVDOEeWpFusmeDrF3w" annotatedElement="_vgEBGFDOEeWpFusmeDrF3w">
+            <body>type uint32;&#xD;
+&#xD;
+A linktrace transaction identifier.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 21.8.3&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBGlDOEeWpFusmeDrF3w" name="MdLevelType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBG1DOEeWpFusmeDrF3w" annotatedElement="_vgEBGlDOEeWpFusmeDrF3w">
+            <body>type int32 {&#xD;
+range &quot;0..7&quot;; }&#xD;
+&#xD;
+Maintenance Domain Level (MD Level) identifier. Higher numbers correspond to higher Maintenance Domains, those with the greatest physical reach, with the highest values for customers' CFM PDUs.&#xD;
+Lower numbers correspond to lower Maintenance Domains, those with more limited physical reach, with the lowest values for CFM PDUs protecting single bridges or physical links.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 18.3, 21.4.1, IEEE8021-CFM-MIB.Dot1agCfmMDLevel&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBHFDOEeWpFusmeDrF3w" name="ErrorConditionsType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBHVDOEeWpFusmeDrF3w" annotatedElement="_vgEBHFDOEeWpFusmeDrF3w">
+            <body>type bits {&#xD;
+bit cfm-leak;&#xD;
+bit conflicting-vids;&#xD;
+bit excessive-levels;&#xD;
+bit overlapped-levels; }&#xD;
+&#xD;
+A list of errors that may occur on creation or deletion of a MEP.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 22.2.4&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBHlDOEeWpFusmeDrF3w" name="PriorityType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBH1DOEeWpFusmeDrF3w" annotatedElement="_vgEBHlDOEeWpFusmeDrF3w">
+            <body>type uint32 {&#xD;
+range &quot;0..7&quot;; }&#xD;
+&#xD;
+A 3 bit priority value to be used in the VLAN tag, if present in the transmitted frame.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 12.14.7.3.2:e&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEBIFDOEeWpFusmeDrF3w" name="RemoteMepStateType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBIVDOEeWpFusmeDrF3w" annotatedElement="_vgEBIFDOEeWpFusmeDrF3w">
+            <body>An enumerated value indicating the operational state of a Remote MEP state machine for a remote MEP.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 12.14.7.6.3:b&#xD;
+IEEE8021-CFM-MIB.Dot1agCfmRemoteMepState&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBIlDOEeWpFusmeDrF3w" name="IDLE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBI1DOEeWpFusmeDrF3w" annotatedElement="_vgEBIlDOEeWpFusmeDrF3w">
+              <body>Indicates momentary state during reset.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBJFDOEeWpFusmeDrF3w" name="START">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBJVDOEeWpFusmeDrF3w" annotatedElement="_vgEBJFDOEeWpFusmeDrF3w">
+              <body>Indicates the timer has not expired since the state machine was reset, and no valid CCM has yet been received.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBJlDOEeWpFusmeDrF3w" name="FAILED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBJ1DOEeWpFusmeDrF3w" annotatedElement="_vgEBJlDOEeWpFusmeDrF3w">
+              <body>Indicates The timer has expired, both since the state machine was reset, and since a valid CCM was received.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBKFDOEeWpFusmeDrF3w" name="OK">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBKVDOEeWpFusmeDrF3w" annotatedElement="_vgEBKFDOEeWpFusmeDrF3w">
+              <body>Indicates The timer has not expired since a valid CCM was received.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vgEBKlDOEeWpFusmeDrF3w" name="ComponentIdType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBK1DOEeWpFusmeDrF3w" annotatedElement="_vgEBKlDOEeWpFusmeDrF3w">
+            <body>type uint32 {&#xD;
+range &quot;1..4294967295&quot;; }&#xD;
+&#xD;
+A Provider Backbone Bridge (PBB) can comprise a number of components, each of which can be managed in a manner essentially equivalent to an 802.1Q bridge. In order to access these components easily, an index is used in a number of places. If any two lists are indexed by component-identifier, then entries in those tables indexed by the same value correspond to the same component.&#xD;
+&#xD;
+reference&#xD;
+&quot;IEEE8021-CFM-MIB.Dot1agCfmPbbComponentIdentifier&quot;</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBLFDOEeWpFusmeDrF3w" name="TargetAddressGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBLVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vgEBLlDOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBL1DOEeWpFusmeDrF3w" annotatedElement="_vgEBLFDOEeWpFusmeDrF3w">
+            <body>An indication of a destination MEP, either:&#xD;
+1) The MEPID of a MEP; or&#xD;
+2) An Individual destination MAC address.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.2:b&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBMFDOEeWpFusmeDrF3w" name="MacAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBMVDOEeWpFusmeDrF3w" annotatedElement="_vgEBMFDOEeWpFusmeDrF3w">
+              <body>Target MAC address.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_f9umUMSGEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBMlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBM1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBNFDOEeWpFusmeDrF3w" name="MepId" visibility="public" type="_vgEA0lDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBNVDOEeWpFusmeDrF3w" annotatedElement="_vgEBNFDOEeWpFusmeDrF3w">
+              <body>Target MEP ID.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBNlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBN1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBOFDOEeWpFusmeDrF3w" name="LoopbackParametersGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBOVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBOlDOEeWpFusmeDrF3w" annotatedElement="_vgEBOFDOEeWpFusmeDrF3w">
+            <body>This is the group of parameters associated with Loopback sessions. It is used for loopback RPC input.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBO1DOEeWpFusmeDrF3w" name="targetAddress" visibility="public" type="_vgEBLFDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBPFDOEeWpFusmeDrF3w" annotatedElement="_vgEBO1DOEeWpFusmeDrF3w">
+              <body>Target MAC address or MEP ID for the Loopback session.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBPVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBPlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBP1DOEeWpFusmeDrF3w" name="numberOfMessages" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBQFDOEeWpFusmeDrF3w" annotatedElement="_vgEBP1DOEeWpFusmeDrF3w">
+              <body>range &quot;1..1024&quot;&#xD;
+&#xD;
+The number of LBM transmissions in a session.&#xD;
+&#xD;
+reference&#xD;
+&quot;[802.1q] 12.14.7.3.2:c, [MEF30] R39&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBQVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBQlDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBQ1DOEeWpFusmeDrF3w" value="1">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBRFDOEeWpFusmeDrF3w" name="dataTlv" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBRVDOEeWpFusmeDrF3w" annotatedElement="_vgEBRFDOEeWpFusmeDrF3w">
+              <body>An arbitrary amount of data to be included in a Data TLV.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.d, IEEE8021-CFM-MIB.dot1agCfmMepTransmitLbmDataTlv&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_8l-CAMSaEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBRlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBR1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBSFDOEeWpFusmeDrF3w" name="vlanPriority" visibility="public" type="_vgEBHlDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBSVDOEeWpFusmeDrF3w" annotatedElement="_vgEBSFDOEeWpFusmeDrF3w">
+              <body>The priority parameter to be used in the transmitted LBMs.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.2:e&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBSlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBS1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBTFDOEeWpFusmeDrF3w" name="vlanDropEligible" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBTVDOEeWpFusmeDrF3w" annotatedElement="_vgEBTFDOEeWpFusmeDrF3w">
+              <body>The drop eligible parameter to be used in the transmitted LBMs.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.2:e&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBTlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBT1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_vgEBUFDOEeWpFusmeDrF3w" value="true">
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            </defaultValue>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBUVDOEeWpFusmeDrF3w" name="LinktraceParametersGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBUlDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBU1DOEeWpFusmeDrF3w" annotatedElement="_vgEBUVDOEeWpFusmeDrF3w">
+            <body>This is the group of parameters associated with linktrace sessions. It is used for linktrace RPC input as well as linktrace database entries.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBVFDOEeWpFusmeDrF3w" name="targetAddress" visibility="public" type="_vgEBLFDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBVVDOEeWpFusmeDrF3w" annotatedElement="_vgEBVFDOEeWpFusmeDrF3w">
+              <body>Target MAC address or MEP ID for the Linktrace session.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBVlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBV1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBWFDOEeWpFusmeDrF3w" name="transmitLtmFlags" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBWVDOEeWpFusmeDrF3w" annotatedElement="_vgEBWFDOEeWpFusmeDrF3w">
+              <body>type bits {&#xD;
+bit use-fdb-only; }&#xD;
+&#xD;
+The Flags field for LTMs transmitted by the MEP.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.4.2:b&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_nOiU8MSbEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBWlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBW1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBXFDOEeWpFusmeDrF3w" name="defaultTtl" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBXVDOEeWpFusmeDrF3w" annotatedElement="_vgEBXFDOEeWpFusmeDrF3w">
+              <body>An initial value for the LTM TTL field.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.4.2:d&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_00nwIMSbEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBXlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBX1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBYFDOEeWpFusmeDrF3w" value="64"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBYVDOEeWpFusmeDrF3w" name="MdLevelGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBYlDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBY1DOEeWpFusmeDrF3w" annotatedElement="_vgEBYVDOEeWpFusmeDrF3w">
+            <body>Data definitions related to a default MD level.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBZFDOEeWpFusmeDrF3w" name="mdLevel" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBZVDOEeWpFusmeDrF3w" annotatedElement="_vgEBZFDOEeWpFusmeDrF3w">
+              <body>range &quot;-1 | 0..7&quot;&#xD;
+&#xD;
+The MD Level at which MHFs are to be created and Sender ID TLV transmission by those MHFs is to be controlled, for the VLAN to which this entry's definitions apply. If this leaf has the value -1, the MD Level for MHF creation for this VLAN is controlled by the content of the default-md-levels container. -1 is not a valid value for this parameter when used in the default-md-levels.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.3.1.3:c&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_0UMuMMScEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBZlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBZ1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBaFDOEeWpFusmeDrF3w" name="mhfCreation" visibility="public" type="_vgEA8FDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBaVDOEeWpFusmeDrF3w" annotatedElement="_vgEBaFDOEeWpFusmeDrF3w">
+              <body>This parameter indicates whether the management entity can create MHFs for this VID(s).&#xD;
+The value 'defer' has different meanings depending on where the grouping is used:&#xD;
+- The value 'defer' is not allowed when this grouping is used in the 'default-md-levels' container&#xD;
+- When used in a member of the 'default-md-level' list the value 'defer' means that MHF creation for the VLAN is controlled by the corresponding 'mhf-creation' leaf in the 'default-md-levels' container.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.3.1.3:d&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBalDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBa1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBbFDOEeWpFusmeDrF3w" name="defaultIdPermission" visibility="public" type="_vgEA-lDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBbVDOEeWpFusmeDrF3w" annotatedElement="_vgEBbFDOEeWpFusmeDrF3w">
+              <body>This parameter indicates what, if anything, is to be included in the Sender ID TLV transmitted by MPs configured in a default MD Level.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.3.1.3:e&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBblDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBb1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBcFDOEeWpFusmeDrF3w" name="portIdTlvGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBcVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBclDOEeWpFusmeDrF3w" annotatedElement="_vgEBcFDOEeWpFusmeDrF3w">
+            <body>Data definitions associated with the Port ID TLV.&#xD;
+&#xD;
+reference &quot;[802.1AB] 9.5.3&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBc1DOEeWpFusmeDrF3w" name="portIdSubtype" visibility="public">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBdFDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vgEBdVDOEeWpFusmeDrF3w" key="Choice?"/>
+            </eAnnotations>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBdlDOEeWpFusmeDrF3w" annotatedElement="_vgEBc1DOEeWpFusmeDrF3w">
+              <body>leaf interface-alias {&#xD;
+type string {&#xD;
+length &quot;0..64&quot;; }&#xD;
+&#xD;
+The ifAlias field from the Interfaces Group MIB.&#xD;
+&#xD;
+reference &quot;[RFC2863]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBd1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBeFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBeVDOEeWpFusmeDrF3w" name="portComponent" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBelDOEeWpFusmeDrF3w" annotatedElement="_vgEBeVDOEeWpFusmeDrF3w">
+              <body>length &quot;0..32&quot;&#xD;
+&#xD;
+EntPhysicalAlias when entPhysClass has a value of port(10) or backplane(4).&#xD;
+&#xD;
+reference &quot;[RFC2737]&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBe1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBfFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBfVDOEeWpFusmeDrF3w" name="macAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBflDOEeWpFusmeDrF3w" annotatedElement="_vgEBfVDOEeWpFusmeDrF3w">
+              <body>A MAC address.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_f9umUMSGEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBf1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBgFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBgVDOEeWpFusmeDrF3w" name="networkAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBglDOEeWpFusmeDrF3w" annotatedElement="_vgEBgVDOEeWpFusmeDrF3w">
+              <body>Network-address is an octet string that identifies a particular network address family and an associated network address that are encoded in network octet order. An IP address, for example, would be encoded with the first octet  containing the IANA Address Family Numbers enumeration value for the specific address type and octets 2 through n containing the address value.&#xD;
+&#xD;
+reference &quot;[802.1AB] Table 9.2&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBg1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBhFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBhVDOEeWpFusmeDrF3w" name="interfaceName" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBhlDOEeWpFusmeDrF3w" annotatedElement="_vgEBhVDOEeWpFusmeDrF3w">
+              <body>length &quot;0..64&quot;&#xD;
+&#xD;
+The ifName field from the Interfaces Group MIB.&#xD;
+&#xD;
+reference &quot;[RFC2863]&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBh1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBiFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBiVDOEeWpFusmeDrF3w" name="agentCircuitId" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBilDOEeWpFusmeDrF3w" annotatedElement="_vgEBiVDOEeWpFusmeDrF3w">
+              <body>Agent circuit ID.&#xD;
+&#xD;
+reference &quot;[RFC3046]&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBi1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBjFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBjVDOEeWpFusmeDrF3w" name="local" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBjlDOEeWpFusmeDrF3w" annotatedElement="_vgEBjVDOEeWpFusmeDrF3w">
+              <body>A locally defined identifier.&#xD;
+&#xD;
+reference &quot;[802.1AB] Table 9.3&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBj1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBkFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEBkVDOEeWpFusmeDrF3w" name="MdNameType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBklDOEeWpFusmeDrF3w" name="NONE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBk1DOEeWpFusmeDrF3w" annotatedElement="_vgEBklDOEeWpFusmeDrF3w">
+              <body>No format specified.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBlFDOEeWpFusmeDrF3w" name="DOMAIN_NAME">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBlVDOEeWpFusmeDrF3w" annotatedElement="_vgEBlFDOEeWpFusmeDrF3w">
+              <body>Domain Name like string, globally unique text string derived from a DNS name.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBllDOEeWpFusmeDrF3w" name="MAC_ADDRESS_AND_UINT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBl1DOEeWpFusmeDrF3w" annotatedElement="_vgEBllDOEeWpFusmeDrF3w">
+              <body>MAC address + 2-octet (unsigned) integer.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBmFDOEeWpFusmeDrF3w" name="CHARACTER_STRING">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBmVDOEeWpFusmeDrF3w" annotatedElement="_vgEBmFDOEeWpFusmeDrF3w">
+              <body>RFC2579 DisplayString, except that the character codes 0-31 (decimal) are not used.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBmlDOEeWpFusmeDrF3w" name="MdName">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBm1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vgEBnFDOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBnVDOEeWpFusmeDrF3w" annotatedElement="_vgEBmlDOEeWpFusmeDrF3w">
+            <body>An indication of a destination MEP, either:&#xD;
+1) The MEPID of a MEP; or&#xD;
+2) An Individual destination MAC address.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.2:b&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBnlDOEeWpFusmeDrF3w" name="domainName" visibility="public">
+            <type xmi:type="uml:DataType" href="../RSA/YANG_Models.uml#_csIZEMSOEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBn1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBoFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBoVDOEeWpFusmeDrF3w" name="macAddressAndUint" visibility="public" type="_vgEBBlDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBolDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBo1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBpFDOEeWpFusmeDrF3w" name="characterString" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBpVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBplDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEBp1DOEeWpFusmeDrF3w" name="MaNameType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBqFDOEeWpFusmeDrF3w" name="PRIMARY_VID">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBqVDOEeWpFusmeDrF3w" annotatedElement="_vgEBqFDOEeWpFusmeDrF3w">
+              <body>No format specified.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBqlDOEeWpFusmeDrF3w" name="CHARACTER_STRING">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBq1DOEeWpFusmeDrF3w" annotatedElement="_vgEBqlDOEeWpFusmeDrF3w">
+              <body>RFC2579 DisplayString, except that the character codes 0-31 (decimal) are not used.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBrFDOEeWpFusmeDrF3w" name="UINT16">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBrVDOEeWpFusmeDrF3w" annotatedElement="_vgEBrFDOEeWpFusmeDrF3w">
+              <body>Domain Name like string, globally unique text string derived from a DNS name.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBrlDOEeWpFusmeDrF3w" name="RFC2685_VPN_ID">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBr1DOEeWpFusmeDrF3w" annotatedElement="_vgEBrlDOEeWpFusmeDrF3w">
+              <body>MAC address + 2-octet (unsigned) integer.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEBsFDOEeWpFusmeDrF3w" name="MaName">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEBsVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vgEBslDOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBs1DOEeWpFusmeDrF3w" annotatedElement="_vgEBsFDOEeWpFusmeDrF3w">
+            <body>An indication of a destination MEP, either:&#xD;
+1) The MEPID of a MEP; or&#xD;
+2) An Individual destination MAC address.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.2:b&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBtFDOEeWpFusmeDrF3w" name="primaryVid" visibility="public" type="_vgEA1FDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBtVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBtlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBt1DOEeWpFusmeDrF3w" name="characterString" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBuFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBuVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBulDOEeWpFusmeDrF3w" name="uint16" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_wWaGIMSgEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBu1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBvFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEBvVDOEeWpFusmeDrF3w" name="rfc2685VpnId" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_8l-CAMSaEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEBvlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEBv1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEBwFDOEeWpFusmeDrF3w" name="CcmInterval">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBwVDOEeWpFusmeDrF3w" name="INVALID">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBwlDOEeWpFusmeDrF3w" annotatedElement="_vgEBwVDOEeWpFusmeDrF3w">
+              <body>No CCMs are sent (disabled).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBw1DOEeWpFusmeDrF3w" name="3.3MS">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBxFDOEeWpFusmeDrF3w" annotatedElement="_vgEBw1DOEeWpFusmeDrF3w">
+              <body>CCMs are sent every 3 1/3 milliseconds (300Hz).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBxVDOEeWpFusmeDrF3w" name="10MS">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBxlDOEeWpFusmeDrF3w" annotatedElement="_vgEBxVDOEeWpFusmeDrF3w">
+              <body>CCMs are sent every 10 milliseconds.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBx1DOEeWpFusmeDrF3w" name="100MS">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEByFDOEeWpFusmeDrF3w" annotatedElement="_vgEBx1DOEeWpFusmeDrF3w">
+              <body>CCMs are sent every 100 milliseconds.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEByVDOEeWpFusmeDrF3w" name="1S">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBylDOEeWpFusmeDrF3w" annotatedElement="_vgEByVDOEeWpFusmeDrF3w">
+              <body>CCMs are sent every 1 second.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBy1DOEeWpFusmeDrF3w" name="10S">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBzFDOEeWpFusmeDrF3w" annotatedElement="_vgEBy1DOEeWpFusmeDrF3w">
+              <body>CCMs are sent every 10 seconds.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBzVDOEeWpFusmeDrF3w" name="1MIN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEBzlDOEeWpFusmeDrF3w" annotatedElement="_vgEBzVDOEeWpFusmeDrF3w">
+              <body>CCMs are sent every minute.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEBz1DOEeWpFusmeDrF3w" name="10MIN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB0FDOEeWpFusmeDrF3w" annotatedElement="_vgEBz1DOEeWpFusmeDrF3w">
+              <body>CCMs are sent every 10 minutes.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEB0VDOEeWpFusmeDrF3w" name="Direction">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB0lDOEeWpFusmeDrF3w" name="UP">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB01DOEeWpFusmeDrF3w" annotatedElement="_vgEB0lDOEeWpFusmeDrF3w">
+              <body>Indicates when CFM frames are transmitted towards and received from the bridging function.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB1FDOEeWpFusmeDrF3w" name="DOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB1VDOEeWpFusmeDrF3w" annotatedElement="_vgEB1FDOEeWpFusmeDrF3w">
+              <body>Indicates when CFM frames are transmitted towards and received from the wire.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_vgEB1lDOEeWpFusmeDrF3w" name="FngState">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB11DOEeWpFusmeDrF3w" name="RESET">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB2FDOEeWpFusmeDrF3w" annotatedElement="_vgEB11DOEeWpFusmeDrF3w">
+              <body>No defect has been present since the fng-reset-time timer expired, or since the state machine was last reset.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB2VDOEeWpFusmeDrF3w" name="DEFECT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB2lDOEeWpFusmeDrF3w" annotatedElement="_vgEB2VDOEeWpFusmeDrF3w">
+              <body>A defect is present, but not for a long enough time to be reported (fng-alarm-time).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB21DOEeWpFusmeDrF3w" name="REPORT_DEFECT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB3FDOEeWpFusmeDrF3w" annotatedElement="_vgEB21DOEeWpFusmeDrF3w">
+              <body>A momentary state during which the defect is reported by sending a fault-alarm notification, if that action is enabled.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB3VDOEeWpFusmeDrF3w" name="DEFECT_REPORTED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB3lDOEeWpFusmeDrF3w" annotatedElement="_vgEB3VDOEeWpFusmeDrF3w">
+              <body>A defect is present, and some defect has been reported.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vgEB31DOEeWpFusmeDrF3w" name="DEFECT_CLEARING">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB4FDOEeWpFusmeDrF3w" annotatedElement="_vgEB31DOEeWpFusmeDrF3w">
+              <body>No defect is present, but the fng-reset-time timer has not yet expired.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgEB4VDOEeWpFusmeDrF3w" name="ChassisIdSubtype">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEB4lDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vgEB41DOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB5FDOEeWpFusmeDrF3w" annotatedElement="_vgEB4VDOEeWpFusmeDrF3w">
+            <body>Data definitions associated with the Port ID TLV.&#xD;
+&#xD;
+reference &quot;[802.1AB] 9.5.3&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB5VDOEeWpFusmeDrF3w" name="chassisComponent" visibility="public">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgEB5lDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB51DOEeWpFusmeDrF3w" annotatedElement="_vgEB5VDOEeWpFusmeDrF3w">
+              <body>leaf interface-alias {&#xD;
+type string {&#xD;
+length &quot;0..64&quot;; }&#xD;
+&#xD;
+The ifAlias field from the Interfaces Group MIB.&#xD;
+&#xD;
+reference &quot;[RFC2863]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEB6FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEB6VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB6lDOEeWpFusmeDrF3w" name="interfaceAlias" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB61DOEeWpFusmeDrF3w" annotatedElement="_vgEB6lDOEeWpFusmeDrF3w">
+              <body>length &quot;0..32&quot;&#xD;
+&#xD;
+EntPhysicalAlias when entPhysClass has a value of port(10) or backplane(4).&#xD;
+&#xD;
+reference &quot;[RFC2737]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEB7FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEB7VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB7lDOEeWpFusmeDrF3w" name="portComponent" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB71DOEeWpFusmeDrF3w" annotatedElement="_vgEB7lDOEeWpFusmeDrF3w">
+              <body>A MAC address.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEB8FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEB8VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB8lDOEeWpFusmeDrF3w" name="macAddressType" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB81DOEeWpFusmeDrF3w" annotatedElement="_vgEB8lDOEeWpFusmeDrF3w">
+              <body>Network-address is an octet string that identifies a particular network address family and an associated network address that are encoded in network octet order. An IP address, for example, would be encoded with the first octet  containing the IANA Address Family Numbers enumeration value for the specific address type and octets 2 through n containing the address value.&#xD;
+&#xD;
+reference &quot;[802.1AB] Table 9.2&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEB9FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEB9VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB9lDOEeWpFusmeDrF3w" name="networkAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB91DOEeWpFusmeDrF3w" annotatedElement="_vgEB9lDOEeWpFusmeDrF3w">
+              <body>length &quot;0..64&quot;&#xD;
+&#xD;
+The ifName field from the Interfaces Group MIB.&#xD;
+&#xD;
+reference &quot;[RFC2863]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEB-FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEB-VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB-lDOEeWpFusmeDrF3w" name="interfaceName" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB-1DOEeWpFusmeDrF3w" annotatedElement="_vgEB-lDOEeWpFusmeDrF3w">
+              <body>Agent circuit ID.&#xD;
+&#xD;
+reference &quot;[RFC3046]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgEB_FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgEB_VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgEB_lDOEeWpFusmeDrF3w" name="local" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgEB_1DOEeWpFusmeDrF3w" annotatedElement="_vgEB_lDOEeWpFusmeDrF3w">
+              <body>A locally defined identifier.&#xD;
+&#xD;
+reference &quot;[802.1AB] Table 9.3&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECAFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECAVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgECAlDOEeWpFusmeDrF3w" name="ManagementAddress">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgECA1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgECBFDOEeWpFusmeDrF3w" annotatedElement="_vgECAlDOEeWpFusmeDrF3w">
+            <body>An indication of a destination MEP, either:&#xD;
+1) The MEPID of a MEP; or&#xD;
+2) An Individual destination MAC address.&#xD;
+&#xD;
+reference &quot;[802.1q] 12.14.7.3.2:b&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECBVDOEeWpFusmeDrF3w" name="&lt;series of case statements>" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECBlDOEeWpFusmeDrF3w" annotatedElement="_vgECBVDOEeWpFusmeDrF3w">
+              <body>Target MAC address.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_f9umUMSGEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECB1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECCFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECCVDOEeWpFusmeDrF3w" name="??" visibility="public" type="_vgEA0lDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECClDOEeWpFusmeDrF3w" annotatedElement="_vgECCVDOEeWpFusmeDrF3w">
+              <body>Target MEP ID.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECC1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECDFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_vgECDVDOEeWpFusmeDrF3w" name="PortIdSubtype">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgECDlDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vgECD1DOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vgECEFDOEeWpFusmeDrF3w" annotatedElement="_vgECDVDOEeWpFusmeDrF3w">
+            <body>Data definitions associated with the Port ID TLV.&#xD;
+&#xD;
+reference &quot;[802.1AB] 9.5.3&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECEVDOEeWpFusmeDrF3w" name="interfaceAlias" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECElDOEeWpFusmeDrF3w" annotatedElement="_vgECEVDOEeWpFusmeDrF3w">
+              <body>length &quot;0..32&quot;&#xD;
+&#xD;
+EntPhysicalAlias when entPhysClass has a value of port(10) or backplane(4).&#xD;
+&#xD;
+reference &quot;[RFC2737]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECE1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECFFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECFVDOEeWpFusmeDrF3w" name="portComponent" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECFlDOEeWpFusmeDrF3w" annotatedElement="_vgECFVDOEeWpFusmeDrF3w">
+              <body>A MAC address.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECF1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECGFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECGVDOEeWpFusmeDrF3w" name="macAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECGlDOEeWpFusmeDrF3w" annotatedElement="_vgECGVDOEeWpFusmeDrF3w">
+              <body>Network-address is an octet string that identifies a particular network address family and an associated network address that are encoded in network octet order. An IP address, for example, would be encoded with the first octet  containing the IANA Address Family Numbers enumeration value for the specific address type and octets 2 through n containing the address value.&#xD;
+&#xD;
+reference &quot;[802.1AB] Table 9.2&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECG1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECHFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECHVDOEeWpFusmeDrF3w" name="networkAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECHlDOEeWpFusmeDrF3w" annotatedElement="_vgECHVDOEeWpFusmeDrF3w">
+              <body>length &quot;0..64&quot;&#xD;
+&#xD;
+The ifName field from the Interfaces Group MIB.&#xD;
+&#xD;
+reference &quot;[RFC2863]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECH1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECIFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECIVDOEeWpFusmeDrF3w" name="interfaceName" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECIlDOEeWpFusmeDrF3w" annotatedElement="_vgECIVDOEeWpFusmeDrF3w">
+              <body>Agent circuit ID.&#xD;
+&#xD;
+reference &quot;[RFC3046]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECI1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECJFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECJVDOEeWpFusmeDrF3w" name="agentCircuitId" visibility="public">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vgECJlDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECJ1DOEeWpFusmeDrF3w" annotatedElement="_vgECJVDOEeWpFusmeDrF3w">
+              <body>leaf interface-alias {&#xD;
+type string {&#xD;
+length &quot;0..64&quot;; }&#xD;
+&#xD;
+The ifAlias field from the Interfaces Group MIB.&#xD;
+&#xD;
+reference &quot;[RFC2863]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECKFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECKVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vgECKlDOEeWpFusmeDrF3w" name="local" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vgECK1DOEeWpFusmeDrF3w" annotatedElement="_vgECKlDOEeWpFusmeDrF3w">
+              <body>A locally defined identifier.&#xD;
+&#xD;
+reference &quot;[802.1AB] Table 9.3&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vgECLFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vgECLVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_8RjWUFDOEeWpFusmeDrF3w" name="MEF SOAM PM Types">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjWUVDOEeWpFusmeDrF3w" source="uml2.diagrams"/>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjWUlDOEeWpFusmeDrF3w" name="TestPatternType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWU1DOEeWpFusmeDrF3w" name="NULL_SIGNAL_WITHOUT_CRC_32"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWVFDOEeWpFusmeDrF3w" name="NULL_SIGNAL_WITH_CRC_32"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWVVDOEeWpFusmeDrF3w" name="PRBS_2311_WITHOUT_CRC_32"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWVlDOEeWpFusmeDrF3w" name="PRBS_2311_WITH_CRC_32"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjWV1DOEeWpFusmeDrF3w" name="MeasurementBinType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWWFDOEeWpFusmeDrF3w" name="TWO_WAY_FRAME_DELAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWWVDOEeWpFusmeDrF3w" name="FORWARD_FRAME_DELAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWWlDOEeWpFusmeDrF3w" name="BACKWARD_FRAME_DELAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWW1DOEeWpFusmeDrF3w" name="TWO_WAY_INTER_FRAME_DELAY_VARIATION"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWXFDOEeWpFusmeDrF3w" name="FORWARD_INTER_FRAME_DELAY_VARIATION"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWXVDOEeWpFusmeDrF3w" name="BACKWARD_INTER_FRAME_DELAY_VARIATION"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWXlDOEeWpFusmeDrF3w" name="TWO_WAY_FRAME_DELAY_RANGE"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWX1DOEeWpFusmeDrF3w" name="FORWARD_FRAME_DELAY_RANGE"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjWYFDOEeWpFusmeDrF3w" name="BACKWARD_FRAME_DELAY_RANGE"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjWYVDOEeWpFusmeDrF3w" name="RemoteMepGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjWYlDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8RjWY1DOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWZFDOEeWpFusmeDrF3w" annotatedElement="_8RjWYVDOEeWpFusmeDrF3w">
+            <body>This grouping includes objects which identify a remote MEP. The remote MEP can be identified by either a MAC address or a MEP ID.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWZVDOEeWpFusmeDrF3w" name="macAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWZlDOEeWpFusmeDrF3w" annotatedElement="_8RjWZVDOEeWpFusmeDrF3w">
+              <body>The Target MAC Address Field to be transmitted: A unicast destination MAC address.&#xD;
+This object is only valid for the entity transmitting the SOAM Loss and Delay Measurement frames and is ignored by the entity receiving SOAM Loss and Delay Measurement frames.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_f9umUMSGEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWZ1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWaFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWaVDOEeWpFusmeDrF3w" name="mepId" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWalDOEeWpFusmeDrF3w" annotatedElement="_8RjWaVDOEeWpFusmeDrF3w">
+              <body>The Maintenance Association End Point Identifier of another MEP in the same Maintenance Association to which the SOAM Loss or Delay Measurement frame is to be sent.&#xD;
+This object is only valid for the entity transmitting the SOAM Loss Measurement or Delay Measurement frames and is ignored by the entity receiving SOAM Loss Measurement or Delay Measurement frames.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_epDjUMSPEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWa1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWbFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjWbVDOEeWpFusmeDrF3w" name="MeasurementTimingGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjWblDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWb1DOEeWpFusmeDrF3w" name="startTime" visibility="public" type="_8RjYX1DOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWcFDOEeWpFusmeDrF3w" annotatedElement="_8RjWb1DOEeWpFusmeDrF3w">
+              <body>This container defines the session start time.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWcVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWclDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWc1DOEeWpFusmeDrF3w" name="stopTime" visibility="public" type="_8RjYX1DOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWdFDOEeWpFusmeDrF3w" annotatedElement="_8RjWc1DOEeWpFusmeDrF3w">
+              <body>This container defines the session stop time.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWdVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWdlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWd1DOEeWpFusmeDrF3w" name="repetitionPeriod" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWeFDOEeWpFusmeDrF3w" annotatedElement="_8RjWd1DOEeWpFusmeDrF3w">
+              <body>This object specifies a configurable repetition time between Measurement Intervals in a Measurement session in hundredths of a second.&#xD;
+If the value is less than or equal to one Measurement Interval there is no time gap between the end of one Measurement Interval and the start of a new Measurement Interval. This is the normal usage case.&#xD;
+If the value is greater than one Measurement Interval there is time gap between the end of one Measurement Interval and the start of the next Measurement Interval.&#xD;
+reference &quot;[MEF SOAM PM IA] R18, D3, R19, R20&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_9pikYMSFEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWeVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWelDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWe1DOEeWpFusmeDrF3w">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_9pikYMSFEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjWfFDOEeWpFusmeDrF3w" name="LossMeasurementConfigurationGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjWfVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWflDOEeWpFusmeDrF3w" annotatedElement="_8RjWfFDOEeWpFusmeDrF3w">
+            <body>This grouping includes configuration objects for the Frame Loss Measurement function defined in [Y.1731] and [MEF SOAM PM IA].&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgTable, [Y.1731] and [MEF SOAM PM IA]&quot;</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_8RjWf1DOEeWpFusmeDrF3w" general="_8Rj-OlDOEeWpFusmeDrF3w"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWgFDOEeWpFusmeDrF3w" name="measurementType" visibility="public" type="_8RjYeVDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWgVDOEeWpFusmeDrF3w" annotatedElement="_8RjWgFDOEeWpFusmeDrF3w">
+              <body>This object specifies what type of Loss Measurement will be performed.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgType&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWglDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWg1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_8RjWhFDOEeWpFusmeDrF3w" name="SLM" type="_8RjYeVDOEeWpFusmeDrF3w" instance="_8RjYfFDOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWhVDOEeWpFusmeDrF3w" name="enabledCounterList?" visibility="public" type="_8RjYglDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWhlDOEeWpFusmeDrF3w" annotatedElement="_8RjWhVDOEeWpFusmeDrF3w">
+              <body>A vector of bits that indicates the type of SOAM LM counters found in the current-stats and history-stats that are enabled.&#xD;
+A present bit enables the specific SOAM LM counter. A not present bit disables the SOAM LM counter.&#xD;
+If a particular SOAM LM counter is not supported the BIT value is not present.&#xD;
+Not all SOAM LM counters are supported for all SOAM LM types.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgMeasurementEnable&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWh1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWiFDOEeWpFusmeDrF3w" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWiVDOEeWpFusmeDrF3w" name="availabilityMeasurementInterval" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWilDOEeWpFusmeDrF3w" annotatedElement="_8RjWiVDOEeWpFusmeDrF3w">
+              <body>range &quot;1..525600&quot;&#xD;
+This object specifies the availability measurement interval in minutes.&#xD;
+A measurement interval of 15 minutes is to be supported, other intervals can be supported.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAvailabilityMeasurementInterval&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWi1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWjFDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWjVDOEeWpFusmeDrF3w" value="15">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWjlDOEeWpFusmeDrF3w" name="availabilityNumberConsecutiveFlrMeasurements" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWj1DOEeWpFusmeDrF3w" annotatedElement="_8RjWjlDOEeWpFusmeDrF3w">
+              <body>range &quot;1..1000000&quot;&#xD;
+This object specifies a configurable number of consecutive loss measurement PDUs to be used in evaluating the availability/unavailability status of each availability indicator per MEF 10.2.1. Loss Measurement PDUs (LMMs, CCMs or SLMs) are sent regularly with a period defined by message-period. Therefore, this object, when multiplied by message-period, is equivalent to the Availability parameter of 'delta_t' as specified by MEF 10.2.1.&#xD;
+If the measurement-type is lmm or ccm, this object defines the number of LMM or CCM PDUs transmitted during each 'delta_t' period. The Availability flr for a given 'delta_t' can be calculated based on the counters in the last LMM/R or CCM during this 'delta_t' and the last LMM/R or CCM in the previous 'delta_t'.&#xD;
+If the measurement-type is slm, this object defines the number of SLM PDUs transmitted during each 'delta_t' period. The Availability flr for a given 'delta_t' is calculated based on the number of those SLM PDUs that are lost.&#xD;
+If the measurement-type is lmm or ccm, the number range of 1 through 10 must be supported. The number range of 10 through 1000000 may be supported, but is not mandatory.&#xD;
+If the measurement-type is slm, the number range of 10 through 100 must be supported. The number range of 100 through 1000000 may be supported, but is not mandatory.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAvailabilityNumConsecutiveMeasPdus&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWkFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWkVDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWklDOEeWpFusmeDrF3w" value="10">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWk1DOEeWpFusmeDrF3w" name="availabilityFlrThreshold" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWlFDOEeWpFusmeDrF3w" annotatedElement="_8RjWk1DOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object specifies a configurable availability threshold to be used in evaluating the availability/unavailability status of an availability indicator per MEF 10.2.1. The availability threshold range of 0.00 (0) through 1.00 (100000) is supported. This parameter is equivalent to the Availability parameter of 'C' as specified by MEF 10.2.1. Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAvailabilityFlrThreshold&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWlVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWllDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWl1DOEeWpFusmeDrF3w" value="50000">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWmFDOEeWpFusmeDrF3w" name="availabilityNumberConsecutiveIntervals" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWmVDOEeWpFusmeDrF3w" annotatedElement="_8RjWmFDOEeWpFusmeDrF3w">
+              <body>range &quot;1..1000&quot;&#xD;
+This object specifies a configurable number of consecutive availability indicators to be used to determine a change in the availability status as indicated by MEF 10.2.1. This parameter is equivalent to the Availability parameter of 'n' as specified by MEF 10.2.1.&#xD;
+The number range of 1 through 10 must be supported. The number range of 1 through 1000 may be supported, but is not mandatory.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAvailabilityNumConsecutiveIntervals&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWmlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWm1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWnFDOEeWpFusmeDrF3w" value="10">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWnVDOEeWpFusmeDrF3w" name="availabilityNumberConsecutiveHighFlr" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWnlDOEeWpFusmeDrF3w" annotatedElement="_8RjWnVDOEeWpFusmeDrF3w">
+              <body>range &quot;1..1000&quot;&#xD;
+This object specifies a configurable number of consecutive availability indicators to be used for assessing CHLI. This parameter is equivalent to the Resilency parameter of 'p' as specified by MEF 10.2.1.&#xD;
+Availability-consecutive-high-flr must be strictly less than availability-number-consecutive-intervals. If not, the count of high loss intervals over time, and the count of consecutive high loss levels, is disabled.&#xD;
+The number range of 1 through 10 must be supported. The number range of 1 through 1000 may be supported, but is not mandatory.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAvailabilityNumConsecutiveHighFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWn1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWoFDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWoVDOEeWpFusmeDrF3w" value="5">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWolDOEeWpFusmeDrF3w" name="thresholdList" visibility="public" association="_8Rj9hlDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWo1DOEeWpFusmeDrF3w" annotatedElement="_8RjWolDOEeWpFusmeDrF3w">
+              <body>This list contains the list of Loss Measurement configuration threshold values for LM Performance Monitoring.&#xD;
+The main purpose of the threshold configuration list is to configure threshold alarm notifications indicating that a specific performance metric is not being met.</body>
+            </ownedComment>
+            <type xmi:type="uml:Class" href="../RSA/YANG_Models.uml#_dWxKAMr7EeOTN5cGD9_rpg"/>
+            <lowerValue xmi:type="uml:LiteralString" xmi:id="_8RjWpFDOEeWpFusmeDrF3w" visibility="public" value="*?">
+              <name xsi:nil="true"/>
+            </lowerValue>
+            <upperValue xmi:type="uml:LiteralString" xmi:id="_8RjWpVDOEeWpFusmeDrF3w" visibility="public" value="*?">
+              <name xsi:nil="true"/>
+            </upperValue>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjWplDOEeWpFusmeDrF3w" name="LossAvailabilityStatsGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjWp1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWqFDOEeWpFusmeDrF3w" annotatedElement="_8RjWplDOEeWpFusmeDrF3w">
+            <body>This grouping includes availability statistics objects for a SOAM Loss Measurement session.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWqVDOEeWpFusmeDrF3w" name="suspectStatus" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWqlDOEeWpFusmeDrF3w" annotatedElement="_8RjWqVDOEeWpFusmeDrF3w">
+              <body>This object indicates whether the Measurement Interval has been marked as suspect.&#xD;
+The object is set to false at the start of a measurement interval. It is set to true when there is a discontinuity in the performance measurements during the Measurement Interval.&#xD;
+Conditions for a discontinuity include, but are not limited to the following:&#xD;
+1 - The local time-of-day clock is adjusted by at least 10 seconds&#xD;
+2 - The conducting of a performance measurement is halted before the current Measurement Interval is completed&#xD;
+3 - A local test, failure, or reconfiguration that disrupts service&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWq1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWrFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWrVDOEeWpFusmeDrF3w" name="forwardHighLoss" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWrlDOEeWpFusmeDrF3w" annotatedElement="_8RjWrVDOEeWpFusmeDrF3w">
+              <body>This object is the number of high loss intervals (HLI) over time in the forward direction.&#xD;
+The value starts at 0 and increments for every HLI that occurs.&#xD;
+This parameter is equivalent to 'L Sub T' found in MEF 10.2.1.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardHighLoss&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWr1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWsFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWsVDOEeWpFusmeDrF3w" name="backwardHighLoss" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWslDOEeWpFusmeDrF3w" annotatedElement="_8RjWsVDOEeWpFusmeDrF3w">
+              <body>This object is the number of high loss intervals (HLI) over time in the backward direction.&#xD;
+The value starts at 0 and increments for every HLI that occurs.&#xD;
+This parameter is equivalent to 'L Sub T' found in MEF 10.2.1.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardHighLoss&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWs1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWtFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWtVDOEeWpFusmeDrF3w" name="forwardConsecutiveHighLoss" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWtlDOEeWpFusmeDrF3w" annotatedElement="_8RjWtVDOEeWpFusmeDrF3w">
+              <body>This object is the number of consecutive high loss intervals (CHLI) over time in the forward direction.&#xD;
+The value starts at 0 and increments for every HLI that occurs.&#xD;
+This parameter is equivalent to 'B Sub T' found in MEF 10.2.1.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardConsecutiveHighLoss&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWt1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWuFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWuVDOEeWpFusmeDrF3w" name="backwardConsecutiveHighLoss" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWulDOEeWpFusmeDrF3w" annotatedElement="_8RjWuVDOEeWpFusmeDrF3w">
+              <body>This object is the number of consecutive high loss intervals (CHLI) over time in the backward direction.&#xD;
+The value starts at 0 and increments for every HLI that occurs.&#xD;
+This parameter is equivalent to 'B Sub T' found in MEF 10.2.1.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardConsecutiveHighLoss&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWu1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWvFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWvVDOEeWpFusmeDrF3w" name="forwardAvailable" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWvlDOEeWpFusmeDrF3w" annotatedElement="_8RjWvVDOEeWpFusmeDrF3w">
+              <body>This object contains the number of availability indicators during a small time interval evaluated as available (low frame loss) in the forward direction by this MEP during this measurement interval.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardAvailable&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWv1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWwFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWwVDOEeWpFusmeDrF3w" name="backwardAvailable" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWwlDOEeWpFusmeDrF3w" annotatedElement="_8RjWwVDOEeWpFusmeDrF3w">
+              <body>This object contains the number of availability indicators during a small time interval evaluated as available (low frame loss) in the backward direction by this MEP during this measurement interval.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardAvailable&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWw1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWxFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWxVDOEeWpFusmeDrF3w" name="forwardUnavailable" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWxlDOEeWpFusmeDrF3w" annotatedElement="_8RjWxVDOEeWpFusmeDrF3w">
+              <body>This object contains the number of availability indicators during a small time interval evaluated as unavailable (high frame loss) in the forward direction by this MEP during this measurement interval.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardUnavailable&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWx1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWyFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWyVDOEeWpFusmeDrF3w" name="backwardUnavailable" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWylDOEeWpFusmeDrF3w" annotatedElement="_8RjWyVDOEeWpFusmeDrF3w">
+              <body>This object contains the number of availability indicators during a small time interval evaluated as unavailable (high frame loss) in the backward direction by this MEP during this measurement interval.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardUnavailable&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWy1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjWzFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjWzVDOEeWpFusmeDrF3w" name="forwardMinFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjWzlDOEeWpFusmeDrF3w" annotatedElement="_8RjWzVDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the minimum one-way availability flr in the forward direction, from among the set of availability flr values calculated by the MEP in this Measurement Interval. There is one availability flr value for each 'delta_t' time period within the Measurement Interval, as specified in MEF 10.2.1.&#xD;
+The flr value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMinFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjWz1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW0FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW0VDOEeWpFusmeDrF3w" name="forwardMaxFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW0lDOEeWpFusmeDrF3w" annotatedElement="_8RjW0VDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the maximum one-way availability flr in the forward direction, from among the set of availability flr values calculated by the MEP in this Measurement Interval. There is one availability flr value for each 'delta_t' time period within the Measurement Interval, as specified in MEF 10.2.1.&#xD;
+The flr value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMaxFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW01DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW1FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW1VDOEeWpFusmeDrF3w" name="forwardAverageFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW1lDOEeWpFusmeDrF3w" annotatedElement="_8RjW1VDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the average one-way availability flr in the for-ward direction, from among the set of availability flr values calculated by the MEP in this Measurement Interval.&#xD;
+There is one availability flr value for each 'delta_t' time period within the Measurement Interval, as specified in MEF 10.2.1.&#xD;
+The flr value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardAvgFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW11DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW2FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW2VDOEeWpFusmeDrF3w" name="backwardMinFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW2lDOEeWpFusmeDrF3w" annotatedElement="_8RjW2VDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the minimum one-way availability flr in the backward direction, from among the set of availability flr values calculated by the MEP in this Measurement Interval.&#xD;
+There is one availability flr value for each 'delta_t' time period within the Measurement Interval, as specified in MEF 10.2.1.&#xD;
+The flr value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMinFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW21DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW3FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW3VDOEeWpFusmeDrF3w" name="backwardMaxFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW3lDOEeWpFusmeDrF3w" annotatedElement="_8RjW3VDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the maximum one-way availability flr in the backward direction, from among the set of availability flr values calculated by the MEP in this Measurement Interval.&#xD;
+There is one availability flr value for each 'delta_t' time period within the Measurement Interval, as specified in MEF 10.2.1.&#xD;
+The flr value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMaxFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW31DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW4FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW4VDOEeWpFusmeDrF3w" name="backwardAverageFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW4lDOEeWpFusmeDrF3w" annotatedElement="_8RjW4VDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the average one-way availability flr in the backward direction, from among the set of availability flr values calculated by the MEP in this Measurement Interval.&#xD;
+There is one availability flr value for each 'delta_t' time period within the Measurement Interval, as specified in MEF 10.2.1.&#xD;
+The flr value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardAvgFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW41DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW5FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjW5VDOEeWpFusmeDrF3w" name="LossMeasurementStatsGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjW5lDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW51DOEeWpFusmeDrF3w" annotatedElement="_8RjW5VDOEeWpFusmeDrF3w">
+            <body>This grouping includes statistics objects for a SOAM Loss Measurement session.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW6FDOEeWpFusmeDrF3w" name="suspectStatus" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW6VDOEeWpFusmeDrF3w" annotatedElement="_8RjW6FDOEeWpFusmeDrF3w">
+              <body>Whether the Measurement Interval has been marked as suspect.&#xD;
+The object is set to false at the start of a measurement interval. It is set to true when there is a discontinuity in the performance measurements during the Measurement Interval.&#xD;
+Conditions for a discontinuity include, but are not limited to the following:&#xD;
+1 - The local time-of-day clock is adjusted by at least 10 seconds&#xD;
+2 - The conducting of a performance measurement is halted before the current Measurement Interval is completed&#xD;
+3 - A local test, failure, or reconfiguration that disrupts service.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsSuspect&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW6lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW61DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW7FDOEeWpFusmeDrF3w" name="forwardTransmittedFrames" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW7VDOEeWpFusmeDrF3w" annotatedElement="_8RjW7FDOEeWpFusmeDrF3w">
+              <body>This object contains the number of frames transmitted in the forward direction by this MEP.&#xD;
+For a PM Session of types lmm or ccm this includes Ethernet Service Frames and SOAM PDUs that are in a higher MEG level only.&#xD;
+For a PM Session of type slm this includes the count of SOAM ETH-SLM frames only.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsForwardTransmittedFrames&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW7lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW71DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW8FDOEeWpFusmeDrF3w" name="forwardReceivedFrames" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW8VDOEeWpFusmeDrF3w" annotatedElement="_8RjW8FDOEeWpFusmeDrF3w">
+              <body>This object contains the number of frames received in the forward direction by this MEP.&#xD;
+For a PM Session of types lmm or ccm this includes Ethernet Service Frames and SOAM PDUs that are in a higher MEG level only.&#xD;
+For a PM Session of type slm this includes the count of SOAM ETH-SLM frames only.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsForwardReceivedFrames&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW8lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW81DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW9FDOEeWpFusmeDrF3w" name="forwardMinFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW9VDOEeWpFusmeDrF3w" annotatedElement="_8RjW9FDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the minimum one-way frame loss ratio in the forward direction calculated by this MEP for this Measurement Interval. The FLR value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsForwardMinFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW9lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW91DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW-FDOEeWpFusmeDrF3w" name="forwardMaxFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW-VDOEeWpFusmeDrF3w" annotatedElement="_8RjW-FDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the maximum one-way frame loss ratio in the forward direction calculated by this MEP for this Measurement Interval. The FLR value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsForwardMaxFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW-lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW-1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjW_FDOEeWpFusmeDrF3w" name="forwardAverageFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjW_VDOEeWpFusmeDrF3w" annotatedElement="_8RjW_FDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the average one-way frame loss ratio in the forward direction calculated by this MEP for this Measurement Interval. The FLR value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsForwardAvgFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjW_lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjW_1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXAFDOEeWpFusmeDrF3w" name="backwardTransmittedFrames" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXAVDOEeWpFusmeDrF3w" annotatedElement="_8RjXAFDOEeWpFusmeDrF3w">
+              <body>This object contains the number of frames transmitted in the backward direction by this MEP.&#xD;
+For a PM Session of type lmm or ccm this includes Ethernet Service Frames and SOAM PDUs that are in a higher MEG level only.&#xD;
+For a PM Session of type slm this includes the count of SOAM ETH-SLM frames only.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsBackwardTransmittedFrames&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXAlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXA1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXBFDOEeWpFusmeDrF3w" name="backwardReceivedFrames" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXBVDOEeWpFusmeDrF3w" annotatedElement="_8RjXBFDOEeWpFusmeDrF3w">
+              <body>This object contains the number of frames received in the backward direction by this MEP.&#xD;
+For a PM Session of type lmm this includes Ethernet Service Frames and SOAM PDUs that are in a higher MEG level only.&#xD;
+For a PM Session of type slm this includes the count of SOAM ETH-SLM frames only.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsBackwardReceivedFrames&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXBlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXB1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXCFDOEeWpFusmeDrF3w" name="backwardMinFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXCVDOEeWpFusmeDrF3w" annotatedElement="_8RjXCFDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the minimum one-way frame loss ratio in the backward direction calculated by this MEP for this Measurement Interval. The FLR value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsBackwardMinFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXClDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXC1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXDFDOEeWpFusmeDrF3w" name="backwardMaxFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXDVDOEeWpFusmeDrF3w" annotatedElement="_8RjXDFDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the maximum one-way frame loss ratio in the backward direction calculated by this MEP for this Measurement Interval. The FLR value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsBackwardMaxFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXDlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXD1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXEFDOEeWpFusmeDrF3w" name="backwardAverageFrameLossRatio" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXEVDOEeWpFusmeDrF3w" annotatedElement="_8RjXEFDOEeWpFusmeDrF3w">
+              <body>range &quot;0..100000&quot;&#xD;
+This object contains the average one-way frame loss ratio in the backward direction calculated by this MEP for this Measurement Interval. The FLR value is a ratio that is expressed as a percent with a value of 0 (ratio 0.00) through 100000 (ratio 1.00).&#xD;
+Units are in milli-percent, where 1 indicates 0.001 percent.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsBackwardAvgFlr&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXElDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXE1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXFFDOEeWpFusmeDrF3w" name="soamPdusSent" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXFVDOEeWpFusmeDrF3w" annotatedElement="_8RjXFFDOEeWpFusmeDrF3w">
+              <body>This object contains the count of the number of SOAM PDUs sent during this Measurement Interval.&#xD;
+This object applies when type is lmm, slm or ccm. It indicates the number of LMM, CCM, or SLM SOAM frames transmitted.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsSoamPdusSent&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXFlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXF1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXGFDOEeWpFusmeDrF3w" name="soamPdusReceived" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXGVDOEeWpFusmeDrF3w" annotatedElement="_8RjXGFDOEeWpFusmeDrF3w">
+              <body>This object contains the count of the number of SOAM PDUs PDUs received in this Measurement Interval.&#xD;
+This object applies when type is lmm, slm, or ccm. This object indicates the number of LMR, CCM, or SLR SOAM frames received.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCurrentStatsSoamPdusReceived&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXGlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXG1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjXHFDOEeWpFusmeDrF3w" name="DelayMeasurementConfigurationGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjXHVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXHlDOEeWpFusmeDrF3w" annotatedElement="_8RjXHFDOEeWpFusmeDrF3w">
+            <body>This grouping includes configuration objects for the Delay Measurement function defined in [Y.1731] and [MEF SOAM PM IA].&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamDmCfgTable, [Y.1731], and [MEF SOAM PM IA].&quot;</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_8RjXH1DOEeWpFusmeDrF3w" general="_8Rj-OlDOEeWpFusmeDrF3w"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXIFDOEeWpFusmeDrF3w" name="measurementType" visibility="public" type="_8Rj9tVDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXIVDOEeWpFusmeDrF3w" annotatedElement="_8RjXIFDOEeWpFusmeDrF3w">
+              <body>This object indicates what type of Delay Measurement is to be performed.&#xD;
+The exact PDUs to use are specified by this object in combination with version.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXIlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXI1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXJFDOEeWpFusmeDrF3w" name="measurementEnable" visibility="public" type="_8Rj9vVDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXJVDOEeWpFusmeDrF3w" annotatedElement="_8RjXJFDOEeWpFusmeDrF3w">
+              <body>A vector of bits that indicates the type of SOAM DM counters that are enabled.&#xD;
+A present bit enables the specific SOAM DM counter.&#xD;
+A not present bit disables the SOAM DM counter.&#xD;
+If a particular SOAM DM counter is not supported the BIT value is not present.&#xD;
+Not all SOAM DM counters are supported for all SOAM DM types.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXJlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXJ1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXKFDOEeWpFusmeDrF3w" name="binsPerFdInterval" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXKVDOEeWpFusmeDrF3w" annotatedElement="_8RjXKFDOEeWpFusmeDrF3w">
+              <body>range &quot;2..100&quot;&#xD;
+This object specifies the number of measurement bins per Measurement Interval for Frame Delay measurements.&#xD;
+At least 3 bins are to be supported; at least 10 bins are recommended to be supported.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXKlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXK1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXLFDOEeWpFusmeDrF3w" value="3">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXLVDOEeWpFusmeDrF3w" name="binsPerIfdvInterval" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXLlDOEeWpFusmeDrF3w" annotatedElement="_8RjXLVDOEeWpFusmeDrF3w">
+              <body>range &quot;2..100&quot;&#xD;
+This object specifies the number of measurement bins per Measurement Interval for Inter-Frame Delay Variation measurements.&#xD;
+The minimum number of measurement bins to be supported is 2. The desired number of measurements bins to be supported is 10.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXL1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXMFDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXMVDOEeWpFusmeDrF3w" value="2">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXMlDOEeWpFusmeDrF3w" name="ifdvSelectionOffset" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXM1DOEeWpFusmeDrF3w" annotatedElement="_8RjXMlDOEeWpFusmeDrF3w">
+              <body>range &quot;1..100&quot;&#xD;
+This object specifies the selection offset for Inter-Frame Delay Variation measurements. If this value is set to n, then the IFDV is calculated by taking the difference in frame delay between frame F and frame (F+n).&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamDmCfgInterFrameDelayVariationSelectionOffset&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXNFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXNVDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXNlDOEeWpFusmeDrF3w" value="1">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXN1DOEeWpFusmeDrF3w" name="binsPerFdrInterval" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXOFDOEeWpFusmeDrF3w" annotatedElement="_8RjXN1DOEeWpFusmeDrF3w">
+              <body>This object specifies the number of measurement bins per Measurement Interval for Frame Delay Range measurements.&#xD;
+reference&#xD;
+&quot;[MEF SOAM PM IA] R31, D15, R32, D16&#xD;
+MEF-SOAM-PM-MIB.mefSoamDmCfgNumMeasBinsPerFrameDelayRangeInterval&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXOVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXOlDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXO1DOEeWpFusmeDrF3w" value="2">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXPFDOEeWpFusmeDrF3w" name="Copy_9_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXPVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXPlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXP1DOEeWpFusmeDrF3w" name="Copy_10_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXQFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXQVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXQlDOEeWpFusmeDrF3w" name="Copy_11_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXQ1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXRFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXRVDOEeWpFusmeDrF3w" name="Copy_12_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXRlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXR1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXSFDOEeWpFusmeDrF3w" name="Copy_13_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXSVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXSlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXS1DOEeWpFusmeDrF3w" name="Copy_14_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXTFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXTVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXTlDOEeWpFusmeDrF3w" name="Copy_15_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXT1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXUFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXUVDOEeWpFusmeDrF3w" name="Copy_16_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXUlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXU1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXVFDOEeWpFusmeDrF3w" name="Copy_17_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXVVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXVlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXV1DOEeWpFusmeDrF3w" name="Copy_18_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXWFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXWVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXWlDOEeWpFusmeDrF3w" name="Copy_19_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXW1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXXFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXXVDOEeWpFusmeDrF3w" name="Copy_20_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXXlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXX1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXYFDOEeWpFusmeDrF3w" name="Copy_21_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXYVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXYlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXY1DOEeWpFusmeDrF3w" name="Copy_22_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXZFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXZVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXZlDOEeWpFusmeDrF3w" name="Copy_23_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXZ1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXaFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXaVDOEeWpFusmeDrF3w" name="Copy_24_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXalDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXa1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXbFDOEeWpFusmeDrF3w" name="Copy_25_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXbVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXblDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXb1DOEeWpFusmeDrF3w" name="Copy_26_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXcFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXcVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXclDOEeWpFusmeDrF3w" name="Copy_27_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXc1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXdFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXdVDOEeWpFusmeDrF3w" name="Copy_28_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXdlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXd1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXeFDOEeWpFusmeDrF3w" name="Copy_29_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXeVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXelDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXe1DOEeWpFusmeDrF3w" name="Copy_30_abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXfFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXfVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXflDOEeWpFusmeDrF3w" name="thresholdList" visibility="public" association="_8Rj-e1DOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXf1DOEeWpFusmeDrF3w" annotatedElement="_8RjXflDOEeWpFusmeDrF3w">
+              <body>This list contains the Delay Measurement threshold configuration values for DM Performance Monitoring.&#xD;
+The main purpose of the threshold configuration list is to configure threshold alarm notifications indicating that a specific performance metric is not being met.</body>
+            </ownedComment>
+            <type xmi:type="uml:Class" href="../RSA/YANG_Models.uml#_rAmsMMxNEeOB1duTJU8bqA"/>
+            <lowerValue xmi:type="uml:LiteralString" xmi:id="_8RjXgFDOEeWpFusmeDrF3w" visibility="public" value="*?">
+              <name xsi:nil="true"/>
+            </lowerValue>
+            <upperValue xmi:type="uml:LiteralString" xmi:id="_8RjXgVDOEeWpFusmeDrF3w" visibility="public" value="*?">
+              <name xsi:nil="true"/>
+            </upperValue>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjXglDOEeWpFusmeDrF3w" name="DelayMeasurementStatsGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjXg1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXhFDOEeWpFusmeDrF3w" annotatedElement="_8RjXglDOEeWpFusmeDrF3w">
+            <body>This grouping includes statistics objects for a SOAM Delay Measurement session.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXhVDOEeWpFusmeDrF3w" name="suspectStatus" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXhlDOEeWpFusmeDrF3w" annotatedElement="_8RjXhVDOEeWpFusmeDrF3w">
+              <body>Whether the Measurement Interval has been marked as suspect.&#xD;
+The object is set to false at the start of a measurement interval. It is set to true when there is a discontinuity in the performance measurements during the Measurement Interval.&#xD;
+Conditions for a discontinuity include, but are not limited to the following:&#xD;
+1 - The local time-of-day clock is adjusted by at least 10 seconds&#xD;
+2 - The conducting of a performance measurement is halted before the current Measurement Interval is completed&#xD;
+3 - A local test, failure, or reconfiguration that disrupts service.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXh1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXiFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXiVDOEeWpFusmeDrF3w" name="frameDelayTwoWayMin" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXilDOEeWpFusmeDrF3w" annotatedElement="_8RjXiVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the minimum two-way frame delay calculated by this MEP for this Measurement Interval.&#xD;
+This object is undefined if measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXi1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXjFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXjVDOEeWpFusmeDrF3w" name="frameDelayTwoWayMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXjlDOEeWpFusmeDrF3w" annotatedElement="_8RjXjVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum two-way frame delay calculated by this MEP for this Measurement Interval.&#xD;
+This object is undefined if measurement-type is dm1DmTx or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXj1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXkFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXkVDOEeWpFusmeDrF3w" name="frameDelayTwoWayAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXklDOEeWpFusmeDrF3w" annotatedElement="_8RjXkVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average two-way frame delay calculated by this MEP for this Measurement Interval.&#xD;
+This object is undefined if measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXk1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXlFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXlVDOEeWpFusmeDrF3w" name="frameDelayForwardMin" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXllDOEeWpFusmeDrF3w" annotatedElement="_8RjXlVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the minimum one-way frame delay in the forward direction calculated by this MEP for this Measurement Interval. The value of this object may not be accurate in the absence of sufficiently precise clock synchronization.&#xD;
+This object is undefined if measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXl1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXmFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXmVDOEeWpFusmeDrF3w" name="frameDelayForwardMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXmlDOEeWpFusmeDrF3w" annotatedElement="_8RjXmVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum one-way frame delay in the forward direction calculated by this MEP for this Measurement Interval. The value of this object may not be accurate in the absence of sufficiently precise clock synchronization.&#xD;
+This object is undefined if measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXm1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXnFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXnVDOEeWpFusmeDrF3w" name="frameDelayForwardAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXnlDOEeWpFusmeDrF3w" annotatedElement="_8RjXnVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average one-way frame delay in the forward direction calculated by this MEP for this Measurement Interval. The value of this object may not be accurate in the absence of sufficiently precise clock synchronization.&#xD;
+This object is undefined if measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXn1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXoFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXoVDOEeWpFusmeDrF3w" name="frameDelayBackwardMin" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXolDOEeWpFusmeDrF3w" annotatedElement="_8RjXoVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the minimum one-way frame delay in the backward direction calculated by this MEP for this Measurement Interval. The value of this object may not be accurate in the absence of sufficiently precise clock  synchronization.&#xD;
+This object is undefined if measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXo1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXpFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXpVDOEeWpFusmeDrF3w" name="frameDelayBackwardMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXplDOEeWpFusmeDrF3w" annotatedElement="_8RjXpVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum one-way frame delay in the backward direction calculated by this MEP for this Measurement Interval. The value of this object may not be accurate in the absence of sufficiently precise clock  synchronization.&#xD;
+This object is undefined if measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXp1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXqFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXqVDOEeWpFusmeDrF3w" name="frameDelayBackwardAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXqlDOEeWpFusmeDrF3w" annotatedElement="_8RjXqVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average one-way frame delay in the backward direction calculated by this MEP for this Measurement Interval. The value of this object may not be accurate in the absence of sufficiently precise clock synchronization.&#xD;
+This object is undefined if measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXq1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXrFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXrVDOEeWpFusmeDrF3w" name="interFrameDelayVariationForwardMin" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXrlDOEeWpFusmeDrF3w" annotatedElement="_8RjXrVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the minimum one-way inter-frame delay interval in the forward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXr1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXsFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXsVDOEeWpFusmeDrF3w" name="interFrameDelayVariationForwardMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXslDOEeWpFusmeDrF3w" annotatedElement="_8RjXsVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum one-way inter-frame delay interval in the forward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXs1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXtFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXtVDOEeWpFusmeDrF3w" name="interFrameDelayVariationForwardAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXtlDOEeWpFusmeDrF3w" annotatedElement="_8RjXtVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average one-way inter-frame delay interval in the forward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXt1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXuFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXuVDOEeWpFusmeDrF3w" name="interframeDelayVariationBackwardMin" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXulDOEeWpFusmeDrF3w" annotatedElement="_8RjXuVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the minimum one-way inter-frame delay interval in the backward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXu1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXvFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXvVDOEeWpFusmeDrF3w" name="interFrameDelayVariationBackwardMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXvlDOEeWpFusmeDrF3w" annotatedElement="_8RjXvVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum one-way inter-frame delay interval in the backward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXv1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXwFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXwVDOEeWpFusmeDrF3w" name="interFrameDelayVariationBackwardAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXwlDOEeWpFusmeDrF3w" annotatedElement="_8RjXwVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average one-way inter-frame delay interval in the backward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXw1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXxFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXxVDOEeWpFusmeDrF3w" name="interFrameDelayVariationTwoWayMin" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXxlDOEeWpFusmeDrF3w" annotatedElement="_8RjXxVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the minimum two-way inter-frame delay interval calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXx1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXyFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXyVDOEeWpFusmeDrF3w" name="interFrameDelayVariationTwoWayMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXylDOEeWpFusmeDrF3w" annotatedElement="_8RjXyVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum two-way inter-frame delay interval calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXy1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjXzFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjXzVDOEeWpFusmeDrF3w" name="interFrameDelayVariationTwoWayAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjXzlDOEeWpFusmeDrF3w" annotatedElement="_8RjXzVDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average two-way inter-frame delay interval calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjXz1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX0FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX0VDOEeWpFusmeDrF3w" name="frameDelayRangeForwardMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX0lDOEeWpFusmeDrF3w" annotatedElement="_8RjX0VDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum one-way Frame Delay Range in the forward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX01DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX1FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX1VDOEeWpFusmeDrF3w" name="frameDelayRangeForwardAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX1lDOEeWpFusmeDrF3w" annotatedElement="_8RjX1VDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average one-way Frame Delay Range in the forward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX11DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX2FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX2VDOEeWpFusmeDrF3w" name="frameDelayRangeBackwardMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX2lDOEeWpFusmeDrF3w" annotatedElement="_8RjX2VDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum one-way Frame Delay Range in the backward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX21DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX3FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX3VDOEeWpFusmeDrF3w" name="frameDelayRangeBackwardAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX3lDOEeWpFusmeDrF3w" annotatedElement="_8RjX3VDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average one-way Frame Delay Range in the backward direction calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX31DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX4FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX4VDOEeWpFusmeDrF3w" name="frameDelayRangeTwoWayMax" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX4lDOEeWpFusmeDrF3w" annotatedElement="_8RjX4VDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the maximum two-way Frame Delay Range calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX41DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX5FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX5VDOEeWpFusmeDrF3w" name="frameDelayRangeTwoWayAverage" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX5lDOEeWpFusmeDrF3w" annotatedElement="_8RjX5VDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object contains the average two-way Frame Delay Range calculated by this MEP for this Measurement Interval.&#xD;
+The value of this object is undefined when measurement-type is dm1-transmitted or dm1-received.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX51DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX6FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX6VDOEeWpFusmeDrF3w" name="soamPdusSent" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX6lDOEeWpFusmeDrF3w" annotatedElement="_8RjX6VDOEeWpFusmeDrF3w">
+              <body>This object contains the count of the number of SOAM PDUs sent during this Measurement Interval.&#xD;
+This object applies when measurement-type is dmm or dm1-transmitted and is undefined if measurement-type is dm1-received. It indicates the number of DMM or 1DM SOAM frames transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX61DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX7FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX7VDOEeWpFusmeDrF3w" name="soamPdusReceived" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX7lDOEeWpFusmeDrF3w" annotatedElement="_8RjX7VDOEeWpFusmeDrF3w">
+              <body>This object contains the count of the number of SOAM PDUs received in this Measurement Interval.&#xD;
+This object indicates the number of DMR and 1DM SOAM frames received. This object applies when measurement-type is dmm or dm1-received and is undefined if measurement-type is dm1-transmitted.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX71DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX8FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjX8VDOEeWpFusmeDrF3w" name="DelayMeasurementBinsContentGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjX8lDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX81DOEeWpFusmeDrF3w" annotatedElement="_8RjX8VDOEeWpFusmeDrF3w">
+            <body>This grouping contains result measurement bin objects for a SOAM Delay Measurement session.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX9FDOEeWpFusmeDrF3w" name="type" visibility="public" type="_8RjWV1DOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX9VDOEeWpFusmeDrF3w" annotatedElement="_8RjX9FDOEeWpFusmeDrF3w">
+              <body>This object specifies whether the bin number is for Frame De-lay, Inter-Frame Delay Variation or Frame Delay Range.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX9lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX91DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX-FDOEeWpFusmeDrF3w" name="number" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX-VDOEeWpFusmeDrF3w" annotatedElement="_8RjX-FDOEeWpFusmeDrF3w">
+              <body>This object specifies the bin number for the configured boundary. The first bin has bin number 1.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX-lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX-1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjX_FDOEeWpFusmeDrF3w" name="lowerBound?" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjX_VDOEeWpFusmeDrF3w" annotatedElement="_8RjX_FDOEeWpFusmeDrF3w">
+              <body>units microseconds&#xD;
+This object specifies the lower boundary for a measurement bin. The upper boundary is defined by the next bin value or infinite for the last bin defined. The measurement boundary for each measurement bin is to be larger than the  measurement boundary of the preceding measurement bin. By default, the next bin is set to 5000us larger than the lower bin boundary.&#xD;
+The values in a bin boundary object represents the time range used to segregate delay data into the appropriate statistical data bin. For five bins with default values, each bin has the following time range:&#xD;
+bin 1 = 0, range is 0us&#xD;
+bin 2 = 5000, range is 5,000us&#xD;
+bin 3 = 10000, range is 10,000us&#xD;
+bin 4 = 15000, range is 15,000us&#xD;
+bin 5 = 20000, range is 20,000us&#xD;
+The first bin boundary (number set to 1) always contains the value of 0. Attempting to write a non-zero value to this bin will result in an error.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjX_lDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjX_1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYAFDOEeWpFusmeDrF3w" name="counter" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYAVDOEeWpFusmeDrF3w" annotatedElement="_8RjYAFDOEeWpFusmeDrF3w">
+              <body>This object contains the count of the number of completed measurements initiated in this Measurement Interval whose value falls within the range specified for this bin (that is, greater than or equal to the measurement boundary for the bin, and (unless the bin is the last bin) less than the measurement boundary for the following bin.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamDmCurrentStatsBinsCounter</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_VeMXQMSEEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYAlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYA1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjYBFDOEeWpFusmeDrF3w" name="DelayMeasurementBinsGroup">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjYBVDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYBlDOEeWpFusmeDrF3w" annotatedElement="_8RjYBFDOEeWpFusmeDrF3w">
+            <body>This grouping contains the top-level structure for the three types of measurements (frame delay, inter frame delay variation, and frame delay range).</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYB1DOEeWpFusmeDrF3w" name="abc" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYCFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYCVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYClDOEeWpFusmeDrF3w" name="frameDelay" visibility="public" type="_8RjX8VDOEeWpFusmeDrF3w" association="_8Rj-yVDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralString" xmi:id="_8RjYC1DOEeWpFusmeDrF3w" visibility="public" value="1?">
+              <name xsi:nil="true"/>
+            </lowerValue>
+            <upperValue xmi:type="uml:LiteralString" xmi:id="_8RjYDFDOEeWpFusmeDrF3w" visibility="public" value="1?">
+              <name xsi:nil="true"/>
+            </upperValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYDVDOEeWpFusmeDrF3w" name="interFrameDelayVariation" visibility="public" type="_8RjX8VDOEeWpFusmeDrF3w" association="_8Rj-zVDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralString" xmi:id="_8RjYDlDOEeWpFusmeDrF3w" visibility="public" value="1?">
+              <name xsi:nil="true"/>
+            </lowerValue>
+            <upperValue xmi:type="uml:LiteralString" xmi:id="_8RjYD1DOEeWpFusmeDrF3w" visibility="public" value="1?">
+              <name xsi:nil="true"/>
+            </upperValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYEFDOEeWpFusmeDrF3w" name="frameDelayRange" visibility="public" type="_8RjX8VDOEeWpFusmeDrF3w" association="_8Rj-0VDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralString" xmi:id="_8RjYEVDOEeWpFusmeDrF3w" visibility="public" value="1?">
+              <name xsi:nil="true"/>
+            </lowerValue>
+            <upperValue xmi:type="uml:LiteralString" xmi:id="_8RjYElDOEeWpFusmeDrF3w" visibility="public" value="1?">
+              <name xsi:nil="true"/>
+            </upperValue>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYE1DOEeWpFusmeDrF3w" name="SessionStatusType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYFFDOEeWpFusmeDrF3w" name="ACTIVE"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYFVDOEeWpFusmeDrF3w" name="NOT_ACTIVE"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYFlDOEeWpFusmeDrF3w" name="AvailabilityType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYF1DOEeWpFusmeDrF3w" name="AVAILABLE"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYGFDOEeWpFusmeDrF3w" name="UNAVAILABLE"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYGVDOEeWpFusmeDrF3w" name="UNKNOWN"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjYGlDOEeWpFusmeDrF3w" name="CurrentStats">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjYG1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYHFDOEeWpFusmeDrF3w" name="startTime" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYHVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYHlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYH1DOEeWpFusmeDrF3w" name="elapsedTime" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYIFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYIVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYIlDOEeWpFusmeDrF3w" name="delayMeasurementStatsGroup" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYI1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYJFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYJVDOEeWpFusmeDrF3w" name="delayMeasurementBinsGroup" visibility="public">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYJlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYJ1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYKFDOEeWpFusmeDrF3w" name="ThresholdId">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYKVDOEeWpFusmeDrF3w" annotatedElement="_8RjYKFDOEeWpFusmeDrF3w">
+            <body>This object identifies the threshold that caused the generation of the notification.&#xD;
+&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamPmNotificationObjThresholdId&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYKlDOEeWpFusmeDrF3w" name="MEASURED_FLR_FORWARD">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYK1DOEeWpFusmeDrF3w" annotatedElement="_8RjYKlDOEeWpFusmeDrF3w">
+              <body>Indicates the measured Frame Loss Ratio forward threshold generated the notification.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYLFDOEeWpFusmeDrF3w" name="MAX_FLR_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYLVDOEeWpFusmeDrF3w" name="AVERAGE_FLR_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYLlDOEeWpFusmeDrF3w" name="MEASURED_FLR_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYL1DOEeWpFusmeDrF3w" name="MAX_FLR_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYMFDOEeWpFusmeDrF3w" name="FORWARD_HIGH_LOSS"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYMVDOEeWpFusmeDrF3w" name="FORWARD_CONSECUTIVE_HIGH_LOSS"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYMlDOEeWpFusmeDrF3w" name="BACKWARD_HIGH_LOSS"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYM1DOEeWpFusmeDrF3w" name="BACKWARD_CONSECUTIVE_HIGH_LOSS"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYNFDOEeWpFusmeDrF3w" name="FORWARD_UNAVAILABLE_COUNT"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYNVDOEeWpFusmeDrF3w" name="FORWARD_AVAILABLE_RATIO"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYNlDOEeWpFusmeDrF3w" name="BACKWARD_UNAVAILABLE_COUNT"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYN1DOEeWpFusmeDrF3w" name="BACKWARD_AVAILABLE_RATIO"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYOFDOEeWpFusmeDrF3w" name="MEASURED_FRAME_DELAY_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYOVDOEeWpFusmeDrF3w" name="AVERAGE_FRAME_DELAY_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYOlDOEeWpFusmeDrF3w" name="MEASURED_INTER_FRAME_DELAY_VARIATION_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYO1DOEeWpFusmeDrF3w" name="MAX_INTER_FRAME_DELAY_VARIATION_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYPFDOEeWpFusmeDrF3w" name="AVERAGE_INTER_FRAME_DELAY_VARIATION_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYPVDOEeWpFusmeDrF3w" name="MAX_FRAME_DELAY_RANGE_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYPlDOEeWpFusmeDrF3w" name="AVERAGE_FRAME_DELAY_RANGE_TWO_WAY"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYP1DOEeWpFusmeDrF3w" name="MEASURED_FRAME_DELAY_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYQFDOEeWpFusmeDrF3w" name="MAX_FRAME_DELAY_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYQVDOEeWpFusmeDrF3w" name="AVERAGE_FRAME_DELAY_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYQlDOEeWpFusmeDrF3w" name="MEASURED_INTER_FRAME_DELAY_VARIATION_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYQ1DOEeWpFusmeDrF3w" name="MAX_INTER_FRAME_DELAY_VARIATION_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYRFDOEeWpFusmeDrF3w" name="AVERAGE_INTER_FRAME_DELAY_VARIATION_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYRVDOEeWpFusmeDrF3w" name="MAX_FRAME_DELAY_RANGE_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYRlDOEeWpFusmeDrF3w" name="AVERAGE_FRAME_DELAY_RANGE_FORWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYR1DOEeWpFusmeDrF3w" name="MEASURED_FRAME_DELAY_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYSFDOEeWpFusmeDrF3w" name="MAX_FRAME_DELAY_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYSVDOEeWpFusmeDrF3w" name="AVERAGE_FRAME_DELAY_BACKWARD_THRESHOLD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYSlDOEeWpFusmeDrF3w" name="MEASURED_INTER_FRAME_DELAY_VARIATION_BackWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYS1DOEeWpFusmeDrF3w" name="MAX_INTER_FRAME_DELAY_VARIATION_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYTFDOEeWpFusmeDrF3w" name="AVERAGE_INTER_FRAME_DELAY_VARIATION_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYTVDOEeWpFusmeDrF3w" name="MAX_FRAME_DELAY_RANGE_BACKWARD"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYTlDOEeWpFusmeDrF3w" name="AVERAGE_FRAME_DELAY_RANGE_BACKWARD"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYT1DOEeWpFusmeDrF3w" name="NotificationCrossingType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYUFDOEeWpFusmeDrF3w" annotatedElement="_8RjYT1DOEeWpFusmeDrF3w">
+            <body>This object indicates the crossing type that caused the generation of the notification.&#xD;
+&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamPmNotificationObjCrossingType</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYUVDOEeWpFusmeDrF3w" name="ABOVE_ALARM">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYUlDOEeWpFusmeDrF3w" annotatedElement="_8RjYUVDOEeWpFusmeDrF3w">
+              <body>Indicates that the crossing type alarm was an above threshold.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYU1DOEeWpFusmeDrF3w" name="SET_ALARM"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYVFDOEeWpFusmeDrF3w" name="CLEAR_ALARM"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8RjYVVDOEeWpFusmeDrF3w" name="MeasurementId">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8RjYVlDOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8RjYV1DOEeWpFusmeDrF3w" key="Choice"/>
+          </eAnnotations>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYWFDOEeWpFusmeDrF3w" annotatedElement="_8RjYVVDOEeWpFusmeDrF3w">
+            <body>The measurement ID can reference either a loss or a delay measurement session.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYWVDOEeWpFusmeDrF3w" name="lossMeasurementSessionId" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYWlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYW1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYXFDOEeWpFusmeDrF3w" name="delayMeasurementSessionId" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYXVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYXlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYX1DOEeWpFusmeDrF3w" name="StartTime?">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYYFDOEeWpFusmeDrF3w" annotatedElement="_8RjYX1DOEeWpFusmeDrF3w">
+            <body>Measurement session start time can be immediate, relative or absolute.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYYVDOEeWpFusmeDrF3w" name="RELATIVE" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYYlDOEeWpFusmeDrF3w" annotatedElement="_8RjYYVDOEeWpFusmeDrF3w">
+              <body>This object specifies the relative start time, from the current system time, to perform on-demand ETH-DM. This attribute has no meaning for proactive ETH-DM.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_9pikYMSFEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYY1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYZFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYZVDOEeWpFusmeDrF3w" name="ABSOLUTE" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYZlDOEeWpFusmeDrF3w" annotatedElement="_8RjYZVDOEeWpFusmeDrF3w">
+              <body>This object specifies the scheduled start date/time to perform the on-demand Performance Monitoring OAM operations. This attribute has no meaning for proactive Performance Monitoring OAM operations.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_m-28MMSFEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYZ1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYaFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYaVDOEeWpFusmeDrF3w" name="IMMEDIATE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYalDOEeWpFusmeDrF3w" annotatedElement="_8RjYaVDOEeWpFusmeDrF3w">
+              <body>This object specifies the start time to be immediately at the time of session creation.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8RjYa1DOEeWpFusmeDrF3w" name="uses" client="_8RjWbVDOEeWpFusmeDrF3w" supplier="_8RjYX1DOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYbFDOEeWpFusmeDrF3w" name="StopTime?">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYbVDOEeWpFusmeDrF3w" annotatedElement="_8RjYbFDOEeWpFusmeDrF3w">
+            <body>Measurement session stop time can be none, relative or absolute.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYblDOEeWpFusmeDrF3w" name="RELATIVE" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYb1DOEeWpFusmeDrF3w" annotatedElement="_8RjYblDOEeWpFusmeDrF3w">
+              <body>This object specifies the duration of the Delay Measurement PM Session. The duration time can be specified as forever (represented by a zero value) or as relative time (e.g., a given number of hours, minutes, and seconds from the start time). If the duration time is relative time, then the duration time should be equal to or greater than the frame transmission period of the PM function(s) comprising the PM Solution.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_9pikYMSFEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYcFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYcVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8RjYclDOEeWpFusmeDrF3w" name="ABSOLUTE" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYc1DOEeWpFusmeDrF3w" annotatedElement="_8RjYclDOEeWpFusmeDrF3w">
+              <body>This object specifies the scheduled stop date and time to perform on-demand Performance Monitoring OAM operations. This attribute has no meaning for proactive Performance Monitoring OAM operations. The stop date and time value should be greater than or equal to the scheduled start date and time value.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_m-28MMSFEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8RjYdFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8RjYdVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYdlDOEeWpFusmeDrF3w" name="NONE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYd1DOEeWpFusmeDrF3w" annotatedElement="_8RjYdlDOEeWpFusmeDrF3w">
+              <body>This object specifies the measurement session to never end.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8RjYeFDOEeWpFusmeDrF3w" name="uses" client="_8RjWbVDOEeWpFusmeDrF3w" supplier="_8RjYbFDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYeVDOEeWpFusmeDrF3w" name="LossMeasurementType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RjYelDOEeWpFusmeDrF3w" annotatedElement="_8RjYeVDOEeWpFusmeDrF3w">
+            <body>This object specifies what type of Loss Measurement will be performed.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgType&quot;</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYe1DOEeWpFusmeDrF3w" name="LMM"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYfFDOEeWpFusmeDrF3w" name="SLM"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYfVDOEeWpFusmeDrF3w" name="CCM"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8RjYflDOEeWpFusmeDrF3w" name="uses" client="_8RjWfFDOEeWpFusmeDrF3w" supplier="_8RjYeVDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYf1DOEeWpFusmeDrF3w" name="Version">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYgFDOEeWpFusmeDrF3w" name="Y.1731-2008"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYgVDOEeWpFusmeDrF3w" name="Y.1731-2011"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RjYglDOEeWpFusmeDrF3w" name="Counters">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYg1DOEeWpFusmeDrF3w" name="forward-transmitted-frames"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYhFDOEeWpFusmeDrF3w" name="forward-received-frames"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RjYhVDOEeWpFusmeDrF3w" name="forward-min-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9YFDOEeWpFusmeDrF3w" name="forward-max-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9YVDOEeWpFusmeDrF3w" name="forward-average-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9YlDOEeWpFusmeDrF3w" name="backward-transmitted-frames"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9Y1DOEeWpFusmeDrF3w" name="backward-received-frames"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9ZFDOEeWpFusmeDrF3w" name="backward-min-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9ZVDOEeWpFusmeDrF3w" name="backward-max-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9ZlDOEeWpFusmeDrF3w" name="backward-average-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9Z1DOEeWpFusmeDrF3w" name="soam-pdus-sent"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9aFDOEeWpFusmeDrF3w" name="soam-pdus-received"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9aVDOEeWpFusmeDrF3w" name="availability-forward-high-loss"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9alDOEeWpFusmeDrF3w" name="availability-forward-consecutive-high-loss"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9a1DOEeWpFusmeDrF3w" name="availability-forward-available"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9bFDOEeWpFusmeDrF3w" name="availability-forward-unavailable"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9bVDOEeWpFusmeDrF3w" name="availabilility-forward-min-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9blDOEeWpFusmeDrF3w" name="availability-forward-max-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9b1DOEeWpFusmeDrF3w" name="availability-forward-average-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9cFDOEeWpFusmeDrF3w" name="availability-backward-high-loss"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9cVDOEeWpFusmeDrF3w" name="availability-backward-consecutive-high-loss"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9clDOEeWpFusmeDrF3w" name="availability-backward-available"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9c1DOEeWpFusmeDrF3w" name="available-backward-unavailable"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9dFDOEeWpFusmeDrF3w" name="available-backward-min-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9dVDOEeWpFusmeDrF3w" name="available-backward-max-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9dlDOEeWpFusmeDrF3w" name="available-backward-average-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9d1DOEeWpFusmeDrF3w" name="measured-stats-forward-measured-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9eFDOEeWpFusmeDrF3w" name="measured-stats-backward-measured-flr"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9eVDOEeWpFusmeDrF3w" name="measured-stats-availability-forward-status"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9elDOEeWpFusmeDrF3w" name="measured-stats-availability-backward-status"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj9e1DOEeWpFusmeDrF3w" name="uses" client="_8RjWfFDOEeWpFusmeDrF3w" supplier="_8RjYglDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8Rj9fFDOEeWpFusmeDrF3w" name="DataPattern">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9fVDOEeWpFusmeDrF3w" name="ZEROS">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9flDOEeWpFusmeDrF3w" annotatedElement="_8Rj9fVDOEeWpFusmeDrF3w">
+              <body>Indicates the Data TLV contains all zeros.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9f1DOEeWpFusmeDrF3w" name="ONES">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9gFDOEeWpFusmeDrF3w" annotatedElement="_8Rj9f1DOEeWpFusmeDrF3w">
+              <body>Indicates the Data TLV contains all ones.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8Rj9gVDOEeWpFusmeDrF3w" name="SessionType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9glDOEeWpFusmeDrF3w" name="PROACTIVE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9g1DOEeWpFusmeDrF3w" annotatedElement="_8Rj9glDOEeWpFusmeDrF3w">
+              <body>The current session is 'proactive'.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9hFDOEeWpFusmeDrF3w" name="ON_DEMAND">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9hVDOEeWpFusmeDrF3w" annotatedElement="_8Rj9hFDOEeWpFusmeDrF3w">
+              <body>The current session is 'on-demand'.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_8Rj9hlDOEeWpFusmeDrF3w" memberEnd="_8RjWolDOEeWpFusmeDrF3w _8Rj9h1DOEeWpFusmeDrF3w">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_8Rj9h1DOEeWpFusmeDrF3w" name="" visibility="private" type="_8RjWfFDOEeWpFusmeDrF3w" association="_8Rj9hlDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9iFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9iVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8Rj9ilDOEeWpFusmeDrF3w" name="SoamLmThresholdNotifications">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9i1DOEeWpFusmeDrF3w" name="measured-flr-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9jFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9jVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9jlDOEeWpFusmeDrF3w" name="max-flr-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9j1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9kFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9kVDOEeWpFusmeDrF3w" name="average-flr-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9klDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9k1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9lFDOEeWpFusmeDrF3w" name="measured-flr-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9lVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9llDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9l1DOEeWpFusmeDrF3w" name="max-flr-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9mFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9mVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9mlDOEeWpFusmeDrF3w" name="average-flr-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9m1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9nFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9nVDOEeWpFusmeDrF3w" name="forward-high-loss" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9nlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9n1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9oFDOEeWpFusmeDrF3w" name="forward-consecutive-high-loss" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9oVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9olDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9o1DOEeWpFusmeDrF3w" name="backward-high-loss" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9pFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9pVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9plDOEeWpFusmeDrF3w" name="backward-consecutive-high-loss" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9p1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9qFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9qVDOEeWpFusmeDrF3w" name="forward-unavailable-count" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9qlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9q1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9rFDOEeWpFusmeDrF3w" name="forward-available-ratio" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9rVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9rlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9r1DOEeWpFusmeDrF3w" name="backward-unavailable-count" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9sFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9sVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9slDOEeWpFusmeDrF3w" name="backward-available-ratio" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9s1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9tFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_8Rj9tVDOEeWpFusmeDrF3w" name="DelayMeasurementType">
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9tlDOEeWpFusmeDrF3w" name="DMM">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9t1DOEeWpFusmeDrF3w" annotatedElement="_8Rj9tlDOEeWpFusmeDrF3w">
+              <body>DMM SOAM PDU generated, DMR responses received (one-way or two-way measurements).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9uFDOEeWpFusmeDrF3w" name="DM1_TRANSMITTED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9uVDOEeWpFusmeDrF3w" annotatedElement="_8Rj9uFDOEeWpFusmeDrF3w">
+              <body>1DM SOAM PDU generated (one-way measurements are made by the receiver).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8Rj9ulDOEeWpFusmeDrF3w" name="DM1_RECEIVED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj9u1DOEeWpFusmeDrF3w" annotatedElement="_8Rj9ulDOEeWpFusmeDrF3w">
+              <body>1DM SOAM PDU received and tracked (one-way measurements).</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj9vFDOEeWpFusmeDrF3w" name="uses" client="_8RjXHFDOEeWpFusmeDrF3w" supplier="_8Rj9tVDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8Rj9vVDOEeWpFusmeDrF3w" name="SoamDmCounters">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9vlDOEeWpFusmeDrF3w" name="soam-pdus-sent" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9v1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9wFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9wVDOEeWpFusmeDrF3w" name="soam-pdus-received" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9wlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9w1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9xFDOEeWpFusmeDrF3w" name="frame-delay-two-way-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9xVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9xlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9x1DOEeWpFusmeDrF3w" name="frame-delay-two-way-min" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9yFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9yVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9ylDOEeWpFusmeDrF3w" name="frame-delay-two-way-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9y1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9zFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9zVDOEeWpFusmeDrF3w" name="frame-delay-two-way-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9zlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9z1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj90FDOEeWpFusmeDrF3w" name="frame-delay-forward-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj90VDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj90lDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj901DOEeWpFusmeDrF3w" name="frame-delay-forward-min" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj91FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj91VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj91lDOEeWpFusmeDrF3w" name="frame-delay-forward-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj911DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj92FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj92VDOEeWpFusmeDrF3w" name="frame-delay-forward-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj92lDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj921DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj93FDOEeWpFusmeDrF3w" name="frame-delay-backward-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj93VDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj93lDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj931DOEeWpFusmeDrF3w" name="frame-delay-backward-min" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj94FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj94VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj94lDOEeWpFusmeDrF3w" name="frame-delay-backward-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj941DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj95FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj95VDOEeWpFusmeDrF3w" name="frame-delay-backward-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj95lDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj951DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj96FDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-forward-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj96VDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj96lDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj961DOEeWpFusmeDrF3w" name="inter-frame-delay-variation-forward-min" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj97FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj97VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj97lDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-forward-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj971DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj98FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj98VDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-forward-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj98lDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj981DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj99FDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-backward-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj99VDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj99lDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj991DOEeWpFusmeDrF3w" name="inter-frame-delay-variation-backward-min" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9-FDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9-VDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9-lDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-backward-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9-1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9_FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj9_VDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-backward-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj9_lDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj9_1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-AFDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-two-way-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-AVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-AlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-A1DOEeWpFusmeDrF3w" name="inter-frame-delay-variation-two-way-min" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-BFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-BVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-BlDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-two-way-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-B1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-CFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-CVDOEeWpFusmeDrF3w" name="inter-frame-delay-variation-two-way-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-ClDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-C1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-DFDOEeWpFusmeDrF3w" name="frame-delay-range-forward-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-DVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-DlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-D1DOEeWpFusmeDrF3w" name="frame-delay-range-forward-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-EFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-EVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-ElDOEeWpFusmeDrF3w" name="frame-delay-range-forward-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-E1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-FFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-FVDOEeWpFusmeDrF3w" name="frame-delay-range-backward-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-FlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-F1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-GFDOEeWpFusmeDrF3w" name="frame-delay-range-backward-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-GVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-GlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-G1DOEeWpFusmeDrF3w" name="frame-delay-range-backward-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-HFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-HVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-HlDOEeWpFusmeDrF3w" name="frame-delay-range-two-way-bins" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-H1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-IFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-IVDOEeWpFusmeDrF3w" name="frame-delay-range-two-way-max" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-IlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-I1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-JFDOEeWpFusmeDrF3w" name="frame-delay-range-two-way-average" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-JVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-JlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-J1DOEeWpFusmeDrF3w" name="measured-stats-frame-delay-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-KFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-KVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-KlDOEeWpFusmeDrF3w" name="measured-stats-frame-delay-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-K1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-LFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-LVDOEeWpFusmeDrF3w" name="measured-stats-frame-delay-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-LlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-L1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-MFDOEeWpFusmeDrF3w" name="measured-stats-inter-frame-delay-variation-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-MVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-MlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-M1DOEeWpFusmeDrF3w" name="measured-stats-inter-frame-delay-variation-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-NFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-NVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-NlDOEeWpFusmeDrF3w" name="measured-stats-inter-frame-delay-variation-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-N1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-OFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj-OVDOEeWpFusmeDrF3w" name="uses" client="_8RjXHFDOEeWpFusmeDrF3w" supplier="_8Rj9vVDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8Rj-OlDOEeWpFusmeDrF3w" name="MeasurementConfiguration" isAbstract="true">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8Rj-O1DOEeWpFusmeDrF3w" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-PFDOEeWpFusmeDrF3w" annotatedElement="_8Rj-OlDOEeWpFusmeDrF3w">
+            <body>This grouping includes configuration objects for the Frame Loss Measurement function defined in [Y.1731] and [MEF SOAM PM IA].&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgTable, [Y.1731] and [MEF SOAM PM IA]&quot;</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-PVDOEeWpFusmeDrF3w" name="version" visibility="public" type="_8RjYf1DOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-PlDOEeWpFusmeDrF3w" annotatedElement="_8Rj-PVDOEeWpFusmeDrF3w">
+              <body>This object indicates the version of the PDUs used to perform Loss/Delay Measurement.&#xD;
+The exact PDUs to use are specified by this object in combination with measurement-type.&#xD;
+&#xD;
+references&#xD;
+- &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgVersion&quot;&#xD;
+- &quot;[Y.1731]&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-P1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-QFDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_8Rj-QVDOEeWpFusmeDrF3w" name="Y.1731-2008" type="_8RjYf1DOEeWpFusmeDrF3w" instance="_8RjYgFDOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-QlDOEeWpFusmeDrF3w" name="messagePeriod" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-Q1DOEeWpFusmeDrF3w" annotatedElement="_8Rj-QlDOEeWpFusmeDrF3w">
+              <body>range &quot;3..3600000&quot;; units ms.&#xD;
+This object specifies the internal between Loss/Delay Measurement OAM message transmission. For Loss Measurement monitoring applications the default value is 1 sec. For Delay Measurement monitoring applications, the default value is 100ms.&#xD;
+This object is not applicable if measurement-type is set to 'ccm' and is ignored for that Loss Measurement Type.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgMessagePeriod&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-RFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-RVDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_8Rj-RlDOEeWpFusmeDrF3w" visibility="public" value="Loss:1000; Delay: 100">
+              <name xsi:nil="true"/>
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-R1DOEeWpFusmeDrF3w" name="priority" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-SFDOEeWpFusmeDrF3w" annotatedElement="_8Rj-R1DOEeWpFusmeDrF3w">
+              <body>This object specifies the priority of frames with Performance Monitoring OAM message information.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgPriority&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_eJVSsMSVEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-SVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-SlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-S1DOEeWpFusmeDrF3w" name="frameSize" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-TFDOEeWpFusmeDrF3w" annotatedElement="_8Rj-S1DOEeWpFusmeDrF3w">
+              <body>units bytes&#xD;
+This object specifies the Loss/Delay Measurement frame size between 64 bytes and the maximum transmission unit of the EVC.&#xD;
+The range of frame sizes from 64 through 2000 octets need to be supported, and the range of frame sizes from 2001 through 9600 octets is suggested be supported.&#xD;
+The adjustment to the frame size of the standard frame size is accomplished by the addition of a Data or Test TLV. A Data or Test TLV is only added to the frame if the frame size is greater than 64 bytes.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgFrameSize&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-TVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-TlDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-T1DOEeWpFusmeDrF3w" value="64">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-UFDOEeWpFusmeDrF3w" name="dataPattern" visibility="public" type="_8Rj9fFDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-UVDOEeWpFusmeDrF3w" annotatedElement="_8Rj-UFDOEeWpFusmeDrF3w">
+              <body>This object specifies the LM/DM data pattern included in a Data TLV when the size of the LM/DM frame is determined by the frame-size object and test-tlv-included is 'false'.&#xD;
+If the frame size object does not define the LM/DM frame size or test-tlv-included is 'true' the value of this object is ignored.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgDataPattern&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-UlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-U1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_8Rj-VFDOEeWpFusmeDrF3w" name="ZEROS" type="_8Rj9fFDOEeWpFusmeDrF3w" instance="_8Rj9fVDOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-VVDOEeWpFusmeDrF3w" name="testTlvIncluded" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-VlDOEeWpFusmeDrF3w" annotatedElement="_8Rj-VVDOEeWpFusmeDrF3w">
+              <body>This object indicates whether a Test TLV or Data TLV is included when the size of the LM/LBM frame is determined by the frame-size object/leaf.&#xD;
+A value of 'true' indicates that the Test TLV is to be included. A value of 'false' indicates that the Data TLV is to be included.&#xD;
+If the frame-size object does not define the LM frame size the value of this object is ignored.&#xD;
+reference&#xD;
+- &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgTestTlvIncluded&quot;&#xD;
+- &quot;[Y.1731] 9.3&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-V1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-WFDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_8Rj-WVDOEeWpFusmeDrF3w">
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-WlDOEeWpFusmeDrF3w" name="testTlvPattern" visibility="public" type="_8RjWUlDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-W1DOEeWpFusmeDrF3w" annotatedElement="_8Rj-WlDOEeWpFusmeDrF3w">
+              <body>This object specifies the type of test pattern to be sent in the LM/DM frame Test TLV when the size of LM/DM PDU is determined by the frame-size object and test-tlv-included is 'true'. If the frame size object does not define the LM/DM frame size or test-tlv-included is 'false' the value of this object is ignored.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgTestTlvPattern&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-XFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-XVDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_8Rj-XlDOEeWpFusmeDrF3w" name="NULL_SIGNAL_WITHOUT_CRC_32" type="_8RjWUlDOEeWpFusmeDrF3w" instance="_8RjWU1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-X1DOEeWpFusmeDrF3w" name="measurementInterval" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-YFDOEeWpFusmeDrF3w" annotatedElement="_8Rj-X1DOEeWpFusmeDrF3w">
+              <body>range LM: &quot;1..525600&quot;; range DM: &quot;1..1440&quot;.&#xD;
+This object specifies the Measurement Interval in minutes.&#xD;
+A Measurement Interval of 15 minutes needs to be supported, other intervals may be supported.&#xD;
+reference&#xD;
+- &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgMeasurementInterval&quot;&#xD;
+-&quot;MEF-SOAM-PM-MIB.mefSoamDmCfgMeasurementInterval&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-YVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-YlDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-Y1DOEeWpFusmeDrF3w" value="15">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-ZFDOEeWpFusmeDrF3w" name="numberIntervalsStored" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-ZVDOEeWpFusmeDrF3w" annotatedElement="_8Rj-ZFDOEeWpFusmeDrF3w">
+              <body>range &quot;2..1000&quot;&#xD;
+This object specifies the number of completed measurement intervals to store in the history statistic table.&#xD;
+At least 32 completed measurement intervals are to be stored. 96 measurement intervals are recommended to be stored.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgNumIntervalsStored&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-ZlDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-Z1DOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-aFDOEeWpFusmeDrF3w" value="32">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-aVDOEeWpFusmeDrF3w" name="alignMeasurementIntervals" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-alDOEeWpFusmeDrF3w" annotatedElement="_8Rj-aVDOEeWpFusmeDrF3w">
+              <body>LM:&#xD;
+This object specifies whether the measurement intervals for the Loss/Delay Measurement session are aligned with a zero offset to real time.&#xD;
+The value 'true' indicates that each Measurement Interval starts at a time which is aligned to NE time source hour if the interval is a factor of an hour, i.e. 60min/15min = 4. For instance, a measurement time interval of 15 minutes would stop/start the measurement interval at 0, 15, 30, and 45 minutes of an hour. A measurement interval of 7 minutes would not align to the hour since 7 minutes is NOT a factor of an hour, i.e. 60min/7min = 8.6, and the behavior is the same as if the object is set to 'false'.&#xD;
+The value 'false' indicates that each Measurement Interval starts at a time which is indicated by repetition-period.&#xD;
+One side effect of the usage of this parameter is that if the value is true and the repetition-period is not a factor of an hour then the start of the next Measurement Interval will be delayed until the next factor of an hour.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAlignMeasurementIntervals&quot;&#xD;
+&#xD;
+DM:&#xD;
+This object specifies whether the Measurement Intervals for the Delay Measurement session are aligned with a zero offset to real time.&#xD;
+The value 'true' indicates that each Measurement Interval starts at a time which is aligned to NE time source hour, if the repetition time (or the Measurement Interval, if the repetition time is 0) is a factor of an hour, i.e. 60min/15min = 4. For instance, a Measurement Interval/Repetition Time of 15 minutes would stop/start the Measurement Interval at 0, 15, 30, and 45 minutes of an hour. A Measurement Interval/Repetition Time of 7 minutes would not align to the hour since 7 minutes is NOT a factor of an hour, i.e. 60min/7min = 8.6. In this case the behavior is the same as if the object is set to 'false'.&#xD;
+The value 'false' indicates that the first Measurement Interval starts at an arbitrary time and each subsequent Measurement Interval starts at a time which is determined by repetition-time.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-a1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-bFDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_8Rj-bVDOEeWpFusmeDrF3w" value="true">
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-blDOEeWpFusmeDrF3w" name="alignMeasurementOffset" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-b1DOEeWpFusmeDrF3w" annotatedElement="_8Rj-blDOEeWpFusmeDrF3w">
+              <body>range &quot;0..525600&quot;&#xD;
+This object specifies the offset in minutes from the time of day value if align-measurement-intervals is 'true' and the repetition time is a factor of 60 minutes. If not, the value of this object is ignored.&#xD;
+If the Measurement Interval is 15 minutes and align-measurement-intervals is true and if this object was set to 5 minutes, the Measurement Intervals would start at 5, 20, 35, 50 minutes past each hour.&#xD;
+reference &quot;MEF-SOAM-PM-MIB.mefSoamLmCfgAlignMeasurementOffset&quot;</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-cFDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-cVDOEeWpFusmeDrF3w" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-clDOEeWpFusmeDrF3w">
+              <type xmi:type="uml:PrimitiveType" href="../RSA/YANG_Models.uml#_61tawMSZEeOAjLjnwOuPBg"/>
+            </defaultValue>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-c1DOEeWpFusmeDrF3w" name="sessionType" visibility="public" type="_8Rj9gVDOEeWpFusmeDrF3w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_8Rj-dFDOEeWpFusmeDrF3w" annotatedElement="_8Rj-c1DOEeWpFusmeDrF3w">
+              <body>This object indicates whether the current session is defined to be 'proactive' or 'on-demand'.&#xD;
+reference &quot;[MEF SOAM IA] R3&quot;</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-dVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-dlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj-d1DOEeWpFusmeDrF3w" name="uses" client="_8Rj-OlDOEeWpFusmeDrF3w" supplier="_8RjYf1DOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj-eFDOEeWpFusmeDrF3w" name="uses" client="_8Rj-OlDOEeWpFusmeDrF3w" supplier="_8Rj9fFDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj-eVDOEeWpFusmeDrF3w" name="uses" client="_8Rj-OlDOEeWpFusmeDrF3w" supplier="_8RjWUlDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj-elDOEeWpFusmeDrF3w" name="uses" client="_8Rj-OlDOEeWpFusmeDrF3w" supplier="_8Rj9gVDOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Association" xmi:id="_8Rj-e1DOEeWpFusmeDrF3w" memberEnd="_8RjXflDOEeWpFusmeDrF3w _8Rj-fFDOEeWpFusmeDrF3w">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_8Rj-fFDOEeWpFusmeDrF3w" name="" visibility="private" type="_8RjXHFDOEeWpFusmeDrF3w" association="_8Rj-e1DOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-fVDOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-flDOEeWpFusmeDrF3w" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_8Rj-f1DOEeWpFusmeDrF3w" name="SoamDmThresholdNotifications">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-gFDOEeWpFusmeDrF3w" name="measured-frame-delay-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-gVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-glDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-g1DOEeWpFusmeDrF3w" name="max-frame-delay-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-hFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-hVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-hlDOEeWpFusmeDrF3w" name="average-frame-delay-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-h1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-iFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-iVDOEeWpFusmeDrF3w" name="measured-inter-frame-delay-variation-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-ilDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-i1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-jFDOEeWpFusmeDrF3w" name="max-inter-frame-delay-variation-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-jVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-jlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-j1DOEeWpFusmeDrF3w" name="average-inter-frame-delay-variation-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-kFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-kVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-klDOEeWpFusmeDrF3w" name="max-frame-delay-range-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-k1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-lFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-lVDOEeWpFusmeDrF3w" name="average-frame-delay-range-two-way" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-llDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-l1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-mFDOEeWpFusmeDrF3w" name="measured-frame-delay-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-mVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-mlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-m1DOEeWpFusmeDrF3w" name="max-frame-delay-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-nFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-nVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-nlDOEeWpFusmeDrF3w" name="average-frame-delay-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-n1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-oFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-oVDOEeWpFusmeDrF3w" name="measured-inter-frame-delay-variation-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-olDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-o1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-pFDOEeWpFusmeDrF3w" name="max-inter-frame-delay-variation-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-pVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-plDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-p1DOEeWpFusmeDrF3w" name="average-inter-frame-delay-variation-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-qFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-qVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-qlDOEeWpFusmeDrF3w" name="max-frame-delay-range-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-q1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-rFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-rVDOEeWpFusmeDrF3w" name="average-frame-delay-range-forward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-rlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-r1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-sFDOEeWpFusmeDrF3w" name="measured-frame-delay-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-sVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-slDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-s1DOEeWpFusmeDrF3w" name="max-frame-delay-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-tFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-tVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-tlDOEeWpFusmeDrF3w" name="average-frame-delay-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-t1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-uFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-uVDOEeWpFusmeDrF3w" name="measured-inter-frame-delay-variation-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-ulDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-u1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-vFDOEeWpFusmeDrF3w" name="max-inter-frame-delay-variation-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-vVDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-vlDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-v1DOEeWpFusmeDrF3w" name="average-inter-frame-delay-variation-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-wFDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-wVDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-wlDOEeWpFusmeDrF3w" name="max-frame-delay-range-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-w1DOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-xFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8Rj-xVDOEeWpFusmeDrF3w" name="average-frame-delay-range-backward" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-xlDOEeWpFusmeDrF3w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-x1DOEeWpFusmeDrF3w" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_8Rj-yFDOEeWpFusmeDrF3w" name="uses" client="_8RjX8VDOEeWpFusmeDrF3w" supplier="_8RjWV1DOEeWpFusmeDrF3w"/>
+        <packagedElement xmi:type="uml:Association" xmi:id="_8Rj-yVDOEeWpFusmeDrF3w" memberEnd="_8RjYClDOEeWpFusmeDrF3w _8Rj-ylDOEeWpFusmeDrF3w">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_8Rj-ylDOEeWpFusmeDrF3w" name="" visibility="private" type="_8RjYBFDOEeWpFusmeDrF3w" association="_8Rj-yVDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-y1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-zFDOEeWpFusmeDrF3w" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_8Rj-zVDOEeWpFusmeDrF3w" memberEnd="_8RjYDVDOEeWpFusmeDrF3w _8Rj-zlDOEeWpFusmeDrF3w">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_8Rj-zlDOEeWpFusmeDrF3w" name="" visibility="private" type="_8RjYBFDOEeWpFusmeDrF3w" association="_8Rj-zVDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-z1DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-0FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_8Rj-0VDOEeWpFusmeDrF3w" memberEnd="_8RjYEFDOEeWpFusmeDrF3w _8Rj-0lDOEeWpFusmeDrF3w">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_8Rj-0lDOEeWpFusmeDrF3w" name="" visibility="private" type="_8RjYBFDOEeWpFusmeDrF3w" association="_8Rj-0VDOEeWpFusmeDrF3w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Rj-01DOEeWpFusmeDrF3w" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Rj-1FDOEeWpFusmeDrF3w" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_Ohs_MJXMEeaz_5UXvCN0Lw" name="BasicTypes"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_Lmf84JXNEeaz_5UXvCN0Lw" name="Processing RelatedTypes"/>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_P2rT8P-0EeWE04JH4LMHNA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_P2siEP-0EeWE04JH4LMHNA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.eclipse.org/uml2/5.0.0/UML/Profile/Standard#/"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/Standard.profile.uml#_0"/>
+    </profileApplication>
+  </uml:Model>
+  <standard:ModelLibrary xmi:id="_cWj8EP-0EeWE04JH4LMHNA" base_Package="_-lRh4FDNEeWpFusmeDrF3w"/>
+</xmi:XMI>

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -2042,7 +2042,7 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HLnN1Yt6Eeiu6boZkiJHCA" x="358" y="-12"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_-RwAgU0WEeaqn4OIuRCwEg" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_-RwAgU0WEeaqn4OIuRCwEg" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_-R5KcE0WEeaqn4OIuRCwEg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_47Tw8It5Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
       <owner xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -626,6 +626,28 @@ Examples:&#xD;
 </body>
         </ownedComment>
       </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_6-ftUC7jEem3g99vIRtESQ" name="MacAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_D10TUC7kEem3g99vIRtESQ" annotatedElement="_6-ftUC7jEem3g99vIRtESQ">
+          <body>pattern &quot;[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){5}&quot;&#xD;
+&#xD;
+description&#xD;
+      &quot;The mac-address type represents a MAC address in the canonical&#xD;
+      format and hexadecimal format specified by IEEE Std 802. The&#xD;
+      hexidecimal representation uses uppercase characters.&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_SR47UC7kEem3g99vIRtESQ" name="Binary">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_pRcnUC7kEem3g99vIRtESQ" annotatedElement="_SR47UC7kEem3g99vIRtESQ">
+          <body>Represents any binary data, i.e., a sequence of octets.&#xD;
+A binary type can be restricted by a length which defines the number of octets it contains.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vK1_AC9lEem3g99vIRtESQ" name="Timeticks">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KT6eEC9mEem3g99vIRtESQ" annotatedElement="_vK1_AC9lEem3g99vIRtESQ">
+          <body>type uint32&#xD;
+The timeticks type represents a non-negative integer that represents the time, modulo 2^32 (4294967296 decimal), in hundredths of a second between two epochs.</body>
+        </ownedComment>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_FhzwMHrqEeavcODnuX7FyA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_JSfMgHrqEeavcODnuX7FyA" name="TapiService">
@@ -822,4 +844,6 @@ Examples:&#xD;
   <OpenModel_Profile:Experimental xmi:id="_aTAKEIk4Eeil5oKL3Vgl-g" base_Element="_-eq88Ik2Eeil5oKL3Vgl-g"/>
   <OpenModel_Profile:Experimental xmi:id="_lnBfMIk8Eeil5oKL3Vgl-g" base_Element="_i92HIL6PEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:Experimental xmi:id="_sghtoIk8Eeil5oKL3Vgl-g" base_Element="_2wdyENnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Reference xmi:id="_E081EC7kEem3g99vIRtESQ" base_Element="_6-ftUC7jEem3g99vIRtESQ" reference="3.1 and 8.1 of IEEE Std 802-2014"/>
+  <OpenModel_Profile:Reference xmi:id="_U9wKkC9mEem3g99vIRtESQ" base_Element="_vK1_AC9lEem3g99vIRtESQ" reference="RFC 2578"/>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -4367,6 +4367,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MfEfgSqvEemz8qUl1H9gFg" x="748" y="-471"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_wsPvEC9fEem3g99vIRtESQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_wsPvES9fEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wsQWIC9fEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wsPvEi9fEem3g99vIRtESQ" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nKEKAC9mEem3g99vIRtESQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nKExEC9mEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nKExEi9mEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nKExES9mEem3g99vIRtESQ" x="748" y="-471"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_LeXWvXMLEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJ-HEIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -5396,6 +5412,26 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MfEfhSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MfEfhiqvEemz8qUl1H9gFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MfEfhyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_wsQWIS9fEem3g99vIRtESQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_wsPvEC9fEem3g99vIRtESQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_wsQWIi9fEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wsRkQC9fEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wsQWIy9fEem3g99vIRtESQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wsQ9MC9fEem3g99vIRtESQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wsQ9MS9fEem3g99vIRtESQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nKExEy9mEem3g99vIRtESQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_nKEKAC9mEem3g99vIRtESQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nKExFC9mEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nKExGC9mEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nKExFS9mEem3g99vIRtESQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nKExFi9mEem3g99vIRtESQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nKExFy9mEem3g99vIRtESQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_QUOkQHMcEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamJobDetails" measurementUnit="Pixel">
@@ -11555,6 +11591,35 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3LAMirMEemz8qUl1H9gFg" x="237" y="-134"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_43Ao8C7OEem3g99vIRtESQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_43Ao8S7OEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_43IkwC7OEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_43Ao8i7OEem3g99vIRtESQ" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gCOJkC7iEem3g99vIRtESQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gCOwoC7iEem3g99vIRtESQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiOam.uml#_eAka4C7iEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCOJkS7iEem3g99vIRtESQ" x="872" y="-520"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yi_1UC9fEem3g99vIRtESQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yi_1US9fEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yi_1Uy9fEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yi_1Ui9fEem3g99vIRtESQ" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_oGyQ8C9mEem3g99vIRtESQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_oGyQ8S9mEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oGyQ8y9mEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oGyQ8i9mEem3g99vIRtESQ" x="237" y="-134"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_bJ59dyqvEemz8qUl1H9gFg" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_bJ59eCqvEemz8qUl1H9gFg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_bJ59eSqvEemz8qUl1H9gFg" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -13117,7 +13182,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7f3IOiq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wCSQoCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3IOyq1Eemz8qUl1H9gFg" x="-9" y="-19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3IOyq1Eemz8qUl1H9gFg" x="-9" y="-12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7f2hISq1Eemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_7d1u8Cq1Eemz8qUl1H9gFg"/>
@@ -13241,6 +13306,43 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q3LnRCrMEemz8qUl1H9gFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q3LnRSrMEemz8qUl1H9gFg"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_43JL0C7OEem3g99vIRtESQ" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_43Ao8C7OEem3g99vIRtESQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_43JL0S7OEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_43KZ8C7OEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_43JL0i7OEem3g99vIRtESQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_43Jy4C7OEem3g99vIRtESQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_43Jy4S7OEem3g99vIRtESQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_g8q_oC7iEem3g99vIRtESQ" type="Comment_AnnotatedElementEdge" source="_gCOJkC7iEem3g99vIRtESQ" target="_DkKp8CrDEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_g8q_oS7iEem3g99vIRtESQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g8q_oi7iEem3g99vIRtESQ" points="[877, 152, -643984, -643984]$[642, 268, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iHTmwC7iEem3g99vIRtESQ" id="(0.0,0.8205128205128205)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8sNwC7iEem3g99vIRtESQ" id="(0.8381696428571429,0.21084337349397592)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yi_1VC9fEem3g99vIRtESQ" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_yi_1UC9fEem3g99vIRtESQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yi_1VS9fEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yi_1WS9fEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yi_1Vi9fEem3g99vIRtESQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yi_1Vy9fEem3g99vIRtESQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yi_1WC9fEem3g99vIRtESQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_oGyQ9C9mEem3g99vIRtESQ" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_oGyQ8C9mEem3g99vIRtESQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_oGyQ9S9mEem3g99vIRtESQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oGyQ-S9mEem3g99vIRtESQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oGyQ9i9mEem3g99vIRtESQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oGyQ9y9mEem3g99vIRtESQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oGyQ-C9mEem3g99vIRtESQ"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9sFKUCrEEemz8qUl1H9gFg" type="PapyrusUMLClassDiagram" name="OamLldpDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_K3c_cCrFEemz8qUl1H9gFg" type="Class_Shape">
@@ -13356,7 +13458,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K365kSrFEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K36ScSrFEemz8qUl1H9gFg" x="12" y="208"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K36ScSrFEemz8qUl1H9gFg" x="12" y="208" width="365"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_K4FRkyrFEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_K4FRlCrFEemz8qUl1H9gFg"/>
@@ -13869,7 +13971,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OUAl8CrFEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OT_XwSrFEemz8qUl1H9gFg" x="96" y="616"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OT_XwSrFEemz8qUl1H9gFg" x="16" y="616"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_OUfuEyrFEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_OUfuFCrFEemz8qUl1H9gFg"/>
@@ -13925,7 +14027,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwzPnyrFEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwyogSrFEemz8qUl1H9gFg" x="520" y="616"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwyogSrFEemz8qUl1H9gFg" x="432" y="616"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_OxOGUCrFEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_OxOGUSrFEemz8qUl1H9gFg"/>
@@ -14025,7 +14127,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiwaSrFEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiJUSrFEemz8qUl1H9gFg" x="927" y="616"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiJUSrFEemz8qUl1H9gFg" x="816" y="616"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_PM1EQCrFEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_PM1EQSrFEemz8qUl1H9gFg"/>
@@ -14274,7 +14376,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PjhtBCrFEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pjge4SrFEemz8qUl1H9gFg" x="1360" y="616"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pjge4SrFEemz8qUl1H9gFg" x="1224" y="616"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Pj0A4yrFEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Pj0A5CrFEemz8qUl1H9gFg"/>
@@ -14442,7 +14544,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVIyrNEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEW98CquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVESrNEemz8qUl1H9gFg" x="888" y="1008"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVESrNEemz8qUl1H9gFg" x="752" y="1008"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_QSxfAyrNEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_QSxfBCrNEemz8qUl1H9gFg"/>
@@ -14539,7 +14641,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QoxkQCrNEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEdEkCquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QowWESrNEemz8qUl1H9gFg" x="1409" y="1008"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QowWESrNEemz8qUl1H9gFg" x="1273" y="1008"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Qo7VMyrNEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Qo7VNCrNEemz8qUl1H9gFg"/>
@@ -14740,7 +14842,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCkyrNEemz8qUl1H9gFg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_hEfg0CquEemz8qUl1H9gFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCgSrNEemz8qUl1H9gFg" x="1840" y="1008"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCgSrNEemz8qUl1H9gFg" x="1704" y="1008"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Q-LzgyrNEemz8qUl1H9gFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Q-LzhCrNEemz8qUl1H9gFg"/>
@@ -15108,6 +15210,26 @@
       <element xmi:type="uml:Enumeration" href="TapiOam.uml#_jSEM0CrIEemz8qUl1H9gFg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DEgmkSrQEemz8qUl1H9gFg" x="1664" y="1176"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_75zJ4C7hEem3g99vIRtESQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_752NMC7hEem3g99vIRtESQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiOam.uml#_52J3IC7hEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_75zJ4S7hEem3g99vIRtESQ" x="496" y="472" height="17"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9eqO4C7hEem3g99vIRtESQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9eqO4i7hEem3g99vIRtESQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiOam.uml#_3pLCMC7hEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9eqO4S7hEem3g99vIRtESQ" x="496" y="440" height="25"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__AjfcC7hEem3g99vIRtESQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="__AkGgC7hEem3g99vIRtESQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiOam.uml#_1Xt88C7hEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__AjfcS7hEem3g99vIRtESQ" x="496" y="408" height="17"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AYjNIC7iEem3g99vIRtESQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_AYjNIi7iEem3g99vIRtESQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiOam.uml#_yKWCAC7hEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AYjNIS7iEem3g99vIRtESQ" x="496" y="376" height="25"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9sFKUSrEEemz8qUl1H9gFg" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9sFKUirEEemz8qUl1H9gFg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_9sFKUyrEEemz8qUl1H9gFg" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -15163,7 +15285,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_gS1vgCqwEemz8qUl1H9gFg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K4h9girFEemz8qUl1H9gFg" points="[568, 80, -643984, -643984]$[136, 80, -643984, -643984]$[136, 208, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZCrFEemz8qUl1H9gFg" id="(0.0,0.32)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZSrFEemz8qUl1H9gFg" id="(0.4945054945054945,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZSrFEemz8qUl1H9gFg" id="(0.44931506849315067,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LYbllCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_LYRNgCrFEemz8qUl1H9gFg" target="_LYblkCrFEemz8qUl1H9gFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_LYbllSrFEemz8qUl1H9gFg"/>
@@ -15337,7 +15459,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_iAzl0CqzEemz8qUl1H9gFg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mu0JsirFEemz8qUl1H9gFg" points="[128, 472, -643984, -643984]$[32, 472, -643984, -643984]$[32, 354, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYirFEemz8qUl1H9gFg" id="(0.0,0.24)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYyrFEemz8qUl1H9gFg" id="(0.054945054945054944,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYyrFEemz8qUl1H9gFg" id="(0.049315068493150684,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_NHz4gCrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_NHz4gyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
@@ -15366,9 +15488,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_NHz4gSrFEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_PF8o4Cq0Eemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NHz4girFEemz8qUl1H9gFg" points="[88, 448, -643984, -643984]$[88, 400, -643984, -643984]$[136, 400, -643984, -643984]$[136, 354, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYCrFEemz8qUl1H9gFg" id="(0.26229508196721313,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYSrFEemz8qUl1H9gFg" id="(0.34065934065934067,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NHz4girFEemz8qUl1H9gFg" points="[136, 448, -643984, -643984]$[136, 400, -643984, -643984]$[128, 400, -643984, -643984]$[128, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYCrFEemz8qUl1H9gFg" id="(0.22950819672131148,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYSrFEemz8qUl1H9gFg" id="(0.3178082191780822,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Nedd8CrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_NeeFACrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
@@ -15397,9 +15519,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Nedd8SrFEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_bAi9MCq1Eemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Nedd8irFEemz8qUl1H9gFg" points="[248, 448, -643984, -643984]$[248, 354, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZirFEemz8qUl1H9gFg" id="(0.7213114754098361,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZyrFEemz8qUl1H9gFg" id="(0.6483516483516484,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Nedd8irFEemz8qUl1H9gFg" points="[224, 448, -643984, -643984]$[224, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZirFEemz8qUl1H9gFg" id="(0.6229508196721312,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZyrFEemz8qUl1H9gFg" id="(0.5808219178082191,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_N51LUCrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_N51yYCrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
@@ -15408,7 +15530,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_N51yYirFEemz8qUl1H9gFg" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V99Z0CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_N51yYyrFEemz8qUl1H9gFg" x="40"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N51yYyrFEemz8qUl1H9gFg" x="28"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_N51yZCrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V-wrECrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -15428,9 +15550,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_N51LUSrFEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_hw1lQCq1Eemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N51LUirFEemz8qUl1H9gFg" points="[260, 472, -643984, -643984]$[368, 472, -643984, -643984]$[368, 354, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkaCrFEemz8qUl1H9gFg" id="(1.0,0.24)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCLLcCrFEemz8qUl1H9gFg" id="(0.978021978021978,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N51LUirFEemz8qUl1H9gFg" points="[316, 472, -643984, -643984]$[344, 472, -643984, -643984]$[344, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkaCrFEemz8qUl1H9gFg" id="(1.0,0.20869565217391303)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCLLcCrFEemz8qUl1H9gFg" id="(0.9095890410958904,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_OUgVISrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_OT_XwCrFEemz8qUl1H9gFg" target="_OUfuEyrFEemz8qUl1H9gFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_OUgVIirFEemz8qUl1H9gFg"/>
@@ -15469,9 +15591,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_OXD54SrFEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_4boiMCq1Eemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OXD54irFEemz8qUl1H9gFg" points="[992, 466, -643984, -643984]$[992, 528, -643984, -643984]$[376, 528, -643984, -643984]$[376, 616, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OXD54irFEemz8qUl1H9gFg" points="[992, 466, -643984, -643984]$[992, 528, -643984, -643984]$[368, 528, -643984, -643984]$[368, 616, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGGICrFEemz8qUl1H9gFg" id="(0.15458937198067632,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGGISrFEemz8qUl1H9gFg" id="(0.6982543640897756,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGGISrFEemz8qUl1H9gFg" id="(0.8778054862842892,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_OxOGVCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_OwyogCrFEemz8qUl1H9gFg" target="_OxOGUCrFEemz8qUl1H9gFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_OxOGVSrFEemz8qUl1H9gFg"/>
@@ -15512,7 +15634,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#_5WY6QCq1Eemz8qUl1H9gFg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OzglUirFEemz8qUl1H9gFg" points="[1064, 466, -643984, -643984]$[1064, 552, -643984, -643984]$[632, 552, -643984, -643984]$[632, 624, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNirFEemz8qUl1H9gFg" id="(0.3864734299516908,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNyrFEemz8qUl1H9gFg" id="(0.5194805194805194,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNyrFEemz8qUl1H9gFg" id="(0.5177111716621253,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_PM1ERCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_PMiJUCrFEemz8qUl1H9gFg" target="_PM1EQCrFEemz8qUl1H9gFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_PM1ERSrFEemz8qUl1H9gFg"/>
@@ -15551,9 +15673,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_PPMbwSrFEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_6TkUMCq1Eemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PPMbwirFEemz8qUl1H9gFg" points="[1192, 466, -643984, -643984]$[1192, 616, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMirFEemz8qUl1H9gFg" id="(0.6376811594202898,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMyrFEemz8qUl1H9gFg" id="(0.6354916067146283,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PPMbwirFEemz8qUl1H9gFg" points="[1176, 466, -643984, -643984]$[1176, 616, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMirFEemz8qUl1H9gFg" id="(0.5990338164251208,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMyrFEemz8qUl1H9gFg" id="(0.9137055837563451,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Pj0n8CrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_Pjge4CrFEemz8qUl1H9gFg" target="_Pj0A4yrFEemz8qUl1H9gFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_Pj0n8SrFEemz8qUl1H9gFg"/>
@@ -15588,11 +15710,11 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_PnBs_SrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lv62sCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs_irFEemz8qUl1H9gFg" x="-9" y="-19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs_irFEemz8qUl1H9gFg" x="-9" y="-12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_PnBs8SrFEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_7d1u8Cq1Eemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PnBs8irFEemz8qUl1H9gFg" points="[1224, 466, -643984, -643984]$[1224, 520, -643984, -643984]$[1392, 520, -643984, -643984]$[1392, 616, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PnBs8irFEemz8qUl1H9gFg" points="[1272, 466, -643984, -643984]$[1272, 552, -643984, -643984]$[1480, 552, -643984, -643984]$[1480, 616, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNCrFEemz8qUl1H9gFg" id="(0.8309178743961353,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNSrFEemz8qUl1H9gFg" id="(0.4970873786407767,0.0)"/>
     </edges>
@@ -15694,7 +15816,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_WlYskSrNEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_WdWK4CrNEemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WlYskirNEemz8qUl1H9gFg" points="[1256, 906, -643984, -643984]$[1256, 952, -643984, -643984]$[984, 952, -643984, -643984]$[984, 1008, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WlYskirNEemz8qUl1H9gFg" points="[1120, 906, -643984, -643984]$[1120, 952, -643984, -643984]$[848, 952, -643984, -643984]$[848, 1008, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvLhwCrNEemz8qUl1H9gFg" id="(0.20194174757281552,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvLhwSrNEemz8qUl1H9gFg" id="(0.49502982107355864,0.0)"/>
     </edges>
@@ -15725,7 +15847,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_XRKNcSrNEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_XIbvQCrNEemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XRKNcirNEemz8qUl1H9gFg" points="[1658, 906, -643984, -643984]$[1658, 960, -643984, -643984]$[1626, 960, -643984, -643984]$[1626, 1008, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XRKNcirNEemz8qUl1H9gFg" points="[1522, 906, -643984, -643984]$[1522, 960, -643984, -643984]$[1490, 960, -643984, -643984]$[1490, 1008, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xaz4sCrNEemz8qUl1H9gFg" id="(0.512621359223301,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xaz4sSrNEemz8qUl1H9gFg" id="(0.5191387559808612,0.0)"/>
     </edges>
@@ -15756,9 +15878,37 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_X8LgYSrNEemz8qUl1H9gFg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_Xz3R4CrNEemz8qUl1H9gFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X8LgYirNEemz8qUl1H9gFg" points="[1544, 906, -643984, -643984]$[1544, 952, -643984, -643984]$[1776, 952, -643984, -643984]$[1776, 1008, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X8LgYirNEemz8qUl1H9gFg" points="[1408, 906, -643984, -643984]$[1408, 952, -643984, -643984]$[1640, 952, -643984, -643984]$[1640, 1008, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YGn10CrNEemz8qUl1H9gFg" id="(0.8388349514563107,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YGn10SrNEemz8qUl1H9gFg" id="(0.5045045045045045,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CGEe4C7iEem3g99vIRtESQ" type="Comment_AnnotatedElementEdge" source="_AYjNIC7iEem3g99vIRtESQ" target="_Mu0JsCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CGEe4S7iEem3g99vIRtESQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CGEe4i7iEem3g99vIRtESQ" points="[565, 175, -643984, -643984]$[99, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IreFkC7iEem3g99vIRtESQ" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CGG7IC7iEem3g99vIRtESQ" id="(0.4409937888198758,0.18823529411764706)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EIY78C7iEem3g99vIRtESQ" type="Comment_AnnotatedElementEdge" source="__AjfcC7hEem3g99vIRtESQ" target="_NHz4gCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EIY78S7iEem3g99vIRtESQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EIY78i7iEem3g99vIRtESQ" points="[572, 192, -643984, -643984]$[174, 129, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L_MgIC7iEem3g99vIRtESQ" id="(0.0,0.55)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIaxIC7iEem3g99vIRtESQ" id="(0.2774566473988439,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FjUB0C7iEem3g99vIRtESQ" type="Comment_AnnotatedElementEdge" source="_9eqO4C7hEem3g99vIRtESQ" target="_Nedd8CrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FjUB0S7iEem3g99vIRtESQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FjUB0i7iEem3g99vIRtESQ" points="[578, 202, -643984, -643984]$[286, 129, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OBg9MC7iEem3g99vIRtESQ" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FjV3AC7iEem3g99vIRtESQ" id="(0.5402298850574713,0.7520661157024794)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_G5-50C7iEem3g99vIRtESQ" type="Comment_AnnotatedElementEdge" source="_75zJ4C7hEem3g99vIRtESQ" target="_N51LUCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G5-50S7iEem3g99vIRtESQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5-50i7iEem3g99vIRtESQ" points="[523, 222, -643984, -643984]$[361, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P7hLwC7iEem3g99vIRtESQ" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6AH8C7iEem3g99vIRtESQ" id="(0.5195530726256983,0.7964071856287425)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -1199,7 +1199,15 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bcvI8iD8EemsM5ohGqY7Gw" x="237" y="-134"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <children xmi:type="notation:Shape" xmi:id="_XLT_wCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XLT_wSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XLT_wyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XLT_wiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_dPf-21dMEeejsLaQeGcDdg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJlFgIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
       <owner xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
@@ -2266,6 +2274,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bcyMQyD8EemsM5ohGqY7Gw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bcyMRCD8EemsM5ohGqY7Gw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bcyMRSD8EemsM5ohGqY7Gw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XLT_xCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_XLT_wCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XLT_xSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XLT_ySqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XLT_xiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLT_xyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XLT_yCqvEemz8qUl1H9gFg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_LeWqMHMLEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamDetails" measurementUnit="Pixel">
@@ -4333,7 +4351,23 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_80BTMiD7EemsM5ohGqY7Gw" x="748" y="-471"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <children xmi:type="notation:Shape" xmi:id="_hEdhECqtEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hEdhESqtEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hEeIICqtEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hEdhEiqtEemz8qUl1H9gFg" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MfD4cCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MfEfgCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MfEfgiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MfEfgSqvEemz8qUl1H9gFg" x="748" y="-471"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_LeXWvXMLEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJ-HEIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
       <owner xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
@@ -4871,9 +4905,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_9bSJ8Yt-Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9bSJ8ot-Eeiu6boZkiJHCA" points="[-22, -180, -643984, -643984]$[190, -180, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u0PyoIt_Eeiu6boZkiJHCA" id="(0.9896551724137931,0.6857142857142857)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-6t8YIt-Eeiu6boZkiJHCA" id="(0.0,0.30198019801980197)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9bSJ8ot-Eeiu6boZkiJHCA" points="[-20, -184, -643984, -643984]$[191, -184, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u0PyoIt_Eeiu6boZkiJHCA" id="(1.0,0.6571428571428571)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-6t8YIt-Eeiu6boZkiJHCA" id="(0.0,0.28217821782178215)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9c3eVIt-Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_9bSJ8It-Eeiu6boZkiJHCA" target="_9c3eUIt-Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_9c3eVYt-Eeiu6boZkiJHCA"/>
@@ -5342,6 +5376,26 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_80BTNiD7EemsM5ohGqY7Gw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_80BTNyD7EemsM5ohGqY7Gw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_80BTOCD7EemsM5ohGqY7Gw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hEevMCqtEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_hEdhECqtEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hEevMSqtEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hEfWQiqtEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hEevMiqtEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hEfWQCqtEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hEfWQSqtEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MfEfgyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_MfD4cCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MfEfhCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MfFGkCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MfEfhSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MfEfhiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MfEfhyqvEemz8qUl1H9gFg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_QUOkQHMcEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamJobDetails" measurementUnit="Pixel">
@@ -9917,6 +9971,5794 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5srEQsWUEeiWCKGKl1wb8w" points="[-32, -116, -643984, -643984]$[-32, 48, -643984, -643984]$[-186, 48, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VWSQMWUEeiWCKGKl1wb8w" id="(0.5348837209302325,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VWSQcWUEeiWCKGKl1wb8w" id="(1.0,0.8448275862068966)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_bJ5VMCqvEemz8qUl1H9gFg" type="PapyrusUMLClassDiagram" name="OamLldpSkeleton" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_bJ5VMSqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5VMiqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5VMyqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5VNCqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5VNSqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VNiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5VNyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5VOCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VOSqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5VOiqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VOyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5VPCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5VPSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VPiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5VPyqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VQCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5VQSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5VQiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VQyqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VbSqvEemz8qUl1H9gFg" x="-309" y="20" width="124" height="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5VbiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VbyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5VcCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VgSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5VgiqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5VgyqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5VhCqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5VhSqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5VhiqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VhyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ViCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ViSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ViiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ViyqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VjCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5VjSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5VjiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VjyqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5VkCqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VkSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5VkiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5VkyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VlCqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5VviqvEemz8qUl1H9gFg" x="-455" y="-148" width="246" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5VvyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5VwCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5VwSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5V0iqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5V0yqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5V1CqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5V1SqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5V1iqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5V1yqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5V2CqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5V2SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5V2iqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5V2yqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5V3CqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5V3SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5V3iqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5V3yqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5V4CqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5V4SqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5V4iqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5V4yqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5V5CqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5V5SqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WDyqvEemz8qUl1H9gFg" x="-470" y="20" width="120" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WECqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WESqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WEiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WIyqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WJCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WJSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WJiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WJyqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WKCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WKSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WKiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WKyqvEemz8qUl1H9gFg" x="588" y="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WLCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WLSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WLiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WLyqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WMCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WMSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WMiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WMyqvEemz8qUl1H9gFg" x="431" y="-1"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WNCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WNSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WNiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WNyqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WOCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WOSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WOiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WOyqvEemz8qUl1H9gFg" x="656" y="45"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WPCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WPSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WPiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WPyqvEemz8qUl1H9gFg" x="802" y="80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WQCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WQSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WQiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WQyqvEemz8qUl1H9gFg" x="591" y="193"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WRCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WRSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WRiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WRyqvEemz8qUl1H9gFg" x="726" y="142"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WSCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WSSqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WSiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WSyqvEemz8qUl1H9gFg" x="588" y="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WTCqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5WTSqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5WTiqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5WTyqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5WUCqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WUSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5WUiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5WUyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WVCqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5WVSqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WViqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5WVyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5WWCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WWSqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5WWiqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WWyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5WXCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5WXSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WXiqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WiCqvEemz8qUl1H9gFg" x="-361" y="-529" width="552" height="68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WiSqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WiiqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WiyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WnCqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WnSqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WniqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WnyqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WoCqvEemz8qUl1H9gFg" x="347" y="134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WoSqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WoiqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5WoyqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WpCqvEemz8qUl1H9gFg" x="349" y="2"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5WpSqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5WpiqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5WpyqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5WqCqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5WqSqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WqiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5WqyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5WrCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WrSqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5WriqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WryqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5WsCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5WsSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WsiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5WsyqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5WtCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5WtSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5WtiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5WtyqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5W4SqvEemz8qUl1H9gFg" x="-301" y="-317" width="195" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5W4iqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5W4yqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5W5CqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5W9SqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5W9iqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5W9yqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5W-CqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5W-SqvEemz8qUl1H9gFg" x="577" y="-546"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5W-iqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5W-yqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5W_CqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5W_SqvEemz8qUl1H9gFg" x="189" y="-294"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5W_iqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5W_yqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XACqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XASqvEemz8qUl1H9gFg" x="320" y="-545"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XAiqvEemz8qUl1H9gFg" type="Interface_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5XAyqvEemz8qUl1H9gFg" type="Interface_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5XBCqvEemz8qUl1H9gFg" type="Interface_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5XBSqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5XBiqvEemz8qUl1H9gFg" type="Interface_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XByqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5XCCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5XCSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XCiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5XCyqvEemz8qUl1H9gFg" visible="false" type="Interface_OperationCompartment">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bJ5XDCqvEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bJ5XDSqvEemz8qUl1H9gFg" key="visible" value="true"/>
+        </eAnnotations>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XDiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5XDyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5XECqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XESqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5XEiqvEemz8qUl1H9gFg" visible="false" type="Interface_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XEyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5XFCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5XFSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XFiqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XLSqvEemz8qUl1H9gFg" x="-487" y="-310" width="134" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XLiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XLyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XMCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XOSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XOiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XOyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XPCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XPSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XPiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XPyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XQCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XQSqvEemz8qUl1H9gFg" x="113" y="-402"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XQiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XQyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XRCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XRSqvEemz8qUl1H9gFg" x="49" y="-541"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XRiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XRyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XSCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XSSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XSiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XSyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XTCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XTSqvEemz8qUl1H9gFg" x="91" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XTiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XTyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XUCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XUSqvEemz8qUl1H9gFg" x="-1" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XUiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XUyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XVCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XVSqvEemz8qUl1H9gFg" x="463" y="-299"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XViqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XVyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XWCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XWSqvEemz8qUl1H9gFg" x="669" y="-298"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XWiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XWyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XXCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XXSqvEemz8qUl1H9gFg" x="771" y="-295"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XXiqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5XXyqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5XYCqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5XYSqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5XYiqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XYyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5XZCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5XZSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XZiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5XZyqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XaCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5XaSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5XaiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XayqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5XbCqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XbSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5XbiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5XbyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XcCqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XsSqvEemz8qUl1H9gFg" x="-527" y="-408" width="116" height="45"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5XsiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5XsyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5XtCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5XzyqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5X0CqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5X0SqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5X0iqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5X2SqvEemz8qUl1H9gFg" x="329" y="-547"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5X2iqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5X2yqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5X3CqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5X3SqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5X3iqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5X3yqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5X4CqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5X4SqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5X4iqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5X4yqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5X5CqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5X5SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5X5iqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5X5yqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5X6CqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5X6SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5X6iqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5X6yqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5X7CqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YFiqvEemz8qUl1H9gFg" x="-187" y="-145" width="172" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YFyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YGCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YGSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YKiqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YKyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YLCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YLSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YLiqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YLyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YMCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YMSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YMiqvEemz8qUl1H9gFg" x="529" y="-152"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YMyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YNCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YNSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YNiqvEemz8qUl1H9gFg" x="534" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YNyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YOCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YOSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YOiqvEemz8qUl1H9gFg" x="534" y="-296"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YOyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YPCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YPSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YPiqvEemz8qUl1H9gFg" x="449" y="-320"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YPyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YQCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YQSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YQiqvEemz8qUl1H9gFg" x="449" y="-420"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YQyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YRCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YRSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YRiqvEemz8qUl1H9gFg" x="515" y="-451"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YRyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YSCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YSSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YSiqvEemz8qUl1H9gFg" x="515" y="-551"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YSyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YTCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YTSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YTiqvEemz8qUl1H9gFg" x="509" y="-155"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YTyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YUCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YUSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YUiqvEemz8qUl1H9gFg" x="519" y="-188"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YUyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YVCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YVSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YViqvEemz8qUl1H9gFg" x="519" y="-288"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YVyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YWCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YWSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YWiqvEemz8qUl1H9gFg" x="449" y="-320"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YWyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YXCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YXSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YXiqvEemz8qUl1H9gFg" x="449" y="-420"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YXyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YYCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YYSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YYiqvEemz8qUl1H9gFg" x="515" y="-451"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YYyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YZCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YZSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YZiqvEemz8qUl1H9gFg" x="515" y="-551"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YZyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YaCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YaSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YaiqvEemz8qUl1H9gFg" x="608" y="-149"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YayqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YbCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YbSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YbiqvEemz8qUl1H9gFg" x="618" y="-182"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YbyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YcCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YcSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YciqvEemz8qUl1H9gFg" x="618" y="-282"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YcyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YdCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YdSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YdiqvEemz8qUl1H9gFg" x="548" y="-314"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YdyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YeCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YeSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YeiqvEemz8qUl1H9gFg" x="548" y="-414"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YeyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YfCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YfSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YfiqvEemz8qUl1H9gFg" x="614" y="-445"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YfyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YgCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YgSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YgiqvEemz8qUl1H9gFg" x="614" y="-545"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YgyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YhCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YhSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YhiqvEemz8qUl1H9gFg" x="608" y="-149"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YhyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YiCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YiSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YiiqvEemz8qUl1H9gFg" x="618" y="-182"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YiyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YjCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YjSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YjiqvEemz8qUl1H9gFg" x="618" y="-282"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YjyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YkCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YkSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YkiqvEemz8qUl1H9gFg" x="548" y="-314"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YkyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YlCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YlSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YliqvEemz8qUl1H9gFg" x="548" y="-414"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YlyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YmCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YmSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YmiqvEemz8qUl1H9gFg" x="614" y="-445"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YmyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YnCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YnSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YniqvEemz8qUl1H9gFg" x="614" y="-545"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YnyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YoCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YoSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YoiqvEemz8qUl1H9gFg" x="289" y="-11"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YoyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YpCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YpSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YpiqvEemz8qUl1H9gFg" x="469" y="-50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YpyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YqCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YqSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YqiqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YqyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YrCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YrSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YriqvEemz8qUl1H9gFg" x="-266" y="189"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YryqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YsCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YsSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YsiqvEemz8qUl1H9gFg" x="-264" y="295"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YsyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YtCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YtSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YtiqvEemz8qUl1H9gFg" x="-264" y="195"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YtyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YuCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YuSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YuiqvEemz8qUl1H9gFg" x="289" y="-11"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YuyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YvCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YvSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YviqvEemz8qUl1H9gFg" x="469" y="-50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YvyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YwCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YwSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YwiqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YwyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YxCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YxSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YxiqvEemz8qUl1H9gFg" x="-266" y="189"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YxyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YyCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YySqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YyiqvEemz8qUl1H9gFg" x="-266" y="189"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YyyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5YzCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5YzSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5YziqvEemz8qUl1H9gFg" x="-266" y="189"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5YzyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y0CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y0SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y0iqvEemz8qUl1H9gFg" x="-266" y="189"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y0yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y1CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y1SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y1iqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y1yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y2CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y2SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y2iqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y2yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y3CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y3SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y3iqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y3yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y4CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y4SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y4iqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y4yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y5CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y5SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y5iqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y5yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y6CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y6SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y6iqvEemz8qUl1H9gFg" x="-266" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y6yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y7CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y7SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y7iqvEemz8qUl1H9gFg" x="289" y="-11"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y7yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y8CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y8SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y8iqvEemz8qUl1H9gFg" x="469" y="-50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y8yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y9CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y9SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y9iqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y9yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y-CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y-SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y-iqvEemz8qUl1H9gFg" x="491" y="-524"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y-yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5Y_CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5Y_SqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5Y_iqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5Y_yqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5ZACqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5ZASqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5ZAiqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ZAyqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZBCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ZBSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ZBiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZByqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ZCCqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZCSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ZCiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ZCyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZDCqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ZDSqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZDiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ZDyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ZECqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZESqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZRiqvEemz8qUl1H9gFg" x="117" y="-317" width="134" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5ZRyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZSCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5ZSSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZXiqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5ZXyqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5ZYCqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5ZYSqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5ZYiqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ZYyqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZZCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ZZSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ZZiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZZyqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ZaCqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZaSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ZaiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ZayqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZbCqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ5ZbSqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZbiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ5ZbyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ5ZcCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZcSqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ5ZpiqvEemz8qUl1H9gFg" x="-85" y="-317" width="180" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ5ZpyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ5ZqCqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5ZqSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58QCqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58QSqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ58QiqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ58QyqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ58RCqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ58RSqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58RiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ58RyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ58SCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58SSqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ58SiqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58SyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ58TCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ58TSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58TiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ58TyqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58UCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ58USqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ58UiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58UyqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58fSqvEemz8qUl1H9gFg" x="37" y="-134" width="128" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58fiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58fyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58gCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58gSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58giqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58gyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58hCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58hSqvEemz8qUl1H9gFg" x="206" y="-174"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58hiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58hyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58iCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58iSqvEemz8qUl1H9gFg" x="206" y="-174"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58iiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58iyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58jCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58jSqvEemz8qUl1H9gFg" x="206" y="-174"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58jiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58jyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58kCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58kSqvEemz8qUl1H9gFg" x="206" y="-174"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58kiqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58kyqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58lCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58lSqvEemz8qUl1H9gFg" x="206" y="-174"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58liqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ58lyqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ58mCqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ58mSqvEemz8qUl1H9gFg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ58miqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58myqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ58nCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ58nSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58niqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ58nyqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58oCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ58oSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ58oiqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58oyqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bJ58pCqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58pSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bJ58piqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJ58pyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58qCqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ580iqvEemz8qUl1H9gFg" x="-24" y="-45" height="56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ580yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ581CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ581SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ585iqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ585yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ586CqvEemz8qUl1H9gFg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ586SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ586iqvEemz8qUl1H9gFg" x="237" y="-161"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ586yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ587CqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ587SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ587iqvEemz8qUl1H9gFg" x="237" y="-161"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ587yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ588CqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ588SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ589iqvEemz8qUl1H9gFg" x="-161" y="-591"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ589yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ58-CqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ58-SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ58_iqvEemz8qUl1H9gFg" x="-161" y="-591"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ58_yqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59ACqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59ASqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59BiqvEemz8qUl1H9gFg" x="-161" y="-591"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59ByqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59CCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59CSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59DiqvEemz8qUl1H9gFg" x="-161" y="-591"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59DyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59ECqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59ESqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59FiqvEemz8qUl1H9gFg" x="-101" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59FyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59GCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59GSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59HiqvEemz8qUl1H9gFg" x="-101" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59HyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59ICqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59ISqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59JiqvEemz8qUl1H9gFg" x="115" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59JyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59KCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59KSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59LiqvEemz8qUl1H9gFg" x="115" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59LyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59MCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59MSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59NiqvEemz8qUl1H9gFg" x="-255" y="-275"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59NyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59OCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59OSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59PiqvEemz8qUl1H9gFg" x="-255" y="-275"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59PyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59QCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59QSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59QiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59QyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59RCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59RSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59RiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59RyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59SCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59SSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59SiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59SyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59TCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59TSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59TiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59TyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59UCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59USqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59UiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59UyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59VCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59VSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59ViqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59VyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59WCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59WSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59WiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59WyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59XCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59XSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59XiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59XyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59YCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59YSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59YiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59YyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59ZCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59ZSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59ZiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59ZyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59aCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59aSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59aiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59ayqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59bCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59bSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59biqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59byqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59cCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59cSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59ciqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bJ59cyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bJ59dCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59dSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJ59diqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fNxaUCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fNxaUSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fNxaUyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fNxaUiqvEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4FRfYCqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4FTUkCqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4FTUkSqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4FT7oCqvEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4FT7oSqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4FT7oiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4FT7oyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4FT7pCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4FT7pSqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4FT7piqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4FT7pyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4FT7qCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4FT7qSqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4FT7qiqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4FT7qyqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4FT7rCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4FT7rSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4FT7riqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4FT7ryqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDnXECquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4FRfYSqvEemz8qUl1H9gFg" x="707" y="-400" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4FlocyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4FlodCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4FmPgCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDnXECquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4FlodSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7k5n8CqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7k6PACqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7k62ECqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7k62ESqvEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7k7dICqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7k7dISqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7k7dIiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7k7dIyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7k7dJCqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7k7dJSqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7k7dJiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7k7dJyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7k7dKCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7k7dKSqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7k7dKiqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7k7dKyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7k7dLCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7k8EMCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7k8EMSqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7k5n8SqvEemz8qUl1H9gFg" x="408" y="-232" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7lO_ICqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7lO_ISqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7lO_IyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7lO_IiqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9pLz4CqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9pMa8CqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9pMa8SqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9pMa8iqvEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9pMa8yqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9pMa9CqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9pMa9SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9pMa9iqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9pMa9yqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9pMa-CqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9pMa-SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9pMa-iqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9pMa-yqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9pMa_CqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9pMa_SqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9pMa_iqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9pMa_yqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9pMbACqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9pMbASqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDv58CquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9pLz4SqvEemz8qUl1H9gFg" x="597" y="-232" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9pcSkCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9pcSkSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9pcSkyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDv58CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9pcSkiqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-kmTQCqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-km6UCqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-km6USqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-km6UiqvEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-km6UyqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-km6VCqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-km6VSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-km6ViqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-km6VyqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-km6WCqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-km6WSqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-km6WiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-km6WyqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-km6XCqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-km6XSqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-km6XiqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-km6XyqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-km6YCqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-km6YSqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hD0LYCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-kmTQSqvEemz8qUl1H9gFg" x="768" y="-232" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-kzHkCqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-kzHkSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-kzHkyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hD0LYCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-kzHkiqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__y0Z4CqvEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="__y0Z4iqvEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="__y0Z4yqvEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__y0Z5CqvEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__y0Z5SqvEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__y0Z5iqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__y0Z5yqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__y0Z6CqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__y0Z6SqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__y0Z6iqvEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__y0Z6yqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__y0Z7CqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__y0Z7SqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__y0Z7iqvEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__y0Z7yqvEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__y0Z8CqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__y0Z8SqvEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__y0Z8iqvEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__y0Z8yqvEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDh3gCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__y0Z4SqvEemz8qUl1H9gFg" x="1040" y="-232" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__zAnIyqvEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__zAnJCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__zAnJiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDh3gCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__zAnJSqvEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_C6HiACqwEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_C6IJECqwEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_C6IJESqwEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_C6IJEiqwEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_C6IJEyqwEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_C6IJFCqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_C6IJFSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_C6IJFiqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C6IJFyqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_C6IJGCqwEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_C6IJGSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_C6IJGiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_C6IJGyqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C6IJHCqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_C6IJHSqwEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_C6IJHiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_C6IJHyqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_C6IJICqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C6IJISqwEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C6HiASqwEemz8qUl1H9gFg" x="795" y="-48" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_C6U9YCqwEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_C6U9YSqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_C6U9YyqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C6U9YiqwEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DcCjUCqwEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DcDKYCqwEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DcDKYSqwEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DcDKYiqwEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DcDKYyqwEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DcDKZCqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DcDKZSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DcDKZiqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DcDKZyqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DcDKaCqwEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DcDKaSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DcDKaiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DcDKayqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DcDKbCqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DcDKbSqwEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DcDKbiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DcDKbyqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DcDKcCqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DcDKcSqwEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DcCjUSqwEemz8qUl1H9gFg" x="904" y="-48" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DcP-syqwEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DcP-tCqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DcP-tiqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DcP-tSqwEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EQ2EYCqwEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EQ2rcCqwEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EQ2rcSqwEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EQ2rciqwEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EQ2rcyqwEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EQ2rdCqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EQ2rdSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EQ2rdiqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EQ2rdyqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EQ2reCqwEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EQ2reSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EQ2reiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EQ2reyqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EQ2rfCqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EQ2rfSqwEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EQ2rfiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EQ2rfyqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EQ2rgCqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EQ2rgSqwEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EQ2EYSqwEemz8qUl1H9gFg" x="1016" y="-48" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EREt4yqwEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EREt5CqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EREt5iqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EREt5SqwEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TFwqMCqwEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_TFxRQCqwEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TFxRQSqwEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TFxRQiqwEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TFxRQyqwEemz8qUl1H9gFg" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TFxRRCqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TFxRRSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TFxRRiqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TFxRRyqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TFxRSCqwEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TFxRSSqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TFxRSiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TFxRSyqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TFxRTCqwEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TFxRTSqwEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TFxRTiqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TFxRTyqwEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TFxRUCqwEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TFxRUSqwEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TFwqMSqwEemz8qUl1H9gFg" x="616" y="-48" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TF-soCqwEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_TF-soSqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TF-soyqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TF-soiqwEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tKpIYCqwEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tKpIYSqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tKpIYyqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_jkjX4CqwEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tKpIYiqwEemz8qUl1H9gFg" x="838" y="-498"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_W2qooCqzEemz8qUl1H9gFg" type="Signal_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_W2rPsCqzEemz8qUl1H9gFg" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_W2rPsSqzEemz8qUl1H9gFg" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_W2rPsiqzEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_W2rPsyqzEemz8qUl1H9gFg" visible="false" type="Signal_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_W2rPtCqzEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_W2rPtSqzEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_W2rPtiqzEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W2rPtyqzEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Signal" href="TapiOam.uml#_1ivtsCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W2qooSqzEemz8qUl1H9gFg" x="397" y="-48" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_W2214CqzEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_W2214SqzEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W2214yqzEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiOam.uml#_1ivtsCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W2214iqzEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VUxsMCrAEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_VUxsMSrAEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VUxsMyrAEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ULiMMCrAEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUxsMirAEemz8qUl1H9gFg" x="896" y="-332"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_m5SZ4yrCEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_m5SZ5CrCEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_m5SZ5irCEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_keOssCrCEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m5SZ5SrCEemz8qUl1H9gFg" x="597" y="-148"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tos4MCrCEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tos4MSrCEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tos4MyrCEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_sgTswCrCEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tos4MirCEemz8qUl1H9gFg" x="907" y="-500"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q3LAMCrMEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_q3LAMSrMEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q3LnQCrMEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3LAMirMEemz8qUl1H9gFg" x="237" y="-134"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_bJ59dyqvEemz8qUl1H9gFg" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_bJ59eCqvEemz8qUl1H9gFg"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_bJ59eSqvEemz8qUl1H9gFg" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59eiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5VMSqvEemz8qUl1H9gFg" target="_bJ5VbiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59eyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59fCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59fSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59fiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59fyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59gCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5VgiqvEemz8qUl1H9gFg" target="_bJ5VvyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59gSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59giqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59gyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59hCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59hSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59hiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5V0yqvEemz8qUl1H9gFg" target="_bJ5WECqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59hyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59iCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59iSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59iiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59iyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59jCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WJCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59jSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59jiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59jyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59kCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59kSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59kiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WKCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59kyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59lCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59lSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59liqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59lyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59mCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WLCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59mSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59miqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59myqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59nCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59nSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59niqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WMCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59nyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59oCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59oSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59oiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59oyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59pCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WNCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59pSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59piqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59pyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59qCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59qSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59qiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WOCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59qyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59rCqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59rSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59riqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59ryqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59sCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5WPCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59sSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59siqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59syqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59tCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59tSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59tiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5WiSqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59tyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59uCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59uSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59uiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59uyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59vCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5WpSqvEemz8qUl1H9gFg" target="_bJ5W4iqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59vSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59viqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59vyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59wCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59wSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59wiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5XAiqvEemz8qUl1H9gFg" target="_bJ5XLiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59wyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59xCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59xSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59xiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59xyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59yCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XOiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59ySqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ59yiqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ59yyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59zCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ59zSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59ziqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XPiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ59zyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ590CqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ590SqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ590iqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ590yqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ591CqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XRiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ591SqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ591iqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ591yqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ592CqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ592SqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ592iqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XSiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ592yqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ593CqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ593SqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ593iqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ593yqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ594CqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XTiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ594SqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ594iqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ594yqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ595CqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ595SqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ595iqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XUiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ595yqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ596CqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ596SqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ596iqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ596yqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ597CqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5XViqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ597SqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ597iqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ597yqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ598CqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ598SqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ598iqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5XXiqvEemz8qUl1H9gFg" target="_bJ5XsiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ598yqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ599CqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ599SqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ599iqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ599yqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ59-CqvEemz8qUl1H9gFg" type="Abstraction_Edge" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5XXiqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ59-SqvEemz8qUl1H9gFg" type="Abstraction_NameLabel">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bJ59-iqvEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bJ59-yqvEemz8qUl1H9gFg" key="visible" value="true"/>
+        </eAnnotations>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ59_CqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ59_SqvEemz8qUl1H9gFg" x="-25" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ59_iqvEemz8qUl1H9gFg" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ59_yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-ACqvEemz8qUl1H9gFg" x="-43" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-ASqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:StringValueStyle" xmi:id="_bJ5-AiqvEemz8qUl1H9gFg" name="sourceDecoration" stringValue="default"/>
+      <element xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-BiqvEemz8qUl1H9gFg" points="[-361, -496, -643984, -643984]$[-496, -496, -643984, -643984]$[-496, -408, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-ByqvEemz8qUl1H9gFg" id="(0.0,0.4852941176470588)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-CCqvEemz8qUl1H9gFg" id="(0.2672413793103448,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-CSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ59-CqvEemz8qUl1H9gFg" target="_bJ5X0CqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-CiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-CyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-DCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-DSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-DiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-DyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5X2iqvEemz8qUl1H9gFg" target="_bJ5YFyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-ECqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-ESqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-EiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-EyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-FCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-FSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5YKyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-FiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-FyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-GCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-GSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-GiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-GyqvEemz8qUl1H9gFg" type="InterfaceRealization_Edge" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5XAiqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-HCqvEemz8qUl1H9gFg" type="InterfaceRealization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-HSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-HiqvEemz8qUl1H9gFg" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-HyqvEemz8qUl1H9gFg" type="InterfaceRealization_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-ICqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-ISqvEemz8qUl1H9gFg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-IiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:StringValueStyle" xmi:id="_bJ5-IyqvEemz8qUl1H9gFg" name="sourceDecoration" stringValue="default"/>
+      <element xmi:type="uml:InterfaceRealization" href="TapiOam.uml#_ojz6oFrnEeexvMtO2oNM9g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-JCqvEemz8qUl1H9gFg" points="[-361, -472, -643984, -643984]$[-400, -472, -643984, -643984]$[-400, -310, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-JSqvEemz8qUl1H9gFg" id="(0.0,0.8382352941176471)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-JiqvEemz8qUl1H9gFg" id="(0.6492537313432836,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-JyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5Y8yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-KCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-KSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-KiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-KyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-LCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-LSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5Y9yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-LiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-LyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-MCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-MSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-MiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-MyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ5Y-yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-NCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-NSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-NiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-NyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-OCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-OSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5Y_yqvEemz8qUl1H9gFg" target="_bJ5ZRyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-OiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-OyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-PCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-PSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-PiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-PyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5ZXyqvEemz8qUl1H9gFg" target="_bJ5ZpyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-QCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-QSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-QiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-QyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-RCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-RSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-RiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-RyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-SCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-SSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-SiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-SyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" target="_bJ58fiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-TCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-TSqvEemz8qUl1H9gFg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-TiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-TyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-UCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-USqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ58giqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-UiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-UyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-VCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-VSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-ViqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-VyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ58hiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-WCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-WSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-WiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-WyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-XCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-XSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ58iiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-XiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-XyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-YCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-YSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-YiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-YyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ58jiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-ZCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-ZSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-ZiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-ZyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-aCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-aSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ58kiqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-aiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-ayqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-bCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-bSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-biqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-byqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58liqvEemz8qUl1H9gFg" target="_bJ580yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-cCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-cSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-ciqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-cyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-dCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-dSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ585yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-diqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-dyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-eCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-eSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-eiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-eyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ586yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-fCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-fSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-fiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-fyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-gCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-gSqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5VgiqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-giqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-gyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-hCqvEemz8qUl1H9gFg" x="-97" y="-4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-hSqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-hiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-hyqvEemz8qUl1H9gFg" x="-114"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-iCqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-iSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-iiqvEemz8qUl1H9gFg" x="37" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-iyqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-jCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-jSqvEemz8qUl1H9gFg" x="-37" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-jiqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-jyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-kCqvEemz8qUl1H9gFg" x="10" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-kSqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-kiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-kyqvEemz8qUl1H9gFg" x="-12" y="17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-lCqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-mCqvEemz8qUl1H9gFg" points="[-112, -423, -643984, -643984]$[-308, -175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-mSqvEemz8qUl1H9gFg" id="(0.05253623188405797,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-miqvEemz8qUl1H9gFg" id="(0.5,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-myqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5-gSqvEemz8qUl1H9gFg" target="_bJ587yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-nCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-nSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-niqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-nyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-oCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-oSqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5WpSqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-oiqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-oyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-pCqvEemz8qUl1H9gFg" x="-16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-pSqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-piqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-pyqvEemz8qUl1H9gFg" x="-31" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-qCqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-qSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-qiqvEemz8qUl1H9gFg" x="16" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-qyqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-rCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-rSqvEemz8qUl1H9gFg" x="-16" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-riqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-ryqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-sCqvEemz8qUl1H9gFg" x="12" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-sSqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-siqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-syqvEemz8qUl1H9gFg" x="-12" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-tCqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-uCqvEemz8qUl1H9gFg" points="[-200, -461, -643984, -643984]$[-200, -317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-uSqvEemz8qUl1H9gFg" id="(0.2916666666666667,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-uiqvEemz8qUl1H9gFg" id="(0.517948717948718,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-uyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5-oSqvEemz8qUl1H9gFg" target="_bJ589yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-vCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-vSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-viqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-vyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-wCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-wSqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5ZXyqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-wiqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-wyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-xCqvEemz8qUl1H9gFg" x="-20" y="3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-xSqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-xiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-xyqvEemz8qUl1H9gFg" x="-35" y="3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-yCqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-ySqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-yiqvEemz8qUl1H9gFg" x="16" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-yyqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-zCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-zSqvEemz8qUl1H9gFg" x="-16" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-ziqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-zyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-0CqvEemz8qUl1H9gFg" x="12" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-0SqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-0iqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-0yqvEemz8qUl1H9gFg" x="-12" y="-15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-1CqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-2CqvEemz8qUl1H9gFg" points="[-40, -461, -643984, -643984]$[-40, -317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-2SqvEemz8qUl1H9gFg" id="(0.5815217391304348,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-2iqvEemz8qUl1H9gFg" id="(0.25,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-2yqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5-wSqvEemz8qUl1H9gFg" target="_bJ58_yqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-3CqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-3SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-3iqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-3yqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-4CqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5-4SqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5WTCqvEemz8qUl1H9gFg" target="_bJ5Y_yqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-4iqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-4yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-5CqvEemz8qUl1H9gFg" x="-24" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-5SqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-5iqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-5yqvEemz8qUl1H9gFg" x="-35" y="6"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-6CqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-6SqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-6iqvEemz8qUl1H9gFg" x="16" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-6yqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-7CqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-7SqvEemz8qUl1H9gFg" x="-16" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-7iqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-7yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-8CqvEemz8qUl1H9gFg" x="12" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5-8SqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5-8iqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5-8yqvEemz8qUl1H9gFg" x="-10" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-9CqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5--CqvEemz8qUl1H9gFg" points="[176, -461, -643984, -643984]$[176, -317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5--SqvEemz8qUl1H9gFg" id="(0.9728260869565217,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5--iqvEemz8qUl1H9gFg" id="(0.44029850746268656,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5--yqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5-4SqvEemz8qUl1H9gFg" target="_bJ59ByqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5-_CqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5-_SqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5-_iqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5-_yqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_ACqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_ASqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5Y_yqvEemz8qUl1H9gFg" target="_bJ5ZXyqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_AiqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_AyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_BCqvEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_BSqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_BiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_ByqvEemz8qUl1H9gFg" x="-2" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_CCqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_CSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_CiqvEemz8qUl1H9gFg" x="10" y="-1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_CyqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_DCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_DSqvEemz8qUl1H9gFg" x="-10" y="39"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_DiqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_DyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_ECqvEemz8qUl1H9gFg" x="8" y="-12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_ESqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_EiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_EyqvEemz8qUl1H9gFg" x="-10" y="-22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_FCqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_w25csIbmEeil5oKL3Vgl-g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_FSqvEemz8qUl1H9gFg" points="[159, -317, -643984, -643984]$[159, -344, -643984, -643984]$[25, -344, -643984, -643984]$[25, -317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_FiqvEemz8qUl1H9gFg" id="(0.31343283582089554,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_FyqvEemz8qUl1H9gFg" id="(0.6055555555555555,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_GCqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5WpSqvEemz8qUl1H9gFg" target="_bJ5VgiqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_GSqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_GiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_GyqvEemz8qUl1H9gFg" x="19" y="-1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_HCqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_HSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_HiqvEemz8qUl1H9gFg" x="4" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_HyqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_ICqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_ISqvEemz8qUl1H9gFg" x="11" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_IiqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_IyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_JCqvEemz8qUl1H9gFg" x="-14" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_JSqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_JiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_JyqvEemz8qUl1H9gFg" x="11" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_KCqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_KSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_KiqvEemz8qUl1H9gFg" x="-14" y="20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_KyqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_LyqvEemz8qUl1H9gFg" points="[-248, -259, -643984, -643984]$[-248, -148, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_MCqvEemz8qUl1H9gFg" id="(0.2717948717948718,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_MSqvEemz8qUl1H9gFg" id="(0.8414634146341463,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_MiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5_GCqvEemz8qUl1H9gFg" target="_bJ59DyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_MyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5_NCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_NSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_NiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_NyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_OCqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5WpSqvEemz8qUl1H9gFg" target="_bJ5X2iqvEemz8qUl1H9gFg" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_OSqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_OiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_OyqvEemz8qUl1H9gFg" x="-9" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_PCqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_PSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_PiqvEemz8qUl1H9gFg" x="-23" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_PyqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_QCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_QSqvEemz8qUl1H9gFg" x="13" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_QiqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_QyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_RCqvEemz8qUl1H9gFg" x="-13" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_RSqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_RiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_RyqvEemz8qUl1H9gFg" x="13" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_SCqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_SSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_SiqvEemz8qUl1H9gFg" x="-15" y="19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_SyqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_TyqvEemz8qUl1H9gFg" points="[-183, -259, -643984, -643984]$[-122, -172, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_UCqvEemz8qUl1H9gFg" id="(0.8769230769230769,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_USqvEemz8qUl1H9gFg" id="(0.3313953488372093,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_UiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5_OCqvEemz8qUl1H9gFg" target="_bJ59FyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_UyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5_VCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_VSqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_ViqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_VyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_WCqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5ZXyqvEemz8qUl1H9gFg" target="_bJ58QSqvEemz8qUl1H9gFg" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bJ5_WSqvEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bJ5_WiqvEemz8qUl1H9gFg" key="lineColor" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_WyqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_XCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_XSqvEemz8qUl1H9gFg" x="-11" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_XiqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_XyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_YCqvEemz8qUl1H9gFg" x="-31" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_YSqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_YiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_YyqvEemz8qUl1H9gFg" x="15" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_ZCqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_ZSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_ZiqvEemz8qUl1H9gFg" x="-15" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_ZyqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_aCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_aSqvEemz8qUl1H9gFg" x="9" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_aiqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_ayqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_bCqvEemz8qUl1H9gFg" x="-15" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_bSqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_cSqvEemz8qUl1H9gFg" points="[21, -260, -643984, -643984]$[81, -161, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_ciqvEemz8qUl1H9gFg" id="(0.9111111111111111,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_cyqvEemz8qUl1H9gFg" id="(0.328125,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_dCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5_WCqvEemz8qUl1H9gFg" target="_bJ59HyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_dSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5_diqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_dyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_eCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_eSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_eiqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5ZXyqvEemz8qUl1H9gFg" target="_bJ58liqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_eyqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_fCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_fSqvEemz8qUl1H9gFg" x="-9" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_fiqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_fyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_gCqvEemz8qUl1H9gFg" x="-24" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_gSqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_giqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_gyqvEemz8qUl1H9gFg" x="28" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_hCqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_hSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_hiqvEemz8qUl1H9gFg" x="-28" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_hyqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_iCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_iSqvEemz8qUl1H9gFg" x="12" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_iiqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_iyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_jCqvEemz8qUl1H9gFg" x="-12" y="-18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_jSqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_kSqvEemz8qUl1H9gFg" points="[8, -260, -643984, -643984]$[8, -45, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_kiqvEemz8qUl1H9gFg" id="(0.5166666666666667,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_kyqvEemz8qUl1H9gFg" id="(0.32,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_lCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5_eiqvEemz8qUl1H9gFg" target="_bJ59JyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_lSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5_liqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_lyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_mCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_mSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_miqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5VgiqvEemz8qUl1H9gFg" target="_bJ5V0yqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_myqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_nCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_nSqvEemz8qUl1H9gFg" x="1" y="-57"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_niqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_nyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_oCqvEemz8qUl1H9gFg" x="-15" y="-52"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_oSqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_oiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_oyqvEemz8qUl1H9gFg" x="11" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_pCqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_pSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_piqvEemz8qUl1H9gFg" x="-11" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_pyqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_qCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_qSqvEemz8qUl1H9gFg" x="11" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_qiqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_qyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_rCqvEemz8qUl1H9gFg" x="-16" y="21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_rSqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_sSqvEemz8qUl1H9gFg" points="[-408, -87, -643984, -643984]$[-408, 20, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_siqvEemz8qUl1H9gFg" id="(0.1910569105691057,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_syqvEemz8qUl1H9gFg" id="(0.5166666666666667,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_tCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5_miqvEemz8qUl1H9gFg" target="_bJ59LyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_tSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5_tiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_tyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_uCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_uSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_uiqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5VgiqvEemz8qUl1H9gFg" target="_bJ5VMSqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_uyqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_vCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_vSqvEemz8qUl1H9gFg" x="6" y="-57"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_viqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_vyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_wCqvEemz8qUl1H9gFg" x="-10" y="-45"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_wSqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_wiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_wyqvEemz8qUl1H9gFg" x="11" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_xCqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_xSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_xiqvEemz8qUl1H9gFg" x="-11" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_xyqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_yCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_ySqvEemz8qUl1H9gFg" x="9" y="-14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_yiqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_yyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_zCqvEemz8qUl1H9gFg" x="-11" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_zSqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_0SqvEemz8qUl1H9gFg" points="[-257, -87, -643984, -643984]$[-257, 20, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_0iqvEemz8qUl1H9gFg" id="(0.8048780487804879,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_0yqvEemz8qUl1H9gFg" id="(0.41935483870967744,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_1CqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ5_uiqvEemz8qUl1H9gFg" target="_bJ59NyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_1SqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ5_1iqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_1yqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_2CqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_2SqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_2iqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5X2iqvEemz8qUl1H9gFg" target="_bJ5V0yqvEemz8qUl1H9gFg" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_2yqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_3CqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_3SqvEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_3iqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_3yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_4CqvEemz8qUl1H9gFg" x="-65" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_4SqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_4iqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_4yqvEemz8qUl1H9gFg" x="52" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_5CqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_5SqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_5iqvEemz8qUl1H9gFg" x="-52" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_5yqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_6CqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_6SqvEemz8qUl1H9gFg" x="13" y="22"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_6iqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_6yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_7CqvEemz8qUl1H9gFg" x="-17" y="-15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ5_7SqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_GTLxYD2kEeihCtCrhJZ45g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ5_7iqvEemz8qUl1H9gFg" points="[-104, -87, -643984, -643984]$[-104, 0, -643984, -643984]$[-320, 0, -643984, -643984]$[-320, 48, -643984, -643984]$[-350, 48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_7yqvEemz8qUl1H9gFg" id="(0.48255813953488375,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ5_8CqvEemz8qUl1H9gFg" id="(1.0,0.4827586206896552)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ5_8SqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5X2iqvEemz8qUl1H9gFg" target="_bJ5VMSqvEemz8qUl1H9gFg" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_8iqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_8yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_9CqvEemz8qUl1H9gFg" x="-1" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_9SqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_9iqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_9yqvEemz8qUl1H9gFg" x="18" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_-CqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5_-SqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5_-iqvEemz8qUl1H9gFg" x="33" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5_-yqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5__CqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ5__SqvEemz8qUl1H9gFg" x="-34" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ5__iqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ5__yqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AACqvEemz8qUl1H9gFg" x="10" y="-21"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AASqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AAiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AAyqvEemz8qUl1H9gFg" x="-12" y="-15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6ABCqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_-sPnoHMgEeeSiaQ95-6r9w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6ABSqvEemz8qUl1H9gFg" points="[-56, -87, -643984, -643984]$[-56, 48, -643984, -643984]$[-185, 48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ABiqvEemz8qUl1H9gFg" id="(0.7616279069767442,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AByqvEemz8qUl1H9gFg" id="(1.0,0.4666666666666667)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6ACCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59PyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6ACSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6ACiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6ACyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ADCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ADSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6ADiqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59QyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6ADyqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AECqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AESqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AEiqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AEyqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AFCqvEemz8qUl1H9gFg" type="Association_Edge" source="_bJ5Y_yqvEemz8qUl1H9gFg" target="_bJ5X2iqvEemz8qUl1H9gFg" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AFSqvEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AFiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AFyqvEemz8qUl1H9gFg" x="1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AGCqvEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AGSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AGiqvEemz8qUl1H9gFg" x="-73" y="97"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AGyqvEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AHCqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AHSqvEemz8qUl1H9gFg" x="62" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AHiqvEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AHyqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AICqvEemz8qUl1H9gFg" x="-65" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AISqvEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AIiqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AIyqvEemz8qUl1H9gFg" x="9" y="-23"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bJ6AJCqvEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bJ6AJSqvEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bJ6AJiqvEemz8qUl1H9gFg" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AJyqvEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_wd3s4JsXEeid4dfn4JFJZg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AKCqvEemz8qUl1H9gFg" points="[176, -259, -643984, -643984]$[176, -72, -643984, -643984]$[24, -72, -643984, -643984]$[24, -112, -643984, -643984]$[-15, -112, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AKSqvEemz8qUl1H9gFg" id="(0.44029850746268656,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AKiqvEemz8qUl1H9gFg" id="(1.0,0.5689655172413793)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AKyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59RyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6ALCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6ALSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6ALiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ALyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AMCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AMSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59SyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AMiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AMyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6ANCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ANSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ANiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6ANyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59TyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AOCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AOSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AOiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AOyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6APCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6APSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59UyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6APiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6APyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AQCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AQSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AQiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AQyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59VyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6ARCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6ARSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6ARiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ARyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ASCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6ASSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59WyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6ASiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6ASyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6ATCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ATSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6ATiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6ATyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59XyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AUCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AUSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AUiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AUyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AVCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AVSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59YyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AViqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AVyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AWCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AWSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AWiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AWyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59ZyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AXCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AXSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AXiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AXyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AYCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AYSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59ayqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AYiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AYyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AZCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AZSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AZiqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AZyqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59byqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AaCqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AaSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AaiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AayqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AbCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bJ6AbSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_bJ59cyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bJ6AbiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bJ6AbyqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bJ6AcCqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AcSqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ6AciqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fNxaVCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_fNxaUCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fNxaVSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fNyBYCqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fNxaViqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fNxaVyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fNxaWCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4FmPgSqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_4FRfYCqvEemz8qUl1H9gFg" target="_4FlocyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4FmPgiqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4FmPhiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDnXECquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4FmPgyqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4FmPhCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4FmPhSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7lO_JCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_7k5n8CqvEemz8qUl1H9gFg" target="_7lO_ICqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7lO_JSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7lPmMiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7lO_JiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7lPmMCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7lPmMSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9pcSlCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_9pLz4CqvEemz8qUl1H9gFg" target="_9pcSkCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9pcSlSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9pdgsiqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDv58CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9pcSliqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9pdgsCqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9pdgsSqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-kzHlCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_-kmTQCqvEemz8qUl1H9gFg" target="_-kzHkCqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-kzHlSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-kzHmSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hD0LYCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-kzHliqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-kzHlyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-kzHmCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__zBOMCqvEemz8qUl1H9gFg" type="StereotypeCommentLink" source="__y0Z4CqvEemz8qUl1H9gFg" target="__zAnIyqvEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="__zBOMSqvEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__zBONSqvEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDh3gCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__zBOMiqvEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__zBOMyqvEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__zBONCqvEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_C6U9ZCqwEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_C6HiACqwEemz8qUl1H9gFg" target="_C6U9YCqwEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_C6U9ZSqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_C6U9aSqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_C6U9ZiqwEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C6U9ZyqwEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C6U9aCqwEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DcP-tyqwEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_DcCjUCqwEemz8qUl1H9gFg" target="_DcP-syqwEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DcP-uCqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DcP-vCqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DcP-uSqwEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DcP-uiqwEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DcP-uyqwEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EREt5yqwEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_EQ2EYCqwEemz8qUl1H9gFg" target="_EREt4yqwEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EREt6CqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EREt7CqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EREt6SqwEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EREt6iqwEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EREt6yqwEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_TF-spCqwEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_TFwqMCqwEemz8qUl1H9gFg" target="_TF-soCqwEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_TF-spSqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TF_TsiqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TF-spiqwEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TF_TsCqwEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TF_TsSqwEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gVLR0CqwEemz8qUl1H9gFg" type="Association_Edge" source="_4FRfYCqvEemz8qUl1H9gFg" target="_7k5n8CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gVL44CqwEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ufy9cCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gVL44SqwEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gVL44iqwEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uiUF8CqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gVL44yqwEemz8qUl1H9gFg" x="-61" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gVL45CqwEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ukhFYCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gVL45SqwEemz8qUl1H9gFg" x="47" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gVL45iqwEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_unT6sCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gVL45yqwEemz8qUl1H9gFg" x="-46" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gVL46CqwEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_upQbcCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gVL46SqwEemz8qUl1H9gFg" x="9" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gVL46iqwEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ura-oCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gVL46yqwEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_gVLR0SqwEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_gS1vgCqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gVLR0iqwEemz8qUl1H9gFg" points="[675, -384, -643984, -643984]$[464, -384, -643984, -643984]$[464, -232, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZ4LoCqwEemz8qUl1H9gFg" id="(0.0,0.2807017543859649)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZ4ysCqwEemz8qUl1H9gFg" id="(0.5137614678899083,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hfaQUCqwEemz8qUl1H9gFg" type="Association_Edge" source="_4FRfYCqvEemz8qUl1H9gFg" target="_9pLz4CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_hfa3YCqwEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Hvo2wCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hfa3YSqwEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hfbecCqwEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Hy-eoCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hfbecSqwEemz8qUl1H9gFg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hfbeciqwEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H1Q9oCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hfbecyqwEemz8qUl1H9gFg" x="21" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hfbedCqwEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H3r_gCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hfbedSqwEemz8qUl1H9gFg" x="-21" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hfbediqwEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H5ogQCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hfbedyqwEemz8qUl1H9gFg" x="9" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hfbeeCqwEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H8GlcCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hfbeeSqwEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_hfaQUSqwEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_hb_v8CqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hfaQUiqwEemz8qUl1H9gFg" points="[675, -352, -643984, -643984]$[624, -352, -643984, -643984]$[624, -232, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hj2EYCqwEemz8qUl1H9gFg" id="(0.0,0.8421052631578947)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hj2EYSqwEemz8qUl1H9gFg" id="(0.3125,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iqYOoCqwEemz8qUl1H9gFg" type="Association_Edge" source="_4FRfYCqvEemz8qUl1H9gFg" target="_-kmTQCqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqY1sCqwEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_xxPgECqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iqY1sSqwEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqY1siqwEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_xzgw8CqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iqY1syqwEemz8qUl1H9gFg" x="3" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqY1tCqwEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_x10eECqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iqY1tSqwEemz8qUl1H9gFg" x="2" y="-50"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqY1tiqwEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_x4OR0CqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iqY1tyqwEemz8qUl1H9gFg" x="-32" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqY1uCqwEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_x6rv8CqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iqY1uSqwEemz8qUl1H9gFg" x="11" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqY1uiqwEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_x8xaoCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iqY1uyqwEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_iqYOoSqwEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ioPgoCqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iqYOoiqwEemz8qUl1H9gFg" points="[810, -352, -643984, -643984]$[843, -352, -643984, -643984]$[843, -232, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ivc74CqwEemz8qUl1H9gFg" id="(1.0,0.8421052631578947)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ivc74SqwEemz8qUl1H9gFg" id="(0.75,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jmiU4CqwEemz8qUl1H9gFg" type="Association_Edge" source="_4FRfYCqvEemz8qUl1H9gFg" target="__y0Z4CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_jmi78iqwEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_whfvcCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jmi78yqwEemz8qUl1H9gFg" x="-40" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jmi79CqwEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wlVGkCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jmi79SqwEemz8qUl1H9gFg" x="-54" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jmi79iqwEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wn88wCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jmi79yqwEemz8qUl1H9gFg" x="45" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jmi7-CqwEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wr1-QCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jmi7-SqwEemz8qUl1H9gFg" x="-45" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jmi7-iqwEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wt83ECqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jmi7-yqwEemz8qUl1H9gFg" x="11" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jmi7_CqwEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wv2UgCqwEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jmi7_SqwEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_jmi78CqwEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_jkjX4CqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jmi78SqwEemz8qUl1H9gFg" points="[810, -384, -643984, -643984]$[1091, -384, -643984, -643984]$[1091, -232, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jq-wACqwEemz8qUl1H9gFg" id="(1.0,0.2807017543859649)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jq-wASqwEemz8qUl1H9gFg" id="(0.51,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tKpIZCqwEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_jmiU4CqwEemz8qUl1H9gFg" target="_tKpIYCqwEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tKpIZSqwEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tKpIaSqwEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_jkjX4CqwEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tKpIZiqwEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tKpIZyqwEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tKpIaCqwEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_W2215CqzEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_W2qooCqzEemz8qUl1H9gFg" target="_W2214CqzEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_W2215SqzEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W2216SqzEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiOam.uml#_1ivtsCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W2215iqzEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W2215yqzEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W2216CqzEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iC_-MCqzEemz8qUl1H9gFg" type="Association_Edge" source="_W2qooCqzEemz8qUl1H9gFg" target="_7k5n8CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_iC_-MyqzEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NBk9YCq0Eemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iC_-NCqzEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iC_-NSqzEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ND2OQCq0Eemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iC_-NiqzEemz8qUl1H9gFg" x="-48" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iC_-NyqzEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NF6DwCq0Eemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iC_-OCqzEemz8qUl1H9gFg" x="25" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iDAlQCqzEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NIF1ECq0Eemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iDAlQSqzEemz8qUl1H9gFg" x="-25" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iDAlQiqzEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NKTbkCq0Eemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iDAlQyqzEemz8qUl1H9gFg" x="8" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iDAlRCqzEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NM4OcCq0Eemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iDAlRSqzEemz8qUl1H9gFg" x="-6" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_iC_-MSqzEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_iAzl0CqzEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iC_-MiqzEemz8qUl1H9gFg" points="[397, -32, -643984, -643984]$[336, -32, -643984, -643984]$[336, -120, -643984, -643984]$[416, -120, -643984, -643984]$[416, -175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iHXg0CqzEemz8qUl1H9gFg" id="(0.0,0.2807017543859649)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iHXg0SqzEemz8qUl1H9gFg" id="(0.07339449541284404,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PIK2cCq0Eemz8qUl1H9gFg" type="Association_Edge" source="_W2qooCqzEemz8qUl1H9gFg" target="_7k5n8CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PILdgCq0Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HH9LsCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PILdgSq0Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PILdgiq0Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HJ5FYCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PILdgyq0Eemz8qUl1H9gFg" x="-7" y="45"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PILdhCq0Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HMBzYCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PILdhSq0Eemz8qUl1H9gFg" x="23" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PILdhiq0Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HOKhYCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PILdhyq0Eemz8qUl1H9gFg" x="-23" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PILdiCq0Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HQHpMCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PILdiSq0Eemz8qUl1H9gFg" x="9" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PILdiiq0Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HSPJECrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PILdiyq0Eemz8qUl1H9gFg" x="-6" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_PIK2cSq0Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_PF8o4Cq0Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PIK2ciq0Eemz8qUl1H9gFg" points="[472, -48, -643984, -643984]$[472, -112, -643984, -643984]$[480, -112, -643984, -643984]$[480, -175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMLzwCq0Eemz8qUl1H9gFg" id="(0.6287878787878788,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMLzwSq0Eemz8qUl1H9gFg" id="(0.6605504587155964,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bCqdECq1Eemz8qUl1H9gFg" type="Association_Edge" source="_W2qooCqzEemz8qUl1H9gFg" target="_7k5n8CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bCrEICq1Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HUMQ4CrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bCrEISq1Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bCrEIiq1Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HWJ_wCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bCrEIyq1Eemz8qUl1H9gFg" x="-31" y="-39"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bCrEJCq1Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HYapkCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bCrEJSq1Eemz8qUl1H9gFg" x="21" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bCrEJiq1Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HbPUECrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bCrEJyq1Eemz8qUl1H9gFg" x="-21" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bCrEKCq1Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HemxICrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bCrEKSq1Eemz8qUl1H9gFg" x="9" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bCrEKiq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HguRACrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bCrEKyq1Eemz8qUl1H9gFg" x="-6" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bCqdESq1Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_bAi9MCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bCqdEiq1Eemz8qUl1H9gFg" points="[448, -48, -643984, -643984]$[448, -175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bIG9wCq1Eemz8qUl1H9gFg" id="(0.38636363636363635,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bIG9wSq1Eemz8qUl1H9gFg" id="(0.3669724770642202,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hzBWkCq1Eemz8qUl1H9gFg" type="Association_Edge" source="_W2qooCqzEemz8qUl1H9gFg" target="_7k5n8CqvEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_hzB9oCq1Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Hi1J0CrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hzB9oSq1Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hzB9oiq1Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HkwccCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hzB9oyq1Eemz8qUl1H9gFg" x="-39" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hzB9pCq1Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Hms9MCrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hzB9pSq1Eemz8qUl1H9gFg" x="24" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hzB9piq1Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ho1EICrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hzB9pyq1Eemz8qUl1H9gFg" x="-24" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hzB9qCq1Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HqzaECrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hzB9qSq1Eemz8qUl1H9gFg" x="12" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hzB9qiq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HsxwACrBEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hzB9qyq1Eemz8qUl1H9gFg" x="-6" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_hzBWkSq1Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_hw1lQCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hzBWkiq1Eemz8qUl1H9gFg" points="[529, -16, -643984, -643984]$[600, -16, -643984, -643984]$[600, -120, -643984, -643984]$[512, -120, -643984, -643984]$[512, -175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h3Wc8Cq1Eemz8qUl1H9gFg" id="(1.0,0.5614035087719298)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h3Wc8Sq1Eemz8qUl1H9gFg" id="(0.9541284403669725,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4eUp0Cq1Eemz8qUl1H9gFg" type="Association_Edge" source="_-kmTQCqvEemz8qUl1H9gFg" target="_TFwqMCqwEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4eUp0yq1Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0fe0sCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4eUp1Cq1Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4eUp1Sq1Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0htpUCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4eUp1iq1Eemz8qUl1H9gFg" x="55" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4eUp1yq1Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0j2XUCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4eUp2Cq1Eemz8qUl1H9gFg" x="37" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4eUp2Sq1Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0l5lwCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4eUp2iq1Eemz8qUl1H9gFg" x="-37" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4eUp2yq1Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0oltYCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4eUp3Cq1Eemz8qUl1H9gFg" x="14" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4eUp3Sq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0rP_0CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4eUp3iq1Eemz8qUl1H9gFg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_4eUp0Sq1Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_4boiMCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4eUp0iq1Eemz8qUl1H9gFg" points="[776, -175, -643984, -643984]$[776, -88, -643984, -643984]$[696, -88, -643984, -643984]$[696, -48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4kT9ECq1Eemz8qUl1H9gFg" id="(0.08,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4kUkICq1Eemz8qUl1H9gFg" id="(0.47619047619047616,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5YYeUCq1Eemz8qUl1H9gFg" type="Association_Edge" source="_-kmTQCqvEemz8qUl1H9gFg" target="_C6HiACqwEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5YYeUyq1Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u1wzICrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5YYeVCq1Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5YYeVSq1Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u3t68CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5YYeViq1Eemz8qUl1H9gFg" x="57" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5YYeVyq1Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u52o8CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5YYeWCq1Eemz8qUl1H9gFg" x="24" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5YYeWSq1Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u720ECrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5YYeWiq1Eemz8qUl1H9gFg" x="-24" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5YYeWyq1Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u93mQCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5YYeXCq1Eemz8qUl1H9gFg" x="14" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5YYeXSq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vALTYCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5YYeXiq1Eemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5YYeUSq1Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_5WY6QCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5YYeUiq1Eemz8qUl1H9gFg" points="[800, -175, -643984, -643984]$[800, -88, -643984, -643984]$[848, -88, -643984, -643984]$[848, -48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5dtqQCq1Eemz8qUl1H9gFg" id="(0.32,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5dtqQSq1Eemz8qUl1H9gFg" id="(0.53,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6VlGYCq1Eemz8qUl1H9gFg" type="Association_Edge" source="_-kmTQCqvEemz8qUl1H9gFg" target="_DcCjUCqwEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6VltcCq1Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vYGEICrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6VltcSq1Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6Vltciq1Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vaPZMCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6Vltcyq1Eemz8qUl1H9gFg" x="-4" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6VltdCq1Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vcMhACrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6VltdSq1Eemz8qUl1H9gFg" x="47" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6Vltdiq1Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_veK28CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6Vltdyq1Eemz8qUl1H9gFg" x="-47" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6VlteCq1Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vgUMACrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6VlteSq1Eemz8qUl1H9gFg" x="14" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6Vlteiq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_viR64CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6Vlteyq1Eemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_6VlGYSq1Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_6TkUMCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VlGYiq1Eemz8qUl1H9gFg" points="[840, -175, -643984, -643984]$[840, -113, -643984, -643984]$[952, -113, -643984, -643984]$[952, -48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6a7gcCq1Eemz8qUl1H9gFg" id="(0.64,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6a7gcSq1Eemz8qUl1H9gFg" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7f2hICq1Eemz8qUl1H9gFg" type="Association_Edge" source="_-kmTQCqvEemz8qUl1H9gFg" target="_EQ2EYCqwEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7f3IMCq1Eemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_v4DWkCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3IMSq1Eemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7f3IMiq1Eemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_v6BsgCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3IMyq1Eemz8qUl1H9gFg" x="-12" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7f3INCq1Eemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_v8JzcCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3INSq1Eemz8qUl1H9gFg" x="1" y="42"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7f3INiq1Eemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_v-LzwCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3INyq1Eemz8qUl1H9gFg" x="-6" y="-37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7f3IOCq1Eemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wAJioCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3IOSq1Eemz8qUl1H9gFg" x="14" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7f3IOiq1Eemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wCSQoCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7f3IOyq1Eemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_7f2hISq1Eemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_7d1u8Cq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7f2hIiq1Eemz8qUl1H9gFg" points="[856, -175, -643984, -643984]$[856, -136, -643984, -643984]$[1088, -136, -643984, -643984]$[1088, -48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7kiM0Cq1Eemz8qUl1H9gFg" id="(0.88,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7kiM0Sq1Eemz8qUl1H9gFg" id="(0.5538461538461539,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UNxn4CrAEemz8qUl1H9gFg" type="Association_Edge" source="_-kmTQCqvEemz8qUl1H9gFg" target="__y0Z4CqvEemz8qUl1H9gFg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UNyO8CrAEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vw_HECrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UNyO8SrAEemz8qUl1H9gFg" x="1" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UNyO8irAEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VzGm8CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UNyO8yrAEemz8qUl1H9gFg" x="-5" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UNy2ACrAEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V1biMCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UNy2ASrAEemz8qUl1H9gFg" x="22" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UNy2AirAEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V3ibACrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UNy2AyrAEemz8qUl1H9gFg" x="-22" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UNy2BCrAEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V5qh8CrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UNy2BSrAEemz8qUl1H9gFg" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UNy2BirAEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V75WkCrAEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UNy2ByrAEemz8qUl1H9gFg" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UNxn4SrAEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ULiMMCrAEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UNxn4irAEemz8qUl1H9gFg" points="[868, -208, -643984, -643984]$[1016, -208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USODACrAEemz8qUl1H9gFg" id="(1.0,0.42105263157894735)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USODASrAEemz8qUl1H9gFg" id="(0.0,0.42105263157894735)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VUxsNCrAEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_UNxn4CrAEemz8qUl1H9gFg" target="_VUxsMCrAEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VUxsNSrAEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VUxsOSrAEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ULiMMCrAEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VUxsNirAEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VUxsNyrAEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VUxsOCrAEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_keSXECrCEemz8qUl1H9gFg" type="Abstraction_Edge" source="_W2qooCqzEemz8qUl1H9gFg" target="_bJ5Y_yqvEemz8qUl1H9gFg" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_keSXEyrCEemz8qUl1H9gFg" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lh03sCrCEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_keSXFCrCEemz8qUl1H9gFg" x="-38" y="63"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_keSXFSrCEemz8qUl1H9gFg" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ljxYcCrCEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_keSXFirCEemz8qUl1H9gFg" x="-54" y="66"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_keSXESrCEemz8qUl1H9gFg" fontColor="16711680"/>
+      <element xmi:type="uml:Abstraction" href="TapiOam.uml#_keOssCrCEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_keSXEirCEemz8qUl1H9gFg" points="[397, -8, -643984, -643984]$[240, -8, -643984, -643984]$[240, -259, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kim2YCrCEemz8qUl1H9gFg" id="(0.0,0.7017543859649122)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kim2YSrCEemz8qUl1H9gFg" id="(0.917910447761194,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_m5TA8CrCEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_keSXECrCEemz8qUl1H9gFg" target="_m5SZ4yrCEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_m5TA8SrCEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_m5TA9SrCEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_keOssCrCEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_m5TA8irCEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m5TA8yrCEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m5TA9CrCEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sgUT0CrCEemz8qUl1H9gFg" type="Abstraction_Edge" source="_4FRfYCqvEemz8qUl1H9gFg" target="_bJ5Y_yqvEemz8qUl1H9gFg" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_sgU64CrCEemz8qUl1H9gFg" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vDn-ECrCEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sgU64SrCEemz8qUl1H9gFg" x="3" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sgU64irCEemz8qUl1H9gFg" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vFu24CrCEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sgU64yrCEemz8qUl1H9gFg" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_sgUT0SrCEemz8qUl1H9gFg" fontColor="16711680"/>
+      <element xmi:type="uml:Abstraction" href="TapiOam.uml#_sgTswCrCEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sgUT0irCEemz8qUl1H9gFg" points="[760, -400, -643984, -643984]$[760, -432, -643984, -643984]$[240, -432, -643984, -643984]$[240, -317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_skqoUCrCEemz8qUl1H9gFg" id="(0.53,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_skqoUSrCEemz8qUl1H9gFg" id="(0.917910447761194,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tos4NCrCEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_sgUT0CrCEemz8qUl1H9gFg" target="_tos4MCrCEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tos4NSrCEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tos4OSrCEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_sgTswCrCEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tos4NirCEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tos4NyrCEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tos4OCrCEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DkKp8CrDEemz8qUl1H9gFg" type="Realization_Edge" source="_-kmTQCqvEemz8qUl1H9gFg" target="_bJ5X2iqvEemz8qUl1H9gFg" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DkKp8yrDEemz8qUl1H9gFg" type="Realization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PhqWsCrDEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DkKp9CrDEemz8qUl1H9gFg" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DkLRACrDEemz8qUl1H9gFg" type="Realization_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PnM-ACrDEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DkLRASrDEemz8qUl1H9gFg" x="-33" y="-24"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_DkKp8SrDEemz8qUl1H9gFg" fontColor="16711680"/>
+      <element xmi:type="uml:Realization" href="TapiOam.uml#_DkJb0CrDEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DkKp8irDEemz8qUl1H9gFg" points="[792, -232, -643984, -643984]$[792, -264, -643984, -643984]$[336, -264, -643984, -643984]$[336, -192, -643984, -643984]$[-72, -192, -643984, -643984]$[-72, -145, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DrcWoCrDEemz8qUl1H9gFg" id="(0.24,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DrcWoSrDEemz8qUl1H9gFg" id="(0.6686046511627907,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_q3LnQSrMEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_bJ58QSqvEemz8qUl1H9gFg" target="_q3LAMCrMEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_q3LnQirMEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q3LnRirMEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_q3LnQyrMEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q3LnRCrMEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q3LnRSrMEemz8qUl1H9gFg"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_9sFKUCrEEemz8qUl1H9gFg" type="PapyrusUMLClassDiagram" name="OamLldpDetails" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_K3c_cCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_K3dmgCrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K3dmgSrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K3dmgirFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_K3dmgyrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_K3dmhCrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_K3dmhSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_K3dmhirFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3dmhyrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_K3dmiCrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_K3dmiSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_K3dmiirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_K3dmiyrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3dmjCrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_K3dmjSrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_K3dmjirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_K3dmjyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_K3dmkCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3dmkSrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDnXECquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3c_cSrFEemz8qUl1H9gFg" x="872" y="48"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_K3pzwyrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K3pzxCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K3pzxirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDnXECquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3pzxSrFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_K36ScCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_K365gCrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K365gSrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K365girFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_K365gyrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Xk2fICrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_bqyZwCrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDrogiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xk2fISrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Xk3GMCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_cF9S0CrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDrohiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xk3GMSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Xk3tQCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ciYwICrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDroiiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xk3tQSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Xk3tQirFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_c6KW8CrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDrojiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xk3tQyrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Xk3tRCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_dTom4CrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDrokiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xk3tRSrFEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_K365hCrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_K365hSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_K365hirFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K365hyrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_K365iCrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_K365iSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_K365iirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_K365iyrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K365jCrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_K365jSrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_K365jirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_K365jyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_K365kCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K365kSrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K36ScSrFEemz8qUl1H9gFg" x="12" y="208"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_K4FRkyrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K4FRlCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K4F4oCrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K4FRlSrFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LYRNgCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_LYR0kCrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LYR0kSrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LYR0kirFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LYR0kyrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_gh5SoCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_hxAxICrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDv58iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gh5SoSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gh7H0CrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_iQydYCrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDv59iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gh7H0SrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gh7H0irFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_isuygCrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDv5-iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gh7H0yrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gh7H1CrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_jLsmcCrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDv5_iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gh7H1SrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gh7H1irFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_jmoO8CrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDv6AiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gh7H1yrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gh7u4CrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_kDJL0CrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDv6BiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gh7u4SrFEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LYR0lCrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LYR0lSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LYR0lirFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LYR0lyrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LYR0mCrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LYR0mSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LYR0mirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LYR0myrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LYR0nCrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LYR0nSrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LYR0nirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LYR0nyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LYR0oCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LYR0oSrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDv58CquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LYRNgSrFEemz8qUl1H9gFg" x="392" y="208"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LYblkCrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LYblkSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LYblkyrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDv58CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LYblkirFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_L0ZI0CrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_L0Zv4CrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L0Zv4SrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L0Zv4irFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_L0aW8CrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_siUXkCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_sjh4gyrFEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_00XGQCrFEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_00XGQSrFEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjh4iSrFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjh4iirFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjh4iyrFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjh4jCrFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjh4jSrFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjh4jirFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjifkCrFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjifkSrFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjifkirFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjifkyrFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjiflCrFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjiflSrFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjiflirFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjiflyrFEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_sjifmCrFEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_sjifmSrFEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_sjh4hCrFEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_sjh4hSrFEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sjh4hirFEemz8qUl1H9gFg"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LZiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siUXkSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_siUXkirFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LaiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siUXkyrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_siUXlCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LbyquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siUXlSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_siU-oCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LdCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siU-oSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_siU-oirFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_9FSaoCrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LfiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siU-oyrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_siU-pCrFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_9hfOcCrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LgiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siU-pSrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_siU-pirFEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_-Dd6ICrFEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hD0LhiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_siU-pyrFEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHN34CrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_4bpwUiq1Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHN34SrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHPGACrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_5WZhUiq1Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHPGASrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHQUICrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_6Tk7Qiq1Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHQUISrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHQ7MCrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_7d2WAiq1Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHQ7MSrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHQ7MirGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_ULjaUirAEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHQ7MyrGEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_L0aW8SrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_L0aW8irFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_L0aW8yrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L0aW9CrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_L0a-ACrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_L0a-ASrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_L0a-AirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_L0a-AyrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L0a-BCrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_L0a-BSrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_L0a-BirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_L0a-ByrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_L0a-CCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L0a-CSrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hD0LYCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L0ZI0SrFEemz8qUl1H9gFg" x="928" y="208"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_L0vHECrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_L0vHESrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L0vHEyrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hD0LYCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L0vHEirFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MPOqsCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MPPRwCrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MPPRwSrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MPPRwirFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MPPRwyrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_EZrOQCrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3giquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZrOQSrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EZr1UCrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3hyquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZr1USrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EZscYCrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3jCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZscYSrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EZscYirGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3jiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZscYyrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EZscZCrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3kCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZscZSrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EZtDcCrGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3kiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZtDcSrGEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EZtDcirGEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hDh3lCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EZtDcyrGEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MPPRxCrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MPPRxSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MPPRxirFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPPRxyrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MPPRyCrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MPPRySrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MPPRyirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MPPRyyrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPPRzCrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MPPRzSrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MPPRzirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MPPRzyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MPPR0CrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPPR0SrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hDh3gCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPOqsSrFEemz8qUl1H9gFg" x="1512" y="208"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MPhloyrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MPhlpCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MPhlpirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDh3gCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPhlpSrFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MRAMUyrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MRAMVCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MRAMVirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_jkjX4CqwEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MRAMVSrFEemz8qUl1H9gFg" x="664" y="-18"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ms_kwCrFEemz8qUl1H9gFg" type="Signal_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ms_kwirFEemz8qUl1H9gFg" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MtAL0CrFEemz8qUl1H9gFg" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtAL0SrFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MtAL0irFEemz8qUl1H9gFg" type="Signal_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_0M4SsCrJEemz8qUl1H9gFg" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_iA1bACqzEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0M4SsSrJEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0M45wCrJEemz8qUl1H9gFg" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_PF93ASq0Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0M45wSrJEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0M45wirJEemz8qUl1H9gFg" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_bAjkQiq1Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0M45wyrJEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0M5g0CrJEemz8qUl1H9gFg" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hw2zYiq1Eemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0M5g0SrJEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MtAL0yrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MtAL1CrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MtAL1SrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MtAL1irFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Signal" href="TapiOam.uml#_1ivtsCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ms_kwSrFEemz8qUl1H9gFg" x="72" y="448"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MtQqgCrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MtQqgSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MtQqgyrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiOam.uml#_1ivtsCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MtQqgirFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OT_XwCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OT_-0CrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OUAl4CrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OUAl4SrFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OUAl4irFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JLy8oCrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_JQf2cCrKEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Y3HmACrKEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Y3HmASrKEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQf2dirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQf2dyrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQf2eCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQf2eSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQgdgCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQgdgSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQgdgirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQgdgyrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQgdhCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQgdhSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQgdhirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQgdhyrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQgdiCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQgdiSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQgdiirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQgdiyrKEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_JQf2cSrKEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_JQf2cirKEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JQf2cyrKEemz8qUl1H9gFg"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEAYoiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JLy8oSrKEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JLzjsCrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_JQqOgyrKEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aJ2ZMCrKEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aJ2ZMSrKEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1kirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1kyrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1lCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1lSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1lirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1lyrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1mCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1mSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1mirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1myrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1nCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1nSrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1nirKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1nyrKEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_JQq1oCrKEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_JQq1oSrKEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_JQqOhCrKEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_JQqOhSrKEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JQqOhirKEemz8qUl1H9gFg"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEAYpiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JLzjsSrKEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JL0KwCrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEAYqiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JL0KwSrKEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JL0KwirKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_WEa04CrKEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEAYryquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JL0KwyrKEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JL0x0CrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Wa_h0CrKEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEAYsyquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JL0x0SrKEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JL1Y4CrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_WxKmICrKEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEAYtyquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JL1Y4SrKEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OUAl4yrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OUAl5CrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OUAl5SrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OUAl5irFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OUAl5yrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OUAl6CrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OUAl6SrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OUAl6irFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OUAl6yrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OUAl7CrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OUAl7SrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OUAl7irFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OUAl7yrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OUAl8CrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OT_XwSrFEemz8qUl1H9gFg" x="96" y="616"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OUfuEyrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OUfuFCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OUgVICrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OUfuFSrFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OwyogCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OwyogirFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OwyogyrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OwzPkCrFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OwzPkSrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_6KHQsCrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_-mR6ACrKEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEGfQiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6KHQsSrKEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6KJs8CrKEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_-OS30CrKEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEGfRiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6KJs8SrKEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OwzPkirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OwzPkyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OwzPlCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwzPlSrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OwzPlirFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OwzPlyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OwzPmCrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OwzPmSrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwzPmirFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OwzPmyrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OwzPnCrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OwzPnSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OwzPnirFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwzPnyrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OwyogSrFEemz8qUl1H9gFg" x="520" y="616"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OxOGUCrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OxOGUSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OxOGUyrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OxOGUirFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PMiJUCrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PMiJUirFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PMiJUyrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PMiJVCrFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PMiJVSrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_AhDkoCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Q4hiUCrLEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEJikiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AhDkoSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AhDkoirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_QX6voCrLEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEJiliquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AhDkoyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AhELsCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_P7w_ICrLEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEJimiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AhELsSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AhELsirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_PgkQ4CrLEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEJiniquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AhELsyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AhELtCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_PGQTcCrLEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEJioiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AhELtSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AhELtirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Ord04CrLEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEJipiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AhELtyrLEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PMiJVirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PMiJVyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PMiJWCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiJWSrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PMiwYCrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PMiwYSrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PMiwYirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PMiwYyrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiwZCrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PMiwZSrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PMiwZirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PMiwZyrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PMiwaCrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiwaSrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMiJUSrFEemz8qUl1H9gFg" x="927" y="616"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PM1EQCrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PM1EQSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PM1EQyrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PM1EQirFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Pjge4CrFEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PjhF8CrFEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PjhF8SrFEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PjhF8irFEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PjhF8yrFEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_aoQ-ECrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_arROwyrLEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_RxZOkCrMEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_RxZOkSrMEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR10irLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR10yrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR11CrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR11SrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR11irLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR11yrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR12CrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR12SrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR12irLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR12yrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR13CrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR13SrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR13irLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR13yrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arR14CrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arR14SrLEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_arROxCrLEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_arROxSrLEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arROxirLEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_DMvSUCrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0AiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoQ-ESrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoQ-EirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_arWuUCrLEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_S_wfICrMEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_S_wfISrMEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuVirLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuVyrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuWCrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuWSrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuWirLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuWyrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuXCrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuXSrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuXirLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuXyrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuYCrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuYSrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuYirLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuYyrLEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_arWuZCrLEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_arWuZSrLEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_arWuUSrLEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_arWuUirLEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arWuUyrLEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_DjrLoCrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0BCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoQ-EyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoRlICrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_D9EjECrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0CCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoRlISrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoRlIirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_KRH7ECrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0DCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoRlIyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoSMMCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_KoNlYCrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0ECquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoSMMSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoSMMirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_K_DYECrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0FCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoSMMyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoSzQCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_LY40YCrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0GCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoSzQSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoSzQirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_LwA68CrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0HCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoSzQyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoTaUCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_MMCvoCrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0ICquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoTaUSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoTaUirLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_CpJdECrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0JCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoTaUyrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aoTaVCrLEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_CLlXUCrMEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEN0KCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aoTaVSrLEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sklu0CrNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_WdXZAirNEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sklu0SrNEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_skmV4CrNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_XIc9YirNEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_skmV4SrNEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_skm88CrNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_Xz4gASrNEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_skm88SrNEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PjhF9CrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PjhF9SrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PjhF9irFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PjhF9yrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PjhF-CrFEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PjhF-SrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PjhF-irFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PjhF-yrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PjhF_CrFEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PjhtACrFEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PjhtASrFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PjhtAirFEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PjhtAyrFEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PjhtBCrFEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pjge4SrFEemz8qUl1H9gFg" x="1360" y="616"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Pj0A4yrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Pj0A5CrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pj0A5irFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pj0A5SrFEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QJs8MyrFEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJs8NCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJtjQCrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ULiMMCrAEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJs8NSrFEemz8qUl1H9gFg" x="638" y="283"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QSoVECrNEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QSoVEirNEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QSoVEyrNEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QSoVFCrNEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QSoVFSrNEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_UkAqsCrNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_UpFX8yrNEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3GiqoCrNEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3GiqoSrNEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_ACrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_ASrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_AirNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_AyrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_BCrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_BSrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_BirNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_ByrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_CCrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_CSrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_CirNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_CyrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_DCrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_DSrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpF_DirNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpF_DyrNEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_UpFX9CrNEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_UpFX9SrNEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UpFX9irNEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_1qbR8CrNEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEW98iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UkAqsSrNEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UkBRwCrNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_UpN60yrNEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4WRNICrNEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4WRNISrNEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpN62SrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpN62irNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh4CrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh4SrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh4irNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh4yrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh5CrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh5SrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh5irNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh5yrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh6CrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh6SrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh6irNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh6yrNEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_UpOh7CrNEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_UpOh7SrNEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_UpN61CrNEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_UpN61SrNEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UpN61irNEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_1LtVoCrNEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEW99iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UkBRwSrNEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UkBRwirNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_0w8FMCrNEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEW9-iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UkBRwyrNEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UkBRxCrNEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_0aX_UCrNEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEW9_iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UkBRxSrNEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QSoVFirNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QSoVFyrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QSoVGCrNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVGSrNEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QSoVGirNEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QSoVGyrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QSoVHCrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QSoVHSrNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVHirNEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QSoVHyrNEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QSoVICrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QSoVISrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QSoVIirNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVIyrNEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEW98CquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSoVESrNEemz8qUl1H9gFg" x="888" y="1008"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QSxfAyrNEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QSxfBCrNEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QSxfBirNEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEW98CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSxfBSrNEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QowWECrNEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Qow9ICrNEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QoxkMCrNEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QoxkMSrNEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QoxkMirNEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_B1C0sCrOEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_B5ZJMCrOEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_KE9ccCrOEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_KE9ccSrOEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJNirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJNyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJOCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJOSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJOirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJOyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJPCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJPSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJPirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJPyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJQCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJQSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJQirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJQyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B5ZJRCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B5ZJRSrOEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_B5ZJMSrOEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_B5ZJMirOEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B5ZJMyrOEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Iv_0oCrOEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEdEkiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B1C0sSrOEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_B1Ep4CrOEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_IYYl4CrOEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEdEliquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B1Ep4SrOEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QoxkMyrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QoxkNCrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QoxkNSrNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QoxkNirNEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QoxkNyrNEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QoxkOCrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QoxkOSrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QoxkOirNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QoxkOyrNEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QoxkPCrNEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QoxkPSrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QoxkPirNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QoxkPyrNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QoxkQCrNEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEdEkCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QowWESrNEemz8qUl1H9gFg" x="1409" y="1008"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Qo7VMyrNEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qo7VNCrNEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qo7VNirNEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEdEkCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qo7VNSrNEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Q-CCgCrNEemz8qUl1H9gFg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q-CCgirNEemz8qUl1H9gFg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q-CCgyrNEemz8qUl1H9gFg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Q-CChCrNEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q-CChSrNEemz8qUl1H9gFg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_SSWUoCrOEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_SWsCEyrOEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bW3CECrOEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bW3CESrOEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWsCGSrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWsCGirOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWsCGyrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWsCHCrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWsCHSrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWsCHirOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWspICrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWspISrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWspIirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWspIyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWspJCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWspJSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWspJirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWspJyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWspKCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWspKSrOEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_SWsCFCrOEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_SWsCFSrOEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SWsCFirOEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Z2Fy4CrOEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEfg0iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SSWUoSrOEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SSW7sCrOEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_SWw6kyrOEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cqRxwCrOEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cqRxwSrOEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhoCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhoSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhoirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhoyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhpCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhpSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhpirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhpyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhqCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhqSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhqirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhqyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhrCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhrSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SWxhrirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SWxhryrOEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_SWw6lCrOEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_SWw6lSrOEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SWw6lirOEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Zf_AACrOEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEfg1iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SSW7sSrOEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SSXiwCrOEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_SW2aICrOEemz8qUl1H9gFg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_d8UocCrOEemz8qUl1H9gFg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_d8UocSrOEemz8qUl1H9gFg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aJirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aJyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aKCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aKSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aKirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aKyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aLCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aLSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aLirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aLyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aMCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aMSrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aMirOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aMyrOEemz8qUl1H9gFg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_SW2aNCrOEemz8qUl1H9gFg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_SW2aNSrOEemz8qUl1H9gFg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_SW2aISrOEemz8qUl1H9gFg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_SW2aIirOEemz8qUl1H9gFg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SW2aIyrOEemz8qUl1H9gFg"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ZB1EYCrOEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEfg2iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SSXiwSrOEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SSYJ0CrOEemz8qUl1H9gFg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_YhCEcCrOEemz8qUl1H9gFg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiOam.uml#_hEfg3iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SSYJ0SrOEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q-CChirNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q-CChyrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q-CCiCrNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCiSrNEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q-CCiirNEemz8qUl1H9gFg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q-CCiyrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q-CCjCrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q-CCjSrNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCjirNEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q-CCjyrNEemz8qUl1H9gFg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q-CCkCrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q-CCkSrNEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q-CCkirNEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCkyrNEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_hEfg0CquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-CCgSrNEemz8qUl1H9gFg" x="1840" y="1008"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Q-LzgyrNEemz8qUl1H9gFg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Q-LzhCrNEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Q-LzhirNEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEfg0CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q-LzhSrNEemz8qUl1H9gFg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BKJoICrPEemz8qUl1H9gFg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BKJoIirPEemz8qUl1H9gFg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BKJoIyrPEemz8qUl1H9gFg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BKJoJCrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BKJoJSrPEemz8qUl1H9gFg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_B-ZIgCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RIRQiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B-ZIgSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_B-ZvkCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RIRRSquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B-ZvkSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_B-ZvkirPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RIRSCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B-ZvkyrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BKJoJirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BKJoJyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BKJoKCrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BKJoKSrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_8RIRQCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BKJoISrPEemz8qUl1H9gFg" x="112" y="1179"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FYwWkCrPEemz8qUl1H9gFg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FYwWkirPEemz8qUl1H9gFg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FYwWkyrPEemz8qUl1H9gFg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FYwWlCrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FYwWlSrPEemz8qUl1H9gFg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_G5RHECrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8ROX4iquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_G5RHESrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FYwWlirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FYwWlyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FYw9oCrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FYw9oSrPEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FYw9oirPEemz8qUl1H9gFg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FYw9oyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FYw9pCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FYw9pSrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FYw9pirPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_8ROX4CquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FYwWkSrPEemz8qUl1H9gFg" x="272" y="1179"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KyYGoCrPEemz8qUl1H9gFg" type="DataType_Shape" fontColor="255" fillColor="8905185" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_KyYGoirPEemz8qUl1H9gFg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_KyYtsCrPEemz8qUl1H9gFg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KyYtsSrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KyYtsirPEemz8qUl1H9gFg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_LgTjoCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95MiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgTjoSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgUKsCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95NCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgUKsSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgUxwCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95NiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgUxwSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgVY0CrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95OCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgVY0SrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgYcICrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95OiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgYcISrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgYcIirPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95PCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgYcIyrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgYcJCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95PiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgYcJSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgZDMCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95QCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgZDMSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgZDMirPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95QiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgZDMyrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgZDNCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95RCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgZDNSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LgZDNirPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q95RiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LgZDNyrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KyYtsyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KyYttCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KyYttSrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KyYttirPEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KyYttyrPEemz8qUl1H9gFg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KyYtuCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KyYtuSrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KyYtuirPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KyYtuyrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_8Q95MCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KyYGoSrPEemz8qUl1H9gFg" x="456" y="1179"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZZPpYCrPEemz8qUl1H9gFg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZZPpYirPEemz8qUl1H9gFg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZZQQcCrPEemz8qUl1H9gFg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZZQQcSrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ZZQQcirPEemz8qUl1H9gFg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_brf_4CrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8RI4UiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_brf_4SrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ZZQQcyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ZZQQdCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ZZQQdSrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZZQQdirPEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ZZQQdyrPEemz8qUl1H9gFg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ZZQQeCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ZZQQeSrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ZZQQeirPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZZQQeyrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_8RI4UCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZZPpYSrPEemz8qUl1H9gFg" x="672" y="1176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_vzxVsCrPEemz8qUl1H9gFg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_vzxVsirPEemz8qUl1H9gFg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_vzxVsyrPEemz8qUl1H9gFg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vzxVtCrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_vzxVtSrPEemz8qUl1H9gFg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_w3pNgCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RHqMiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_w3pNgSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_w3pNgirPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RHqNSquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_w3pNgyrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_w3p0kCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RHqOCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_w3p0kSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_w3p0kirPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_8RHqOyquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_w3p0kyrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_vzxVtirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_vzxVtyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_vzxVuCrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vzxVuSrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_8RHqMCquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vzxVsSrPEemz8qUl1H9gFg" x="816" y="1176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zToHwCrPEemz8qUl1H9gFg" type="DataType_Shape" fontColor="255" fillColor="8905185" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_zToHwirPEemz8qUl1H9gFg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zToHwyrPEemz8qUl1H9gFg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zToHxCrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zToHxSrPEemz8qUl1H9gFg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_0GFfcCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8RF1AiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0GFfcSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0GGGgCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8RF1BCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0GGGgSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0GGGgirPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8RF1BiquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0GGGgyrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0GGGhCrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8RF1CCquEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0GGGhSrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zToHxirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zToHxyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zToHyCrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zToHySrPEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zToHyirPEemz8qUl1H9gFg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zToHyyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zToHzCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zToHzSrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zToHzirPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_8RF1ACquEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zToHwSrPEemz8qUl1H9gFg" x="936" y="1176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3HgpECrPEemz8qUl1H9gFg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3HgpEirPEemz8qUl1H9gFg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3HgpEyrPEemz8qUl1H9gFg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3HgpFCrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3HgpFSrPEemz8qUl1H9gFg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_4C7IcCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_z-xv0CrKEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4C7IcSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_4C7IcirPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_2bTcoCrKEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4C7IcyrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3HgpFirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3HgpFyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3HgpGCrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3HgpGSrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_jW9pACrKEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3HgpESrPEemz8qUl1H9gFg" x="1104" y="1176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6DGQcCrPEemz8qUl1H9gFg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6DG3gCrPEemz8qUl1H9gFg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6DG3gSrPEemz8qUl1H9gFg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6DG3girPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_6DG3gyrPEemz8qUl1H9gFg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_7FjL8CrPEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_jSFa8irIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7FjL8SrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_6DG3hCrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_6DG3hSrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_6DG3hirPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6DG3hyrPEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_6DG3iCrPEemz8qUl1H9gFg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_6DG3iSrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_6DG3iirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_6DG3iyrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6DG3jCrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_jSFa8CrIEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6DGQcSrPEemz8qUl1H9gFg" x="1224" y="1176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9iDqoCrPEemz8qUl1H9gFg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9iDqoirPEemz8qUl1H9gFg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9iDqoyrPEemz8qUl1H9gFg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9iDqpCrPEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9iDqpSrPEemz8qUl1H9gFg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_-XrEACrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDlwirIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XrEASrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-XrrECrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDlxSrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XrrESrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-XrrEirPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDlyCrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XrrEyrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-XrrFCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDlyyrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XrrFSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-XrrFirPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDlzirIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XrrFyrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-XrrGCrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDl0SrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XrrGSrPEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-XsSICrPEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSDl1CrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-XsSISrPEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9iDqpirPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9iDqpyrPEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9iDqqCrPEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9iDqqSrPEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_jSDlwCrIEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9iDqoSrPEemz8qUl1H9gFg" x="1376" y="1176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AyuKICrQEemz8qUl1H9gFg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_AyuxMCrQEemz8qUl1H9gFg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AyuxMSrQEemz8qUl1H9gFg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AyuxMirQEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AyuxMyrQEemz8qUl1H9gFg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_ByhaQCrQEemz8qUl1H9gFg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_jSGCAirIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ByhaQSrQEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AyuxNCrQEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AyuxNSrQEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AyuxNirQEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AyuxNyrQEemz8qUl1H9gFg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AyuxOCrQEemz8qUl1H9gFg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AyuxOSrQEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AyuxOirQEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AyuxOyrQEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AyuxPCrQEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_jSGCACrIEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AyuKISrQEemz8qUl1H9gFg" x="1528" y="1179"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DEgmkCrQEemz8qUl1H9gFg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DEhNoCrQEemz8qUl1H9gFg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DEhNoSrQEemz8qUl1H9gFg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DEhNoirQEemz8qUl1H9gFg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DEhNoyrQEemz8qUl1H9gFg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_D9_zUCrQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEM0irIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D9_zUSrQEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D-AaYCrQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEz4irIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D-AaYSrQEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D-AaYirQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEz5SrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D-AaYyrQEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D-AaZCrQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEz6CrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D-AaZSrQEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D-BBcCrQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEz6yrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D-BBcSrQEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D-BBcirQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEz7irIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D-BBcyrQEemz8qUl1H9gFg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D-BBdCrQEemz8qUl1H9gFg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_jSEz8SrIEemz8qUl1H9gFg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D-BBdSrQEemz8qUl1H9gFg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DEhNpCrQEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DEhNpSrQEemz8qUl1H9gFg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DEhNpirQEemz8qUl1H9gFg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DEhNpyrQEemz8qUl1H9gFg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_jSEM0CrIEemz8qUl1H9gFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DEgmkSrQEemz8qUl1H9gFg" x="1664" y="1176"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_9sFKUSrEEemz8qUl1H9gFg" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_9sFKUirEEemz8qUl1H9gFg"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_9sFKUyrEEemz8qUl1H9gFg" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
+    <edges xmi:type="notation:Connector" xmi:id="_K3pzxyrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_K3c_cCrFEemz8qUl1H9gFg" target="_K3pzwyrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K3pzyCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K3qa0irFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDnXECquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K3pzySrFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3qa0CrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3qa0SrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_K4F4oSrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_K36ScCrFEemz8qUl1H9gFg" target="_K4FRkyrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K4F4oirFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K4F4pirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDrogCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K4F4oyrFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K4F4pCrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K4F4pSrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_K4h9gCrFEemz8qUl1H9gFg" type="Association_Edge" source="_K3c_cCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_K4h9gyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VkuacCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K4h9hCrFEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K4h9hSrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vlf2gCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K4h9hirFEemz8qUl1H9gFg" x="-30" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K4h9hyrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VmU88CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K4h9iCrFEemz8qUl1H9gFg" x="12" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K4h9iSrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VnFx8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K4h9iirFEemz8qUl1H9gFg" x="-13" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K4h9iyrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vn64YCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K4h9jCrFEemz8qUl1H9gFg" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_K4h9jSrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VpMDsCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_K4h9jirFEemz8qUl1H9gFg" x="-12" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_K4h9gSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_gS1vgCqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K4h9girFEemz8qUl1H9gFg" points="[568, 80, -643984, -643984]$[136, 80, -643984, -643984]$[136, 208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZCrFEemz8qUl1H9gFg" id="(0.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZSrFEemz8qUl1H9gFg" id="(0.4945054945054945,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LYbllCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_LYRNgCrFEemz8qUl1H9gFg" target="_LYblkCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LYbllSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LYblmSrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDv58CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LYbllirFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LYbllyrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LYblmCrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LY6twCrFEemz8qUl1H9gFg" type="Association_Edge" source="_K3c_cCrFEemz8qUl1H9gFg" target="_LYRNgCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_LY7U0CrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e-85MCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LY7U0SrFEemz8qUl1H9gFg" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LY7U0irFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fAXOcCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LY7U0yrFEemz8qUl1H9gFg" x="-28" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LY7U1CrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fBugYCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LY7U1SrFEemz8qUl1H9gFg" x="7" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LY7U1irFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fCwbICrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LY7U1yrFEemz8qUl1H9gFg" x="-8" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LY7U2CrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fD-jICrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LY7U2SrFEemz8qUl1H9gFg" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LY7U2irFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fFAd4CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LY7U2yrFEemz8qUl1H9gFg" x="-8" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_LY6twSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_hb_v8CqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LY6twirFEemz8qUl1H9gFg" points="[672, 128, -643984, -643984]$[552, 128, -643984, -643984]$[552, 208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fGFb8CrFEemz8qUl1H9gFg" id="(0.0,0.8)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fGFb8SrFEemz8qUl1H9gFg" id="(0.4970873786407767,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_L0vuICrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_L0ZI0CrFEemz8qUl1H9gFg" target="_L0vHECrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_L0vuISrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L0wVMCrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hD0LYCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L0vuIirFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L0vuIyrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L0vuJCrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_L15ksCrFEemz8qUl1H9gFg" type="Association_Edge" source="_K3c_cCrFEemz8qUl1H9gFg" target="_L0ZI0CrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_L16LwCrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l64wkCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L16LwSrFEemz8qUl1H9gFg" x="-1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L16LwirFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l8NmQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L16LwyrFEemz8qUl1H9gFg" x="-27" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L16LxCrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l-MjQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L16LxSrFEemz8qUl1H9gFg" x="29" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L16LxirFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mAH14CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L16LxyrFEemz8qUl1H9gFg" x="-30" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L16LyCrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mCud8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L16LySrFEemz8qUl1H9gFg" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_L16LyirFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mF1cUCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_L16LyyrFEemz8qUl1H9gFg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_L15ksSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ioPgoCqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L15ksirFEemz8qUl1H9gFg" points="[892, 128, -643984, -643984]$[1040, 128, -643984, -643984]$[1040, 208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtOCrFEemz8qUl1H9gFg" id="(1.0,0.8)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtOSrFEemz8qUl1H9gFg" id="(0.5217391304347826,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MPhlpyrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_MPOqsCrFEemz8qUl1H9gFg" target="_MPhloyrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MPhlqCrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MPiMsirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hDh3gCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MPhlqSrFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPiMsCrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPiMsSrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MQ4QgCrFEemz8qUl1H9gFg" type="Association_Edge" source="_K3c_cCrFEemz8qUl1H9gFg" target="_MPOqsCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MQ4QgyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AzHXQCrGEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MQ4QhCrFEemz8qUl1H9gFg" x="1" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MQ4QhSrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A0-_gCrGEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MQ4QhirFEemz8qUl1H9gFg" x="3" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MQ4QhyrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A2y9YCrGEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MQ4QiCrFEemz8qUl1H9gFg" x="27" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MQ4QiSrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A4rMsCrGEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MQ4QiirFEemz8qUl1H9gFg" x="-29" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MQ4QiyrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A6X10CrGEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MQ4QjCrFEemz8qUl1H9gFg" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MQ43kCrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A8HiQCrGEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MQ43kSrFEemz8qUl1H9gFg" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_MQ4QgSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_jkjX4CqwEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MQ4QgirFEemz8qUl1H9gFg" points="[892, 80, -643984, -643984]$[1512, 80, -643984, -643984]$[1512, 208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A-bPYCrGEemz8qUl1H9gFg" id="(1.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A-b2cCrGEemz8qUl1H9gFg" id="(0.48632218844984804,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MRAzYCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_MQ4QgCrFEemz8qUl1H9gFg" target="_MRAMUyrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MRAzYSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MRAzZSrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_jkjX4CqwEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MRAzYirFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MRAzYyrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MRAzZCrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MtQqhCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_MtQqgCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MtQqhSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MtQqiSrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiOam.uml#_1ivtsCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MtQqhirFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MtQqhyrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MtQqiCrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Mu0JsCrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Mu0JsyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VqPzoCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mu0JtCrFEemz8qUl1H9gFg" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Mu0JtSrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VraRQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mu0wwCrFEemz8qUl1H9gFg" x="18" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Mu0wwSrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VsmkECrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mu0wwirFEemz8qUl1H9gFg" x="34" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Mu0wwyrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VtwaoCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mu0wxCrFEemz8qUl1H9gFg" x="-34" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Mu0wxSrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VuzjgCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mu0wxirFEemz8qUl1H9gFg" x="11" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Mu0wxyrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vvya8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mu0wyCrFEemz8qUl1H9gFg" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Mu0JsSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_iAzl0CqzEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mu0JsirFEemz8qUl1H9gFg" points="[128, 472, -643984, -643984]$[32, 472, -643984, -643984]$[32, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYirFEemz8qUl1H9gFg" id="(0.0,0.24)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYyrFEemz8qUl1H9gFg" id="(0.054945054945054944,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NHz4gCrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NHz4gyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vw-twCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0fkCrFEemz8qUl1H9gFg" x="1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NH0fkSrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VyGIECrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0fkirFEemz8qUl1H9gFg" x="10" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NH0fkyrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vy3kICrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0flCrFEemz8qUl1H9gFg" x="34" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NH0flSrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VznyECrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0flirFEemz8qUl1H9gFg" x="-34" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NH0flyrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V0YnECrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0fmCrFEemz8qUl1H9gFg" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NH0fmSrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V1KDICrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0fmirFEemz8qUl1H9gFg" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_NHz4gSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_PF8o4Cq0Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NHz4girFEemz8qUl1H9gFg" points="[88, 448, -643984, -643984]$[88, 400, -643984, -643984]$[136, 400, -643984, -643984]$[136, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYCrFEemz8qUl1H9gFg" id="(0.26229508196721313,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkYSrFEemz8qUl1H9gFg" id="(0.34065934065934067,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Nedd8CrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NeeFACrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V18GQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NeeFASrFEemz8qUl1H9gFg" x="1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NeeFAirFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V269sCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NeeFAyrFEemz8qUl1H9gFg" x="-14" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NeeFBCrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V37DQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NeeFBSrFEemz8qUl1H9gFg" x="34" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NeeFBirFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V4_aQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NeeFByrFEemz8qUl1H9gFg" x="-34" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NeeFCCrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V6BVACrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NeeFCSrFEemz8qUl1H9gFg" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NeeFCirFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V7CBoCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NeeFCyrFEemz8qUl1H9gFg" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Nedd8SrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_bAi9MCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Nedd8irFEemz8qUl1H9gFg" points="[248, 448, -643984, -643984]$[248, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZirFEemz8qUl1H9gFg" id="(0.7213114754098361,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkZyrFEemz8qUl1H9gFg" id="(0.6483516483516484,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_N51LUCrFEemz8qUl1H9gFg" type="Association_Edge" source="_Ms_kwCrFEemz8qUl1H9gFg" target="_K36ScCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_N51yYCrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V8Jb8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N51yYSrFEemz8qUl1H9gFg" x="1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N51yYirFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V99Z0CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N51yYyrFEemz8qUl1H9gFg" x="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N51yZCrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V-wrECrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N51yZSrFEemz8qUl1H9gFg" x="34" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N52ZcCrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_V_qqACrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N52ZcSrFEemz8qUl1H9gFg" x="-34" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N52ZcirFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WAeiUCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N52ZcyrFEemz8qUl1H9gFg" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N52ZdCrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WBPXUCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N52ZdSrFEemz8qUl1H9gFg" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_N51LUSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_hw1lQCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N51LUirFEemz8qUl1H9gFg" points="[260, 472, -643984, -643984]$[368, 472, -643984, -643984]$[368, 354, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCKkaCrFEemz8qUl1H9gFg" id="(1.0,0.24)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WCLLcCrFEemz8qUl1H9gFg" id="(0.978021978021978,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OUgVISrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_OT_XwCrFEemz8qUl1H9gFg" target="_OUfuEyrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OUgVIirFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OUgVJirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEAYoCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OUgVIyrFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OUgVJCrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OUgVJSrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OXD54CrFEemz8qUl1H9gFg" type="Association_Edge" source="_L0ZI0CrFEemz8qUl1H9gFg" target="_OT_XwCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OXEg8CrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lKw7MCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OXEg8SrFEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OXEg8irFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lMOTwCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OXEg8yrFEemz8qUl1H9gFg" x="-33" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OXEg9CrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lOCRoCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OXEg9SrFEemz8qUl1H9gFg" x="6" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OXEg9irFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lPj7oCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OXEg9yrFEemz8qUl1H9gFg" x="-6" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OXEg-CrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lQ6mgCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OXEg-SrFEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OXEg-irFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lSUUsCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OXEg-yrFEemz8qUl1H9gFg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_OXD54SrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_4boiMCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OXD54irFEemz8qUl1H9gFg" points="[992, 466, -643984, -643984]$[992, 528, -643984, -643984]$[376, 528, -643984, -643984]$[376, 616, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGGICrFEemz8qUl1H9gFg" id="(0.15458937198067632,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGGISrFEemz8qUl1H9gFg" id="(0.6982543640897756,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OxOGVCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_OwyogCrFEemz8qUl1H9gFg" target="_OxOGUCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OxOGVSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OxOGWSrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEGfQCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OxOGVirFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OxOGVyrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OxOGWCrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OzglUCrFEemz8qUl1H9gFg" type="Association_Edge" source="_L0ZI0CrFEemz8qUl1H9gFg" target="_OwyogCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OzglUyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lT0JgCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OzglVCrFEemz8qUl1H9gFg" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OzhMYCrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lVQT8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OzhMYSrFEemz8qUl1H9gFg" x="5" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OzhMYirFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lWoM8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OzhMYyrFEemz8qUl1H9gFg" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OzhMZCrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lX-30CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OzhMZSrFEemz8qUl1H9gFg" x="-2" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OzhMZirFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lZpEsCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OzhMZyrFEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OzhMaCrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lbnaoCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OzhMaSrFEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_OzglUSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_5WY6QCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OzglUirFEemz8qUl1H9gFg" points="[1064, 466, -643984, -643984]$[1064, 552, -643984, -643984]$[632, 552, -643984, -643984]$[632, 624, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNirFEemz8qUl1H9gFg" id="(0.3864734299516908,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNyrFEemz8qUl1H9gFg" id="(0.5194805194805194,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PM1ERCrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_PMiJUCrFEemz8qUl1H9gFg" target="_PM1EQCrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PM1ERSrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PM1ESSrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEJikCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PM1ERirFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PM1ERyrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PM1ESCrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PPMbwCrFEemz8qUl1H9gFg" type="Association_Edge" source="_L0ZI0CrFEemz8qUl1H9gFg" target="_PMiJUCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PPMbwyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ldgRACrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPMbxCrFEemz8qUl1H9gFg" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PPNC0CrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lgCAkCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPNC0SrFEemz8qUl1H9gFg" x="-6" y="6"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PPNC0irFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lhhOUCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPNC0yrFEemz8qUl1H9gFg" x="3" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PPNC1CrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_li8xsCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPNC1SrFEemz8qUl1H9gFg" x="-3" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PPNC1irFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lkSOcCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPNC1yrFEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PPNC2CrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_llyDQCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPNC2SrFEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_PPMbwSrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_6TkUMCq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PPMbwirFEemz8qUl1H9gFg" points="[1192, 466, -643984, -643984]$[1192, 616, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMirFEemz8qUl1H9gFg" id="(0.6376811594202898,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMyrFEemz8qUl1H9gFg" id="(0.6354916067146283,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Pj0n8CrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_Pjge4CrFEemz8qUl1H9gFg" target="_Pj0A4yrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Pj0n8SrFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pj0n9SrFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEN0ACquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pj0n8irFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pj0n8yrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pj0n9CrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PnBs8CrFEemz8qUl1H9gFg" type="Association_Edge" source="_L0ZI0CrFEemz8qUl1H9gFg" target="_Pjge4CrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PnBs8yrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lnIuICrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs9CrFEemz8qUl1H9gFg" x="1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PnBs9SrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_loc8wCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs9irFEemz8qUl1H9gFg" x="-16" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PnBs9yrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lqIXwCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs-CrFEemz8qUl1H9gFg" x="37" y="-17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PnBs-SrFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lsDDUCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs-irFEemz8qUl1H9gFg" x="-36" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PnBs-yrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lt6rkCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs_CrFEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PnBs_SrFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lv62sCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PnBs_irFEemz8qUl1H9gFg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_PnBs8SrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_7d1u8Cq1Eemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PnBs8irFEemz8qUl1H9gFg" points="[1224, 466, -643984, -643984]$[1224, 520, -643984, -643984]$[1392, 520, -643984, -643984]$[1392, 616, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNCrFEemz8qUl1H9gFg" id="(0.8309178743961353,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtNSrFEemz8qUl1H9gFg" id="(0.4970873786407767,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QI65ECrFEemz8qUl1H9gFg" type="Association_Edge" source="_L0ZI0CrFEemz8qUl1H9gFg" target="_MPOqsCrFEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QI65EyrFEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lyXtwCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QI65FCrFEemz8qUl1H9gFg" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QI65FSrFEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lz7M8CrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QI65FirFEemz8qUl1H9gFg" x="2" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QI7gICrFEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l1RQwCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QI7gISrFEemz8qUl1H9gFg" x="2" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QI7gIirFEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l2pJwCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QI7gIyrFEemz8qUl1H9gFg" x="-3" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QI9VUCrFEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l4KzwCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QI9VUSrFEemz8qUl1H9gFg" x="8" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QI9VUirFEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l5g3kCrFEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QI9VUyrFEemz8qUl1H9gFg" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_QI65ESrFEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ULiMMCrAEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QI65EirFEemz8qUl1H9gFg" points="[1282, 296, -643984, -643984]$[1456, 296, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMCrFEemz8qUl1H9gFg" id="(1.0,0.34108527131782945)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIGtMSrFEemz8qUl1H9gFg" id="(0.0,0.4943820224719101)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QJtjQSrFEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_QI65ECrFEemz8qUl1H9gFg" target="_QJs8MyrFEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJtjQirFEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJtjRirFEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ULiMMCrAEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJtjQyrFEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJtjRCrFEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJtjRSrFEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QSxfByrNEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_QSoVECrNEemz8qUl1H9gFg" target="_QSxfAyrNEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QSyGECrNEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QSyGFCrNEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEW98CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QSyGESrNEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QSyGEirNEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QSyGEyrNEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Qo7VNyrNEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_QowWECrNEemz8qUl1H9gFg" target="_Qo7VMyrNEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qo7VOCrNEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qo78QyrNEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEdEkCquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qo78QCrNEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qo78QSrNEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qo78QirNEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Q-LzhyrNEemz8qUl1H9gFg" type="StereotypeCommentLink" source="_Q-CCgCrNEemz8qUl1H9gFg" target="_Q-LzgyrNEemz8qUl1H9gFg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Q-LziCrNEemz8qUl1H9gFg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Q-LzjCrNEemz8qUl1H9gFg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_hEfg0CquEemz8qUl1H9gFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Q-LziSrNEemz8qUl1H9gFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q-LziirNEemz8qUl1H9gFg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q-LziyrNEemz8qUl1H9gFg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WlYskCrNEemz8qUl1H9gFg" type="Association_Edge" source="_Pjge4CrFEemz8qUl1H9gFg" target="_QSoVECrNEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WlYskyrNEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eRNIwCrNEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlYslCrNEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WlYslSrNEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eVYeICrNEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlYslirNEemz8qUl1H9gFg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WlYslyrNEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ebJu8CrNEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlYsmCrNEemz8qUl1H9gFg" x="38" y="-42"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WlYsmSrNEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eh-vsCrNEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlYsmirNEemz8qUl1H9gFg" x="-20" y="60"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WlYsmyrNEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_emPkoCrNEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlYsnCrNEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WlYsnSrNEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_erAv4CrNEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlYsnirNEemz8qUl1H9gFg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_WlYskSrNEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_WdWK4CrNEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WlYskirNEemz8qUl1H9gFg" points="[1256, 906, -643984, -643984]$[1256, 952, -643984, -643984]$[984, 952, -643984, -643984]$[984, 1008, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvLhwCrNEemz8qUl1H9gFg" id="(0.20194174757281552,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvLhwSrNEemz8qUl1H9gFg" id="(0.49502982107355864,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XRKNcCrNEemz8qUl1H9gFg" type="Association_Edge" source="_Pjge4CrFEemz8qUl1H9gFg" target="_QowWECrNEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_XRKNcyrNEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AlJ6ICrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XRK0gCrNEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XRK0gSrNEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ArX24CrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XRK0girNEemz8qUl1H9gFg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XRK0gyrNEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AxlzoCrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XRK0hCrNEemz8qUl1H9gFg" x="1" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XRK0hSrNEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A15r4CrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XRK0hirNEemz8qUl1H9gFg" x="-1" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XRK0hyrNEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A7uAACrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XRK0iCrNEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XRK0iSrNEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BBwWkCrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XRK0iirNEemz8qUl1H9gFg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_XRKNcSrNEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_XIbvQCrNEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XRKNcirNEemz8qUl1H9gFg" points="[1658, 906, -643984, -643984]$[1658, 960, -643984, -643984]$[1626, 960, -643984, -643984]$[1626, 1008, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xaz4sCrNEemz8qUl1H9gFg" id="(0.512621359223301,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xaz4sSrNEemz8qUl1H9gFg" id="(0.5191387559808612,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_X8LgYCrNEemz8qUl1H9gFg" type="Association_Edge" source="_Pjge4CrFEemz8qUl1H9gFg" target="_Q-CCgCrNEemz8qUl1H9gFg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_X8LgYyrNEemz8qUl1H9gFg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RNnhMCrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_X8LgZCrNEemz8qUl1H9gFg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_X8LgZSrNEemz8qUl1H9gFg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RSJb4CrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_X8LgZirNEemz8qUl1H9gFg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_X8LgZyrNEemz8qUl1H9gFg" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RXAtwCrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_X8LgaCrNEemz8qUl1H9gFg" x="83" y="-111"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_X8LgaSrNEemz8qUl1H9gFg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Rd1ugCrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_X8LgairNEemz8qUl1H9gFg" x="-8" y="-146"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_X8LgayrNEemz8qUl1H9gFg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RiT-0CrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_X8LgbCrNEemz8qUl1H9gFg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_X8LgbSrNEemz8qUl1H9gFg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RnJbgCrOEemz8qUl1H9gFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_X8LgbirNEemz8qUl1H9gFg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_X8LgYSrNEemz8qUl1H9gFg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_Xz3R4CrNEemz8qUl1H9gFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X8LgYirNEemz8qUl1H9gFg" points="[1544, 906, -643984, -643984]$[1544, 952, -643984, -643984]$[1776, 952, -643984, -643984]$[1776, 1008, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YGn10CrNEemz8qUl1H9gFg" id="(0.8388349514563107,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YGn10SrNEemz8qUl1H9gFg" id="(0.5045045045045045,0.0)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -389,7 +389,7 @@ An NMS can use this object to reduce polling of the remote-systems-data objects.
 The complete set of information received from a particular MSAP should be inserted into related tables.  If partial information cannot be inserted for a reason such as lack of resources, all of the complete set of information should be removed.&#xD;
 This counter should be incremented only once after the complete set of information is successfully recorded in all related tables.  Any failures during inserting information set which result in deletion of previously inserted information should not trigger any changes in inserts since the insert is not completed yet or or in deletes, since the deletion would only be a partial deletion. If the failure was the result of lack of resources, the drops counter should be incremented once.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDroiCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDroiSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -407,7 +407,7 @@ This counter should be incremented only once after the complete set of informati
            but not from all tables are not allowed, thus should not&#xD;
            change the value of this counter.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrojCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrojSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -418,7 +418,7 @@ This counter should be incremented only once after the complete set of informati
            tables contained in remote-systems-data and lldpExtensions&#xD;
            objects because of insufficient resources.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrokCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrokSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -435,7 +435,7 @@ This counter should be incremented only once after the complete set of informati
            case, is not allowed, and thus, should not change the value&#xD;
            of this counter.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrolCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrolSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -512,7 +512,7 @@ This counter should be incremented only once after the complete set of informati
             <body>The dest-mac-address specifies the destination MAC&#xD;
            addresses.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_iP9yQ_ZaEeWhRf3FikFX5w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_6-ftUC7jEem3g99vIRtESQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LaCquEemz8qUl1H9gFg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LaSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -605,7 +605,7 @@ This counter should be incremented only once after the complete set of informati
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7d2WAiq1Eemz8qUl1H9gFg" name="_remoteSystemsData" type="_hEN0ACquEemz8qUl1H9gFg" aggregation="composite" association="_7d1u8Cq1Eemz8qUl1H9gFg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7d3kISq1Eemz8qUl1H9gFg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7d3kIiq1Eemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7d3kIiq1Eemz8qUl1H9gFg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ULjaUirAEemz8qUl1H9gFg" name="_lldpCfg" type="_hDh3gCquEemz8qUl1H9gFg" aggregation="composite" association="_ULiMMCrAEemz8qUl1H9gFg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ULkBYSrAEemz8qUl1H9gFg" value="1"/>
@@ -710,7 +710,7 @@ This counter should be incremented only once after the complete set of informati
           <ownedComment xmi:type="uml:Comment" xmi:id="_hEGfQyquEemz8qUl1H9gFg" annotatedElement="_hEGfQiquEemz8qUl1H9gFg">
             <body>A count of all LLDP frames transmitted through the port.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEGfRCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEGfRSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -719,7 +719,7 @@ This counter should be incremented only once after the complete set of informati
             <body>A count of all LLDP length errors detected when constructing&#xD;
             LLPDU frames for transmission through the port.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEGfSCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEGfSSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -746,7 +746,7 @@ This counter should be incremented only once after the complete set of informati
              is deleted from the LLDP remote systems MIB because&#xD;
              of rxInfoTTL timer expiration.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJilCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJilSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -754,7 +754,7 @@ This counter should be incremented only once after the complete set of informati
           <ownedComment xmi:type="uml:Comment" xmi:id="_hEJilyquEemz8qUl1H9gFg" annotatedElement="_hEJiliquEemz8qUl1H9gFg">
             <body>A count of all LLDPDUs received and then discarded.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJimCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJimSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -763,7 +763,7 @@ This counter should be incremented only once after the complete set of informati
             <body>A count of all LLDPDUs received at the port with one or more&#xD;
              detectable errors.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJinCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJinSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -771,7 +771,7 @@ This counter should be incremented only once after the complete set of informati
           <ownedComment xmi:type="uml:Comment" xmi:id="_hEJinyquEemz8qUl1H9gFg" annotatedElement="_hEJiniquEemz8qUl1H9gFg">
             <body>A count of all LLDP frames received at the port.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJioCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJioSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -780,7 +780,7 @@ This counter should be incremented only once after the complete set of informati
             <body>A count of all TLVs received at the port and discarded for any&#xD;
              reason.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJipCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJipSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -789,7 +789,7 @@ This counter should be incremented only once after the complete set of informati
             <body>This counter provides a count of all TLVs not recognized by&#xD;
              the receiving LLDP local agent.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJiqCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJiqSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -807,7 +807,7 @@ This counter should be incremented only once after the complete set of informati
              http://www.ietf.org/IESG/Implementations/RFC2021-Implementation.txt&#xD;
              to see how TimeFilter works.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_iP8kIfZaEeWhRf3FikFX5w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_vK1_AC9lEem3g99vIRtESQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0BCquEemz8qUl1H9gFg" name="remoteIndex" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0BSquEemz8qUl1H9gFg" annotatedElement="_hEN0BCquEemz8qUl1H9gFg">
@@ -1044,7 +1044,7 @@ This counter should be incremented only once after the complete set of informati
             <body>This object represents the value extracted from the value&#xD;
                field of the tlv.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEdEmCquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEdEmSquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -1074,7 +1074,7 @@ This counter should be incremented only once after the complete set of informati
                unique assigned number referenced by various standards,&#xD;
                of the information received from the remote system.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEfg1CquEemz8qUl1H9gFg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEfg1SquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
@@ -1117,13 +1117,11 @@ This counter should be incremented only once after the complete set of informati
                defined information of the remote system.  The encoding for&#xD;
                this object should be as defined for SnmpAdminString TC.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEfg4CquEemz8qUl1H9gFg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEfg4SquEemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_sgTswCrCEemz8qUl1H9gFg" name="AugmentOamJob" client="_hDnXECquEemz8qUl1H9gFg" supplier="_2-15sEI6EeiDweqmZm-ZXQ"/>
-      <packagedElement xmi:type="uml:Realization" xmi:id="_DkJb0CrDEemz8qUl1H9gFg" name="name attribute realized by localId" client="_hD0LYCquEemz8qUl1H9gFg" supplier="_W48McBP7EeepnPPr_BcZKg"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_zf2PwMOcEeaFfJxGCRaf4A" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_Nm0qoOxYEeaTUPmcu3rLwA" name="OamService">
@@ -1575,24 +1573,36 @@ This counter should be incremented only once after the complete set of informati
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iA0z8CqzEemz8qUl1H9gFg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iA0z8SqzEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
         </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_yKWCAC7hEem3g99vIRtESQ" annotatedElement="_iAzl0CqzEemz8qUl1H9gFg">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-inserts&quot;</body>
+        </ownedComment>
         <ownedEnd xmi:type="uml:Property" xmi:id="_iA2CEiqzEemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_iAzl0CqzEemz8qUl1H9gFg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_PF8o4Cq0Eemz8qUl1H9gFg" name="RtcNotifiesRemoteDeletes" memberEnd="_PF93ASq0Eemz8qUl1H9gFg _PF-eEyq0Eemz8qUl1H9gFg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PF9P8Cq0Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PF93ACq0Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
         </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_1Xt88C7hEem3g99vIRtESQ" annotatedElement="_PF8o4Cq0Eemz8qUl1H9gFg">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-deletes&quot;</body>
+        </ownedComment>
         <ownedEnd xmi:type="uml:Property" xmi:id="_PF-eEyq0Eemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_PF8o4Cq0Eemz8qUl1H9gFg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_bAi9MCq1Eemz8qUl1H9gFg" name="RtcNotifiesRemoteDrops" memberEnd="_bAjkQiq1Eemz8qUl1H9gFg _bAkyYSq1Eemz8qUl1H9gFg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bAjkQCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bAjkQSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
         </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_3pLCMC7hEem3g99vIRtESQ" annotatedElement="_bAi9MCq1Eemz8qUl1H9gFg">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-drops&quot;</body>
+        </ownedComment>
         <ownedEnd xmi:type="uml:Property" xmi:id="_bAkyYSq1Eemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_bAi9MCq1Eemz8qUl1H9gFg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_hw1lQCq1Eemz8qUl1H9gFg" name="RtcNotifiesRemoteAgeouts" memberEnd="_hw2zYiq1Eemz8qUl1H9gFg _hw5Poiq1Eemz8qUl1H9gFg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hw2zYCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hw2zYSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
         </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_52J3IC7hEem3g99vIRtESQ" annotatedElement="_hw1lQCq1Eemz8qUl1H9gFg">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-ageouts&quot;</body>
+        </ownedComment>
         <ownedEnd xmi:type="uml:Property" xmi:id="_hw5Poiq1Eemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_hw1lQCq1Eemz8qUl1H9gFg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_4boiMCq1Eemz8qUl1H9gFg" name="PortHasMgmtAddresses" memberEnd="_4bpwUiq1Eemz8qUl1H9gFg _4bq-ciq1Eemz8qUl1H9gFg">
@@ -1625,6 +1635,19 @@ This counter should be incremented only once after the complete set of informati
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_ULkocCrAEemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" association="_ULiMMCrAEemz8qUl1H9gFg"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_sgTswCrCEemz8qUl1H9gFg" name="AugmentOamJob" client="_hDnXECquEemz8qUl1H9gFg" supplier="_2-15sEI6EeiDweqmZm-ZXQ"/>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_DkJb0CrDEemz8qUl1H9gFg" name="name attribute realized by localId" client="_hD0LYCquEemz8qUl1H9gFg" supplier="_W48McBP7EeepnPPr_BcZKg">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_eAka4C7iEem3g99vIRtESQ" annotatedElement="_DkJb0CrDEemz8qUl1H9gFg">
+          <body> must &quot;deref(.)/../type = 'ianaift:ethernetCsmacd'&quot; &#xD;
++ &quot; or deref(.)/../type = 'ianaift:ieee8023adLag'&quot; {&#xD;
+error-message&#xD;
+&quot;The LLDP is only configured on Link Aggreagation&#xD;
+and Ethernet Port.&quot;;&#xD;
+}&#xD;
+Not defined in UML</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_keOssCrCEemz8qUl1H9gFg" name="AugmentOamJob" client="_1ivtsCquEemz8qUl1H9gFg" supplier="_2-15sEI6EeiDweqmZm-ZXQ"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_-MPC0OvREealldJ4rm6P_g" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_HIIm0OvSEealldJ4rm6P_g">
@@ -1877,7 +1900,7 @@ This counter should be incremented only once after the complete set of informati
        the port is not included if its bit has a value of '0'.</body>
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_8RI4UiquEemz8qUl1H9gFg" name="portList">
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_8ROX4CquEemz8qUl1H9gFg" name="ManAddrType">
@@ -1894,7 +1917,7 @@ This counter should be incremented only once after the complete set of informati
        LLDP agent.</body>
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_8ROX4iquEemz8qUl1H9gFg" name="manAddrType">
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_jSDlwCrIEemz8qUl1H9gFg" name="ChassisIdSubtypeType" isLeaf="true">
@@ -2225,7 +2248,6 @@ This counter should be incremented only once after the complete set of informati
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hw5PoSq1Eemz8qUl1H9gFg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_keOssCrCEemz8qUl1H9gFg" name="AugmentOamJob" client="_1ivtsCquEemz8qUl1H9gFg" supplier="_2-15sEI6EeiDweqmZm-ZXQ"/>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_x2I28BMwEee0L_IMWjydgQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TeGtAWm2EeiLh_06MH5Rjg" source="PapyrusVersion">

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -298,6 +298,832 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <type xmi:type="uml:DataType" href="TapiCommon.uml#_Ay2V0F6UEeitO-Stqhyn1g"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hDh3gCquEemz8qUl1H9gFg" name="LldpCfg">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hDh3gSquEemz8qUl1H9gFg" annotatedElement="_hDh3gCquEemz8qUl1H9gFg">
+          <body>LLDP basic configuration group.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3giquEemz8qUl1H9gFg" name="messageFastTx">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDh3gyquEemz8qUl1H9gFg" annotatedElement="_hDh3giquEemz8qUl1H9gFg">
+            <body>This node indicates the time interval in timer ticks between transmissions during fast transmission periods(i.e., txFast is non-zero).&#xD;
+The recommended default value of msgFastTx is 1; this value can be changed by management to any value in the range 1 through 3600.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3hCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDh3hSquEemz8qUl1H9gFg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3hiquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3hyquEemz8qUl1H9gFg" name="messageTxHoldMultiplier">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDh3iCquEemz8qUl1H9gFg" annotatedElement="_hDh3hyquEemz8qUl1H9gFg">
+            <body>This node is used, as a multiplier of msg-tx-interval, to determine the value of txTTL that is carried in LLDP frames transmitted by the LLDP agent.&#xD;
+The recommended default value of msgTxHold is 4;  this value can be changed by management to any value in the range 2 through 10.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3iSquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDh3iiquEemz8qUl1H9gFg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3iyquEemz8qUl1H9gFg" value="4"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3jCquEemz8qUl1H9gFg" name="messageTxInterval">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3jSquEemz8qUl1H9gFg" value="30"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3jiquEemz8qUl1H9gFg" name="reinitDelay">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3jyquEemz8qUl1H9gFg" value="2"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3kCquEemz8qUl1H9gFg" name="txCreditMax">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3kSquEemz8qUl1H9gFg" value="5"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3kiquEemz8qUl1H9gFg" name="txFastInit">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3kyquEemz8qUl1H9gFg" value="4"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDh3lCquEemz8qUl1H9gFg" name="notificationInterval">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_hDh3lSquEemz8qUl1H9gFg" value="30"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hDnXECquEemz8qUl1H9gFg" name="Lldp">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hDn-ICquEemz8qUl1H9gFg" annotatedElement="_hDnXECquEemz8qUl1H9gFg">
+          <body>Link Layer Discovery Protocol configuration and operational information.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gS5Z4CqwEemz8qUl1H9gFg" name="_remoteStatistics" type="_hDrogCquEemz8qUl1H9gFg" aggregation="composite" association="_gS1vgCqwEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GsguMCqzEemz8qUl1H9gFg" annotatedElement="_gS5Z4CqwEemz8qUl1H9gFg">
+            <body>LLDP remote operational statistics data.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gS6oASqwEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gS7PECqwEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hcA-EiqwEemz8qUl1H9gFg" name="_localSystemData" type="_hDv58CquEemz8qUl1H9gFg" aggregation="composite" association="_hb_v8CqwEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Cp3YICqzEemz8qUl1H9gFg" annotatedElement="_hcA-EiqwEemz8qUl1H9gFg">
+            <body>LLDP local system operational data.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hcCMMCqwEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hcCMMSqwEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ioQuwiqwEemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" aggregation="composite" association="_ioPgoCqwEemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ioR84CqwEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ioR84SqwEemz8qUl1H9gFg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jkkmASqwEemz8qUl1H9gFg" name="_lldpCfg" type="_hDh3gCquEemz8qUl1H9gFg" aggregation="composite" association="_jkjX4CqwEemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jklNESqwEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jkl0ICqwEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hDrogCquEemz8qUl1H9gFg" name="RemoteStatistics">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hDrogSquEemz8qUl1H9gFg" annotatedElement="_hDrogCquEemz8qUl1H9gFg">
+          <body>LLDP remote operational statistics data.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDrogiquEemz8qUl1H9gFg" name="lastChangeTime" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDrogyquEemz8qUl1H9gFg" annotatedElement="_hDrogiquEemz8qUl1H9gFg">
+            <body>The value of sysUpTime object (defined in IETF RFC 3418) at the time an entry is created, modified, or deleted in the in tables associated with the remote-systems-data objects and all LLDP extension objects associated with remote systems.&#xD;
+An NMS can use this object to reduce polling of the remote-systems-data objects.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_6iCS8O-fEeWLlrwIF3w0vA"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrohCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrohSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDrohiquEemz8qUl1H9gFg" name="remoteInserts" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDrohyquEemz8qUl1H9gFg" annotatedElement="_hDrohiquEemz8qUl1H9gFg">
+            <body>The number of times the complete set of information advertised by a particular MSAP has been inserted into tables contained in remote-systems-data and lldpExtensions objects.&#xD;
+The complete set of information received from a particular MSAP should be inserted into related tables.  If partial information cannot be inserted for a reason such as lack of resources, all of the complete set of information should be removed.&#xD;
+This counter should be incremented only once after the complete set of information is successfully recorded in all related tables.  Any failures during inserting information set which result in deletion of previously inserted information should not trigger any changes in inserts since the insert is not completed yet or or in deletes, since the deletion would only be a partial deletion. If the failure was the result of lack of resources, the drops counter should be incremented once.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDroiCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDroiSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDroiiquEemz8qUl1H9gFg" name="remoteDeletes" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDroiyquEemz8qUl1H9gFg" annotatedElement="_hDroiiquEemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP has been deleted from&#xD;
+           tables contained in remote-systems-data and lldpExtensions&#xD;
+           objects.&#xD;
+  &#xD;
+           This counter should be incremented only once when the&#xD;
+           complete set of information is completely deleted from all&#xD;
+           related tables.  Partial deletions, such as deletion of&#xD;
+           rows associated with a particular MSAP from some tables,&#xD;
+           but not from all tables are not allowed, thus should not&#xD;
+           change the value of this counter.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrojCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrojSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDrojiquEemz8qUl1H9gFg" name="remoteDrops" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDrojyquEemz8qUl1H9gFg" annotatedElement="_hDrojiquEemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP could not be entered into&#xD;
+           tables contained in remote-systems-data and lldpExtensions&#xD;
+           objects because of insufficient resources.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrokCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrokSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDrokiquEemz8qUl1H9gFg" name="remoteAgeouts" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDrokyquEemz8qUl1H9gFg" annotatedElement="_hDrokiquEemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP has been deleted from tables&#xD;
+           contained in remote-systems-data and lldpExtensions objects&#xD;
+           because the information timeliness interval has expired.&#xD;
+  &#xD;
+           This counter should be incremented only once when the complete&#xD;
+           set of information is completely invalidated (aged out)&#xD;
+           from all related tables.  Partial aging, similar to deletion&#xD;
+           case, is not allowed, and thus, should not change the value&#xD;
+           of this counter.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDrolCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDrolSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hDv58CquEemz8qUl1H9gFg" name="LocalSystemData">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hDv58SquEemz8qUl1H9gFg" annotatedElement="_hDv58CquEemz8qUl1H9gFg">
+          <body>LLDP local system operational data.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDv58iquEemz8qUl1H9gFg" name="chassisIdSubtype" type="_jSDlwCrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDv58yquEemz8qUl1H9gFg" annotatedElement="_hDv58iquEemz8qUl1H9gFg">
+            <body>The type of encoding used to identify the chassis&#xD;
+           associated with the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDv59CquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDv59SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDv59iquEemz8qUl1H9gFg" name="chassisId" type="_jSFa8CrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDv59yquEemz8qUl1H9gFg" annotatedElement="_hDv59iquEemz8qUl1H9gFg">
+            <body>The string value used to identify the chassis component&#xD;
+           associated with the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDv5-CquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDv5-SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDv5-iquEemz8qUl1H9gFg" name="systemName" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDv5-yquEemz8qUl1H9gFg" annotatedElement="_hDv5-iquEemz8qUl1H9gFg">
+            <body>The string value used to identify the system name of the&#xD;
+           local system.  If the local agent supports IETF RFC 3418,&#xD;
+           system-name object should have the same value of sys-name&#xD;
+           object.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDv5_CquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDv5_SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDv5_iquEemz8qUl1H9gFg" name="systemDescription" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDv5_yquEemz8qUl1H9gFg" annotatedElement="_hDv5_iquEemz8qUl1H9gFg">
+            <body>The string value used to identify the system description&#xD;
+          of the local system.  If the local agent supports IETF RFC 3418,&#xD;
+          system-name object should have the same value of sys-desc&#xD;
+          object.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDv6ACquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDv6ASquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDv6AiquEemz8qUl1H9gFg" name="systemCapabilitiesSupported" type="_8Q95MCquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDv6AyquEemz8qUl1H9gFg" annotatedElement="_hDv6AiquEemz8qUl1H9gFg">
+            <body>The bitmap value used to identify which system capabilities&#xD;
+           are supported on the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDv6BCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDv6BSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hDv6BiquEemz8qUl1H9gFg" name="systemCapabilitiesEnabled" type="_8Q95MCquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hDv6ByquEemz8qUl1H9gFg" annotatedElement="_hDv6BiquEemz8qUl1H9gFg">
+            <body>The bitmap value used to identify which system capabilities&#xD;
+           are enabled on the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDv6CCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDv6CSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hD0LYCquEemz8qUl1H9gFg" name="Port">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LYSquEemz8qUl1H9gFg" annotatedElement="_hD0LYCquEemz8qUl1H9gFg">
+          <body>LLDP configuration information for a particular port.&#xD;
+  &#xD;
+         This configuration parameter controls the transmission and&#xD;
+         the reception of LLDP frames on those ports whose rows are&#xD;
+         created in this table.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LZiquEemz8qUl1H9gFg" name="destMacAddress">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LZyquEemz8qUl1H9gFg" annotatedElement="_hD0LZiquEemz8qUl1H9gFg">
+            <body>The dest-mac-address specifies the destination MAC&#xD;
+           addresses.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_iP9yQ_ZaEeWhRf3FikFX5w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LaCquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LaSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LaiquEemz8qUl1H9gFg" name="adminStatus" type="_8RHqMCquEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LayquEemz8qUl1H9gFg" annotatedElement="_hD0LaiquEemz8qUl1H9gFg">
+            <body>The administratively desired status of the local LLDP agent.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LbCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LbSquEemz8qUl1H9gFg" value="1"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_NHCfoCrJEemz8qUl1H9gFg" type="_8RHqMCquEemz8qUl1H9gFg" instance="_8RHqOCquEemz8qUl1H9gFg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LbyquEemz8qUl1H9gFg" name="notificationEnable">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LcCquEemz8qUl1H9gFg" annotatedElement="_hD0LbyquEemz8qUl1H9gFg">
+            <body>The notification-enable controls, on a per&#xD;
+           port basis,  whether or not notifications from the agent&#xD;
+           are enabled. The value true(1) means that notifications are&#xD;
+           enabled; the value false(2) means that they are not.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LcSquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LciquEemz8qUl1H9gFg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_hD0LcyquEemz8qUl1H9gFg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LdCquEemz8qUl1H9gFg" name="tlvsTxEnable" type="_8RF1ACquEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LdSquEemz8qUl1H9gFg" annotatedElement="_hD0LdCquEemz8qUl1H9gFg">
+            <body>The tlvs-tx-enable, defined as a bitmap,&#xD;
+          includes the basic set of LLDP tlvs whose transmission is&#xD;
+          allowed on the local LLDP agent by the network management.&#xD;
+          Each bit in the bitmap corresponds to a tlv type associated&#xD;
+          with a specific optional tlv.&#xD;
+  &#xD;
+          It should be noted that the organizationally-specific tlvs&#xD;
+          are excluded from the lldptlvsTxEnable bitmap.&#xD;
+  &#xD;
+          LLDP Organization Specific Information Extension MIBs should&#xD;
+          have similar configuration object to control transmission&#xD;
+          of their organizationally defined tlvs.&#xD;
+  &#xD;
+          There is no bit reserved for the management address tlv type&#xD;
+          since transmission of management address tlvs are controlled&#xD;
+          by another object, man-addr-type.&#xD;
+  &#xD;
+          The default value for tlvs-tx-enable object is&#xD;
+          empty set, which means no enumerated values are set.&#xD;
+  &#xD;
+          The value of this object must be restored from non-volatile&#xD;
+          storage after a re-initialization of the management system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LdiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LdyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LfiquEemz8qUl1H9gFg" name="portIdSubtype" type="_jSEM0CrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LfyquEemz8qUl1H9gFg" annotatedElement="_hD0LfiquEemz8qUl1H9gFg">
+            <body>The type of port identifier encoding used in the associated&#xD;
+           'port-id' object.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LgCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LgSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LgiquEemz8qUl1H9gFg" name="portId" type="_jSGCACrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LgyquEemz8qUl1H9gFg" annotatedElement="_hD0LgiquEemz8qUl1H9gFg">
+            <body>The string value used to identify the port component&#xD;
+           associated with a given port in the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LhCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LhSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hD0LhiquEemz8qUl1H9gFg" name="portDesc" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hD0LhyquEemz8qUl1H9gFg" annotatedElement="_hD0LhiquEemz8qUl1H9gFg">
+            <body>The string value used to identify the 802 LAN station's port&#xD;
+           description associated with the local system.  If the local&#xD;
+           agent supports IETF RFC 2863, port-desc object should&#xD;
+           have the same value of ifDescr object.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hD0LiCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hD0LiSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4bpwUiq1Eemz8qUl1H9gFg" name="_managementAddressTxPort" type="_hEAYoCquEemz8qUl1H9gFg" aggregation="composite" association="_4boiMCq1Eemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4bq-cCq1Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4bq-cSq1Eemz8qUl1H9gFg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5WZhUiq1Eemz8qUl1H9gFg" name="_txStatistics" type="_hEGfQCquEemz8qUl1H9gFg" aggregation="composite" association="_5WY6QCq1Eemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5WaIYCq1Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5WaIYSq1Eemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6Tk7Qiq1Eemz8qUl1H9gFg" name="_rxStatistics" type="_hEJikCquEemz8qUl1H9gFg" aggregation="composite" association="_6TkUMCq1Eemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6TliUSq1Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6TliUiq1Eemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7d2WAiq1Eemz8qUl1H9gFg" name="_remoteSystemsData" type="_hEN0ACquEemz8qUl1H9gFg" aggregation="composite" association="_7d1u8Cq1Eemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7d3kISq1Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7d3kIiq1Eemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ULjaUirAEemz8qUl1H9gFg" name="_lldpCfg" type="_hDh3gCquEemz8qUl1H9gFg" aggregation="composite" association="_ULiMMCrAEemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ULkBYSrAEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ULkBYirAEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEAYoCquEemz8qUl1H9gFg" name="ManagementAddressTxPort">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYoSquEemz8qUl1H9gFg" annotatedElement="_hEAYoCquEemz8qUl1H9gFg">
+          <body>LLDP configuration information that specifies the set&#xD;
+           of ports (represented as a PortList) on which the local&#xD;
+           system management address instance will be transmitted.&#xD;
+      &#xD;
+           This configuration object augments the local-management-address,&#xD;
+           therefore it is only present along with the management&#xD;
+           address instance contained in the associated&#xD;
+           local-management-address entry.&#xD;
+      &#xD;
+           Each active man-address must be restored from&#xD;
+           non-volatile and re-created (along with the corresponding&#xD;
+           local-management-address) after a re-initialization of the&#xD;
+           management system.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEAYoiquEemz8qUl1H9gFg" name="addressSubtype" type="_jW9pACrKEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYoyquEemz8qUl1H9gFg" annotatedElement="_hEAYoiquEemz8qUl1H9gFg">
+            <body>The management address subtype field shall contain an&#xD;
+             integer value indicating the type of address.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEAYpCquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEAYpSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEAYpiquEemz8qUl1H9gFg" name="manAddress" type="_8ROX4CquEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYpyquEemz8qUl1H9gFg" annotatedElement="_hEAYpiquEemz8qUl1H9gFg">
+            <body>The management address field shall contain an octet string&#xD;
+             indicating the particular management address associated&#xD;
+             with this TLV.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEAYqCquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEAYqSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEAYqiquEemz8qUl1H9gFg" name="txEnable">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYqyquEemz8qUl1H9gFg" annotatedElement="_hEAYqiquEemz8qUl1H9gFg">
+            <body>Specify to enable transmission of system&#xD;
+             management address instance on a particular port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEAYrCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEAYrSquEemz8qUl1H9gFg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_hEAYriquEemz8qUl1H9gFg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEAYryquEemz8qUl1H9gFg" name="addrLen" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYsCquEemz8qUl1H9gFg" annotatedElement="_hEAYryquEemz8qUl1H9gFg">
+            <body>The total length of the management address subtype and the&#xD;
+             management address fields in LLDPDUs transmitted by the&#xD;
+             local LLDP agent.&#xD;
+        &#xD;
+             The management address length field is needed so that the&#xD;
+             receiving systems that do not implement SNMP will not be&#xD;
+             required to implement an iana family numbers/address length&#xD;
+             equivalency table in order to decode the management adress.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEAYsSquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEAYsiquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEAYsyquEemz8qUl1H9gFg" name="ifSubtype" type="_8RIRQCquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYtCquEemz8qUl1H9gFg" annotatedElement="_hEAYsyquEemz8qUl1H9gFg">
+            <body>The enumeration value that identifies the interface numbering&#xD;
+             method used for defining the interface number, associated&#xD;
+             with the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEAYtSquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEAYtiquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEAYtyquEemz8qUl1H9gFg" name="ifId" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEAYuCquEemz8qUl1H9gFg" annotatedElement="_hEAYtyquEemz8qUl1H9gFg">
+            <body>The integer value used to identify the interface number&#xD;
+             regarding the management address component associated with&#xD;
+             the local system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEAYuSquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEAYuiquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEGfQCquEemz8qUl1H9gFg" name="TxStatistics">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEGfQSquEemz8qUl1H9gFg" annotatedElement="_hEGfQCquEemz8qUl1H9gFg">
+          <body>LLDP frame transmission statistics for a particular port.  &#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEGfQiquEemz8qUl1H9gFg" name="totalFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEGfQyquEemz8qUl1H9gFg" annotatedElement="_hEGfQiquEemz8qUl1H9gFg">
+            <body>A count of all LLDP frames transmitted through the port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEGfRCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEGfRSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEGfRiquEemz8qUl1H9gFg" name="totalLengthErrors" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEGfRyquEemz8qUl1H9gFg" annotatedElement="_hEGfRiquEemz8qUl1H9gFg">
+            <body>A count of all LLDP length errors detected when constructing&#xD;
+            LLPDU frames for transmission through the port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEGfSCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEGfSSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEJikCquEemz8qUl1H9gFg" name="RxStatistics">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEJikSquEemz8qUl1H9gFg" annotatedElement="_hEJikCquEemz8qUl1H9gFg">
+          <body>LLDP frame reception statistics for a particular port.&#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEJikiquEemz8qUl1H9gFg" name="totalAgeouts" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEJikyquEemz8qUl1H9gFg" annotatedElement="_hEJikiquEemz8qUl1H9gFg">
+            <body>A count of the times that a neighbor’s information&#xD;
+             is deleted from the LLDP remote systems MIB because&#xD;
+             of rxInfoTTL timer expiration.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3VVDOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJilCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJilSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEJiliquEemz8qUl1H9gFg" name="totalDiscardedFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEJilyquEemz8qUl1H9gFg" annotatedElement="_hEJiliquEemz8qUl1H9gFg">
+            <body>A count of all LLDPDUs received and then discarded.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJimCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJimSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEJimiquEemz8qUl1H9gFg" name="errorFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEJimyquEemz8qUl1H9gFg" annotatedElement="_hEJimiquEemz8qUl1H9gFg">
+            <body>A count of all LLDPDUs received at the port with one or more&#xD;
+             detectable errors.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJinCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJinSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEJiniquEemz8qUl1H9gFg" name="totalFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEJinyquEemz8qUl1H9gFg" annotatedElement="_hEJiniquEemz8qUl1H9gFg">
+            <body>A count of all LLDP frames received at the port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJioCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJioSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEJioiquEemz8qUl1H9gFg" name="totalDiscardedTlvs" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEJioyquEemz8qUl1H9gFg" annotatedElement="_hEJioiquEemz8qUl1H9gFg">
+            <body>A count of all TLVs received at the port and discarded for any&#xD;
+             reason.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJipCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJipSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEJipiquEemz8qUl1H9gFg" name="totalUnrecognizedTlvs" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEJipyquEemz8qUl1H9gFg" annotatedElement="_hEJipiquEemz8qUl1H9gFg">
+            <body>This counter provides a count of all TLVs not recognized by&#xD;
+             the receiving LLDP local agent.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEJiqCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEJiqSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEN0ACquEemz8qUl1H9gFg" name="RemoteSystemsData">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0ASquEemz8qUl1H9gFg" annotatedElement="_hEN0ACquEemz8qUl1H9gFg">
+          <body>Information about a particular physical network connection.&#xD;
+           Entries may be created and deleted in this table by the agent,&#xD;
+           if a physical topology discovery process is active.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0AiquEemz8qUl1H9gFg" name="timeMark" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0AyquEemz8qUl1H9gFg" annotatedElement="_hEN0AiquEemz8qUl1H9gFg">
+            <body>A TimeFilter for this entry.  See the TimeFilter textual&#xD;
+             convention in IETF RFC 2021 and &#xD;
+             http://www.ietf.org/IESG/Implementations/RFC2021-Implementation.txt&#xD;
+             to see how TimeFilter works.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_iP8kIfZaEeWhRf3FikFX5w"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0BCquEemz8qUl1H9gFg" name="remoteIndex" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0BSquEemz8qUl1H9gFg" annotatedElement="_hEN0BCquEemz8qUl1H9gFg">
+            <body>This object represents an arbitrary local integer value used&#xD;
+             by this agent to identify a particular connection instance,&#xD;
+             unique only for the indicated remote system.&#xD;
+            &#xD;
+             An agent is encouraged to assign monotonically increasing&#xD;
+             index values to new entries, starting with one, after each&#xD;
+             reboot.  It is considered unlikely that the index&#xD;
+             will wrap between reboots.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0BiquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0ByquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0CCquEemz8qUl1H9gFg" name="chassisIdSubtype" type="_jSDlwCrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0CSquEemz8qUl1H9gFg" annotatedElement="_hEN0CCquEemz8qUl1H9gFg">
+            <body>The type of encoding used to identify the chassis associated&#xD;
+             with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0CiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0CyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0DCquEemz8qUl1H9gFg" name="chassisId" type="_jSFa8CrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0DSquEemz8qUl1H9gFg" annotatedElement="_hEN0DCquEemz8qUl1H9gFg">
+            <body>The string value used to identify the chassis component&#xD;
+             associated with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0DiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0DyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0ECquEemz8qUl1H9gFg" name="portIdSubtype" type="_jSEM0CrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0ESquEemz8qUl1H9gFg" annotatedElement="_hEN0ECquEemz8qUl1H9gFg">
+            <body>The type of port identifier encoding used in the associated&#xD;
+            'port-id' object.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0EiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0EyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0FCquEemz8qUl1H9gFg" name="portId" type="_jSGCACrIEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0FSquEemz8qUl1H9gFg" annotatedElement="_hEN0FCquEemz8qUl1H9gFg">
+            <body>The string value used to identify the port component&#xD;
+             associated with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0FiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0FyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0GCquEemz8qUl1H9gFg" name="portDesc" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0GSquEemz8qUl1H9gFg" annotatedElement="_hEN0GCquEemz8qUl1H9gFg">
+            <body>The string value used to identify the description of&#xD;
+             the given port associated with the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0GiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0GyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0HCquEemz8qUl1H9gFg" name="systemName" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0HSquEemz8qUl1H9gFg" annotatedElement="_hEN0HCquEemz8qUl1H9gFg">
+            <body>The string value used to identify the system name of the&#xD;
+             remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0HiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0HyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0ICquEemz8qUl1H9gFg" name="systemDescription" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0ISquEemz8qUl1H9gFg" annotatedElement="_hEN0ICquEemz8qUl1H9gFg">
+            <body>The string value used to identify the system description&#xD;
+             of the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0IiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0IyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0JCquEemz8qUl1H9gFg" name="systemCapabilitiesSupported" type="_8Q95MCquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0JSquEemz8qUl1H9gFg" annotatedElement="_hEN0JCquEemz8qUl1H9gFg">
+            <body>The bitmap value used to identify which system &#xD;
+              capabilities are supported on the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0JiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0JyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0KCquEemz8qUl1H9gFg" name="systemCapabilitiesEnabled" type="_8Q95MCquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0KSquEemz8qUl1H9gFg" annotatedElement="_hEN0KCquEemz8qUl1H9gFg">
+            <body>The bitmap value used to identify which system capabilities&#xD;
+             are enabled on the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEN0KiquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEN0KyquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WdXZAirNEemz8qUl1H9gFg" name="_managementAddress" type="_hEW98CquEemz8qUl1H9gFg" aggregation="composite" association="_WdWK4CrNEemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WdYnICrNEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WdYnISrNEemz8qUl1H9gFg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XIc9YirNEemz8qUl1H9gFg" name="_remoteUnknownTlv" type="_hEdEkCquEemz8qUl1H9gFg" aggregation="composite" association="_XIbvQCrNEemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XIeLgCrNEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XIeLgSrNEemz8qUl1H9gFg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xz4gASrNEemz8qUl1H9gFg" name="_remoteOrgDefinedInfo" type="_hEfg0CquEemz8qUl1H9gFg" aggregation="composite" association="_Xz3R4CrNEemz8qUl1H9gFg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Xz5HECrNEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Xz5HESrNEemz8qUl1H9gFg" value="*"/>
+        </ownedAttribute>
+        <nestedClassifier xmi:type="uml:Class" xmi:id="_hEN0NSquEemz8qUl1H9gFg" name="TxStatistics">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0NiquEemz8qUl1H9gFg" annotatedElement="_hEN0NSquEemz8qUl1H9gFg">
+            <body>LLDP frame transmission statistics for a particular port.  &#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0NyquEemz8qUl1H9gFg" name="totalFrames">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0OCquEemz8qUl1H9gFg" annotatedElement="_hEN0NyquEemz8qUl1H9gFg">
+              <body>A count of all LLDP frames transmitted through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../IeeeModels/ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_hEN0OSquEemz8qUl1H9gFg" name="totalLengthErrors">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_hEN0OiquEemz8qUl1H9gFg" annotatedElement="_hEN0OSquEemz8qUl1H9gFg">
+              <body>A count of all LLDP length errors detected when constructing&#xD;
+            LLPDU frames for transmission through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../IeeeModels/ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+        </nestedClassifier>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEW98CquEemz8qUl1H9gFg" name="ManagementAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEW98SquEemz8qUl1H9gFg" annotatedElement="_hEW98CquEemz8qUl1H9gFg">
+          <body>Management address information about a particular chassis&#xD;
+             component.  There may be multiple management addresses&#xD;
+             configured on the remote system identified by a particular&#xD;
+             index whose information is received on&#xD;
+             port-num of the local system.  Each management&#xD;
+             address should have distinct 'management address&#xD;
+             type' (subtype) and 'management address'&#xD;
+            (address.)&#xD;
+        &#xD;
+             Entries may be created and deleted in this table by the&#xD;
+             agent.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEW98iquEemz8qUl1H9gFg" name="addressSubtype" type="_jW9pACrKEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEW98yquEemz8qUl1H9gFg" annotatedElement="_hEW98iquEemz8qUl1H9gFg">
+            <body>The type of management address identifier encoding used in&#xD;
+               the associated 'lldpRemManagmentAddr' object.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEW99CquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEW99SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEW99iquEemz8qUl1H9gFg" name="address" type="_8ROX4CquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEW99yquEemz8qUl1H9gFg" annotatedElement="_hEW99iquEemz8qUl1H9gFg">
+            <body>The string value used to identify the management address&#xD;
+               component associated with the remote system.  The purpose&#xD;
+               of this address is to contact the management entity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEW9-CquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEW9-SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEW9-iquEemz8qUl1H9gFg" name="ifSubtype" type="_8RIRQCquEemz8qUl1H9gFg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEW9-yquEemz8qUl1H9gFg" annotatedElement="_hEW9-iquEemz8qUl1H9gFg">
+            <body>The enumeration value that identifies the interface numbering&#xD;
+               method used for defining the interface number, associated&#xD;
+               with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEW9_CquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEW9_SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEW9_iquEemz8qUl1H9gFg" name="ifId" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEW9_yquEemz8qUl1H9gFg" annotatedElement="_hEW9_iquEemz8qUl1H9gFg">
+            <body>The integer value used to identify the interface number&#xD;
+               regarding the management address component associated with&#xD;
+               the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEW-ACquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEW-ASquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <nestedClassifier xmi:type="uml:Class" xmi:id="_hEW-AiquEemz8qUl1H9gFg" name="TxStatistics">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEW-AyquEemz8qUl1H9gFg" annotatedElement="_hEW-AiquEemz8qUl1H9gFg">
+            <body>LLDP frame transmission statistics for a particular port.  &#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_hEW-BCquEemz8qUl1H9gFg" name="totalFrames">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_hEW-BSquEemz8qUl1H9gFg" annotatedElement="_hEW-BCquEemz8qUl1H9gFg">
+              <body>A count of all LLDP frames transmitted through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../IeeeModels/ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_hEW-BiquEemz8qUl1H9gFg" name="totalLengthErrors">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_hEW-ByquEemz8qUl1H9gFg" annotatedElement="_hEW-BiquEemz8qUl1H9gFg">
+              <body>A count of all LLDP length errors detected when constructing&#xD;
+            LLPDU frames for transmission through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="../IeeeModels/ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+        </nestedClassifier>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEdEkCquEemz8qUl1H9gFg" name="RemoteUnknownTlv">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEdEkSquEemz8qUl1H9gFg" annotatedElement="_hEdEkCquEemz8qUl1H9gFg">
+          <body>Information about an unrecognized tlv received from a&#xD;
+             physical network connection.  Entries may be created and&#xD;
+             deleted in this table by the agent, if a physical topology&#xD;
+             discovery process is active.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEdEkiquEemz8qUl1H9gFg" name="tlvType" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEdEkyquEemz8qUl1H9gFg" annotatedElement="_hEdEkiquEemz8qUl1H9gFg">
+            <body>This object represents the value extracted from the type&#xD;
+               field of the tlv.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEdElCquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEdElSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEdEliquEemz8qUl1H9gFg" name="tlvInfo" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEdElyquEemz8qUl1H9gFg" annotatedElement="_hEdEliquEemz8qUl1H9gFg">
+            <body>This object represents the value extracted from the value&#xD;
+               field of the tlv.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEdEmCquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEdEmSquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_hEfg0CquEemz8qUl1H9gFg" name="RemoteOrgDefinedInfo">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hEfg0SquEemz8qUl1H9gFg" annotatedElement="_hEfg0CquEemz8qUl1H9gFg">
+          <body>Information about the unrecognized organizationally&#xD;
+             defined information advertised by the remote system.&#xD;
+             The time-mark, port-num, index,&#xD;
+             info-identifier, info-subtype, and&#xD;
+             info-index are indexes to this table.  If there is&#xD;
+             an remote-org-defined-info associated with a particular remote&#xD;
+             system identified by the port-num and index,&#xD;
+             there must be an remote associated with the same&#xD;
+             instance (i.e, using same indexes.)  When the remote&#xD;
+             for the same index is removed from the lldpRemTable, the&#xD;
+             associated remote-org-defined-info should be removed from&#xD;
+             the remote-org-defined-infoTable.&#xD;
+            &#xD;
+             Entries may be created and deleted in this table by the&#xD;
+             agent.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEfg0iquEemz8qUl1H9gFg" name="infoIdentifier" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEfg0yquEemz8qUl1H9gFg" annotatedElement="_hEfg0iquEemz8qUl1H9gFg">
+            <body>The Organizationally Unique Identifier (OUI), as defined&#xD;
+               in IEEE std 802-2001, is a 24 bit (three octets) globally&#xD;
+               unique assigned number referenced by various standards,&#xD;
+               of the information received from the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEfg1CquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEfg1SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEfg1iquEemz8qUl1H9gFg" name="infoSubtype" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEfg1yquEemz8qUl1H9gFg" annotatedElement="_hEfg1iquEemz8qUl1H9gFg">
+            <body>The integer value used to identify the subtype of the&#xD;
+               organizationally defined information received from the&#xD;
+               remote system.&#xD;
+        &#xD;
+               The subtype value is required to identify different instances&#xD;
+               of organizationally defined information that could not be&#xD;
+               retrieved without a unique identifier that indicates the&#xD;
+               particular type of information contained in the information&#xD;
+               string.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEfg2CquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEfg2SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEfg2iquEemz8qUl1H9gFg" name="infoIndex" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEfg2yquEemz8qUl1H9gFg" annotatedElement="_hEfg2iquEemz8qUl1H9gFg">
+            <body>This object represents an arbitrary local integer value&#xD;
+               used by this agent to identify a particular unrecognized&#xD;
+               organizationally defined information instance, unique only&#xD;
+               for the info-identifier and info-subtype&#xD;
+               from the same remote system.&#xD;
+        &#xD;
+               An agent is encouraged to assign monotonically increasing&#xD;
+               index values to new entries, starting with one, after each&#xD;
+               reboot.  It is considered unlikely that the&#xD;
+               info-index will wrap between reboots.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEfg3CquEemz8qUl1H9gFg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEfg3SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEfg3iquEemz8qUl1H9gFg" name="remoteInfo" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hEfg3yquEemz8qUl1H9gFg" annotatedElement="_hEfg3iquEemz8qUl1H9gFg">
+            <body>The string value used to identify the organizationally&#xD;
+               defined information of the remote system.  The encoding for&#xD;
+               this object should be as defined for SnmpAdminString TC.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hEfg4CquEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hEfg4SquEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_sgTswCrCEemz8qUl1H9gFg" name="AugmentOamJob" client="_hDnXECquEemz8qUl1H9gFg" supplier="_2-15sEI6EeiDweqmZm-ZXQ"/>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_DkJb0CrDEemz8qUl1H9gFg" name="name attribute realized by localId" client="_hD0LYCquEemz8qUl1H9gFg" supplier="_W48McBP7EeepnPPr_BcZKg"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_zf2PwMOcEeaFfJxGCRaf4A" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_Nm0qoOxYEeaTUPmcu3rLwA" name="OamService">
@@ -721,6 +1547,84 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JsZK0JsYEeid4dfn4JFJZg" value="*"/>
         </ownedEnd>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_gS1vgCqwEemz8qUl1H9gFg" name="LldpProvidesRemoteStatistics" memberEnd="_gS5Z4CqwEemz8qUl1H9gFg _gS7PESqwEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gS4LwCqwEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gS4y0CqwEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_gS7PESqwEemz8qUl1H9gFg" name="_lldp" type="_hDnXECquEemz8qUl1H9gFg" association="_gS1vgCqwEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_hb_v8CqwEemz8qUl1H9gFg" name="LldpHas LocalSystemData" memberEnd="_hcA-EiqwEemz8qUl1H9gFg _hcCMMiqwEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hcA-ECqwEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hcA-ESqwEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_hcCMMiqwEemz8qUl1H9gFg" name="_lldp" type="_hDnXECquEemz8qUl1H9gFg" association="_hb_v8CqwEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ioPgoCqwEemz8qUl1H9gFg" name="LldpHasPortConfigData" visibility="public" memberEnd="_ioQuwiqwEemz8qUl1H9gFg _ioR84iqwEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ioQuwCqwEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ioQuwSqwEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ioR84iqwEemz8qUl1H9gFg" name="_lldp" type="_hDnXECquEemz8qUl1H9gFg" association="_ioPgoCqwEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_jkjX4CqwEemz8qUl1H9gFg" name="LldpHasBasicConfig" memberEnd="_jkkmASqwEemz8qUl1H9gFg _jkl0ISqwEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jkj-8CqwEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jkkmACqwEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_jkl0ISqwEemz8qUl1H9gFg" name="_lldp" type="_hDnXECquEemz8qUl1H9gFg" association="_jkjX4CqwEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_iAzl0CqzEemz8qUl1H9gFg" name="RtcNotifiesRemoteInserts" memberEnd="_iA1bACqzEemz8qUl1H9gFg _iA2CEiqzEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iA0z8CqzEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iA0z8SqzEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_iA2CEiqzEemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_iAzl0CqzEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_PF8o4Cq0Eemz8qUl1H9gFg" name="RtcNotifiesRemoteDeletes" memberEnd="_PF93ASq0Eemz8qUl1H9gFg _PF-eEyq0Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PF9P8Cq0Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PF93ACq0Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_PF-eEyq0Eemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_PF8o4Cq0Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_bAi9MCq1Eemz8qUl1H9gFg" name="RtcNotifiesRemoteDrops" memberEnd="_bAjkQiq1Eemz8qUl1H9gFg _bAkyYSq1Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bAjkQCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bAjkQSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_bAkyYSq1Eemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_bAi9MCq1Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_hw1lQCq1Eemz8qUl1H9gFg" name="RtcNotifiesRemoteAgeouts" memberEnd="_hw2zYiq1Eemz8qUl1H9gFg _hw5Poiq1Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hw2zYCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hw2zYSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_hw5Poiq1Eemz8qUl1H9gFg" name="_remoteTableChange" type="_1ivtsCquEemz8qUl1H9gFg" association="_hw1lQCq1Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_4boiMCq1Eemz8qUl1H9gFg" name="PortHasMgmtAddresses" memberEnd="_4bpwUiq1Eemz8qUl1H9gFg _4bq-ciq1Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4bpwUCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4bpwUSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_4bq-ciq1Eemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" association="_4boiMCq1Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_5WY6QCq1Eemz8qUl1H9gFg" name="PortHasTxStatistics" memberEnd="_5WZhUiq1Eemz8qUl1H9gFg _5WaIYiq1Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WZhUCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WZhUSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_5WaIYiq1Eemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" association="_5WY6QCq1Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_6TkUMCq1Eemz8qUl1H9gFg" name="PortHasRxStatistics" memberEnd="_6Tk7Qiq1Eemz8qUl1H9gFg _6TliUyq1Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6Tk7QCq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6Tk7QSq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_6TliUyq1Eemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" association="_6TkUMCq1Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_7d1u8Cq1Eemz8qUl1H9gFg" name="PortHasRemoteSystemData" memberEnd="_7d2WAiq1Eemz8qUl1H9gFg _7d3kIyq1Eemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7d2WACq1Eemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7d2WASq1Eemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_7d3kIyq1Eemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" association="_7d1u8Cq1Eemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ULiMMCrAEemz8qUl1H9gFg" name="PortHasBasicConfig" memberEnd="_ULjaUirAEemz8qUl1H9gFg _ULkocCrAEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ULjaUCrAEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ULjaUSrAEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ULkocCrAEemz8qUl1H9gFg" name="_port" type="_hD0LYCquEemz8qUl1H9gFg" association="_ULiMMCrAEemz8qUl1H9gFg"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_-MPC0OvREealldJ4rm6P_g" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_HIIm0OvSEealldJ4rm6P_g">
@@ -734,9 +1638,594 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
       </packageImport>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_7xKpoCNrEeenc_m30jt0Ow" name="Rules"/>
-    <packagedElement xmi:type="uml:Package" xmi:id="_XQfKcOvSEealldJ4rm6P_g" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_XQfKcOvSEealldJ4rm6P_g" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_WdWK4CrNEemz8qUl1H9gFg" memberEnd="_WdXZAirNEemz8qUl1H9gFg _WdYnIirNEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WdXZACrNEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WdXZASrNEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_WdYnIirNEemz8qUl1H9gFg" name="_remoteSystemsData" type="_hEN0ACquEemz8qUl1H9gFg" association="_WdWK4CrNEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_XIbvQCrNEemz8qUl1H9gFg" memberEnd="_XIc9YirNEemz8qUl1H9gFg _XIeLgirNEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_XIc9YCrNEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_XIc9YSrNEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_XIeLgirNEemz8qUl1H9gFg" name="_remoteSystemsData" type="_hEN0ACquEemz8qUl1H9gFg" association="_XIbvQCrNEemz8qUl1H9gFg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_Xz3R4CrNEemz8qUl1H9gFg" memberEnd="_Xz4gASrNEemz8qUl1H9gFg _Xz5HEirNEemz8qUl1H9gFg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Xz348CrNEemz8qUl1H9gFg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Xz4gACrNEemz8qUl1H9gFg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Xz5HEirNEemz8qUl1H9gFg" name="_remoteSystemsData" type="_hEN0ACquEemz8qUl1H9gFg" association="_Xz3R4CrNEemz8qUl1H9gFg"/>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_pdh3cF3eEeit4-HSxnZlvw" name="TypeDefinitions">
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_tqiDYF3eEeit4-HSxnZlvw" name="OamJobType"/>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8Q95MCquEemz8qUl1H9gFg" name="SystemCapabilitiesMap">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95MSquEemz8qUl1H9gFg" annotatedElement="_8Q95MCquEemz8qUl1H9gFg">
+          <body>This describes system capabilities.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95MiquEemz8qUl1H9gFg" name="other">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95MyquEemz8qUl1H9gFg" annotatedElement="_8Q95MiquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has capabilities&#xD;
+           other than those listed below.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95NCquEemz8qUl1H9gFg" name="repeater">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95NSquEemz8qUl1H9gFg" annotatedElement="_8Q95NCquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has repeater&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95NiquEemz8qUl1H9gFg" name="bridge">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95NyquEemz8qUl1H9gFg" annotatedElement="_8Q95NiquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has bridge&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95OCquEemz8qUl1H9gFg" name="wlanAccessPoint">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95OSquEemz8qUl1H9gFg" annotatedElement="_8Q95OCquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has&#xD;
+           WLAN access point capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95OiquEemz8qUl1H9gFg" name="router">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95OyquEemz8qUl1H9gFg" annotatedElement="_8Q95OiquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has router&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95PCquEemz8qUl1H9gFg" name="telephone">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95PSquEemz8qUl1H9gFg" annotatedElement="_8Q95PCquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has telephone&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95PiquEemz8qUl1H9gFg" name="docsisCableDevice">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95PyquEemz8qUl1H9gFg" annotatedElement="_8Q95PiquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has&#xD;
+           DOCSIS Cable Device capability (IETF RFC 4639 &amp; 2670).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95QCquEemz8qUl1H9gFg" name="stationOnly">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95QSquEemz8qUl1H9gFg" annotatedElement="_8Q95QCquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has only&#xD;
+           station capability and nothing else.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95QiquEemz8qUl1H9gFg" name="cvlanComponent">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95QyquEemz8qUl1H9gFg" annotatedElement="_8Q95QiquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has&#xD;
+           C-VLAN component functionality.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95RCquEemz8qUl1H9gFg" name="svlanComponent">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95RSquEemz8qUl1H9gFg" annotatedElement="_8Q95RCquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has&#xD;
+           S-VLAN component functionality.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q95RiquEemz8qUl1H9gFg" name="twoPortMacRelay">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8Q95RyquEemz8qUl1H9gFg" annotatedElement="_8Q95RiquEemz8qUl1H9gFg">
+            <body>This bit indicates that the system has&#xD;
+           Two-port MAC Relay (TPMR) functionality.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8RF1ACquEemz8qUl1H9gFg" name="TlvsTxEnable">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8RF1ASquEemz8qUl1H9gFg" annotatedElement="_8RF1ACquEemz8qUl1H9gFg">
+          <body>The tlvs-tx-enable, defined as a bitmap,&#xD;
+          includes the basic set of LLDP tlvs whose transmission is&#xD;
+          allowed on the local LLDP agent by the network management.&#xD;
+          Each bit in the bitmap corresponds to a tlv type associated&#xD;
+          with a specific optional tlv.&#xD;
+  &#xD;
+          It should be noted that the organizationally-specific tlvs&#xD;
+          are excluded from the lldptlvsTxEnable bitmap.&#xD;
+  &#xD;
+          LLDP Organization Specific Information Extension MIBs should&#xD;
+          have similar configuration object to control transmission&#xD;
+          of their organizationally defined tlvs.&#xD;
+  &#xD;
+          There is no bit reserved for the management address tlv type&#xD;
+          since transmission of management address tlvs are controlled&#xD;
+          by another object, man-addr-type.&#xD;
+  &#xD;
+          The default value for tlvs-tx-enable object is&#xD;
+          empty set, which means no enumerated values are set.&#xD;
+  &#xD;
+          The value of this object must be restored from non-volatile&#xD;
+          storage after a re-initialization of the management system.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8RF1AiquEemz8qUl1H9gFg" name="portDesc">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RF1AyquEemz8qUl1H9gFg" annotatedElement="_8RF1AiquEemz8qUl1H9gFg">
+            <body>The bit 'port-desc(0)' indicates that LLDP agent should&#xD;
+               transmit 'Port Description tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8RF1BCquEemz8qUl1H9gFg" name="sysName">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RF1BSquEemz8qUl1H9gFg" annotatedElement="_8RF1BCquEemz8qUl1H9gFg">
+            <body>The bit 'sys-name(1)' indicates that LLDP agent should transmit&#xD;
+               'System Name tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8RF1BiquEemz8qUl1H9gFg" name="sysDesc">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RF1ByquEemz8qUl1H9gFg" annotatedElement="_8RF1BiquEemz8qUl1H9gFg">
+            <body>The bit 'sys-desc(2)' indicates that LLDP agent should transmit&#xD;
+               'System Description tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8RF1CCquEemz8qUl1H9gFg" name="sysCap">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RF1CSquEemz8qUl1H9gFg" annotatedElement="_8RF1CCquEemz8qUl1H9gFg">
+            <body>The bit 'sys-cap(3)' indicates that LLDP agent should transmit&#xD;
+               'System Capabilities tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RHqMCquEemz8qUl1H9gFg" name="AdminStatus" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8RHqMSquEemz8qUl1H9gFg" annotatedElement="_8RHqMCquEemz8qUl1H9gFg">
+          <body>The administratively desired status of the local LLDP agent.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RHqMiquEemz8qUl1H9gFg" name="tx-only">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RHqMyquEemz8qUl1H9gFg" annotatedElement="_8RHqMiquEemz8qUl1H9gFg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'tx-only(1)', then LLDP agent will transmit LLDP&#xD;
+               frames on this port and it will not store any information&#xD;
+               about the remote systems connected.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RHqNCquEemz8qUl1H9gFg" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RHqNSquEemz8qUl1H9gFg" name="rx-only">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RHqNiquEemz8qUl1H9gFg" annotatedElement="_8RHqNSquEemz8qUl1H9gFg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'rx-only(2)', then the LLDP agent will receive,&#xD;
+               but it will not transmit LLDP frames on this port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RHqNyquEemz8qUl1H9gFg" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RHqOCquEemz8qUl1H9gFg" name="tx-and-rx">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RHqOSquEemz8qUl1H9gFg" annotatedElement="_8RHqOCquEemz8qUl1H9gFg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'tx-and-rx(3)', then the LLDP agent will transmit&#xD;
+               and receive LLDP frames on this port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RHqOiquEemz8qUl1H9gFg" value="3"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RHqOyquEemz8qUl1H9gFg" name="disabled">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RHqPCquEemz8qUl1H9gFg" annotatedElement="_8RHqOyquEemz8qUl1H9gFg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'disabled(4)', then LLDP agent will not transmit or&#xD;
+               receive LLDP frames on this port.  If there is remote systems&#xD;
+               information which is received on this port and stored in&#xD;
+               other tables, before the port's admin-status&#xD;
+               becomes disabled, then the information will naturally age out.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RHqPSquEemz8qUl1H9gFg" value="4"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_8RIRQCquEemz8qUl1H9gFg" name="ManAddrIfSubtype" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8RIRQSquEemz8qUl1H9gFg" annotatedElement="_8RIRQCquEemz8qUl1H9gFg">
+          <body>This is the basis of a particular type of&#xD;
+       interface associated with the management address.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RIRQiquEemz8qUl1H9gFg" name="unknown">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RIRQyquEemz8qUl1H9gFg" annotatedElement="_8RIRQiquEemz8qUl1H9gFg">
+            <body>The subtype 'unknown(1)' represents the case where the&#xD;
+           interface is not known.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RIRRCquEemz8qUl1H9gFg" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RIRRSquEemz8qUl1H9gFg" name="port-ref">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RIRRiquEemz8qUl1H9gFg" annotatedElement="_8RIRRSquEemz8qUl1H9gFg">
+            <body>The subtype 'port-ref(2)' represents interface identifier&#xD;
+           based on the port-ref MIB object.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RIRRyquEemz8qUl1H9gFg" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8RIRSCquEemz8qUl1H9gFg" name="system-port-number">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8RIRSSquEemz8qUl1H9gFg" annotatedElement="_8RIRSCquEemz8qUl1H9gFg">
+            <body>The subtype 'system-port-number(3)' represents interface&#xD;
+           identifier based on the system port numbering convention.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8RIRSiquEemz8qUl1H9gFg" value="3"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8RI4UCquEemz8qUl1H9gFg" name="PortList">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8RI4USquEemz8qUl1H9gFg" annotatedElement="_8RI4UCquEemz8qUl1H9gFg">
+          <body>Each octet within this value specifies a set of eight ports,&#xD;
+       with the first octet specifying ports 1 through 8, the second&#xD;
+       octet specifying ports 9 through 16, etc.  Within each octet,&#xD;
+       the most significant bit represents the lowest numbered port,&#xD;
+       and the least significant bit represents the highest numbered&#xD;
+       port.  Thus, each port of the system is represented by a&#xD;
+       single bit within the value of this object.  If that bit has&#xD;
+       a value of '1' then that port is included in the set of ports;&#xD;
+       the port is not included if its bit has a value of '0'.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8RI4UiquEemz8qUl1H9gFg" name="portList">
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ROX4CquEemz8qUl1H9gFg" name="ManAddrType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8ROX4SquEemz8qUl1H9gFg" annotatedElement="_8ROX4CquEemz8qUl1H9gFg">
+          <body>The value of a management address associated with the LLDP&#xD;
+       agent that may be used to reach higher layer entities to&#xD;
+       assist discovery by network management.&#xD;
+       &#xD;
+       It should be noted that appropriate security credentials,&#xD;
+       such as SNMP engineId, may be required to access the LLDP&#xD;
+       agent using a management address.  These necessary credentials&#xD;
+       should be known by the network management and the objects&#xD;
+       associated with the credentials are not included in the&#xD;
+       LLDP agent.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ROX4iquEemz8qUl1H9gFg" name="manAddrType">
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_jSDlwCrIEemz8qUl1H9gFg" name="ChassisIdSubtypeType" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_jSDlwSrIEemz8qUl1H9gFg" annotatedElement="_jSDlwCrIEemz8qUl1H9gFg">
+          <body>The source of a chassis identifier.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDlwirIEemz8qUl1H9gFg" name="chassis-component">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDlwyrIEemz8qUl1H9gFg" annotatedElement="_jSDlwirIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				entPhysicalAlias object (defined in IETF RFC 2737) for a&#xD;
+  				chassis component (i.e., an entPhysicalClass value of&#xD;
+  				chassis(3))</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDlxCrIEemz8qUl1H9gFg" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDlxSrIEemz8qUl1H9gFg" name="interface-alias">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDlxirIEemz8qUl1H9gFg" annotatedElement="_jSDlxSrIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				ifAlias object (defined in IETF RFC 2863) for an interface&#xD;
+  				on the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDlxyrIEemz8qUl1H9gFg" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDlyCrIEemz8qUl1H9gFg" name="port-component">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDlySrIEemz8qUl1H9gFg" annotatedElement="_jSDlyCrIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				entPhysicalAlias object (defined in IETF RFC 2737) for a&#xD;
+  				port or backplane component (i.e., entPhysicalClass value of&#xD;
+  				port(10) or backplane(4)), within the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDlyirIEemz8qUl1H9gFg" value="3"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDlyyrIEemz8qUl1H9gFg" name="mac-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDlzCrIEemz8qUl1H9gFg" annotatedElement="_jSDlyyrIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on the value of a&#xD;
+  				unicast source address (encoded in network byte order and&#xD;
+  				IEEE 802.3 canonical bit order), of a port on the containing&#xD;
+  				chassis as defined in IEEE Std 802-2001.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDlzSrIEemz8qUl1H9gFg" value="4"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDlzirIEemz8qUl1H9gFg" name="network-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDlzyrIEemz8qUl1H9gFg" annotatedElement="_jSDlzirIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on a network address,&#xD;
+  				associated with a particular chassis.  The encoded address is&#xD;
+  				actually composed of two fields.  The first field is a&#xD;
+  				single octet, representing the IANA AddressFamilyNumbers&#xD;
+  				value for the specific address type, and the second field is&#xD;
+  				the network address value.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDl0CrIEemz8qUl1H9gFg" value="5"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDl0SrIEemz8qUl1H9gFg" name="interface-name">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDl0irIEemz8qUl1H9gFg" annotatedElement="_jSDl0SrIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				ifName object (defined in IETF RFC 2863) for an interface&#xD;
+  				on the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDl0yrIEemz8qUl1H9gFg" value="6"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSDl1CrIEemz8qUl1H9gFg" name="local">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSDl1SrIEemz8qUl1H9gFg" annotatedElement="_jSDl1CrIEemz8qUl1H9gFg">
+            <body>Represents a chassis identifier based on a locally defined&#xD;
+  				value.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSDl1irIEemz8qUl1H9gFg" value="7"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_jSEM0CrIEemz8qUl1H9gFg" name="PortIdSubtypeType" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_jSEM0SrIEemz8qUl1H9gFg" annotatedElement="_jSEM0CrIEemz8qUl1H9gFg">
+          <body>The source of a particular type of port identifier used&#xD;
+  		in the LLDP YANG module.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEM0irIEemz8qUl1H9gFg" name="interface-alias">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz4CrIEemz8qUl1H9gFg" annotatedElement="_jSEM0irIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on the ifAlias&#xD;
+  				MIB object, defined in IETF RFC 2863.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz4SrIEemz8qUl1H9gFg" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEz4irIEemz8qUl1H9gFg" name="port-component">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz4yrIEemz8qUl1H9gFg" annotatedElement="_jSEz4irIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on the value of&#xD;
+  				entPhysicalAlias (defined in IETF RFC 2737) for a port&#xD;
+  				component (i.e., entPhysicalClass value of port(10)), &#xD;
+  				within the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz5CrIEemz8qUl1H9gFg" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEz5SrIEemz8qUl1H9gFg" name="mac-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz5irIEemz8qUl1H9gFg" annotatedElement="_jSEz5SrIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on a unicast source&#xD;
+  				address (encoded in network byte order and IEEE 802.3&#xD;
+  				canonical bit order), which has been detected by the agent&#xD;
+  				and associated with a particular port (IEEE Std 802-2001).</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz5yrIEemz8qUl1H9gFg" value="3"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEz6CrIEemz8qUl1H9gFg" name="network-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz6SrIEemz8qUl1H9gFg" annotatedElement="_jSEz6CrIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on a network address,&#xD;
+  				detected by the agent and associated with a particular &#xD;
+  				port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz6irIEemz8qUl1H9gFg" value="4"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEz6yrIEemz8qUl1H9gFg" name="interface-name">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz7CrIEemz8qUl1H9gFg" annotatedElement="_jSEz6yrIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on the ifName MIB object,&#xD;
+  				defined in IETF RFC 2863.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz7SrIEemz8qUl1H9gFg" value="5"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEz7irIEemz8qUl1H9gFg" name="agent-circuit-id">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz7yrIEemz8qUl1H9gFg" annotatedElement="_jSEz7irIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on the agent-local&#xD;
+  				identifier of the circuit (defined in RFC 3046), detected by&#xD;
+  				the agent and associated with a particular port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz8CrIEemz8qUl1H9gFg" value="6"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jSEz8SrIEemz8qUl1H9gFg" name="local">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSEz8irIEemz8qUl1H9gFg" annotatedElement="_jSEz8SrIEemz8qUl1H9gFg">
+            <body>Represents a port identifier based on a value locally&#xD;
+  				assigned.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_jSEz8yrIEemz8qUl1H9gFg" value="7"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_jSFa8CrIEemz8qUl1H9gFg" name="ChassisIdType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_jSFa8SrIEemz8qUl1H9gFg" annotatedElement="_jSFa8CrIEemz8qUl1H9gFg">
+          <body>The format of a chassis identifier string. Objects of this type&#xD;
+  		are always used with an associated lldp-chassis-is-subtype&#xD;
+  		object, which identifies the format of the particular&#xD;
+  		lldp-chassis-id object instance.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      chassis-component, then the octet string identifies&#xD;
+      a particular instance of the entPhysicalAlias object&#xD;
+      (defined in IETF RFC 2737) for a chassis component (i.e.,&#xD;
+      an entPhysicalClass value of chassis(3)).&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value&#xD;
+      of interface-alias, then the octet string identifies&#xD;
+      a particular instance of the ifAlias object (defined in&#xD;
+      IETF RFC 2863) for an interface on the containing chassis.&#xD;
+      If the particular ifAlias object does not contain any values,&#xD;
+      another chassis identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value&#xD;
+      of port-component, then the octet string identifies a&#xD;
+      particular instance of the entPhysicalAlias object (defined&#xD;
+      in IETF RFC 2737) for a port or backplane component within&#xD;
+      the containing chassis.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      mac-address, then this string identifies a particular&#xD;
+      unicast source address (encoded in network byte order and&#xD;
+      IEEE 802.3 canonical bit order), of a port on the containing&#xD;
+      chassis as defined in IEEE Std 802-2001.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      network-address, then this string identifies a particular&#xD;
+      network address, encoded in network byte order, associated&#xD;
+      with one or more ports on the containing chassis.  The first&#xD;
+      octet contains the IANA Address Family Numbers enumeration&#xD;
+      value for the specific address type, and octets 2 through&#xD;
+      N contain the network address value in network byte order.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value&#xD;
+      of interface-name, then the octet string identifies&#xD;
+      a particular instance of the ifName object (defined in&#xD;
+      IETF RFC 2863) for an interface on the containing chassis.&#xD;
+      If the particular ifName object does not contain any values,&#xD;
+      another chassis identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      local, then this string identifies a locally assigned&#xD;
+      Chassis ID.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jSFa8irIEemz8qUl1H9gFg" name="chassisId">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_jSGCACrIEemz8qUl1H9gFg" name="PortIdType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_jSGCASrIEemz8qUl1H9gFg" annotatedElement="_jSGCACrIEemz8qUl1H9gFg">
+          <body>The format of a port identifier string. Objects of this type&#xD;
+  		are always used with an associated lldp-port-id-subtype object,&#xD;
+  		which identifies the format of the particular lldp-port-id&#xD;
+  		object instance.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      interface-alias, then the octet string identifies a&#xD;
+      particular instance of the ifAlias object (defined in IETF&#xD;
+      RFC 2863).  If the particular ifAlias object does not contain&#xD;
+      any values, another port identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      port-component, then the octet string identifies a&#xD;
+      particular instance of the entPhysicalAlias object (defined&#xD;
+      in IETF RFC 2737) for a port or backplane component.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      mac-address, then this string identifies a particular&#xD;
+      unicast source address (encoded in network byte order&#xD;
+      and IEEE 802.3 canonical bit order) associated with the port&#xD;
+      (IEEE Std 802-2001).&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      network-address, then this string identifies a network&#xD;
+      address associated with the port.  The first octet contains&#xD;
+      the IANA AddressFamilyNumbers enumeration value for the&#xD;
+      specific address type, and octets 2 through N contain the&#xD;
+      networkAddress address value in network byte order.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      interface-name, then the octet string identifies a&#xD;
+      particular instance of the ifName object (defined in IETF&#xD;
+      RFC 2863).  If the particular ifName object does not contain&#xD;
+      any values, another port identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      agent-circuit-id, then this string identifies a agent-local&#xD;
+      identifier of the circuit (defined in RFC 3046).&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      local, then this string identifies a locally assigned port ID.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jSGCAirIEemz8qUl1H9gFg" name="portId">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_jW9pACrKEemz8qUl1H9gFg" name="AddressFamily">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_BMUdQCrNEemz8qUl1H9gFg" annotatedElement="_jW9pACrKEemz8qUl1H9gFg">
+          <body>Base identity from which identities describing address families are derived.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_z-xv0CrKEemz8qUl1H9gFg" name="IP_V4">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EDyZoCrNEemz8qUl1H9gFg" annotatedElement="_z-xv0CrKEemz8qUl1H9gFg">
+            <body>This identity represents an IPv4 address family.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2bTcoCrKEemz8qUl1H9gFg" name="IP_V6">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GEkloCrNEemz8qUl1H9gFg" annotatedElement="_2bTcoCrKEemz8qUl1H9gFg">
+            <body>This identity represents an IPv6 address family.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_0MqrkCquEemz8qUl1H9gFg" name="Notifications">
+      <packagedElement xmi:type="uml:Signal" xmi:id="_1ivtsCquEemz8qUl1H9gFg" name="RemoteTableChange">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_1ivtsSquEemz8qUl1H9gFg" annotatedElement="_1ivtsCquEemz8qUl1H9gFg">
+          <body>A rem-table-change notification is sent when the value&#xD;
+       of remote-table-last-change-time changes.  It can be&#xD;
+       utilized by an NMS to trigger LLDP remote systems table&#xD;
+       maintenance polls.&#xD;
+&#xD;
+       Note that transmission of remote-table-change&#xD;
+       notifications are throttled by the agent, as specified by the&#xD;
+      'notification-interval' object.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iA1bACqzEemz8qUl1H9gFg" name="_remoteInserts" type="_hDrogCquEemz8qUl1H9gFg" association="_iAzl0CqzEemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0CMcwCq1Eemz8qUl1H9gFg" annotatedElement="_iA1bACqzEemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+         advertised by a particular MSAP has been inserted into tables&#xD;
+         contained in remote-systems-data and lldpExtensions objects.&#xD;
+&#xD;
+         The complete set of information received from a particular&#xD;
+         MSAP should be inserted into related tables. If partial&#xD;
+         information cannot be inserted for a reason such as lack&#xD;
+         of resources, all of the complete set of information should&#xD;
+         be removed.&#xD;
+&#xD;
+         This counter should be incremented only once after the&#xD;
+         complete set of information is successfully recorded&#xD;
+         in all related tables.  Any failures during inserting&#xD;
+         information set which result in deletion of previously&#xD;
+         inserted information should not trigger any changes in&#xD;
+         inserts since the insert is not completed&#xD;
+         yet or or in deletes, since the deletion&#xD;
+         would only be a partial deletion. If the failure was the&#xD;
+         result of lack of resources, the drops&#xD;
+         counter should be incremented once.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iA2CECqzEemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iA2CESqzEemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PF93ASq0Eemz8qUl1H9gFg" name="_remoteDelete" type="_hDrogCquEemz8qUl1H9gFg" association="_PF8o4Cq0Eemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wEl-wCq1Eemz8qUl1H9gFg" annotatedElement="_PF93ASq0Eemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+        advertised by a particular MSAP has been deleted from&#xD;
+        tables contained in remote-systems-data and lldpExtensions&#xD;
+        objects.&#xD;
+&#xD;
+        This counter should be incremented only once when the&#xD;
+        complete set of information is completely deleted from all&#xD;
+        related tables.  Partial deletions, such as deletion of&#xD;
+        rows associated with a particular MSAP from some tables,&#xD;
+        but not from all tables are not allowed, thus should not&#xD;
+        change the value of this counter.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PF-eESq0Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PF-eEiq0Eemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_bAjkQiq1Eemz8qUl1H9gFg" name="_remoteDrops" type="_hDrogCquEemz8qUl1H9gFg" association="_bAi9MCq1Eemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yFT5UCq1Eemz8qUl1H9gFg" annotatedElement="_bAjkQiq1Eemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+         advertised by a particular MSAP could not be entered into&#xD;
+         tables contained in remote-systems-data and lldpExtensions&#xD;
+         objects because of insufficient resources.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bAkLUiq1Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bAkyYCq1Eemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hw2zYiq1Eemz8qUl1H9gFg" name="_remoteAgeouts" type="_hDrogCquEemz8qUl1H9gFg" association="_hw1lQCq1Eemz8qUl1H9gFg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_tgqpcCq1Eemz8qUl1H9gFg" annotatedElement="_hw2zYiq1Eemz8qUl1H9gFg">
+            <body>The number of times the complete set of information&#xD;
+         advertised by a particular MSAP has been deleted from tables&#xD;
+         contained in remote-systems-data and lldpExtensions objects&#xD;
+         because the information timeliness interval has expired.&#xD;
+&#xD;
+         This counter should be incremented only once when the complete&#xD;
+         set of information is completely invalidated (aged out)&#xD;
+         from all related tables.  Partial aging, similar to deletion&#xD;
+         case, is not allowed, and thus, should not change the value&#xD;
+         of this counter.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hw5PoCq1Eemz8qUl1H9gFg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hw5PoSq1Eemz8qUl1H9gFg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_keOssCrCEemz8qUl1H9gFg" name="AugmentOamJob" client="_1ivtsCquEemz8qUl1H9gFg" supplier="_2-15sEI6EeiDweqmZm-ZXQ"/>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_x2I28BMwEee0L_IMWjydgQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TeGtAWm2EeiLh_06MH5Rjg" source="PapyrusVersion">
@@ -1058,4 +2547,317 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelParameter xmi:id="_pksigRKgEemxeNG9TDCtFQ" base_Parameter="_pksigBKgEemxeNG9TDCtFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DzN_oBN3EemxeNG9TDCtFQ" base_Property="_DzNYkBN3EemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_DzN_oRN3EemxeNG9TDCtFQ" base_StructuralFeature="_DzNYkBN3EemxeNG9TDCtFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hDiekCquEemz8qUl1H9gFg" base_Class="_hDh3gCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hDjFoCquEemz8qUl1H9gFg" base_Class="_hDh3gCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDjFoSquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3giquEemz8qUl1H9gFg" valueRange="1..3600" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDjssCquEemz8qUl1H9gFg" base_Property="_hDh3giquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDjssSquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3hyquEemz8qUl1H9gFg" valueRange="2..10" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDjssiquEemz8qUl1H9gFg" base_Property="_hDh3hyquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDjssyquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3jCquEemz8qUl1H9gFg" valueRange="1..3600" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDkTwCquEemz8qUl1H9gFg" base_Property="_hDh3jCquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDkTwSquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3jiquEemz8qUl1H9gFg" valueRange="1..10" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDkTwiquEemz8qUl1H9gFg" base_Property="_hDh3jiquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDkTwyquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3kCquEemz8qUl1H9gFg" valueRange="1..10" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDkTxCquEemz8qUl1H9gFg" base_Property="_hDh3kCquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDk60CquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3kiquEemz8qUl1H9gFg" valueRange="1..8" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDk60SquEemz8qUl1H9gFg" base_Property="_hDh3kiquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDlh4CquEemz8qUl1H9gFg" base_StructuralFeature="_hDh3lCquEemz8qUl1H9gFg" valueRange="1..3600" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDlh4SquEemz8qUl1H9gFg" base_Property="_hDh3lCquEemz8qUl1H9gFg" bitLength="LENGTH_32_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hDn-MyquEemz8qUl1H9gFg" base_Class="_hDnXECquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hDolMCquEemz8qUl1H9gFg" base_Class="_hDnXECquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hDsPkCquEemz8qUl1H9gFg" base_Class="_hDrogCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hDs2oCquEemz8qUl1H9gFg" base_Class="_hDrogCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDs2oSquEemz8qUl1H9gFg" base_StructuralFeature="_hDrogiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDtdsCquEemz8qUl1H9gFg" base_Property="_hDrogiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDtdsSquEemz8qUl1H9gFg" base_StructuralFeature="_hDrohiquEemz8qUl1H9gFg" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDtdsiquEemz8qUl1H9gFg" base_Property="_hDrohiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDuEwCquEemz8qUl1H9gFg" base_StructuralFeature="_hDroiiquEemz8qUl1H9gFg" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDuEwSquEemz8qUl1H9gFg" base_Property="_hDroiiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDuEwiquEemz8qUl1H9gFg" base_StructuralFeature="_hDrojiquEemz8qUl1H9gFg" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDur0CquEemz8qUl1H9gFg" base_Property="_hDrojiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDur0SquEemz8qUl1H9gFg" base_StructuralFeature="_hDrokiquEemz8qUl1H9gFg" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDur0iquEemz8qUl1H9gFg" base_Property="_hDrokiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hDwhACquEemz8qUl1H9gFg" base_Class="_hDv58CquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hDwhASquEemz8qUl1H9gFg" base_Class="_hDv58CquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDxIECquEemz8qUl1H9gFg" base_StructuralFeature="_hDv58iquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDxIESquEemz8qUl1H9gFg" base_Property="_hDv58iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDxvICquEemz8qUl1H9gFg" base_StructuralFeature="_hDv59iquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDxvISquEemz8qUl1H9gFg" base_Property="_hDv59iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDxvIiquEemz8qUl1H9gFg" base_StructuralFeature="_hDv5-iquEemz8qUl1H9gFg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDyWMCquEemz8qUl1H9gFg" base_Property="_hDv5-iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDyWMSquEemz8qUl1H9gFg" base_StructuralFeature="_hDv5_iquEemz8qUl1H9gFg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDyWMiquEemz8qUl1H9gFg" base_Property="_hDv5_iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDy9QCquEemz8qUl1H9gFg" base_StructuralFeature="_hDv6AiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDy9QSquEemz8qUl1H9gFg" base_Property="_hDv6AiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hDy9QiquEemz8qUl1H9gFg" base_StructuralFeature="_hDv6BiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDy9QyquEemz8qUl1H9gFg" base_Property="_hDv6BiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hD0ycCquEemz8qUl1H9gFg" base_Class="_hD0LYCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hD1ZgCquEemz8qUl1H9gFg" base_Class="_hD0LYCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD2AkSquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LZiquEemz8qUl1H9gFg" partOfObjectKey="2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD2AkiquEemz8qUl1H9gFg" base_Property="_hD0LZiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD2noCquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LaiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD2noSquEemz8qUl1H9gFg" base_Property="_hD0LaiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD2noiquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LbyquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD3OsCquEemz8qUl1H9gFg" base_Property="_hD0LbyquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD3OsSquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LdCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD3OsiquEemz8qUl1H9gFg" base_Property="_hD0LdCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD6SACquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LfiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD6SASquEemz8qUl1H9gFg" base_Property="_hD0LfiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD6SAiquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LgiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD6SAyquEemz8qUl1H9gFg" base_Property="_hD0LgiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hD65ECquEemz8qUl1H9gFg" base_StructuralFeature="_hD0LhiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hD65ESquEemz8qUl1H9gFg" base_Property="_hD0LhiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEA_sCquEemz8qUl1H9gFg" base_Class="_hEAYoCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEA_sSquEemz8qUl1H9gFg" base_Class="_hEAYoCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEBmwCquEemz8qUl1H9gFg" base_StructuralFeature="_hEAYoiquEemz8qUl1H9gFg" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEBmwSquEemz8qUl1H9gFg" base_Property="_hEAYoiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEBmwiquEemz8qUl1H9gFg" base_StructuralFeature="_hEAYpiquEemz8qUl1H9gFg" partOfObjectKey="2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEBmwyquEemz8qUl1H9gFg" base_Property="_hEAYpiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hECN0CquEemz8qUl1H9gFg" base_StructuralFeature="_hEAYqiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hECN0SquEemz8qUl1H9gFg" base_Property="_hEAYqiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hECN0iquEemz8qUl1H9gFg" base_StructuralFeature="_hEAYryquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hECN0yquEemz8qUl1H9gFg" base_Property="_hEAYryquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEC04CquEemz8qUl1H9gFg" base_StructuralFeature="_hEAYsyquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEC04SquEemz8qUl1H9gFg" base_Property="_hEAYsyquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEC04iquEemz8qUl1H9gFg" base_StructuralFeature="_hEAYtyquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEC04yquEemz8qUl1H9gFg" base_Property="_hEAYtyquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEHGUCquEemz8qUl1H9gFg" base_Class="_hEGfQCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEHGUSquEemz8qUl1H9gFg" base_Class="_hEGfQCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEHtYCquEemz8qUl1H9gFg" base_StructuralFeature="_hEGfQiquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEHtYSquEemz8qUl1H9gFg" base_Property="_hEGfQiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEHtYiquEemz8qUl1H9gFg" base_StructuralFeature="_hEGfRiquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEIUcCquEemz8qUl1H9gFg" base_Property="_hEGfRiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEJiqiquEemz8qUl1H9gFg" base_Class="_hEJikCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEKJoCquEemz8qUl1H9gFg" base_Class="_hEJikCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEKJoSquEemz8qUl1H9gFg" base_StructuralFeature="_hEJikiquEemz8qUl1H9gFg" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEKJoiquEemz8qUl1H9gFg" base_Property="_hEJikiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEKwsCquEemz8qUl1H9gFg" base_StructuralFeature="_hEJiliquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEKwsSquEemz8qUl1H9gFg" base_Property="_hEJiliquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEKwsiquEemz8qUl1H9gFg" base_StructuralFeature="_hEJimiquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEKwsyquEemz8qUl1H9gFg" base_Property="_hEJimiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hELXwCquEemz8qUl1H9gFg" base_StructuralFeature="_hEJiniquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hELXwSquEemz8qUl1H9gFg" base_Property="_hEJiniquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hELXwiquEemz8qUl1H9gFg" base_StructuralFeature="_hEJioiquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEL-0CquEemz8qUl1H9gFg" base_Property="_hEJioiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEL-0SquEemz8qUl1H9gFg" base_StructuralFeature="_hEJipiquEemz8qUl1H9gFg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEMl4CquEemz8qUl1H9gFg" base_Property="_hEJipiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEObECquEemz8qUl1H9gFg" base_Class="_hEN0ACquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEObESquEemz8qUl1H9gFg" base_Class="_hEN0ACquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEPCICquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0AiquEemz8qUl1H9gFg" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEPCISquEemz8qUl1H9gFg" base_Property="_hEN0AiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEPpMCquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0BCquEemz8qUl1H9gFg" partOfObjectKey="2" valueRange="1..2147483647" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEPpMSquEemz8qUl1H9gFg" base_Property="_hEN0BCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEPpMiquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0CCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEPpMyquEemz8qUl1H9gFg" base_Property="_hEN0CCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEQQQCquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0DCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEQQQSquEemz8qUl1H9gFg" base_Property="_hEN0DCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEQ3UCquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0ECquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEQ3USquEemz8qUl1H9gFg" base_Property="_hEN0ECquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEQ3UiquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0FCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEReYCquEemz8qUl1H9gFg" base_Property="_hEN0FCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEReYSquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0GCquEemz8qUl1H9gFg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEReYiquEemz8qUl1H9gFg" base_Property="_hEN0GCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEReYyquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0HCquEemz8qUl1H9gFg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEReZCquEemz8qUl1H9gFg" base_Property="_hEN0HCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEReZSquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0ICquEemz8qUl1H9gFg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hESFcCquEemz8qUl1H9gFg" base_Property="_hEN0ICquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hESFcSquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0JCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hESFciquEemz8qUl1H9gFg" base_Property="_hEN0JCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hESFcyquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0KCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hESsgCquEemz8qUl1H9gFg" base_Property="_hEN0KCquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hET6oSquEemz8qUl1H9gFg" base_Class="_hEN0NSquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hET6oiquEemz8qUl1H9gFg" base_Class="_hEN0NSquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hET6oyquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0NyquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEUhsCquEemz8qUl1H9gFg" base_Property="_hEN0NyquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEUhsSquEemz8qUl1H9gFg" base_StructuralFeature="_hEN0OSquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEUhsiquEemz8qUl1H9gFg" base_Property="_hEN0OSquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEXlACquEemz8qUl1H9gFg" base_Class="_hEW98CquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEXlASquEemz8qUl1H9gFg" base_Class="_hEW98CquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEYMECquEemz8qUl1H9gFg" base_StructuralFeature="_hEW98iquEemz8qUl1H9gFg" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEYMESquEemz8qUl1H9gFg" base_Property="_hEW98iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEYMEiquEemz8qUl1H9gFg" base_StructuralFeature="_hEW99iquEemz8qUl1H9gFg" partOfObjectKey="2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEYzICquEemz8qUl1H9gFg" base_Property="_hEW99iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEYzISquEemz8qUl1H9gFg" base_StructuralFeature="_hEW9-iquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEYzIiquEemz8qUl1H9gFg" base_Property="_hEW9-iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEZaMCquEemz8qUl1H9gFg" base_StructuralFeature="_hEW9_iquEemz8qUl1H9gFg" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEZaMSquEemz8qUl1H9gFg" base_Property="_hEW9_iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEZaMiquEemz8qUl1H9gFg" base_Class="_hEW-AiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEaBQCquEemz8qUl1H9gFg" base_Class="_hEW-AiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEaBQSquEemz8qUl1H9gFg" base_StructuralFeature="_hEW-BCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEaoUCquEemz8qUl1H9gFg" base_Property="_hEW-BCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEaoUSquEemz8qUl1H9gFg" base_StructuralFeature="_hEW-BiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEaoUiquEemz8qUl1H9gFg" base_Property="_hEW-BiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEdroCquEemz8qUl1H9gFg" base_Class="_hEdEkCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEdroSquEemz8qUl1H9gFg" base_Class="_hEdEkCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEeSsCquEemz8qUl1H9gFg" base_StructuralFeature="_hEdEkiquEemz8qUl1H9gFg" partOfObjectKey="1" valueRange="9..126" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEeSsSquEemz8qUl1H9gFg" base_Property="_hEdEkiquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEeSsiquEemz8qUl1H9gFg" base_StructuralFeature="_hEdEliquEemz8qUl1H9gFg" valueRange="0..511"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEeSsyquEemz8qUl1H9gFg" base_Property="_hEdEliquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_hEgH4CquEemz8qUl1H9gFg" base_Class="_hEfg0CquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hEgH4SquEemz8qUl1H9gFg" base_Class="_hEfg0CquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEgu8CquEemz8qUl1H9gFg" base_StructuralFeature="_hEfg0iquEemz8qUl1H9gFg" partOfObjectKey="1" valueRange="3"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEgu8SquEemz8qUl1H9gFg" base_Property="_hEfg0iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEgu8iquEemz8qUl1H9gFg" base_StructuralFeature="_hEfg1iquEemz8qUl1H9gFg" partOfObjectKey="2" valueRange="1..255" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEgu8yquEemz8qUl1H9gFg" base_Property="_hEfg1iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEhWACquEemz8qUl1H9gFg" base_StructuralFeature="_hEfg2iquEemz8qUl1H9gFg" partOfObjectKey="3" valueRange="1..2147483647" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEhWASquEemz8qUl1H9gFg" base_Property="_hEfg2iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEh9ECquEemz8qUl1H9gFg" base_StructuralFeature="_hEfg3iquEemz8qUl1H9gFg" valueRange="0..507"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEh9ESquEemz8qUl1H9gFg" base_Property="_hEfg3iquEemz8qUl1H9gFg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelNotification xmi:id="_1ivtwiquEemz8qUl1H9gFg" base_Signal="_1ivtsCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8Q-gQCquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95MiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8Q_uYCquEemz8qUl1H9gFg" base_Property="_8Q95MiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8Q_uYSquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95NCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8Q_uYiquEemz8qUl1H9gFg" base_Property="_8Q95NCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RAVcCquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95NiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RAVcSquEemz8qUl1H9gFg" base_Property="_8Q95NiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RAVciquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95OCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RA8gCquEemz8qUl1H9gFg" base_Property="_8Q95OCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RA8gSquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95OiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RA8giquEemz8qUl1H9gFg" base_Property="_8Q95OiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RA8gyquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95PCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RBjkCquEemz8qUl1H9gFg" base_Property="_8Q95PCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RCKoCquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95PiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RCKoSquEemz8qUl1H9gFg" base_Property="_8Q95PiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RCxsCquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95QCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RCxsSquEemz8qUl1H9gFg" base_Property="_8Q95QCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RCxsiquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95QiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RDYwCquEemz8qUl1H9gFg" base_Property="_8Q95QiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RDYwSquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95RCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RDYwiquEemz8qUl1H9gFg" base_Property="_8Q95RCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RD_0CquEemz8qUl1H9gFg" base_StructuralFeature="_8Q95RiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RD_0SquEemz8qUl1H9gFg" base_Property="_8Q95RiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RF1CiquEemz8qUl1H9gFg" base_StructuralFeature="_8RF1AiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RGcECquEemz8qUl1H9gFg" base_Property="_8RF1AiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RGcESquEemz8qUl1H9gFg" base_StructuralFeature="_8RF1BCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RGcEiquEemz8qUl1H9gFg" base_Property="_8RF1BCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RGcEyquEemz8qUl1H9gFg" base_StructuralFeature="_8RF1BiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RGcFCquEemz8qUl1H9gFg" base_Property="_8RF1BiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RGcFSquEemz8qUl1H9gFg" base_StructuralFeature="_8RF1CCquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RHDICquEemz8qUl1H9gFg" base_Property="_8RF1CCquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RJfYCquEemz8qUl1H9gFg" base_StructuralFeature="_8RI4UiquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RJfYSquEemz8qUl1H9gFg" base_Property="_8RI4UiquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8RO-8CquEemz8qUl1H9gFg" base_StructuralFeature="_8ROX4iquEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8RO-8SquEemz8qUl1H9gFg" base_Property="_8ROX4iquEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gS5Z4SqwEemz8qUl1H9gFg" base_StructuralFeature="_gS5Z4CqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gS6oACqwEemz8qUl1H9gFg" base_Property="_gS5Z4CqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gS7PEiqwEemz8qUl1H9gFg" base_StructuralFeature="_gS7PESqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gS7PEyqwEemz8qUl1H9gFg" base_Property="_gS7PESqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hcBlICqwEemz8qUl1H9gFg" base_StructuralFeature="_hcA-EiqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hcBlISqwEemz8qUl1H9gFg" base_Property="_hcA-EiqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hcCMMyqwEemz8qUl1H9gFg" base_StructuralFeature="_hcCMMiqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hcCzQCqwEemz8qUl1H9gFg" base_Property="_hcCMMiqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ioQuwyqwEemz8qUl1H9gFg" base_StructuralFeature="_ioQuwiqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ioRV0CqwEemz8qUl1H9gFg" base_Property="_ioQuwiqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ioSj8CqwEemz8qUl1H9gFg" base_StructuralFeature="_ioR84iqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ioSj8SqwEemz8qUl1H9gFg" base_Property="_ioR84iqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jkkmAiqwEemz8qUl1H9gFg" base_StructuralFeature="_jkkmASqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jklNECqwEemz8qUl1H9gFg" base_Property="_jkkmASqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jkl0IiqwEemz8qUl1H9gFg" base_StructuralFeature="_jkl0ISqwEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jkl0IyqwEemz8qUl1H9gFg" base_Property="_jkl0ISqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_tIGKsCqwEemz8qUl1H9gFg" base_Association="_jkjX4CqwEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iA1bASqzEemz8qUl1H9gFg" base_StructuralFeature="_iA1bACqzEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_iA1bAiqzEemz8qUl1H9gFg" base_Property="_iA1bACqzEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iA2CEyqzEemz8qUl1H9gFg" base_StructuralFeature="_iA2CEiqzEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_iA2pICqzEemz8qUl1H9gFg" base_Property="_iA2CEiqzEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PF93Aiq0Eemz8qUl1H9gFg" base_StructuralFeature="_PF93ASq0Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PF-eECq0Eemz8qUl1H9gFg" base_Property="_PF93ASq0Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PF-eFCq0Eemz8qUl1H9gFg" base_StructuralFeature="_PF-eEyq0Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PF-eFSq0Eemz8qUl1H9gFg" base_Property="_PF-eEyq0Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bAkLUCq1Eemz8qUl1H9gFg" base_StructuralFeature="_bAjkQiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_bAkLUSq1Eemz8qUl1H9gFg" base_Property="_bAjkQiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bAkyYiq1Eemz8qUl1H9gFg" base_StructuralFeature="_bAkyYSq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_bAkyYyq1Eemz8qUl1H9gFg" base_Property="_bAkyYSq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hw4BgCq1Eemz8qUl1H9gFg" base_StructuralFeature="_hw2zYiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hw4okCq1Eemz8qUl1H9gFg" base_Property="_hw2zYiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hw52sCq1Eemz8qUl1H9gFg" base_StructuralFeature="_hw5Poiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hw52sSq1Eemz8qUl1H9gFg" base_Property="_hw5Poiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4bqXYCq1Eemz8qUl1H9gFg" base_StructuralFeature="_4bpwUiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_4bqXYSq1Eemz8qUl1H9gFg" base_Property="_4bpwUiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4bq-cyq1Eemz8qUl1H9gFg" base_StructuralFeature="_4bq-ciq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_4brlgCq1Eemz8qUl1H9gFg" base_Property="_4bq-ciq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5WZhUyq1Eemz8qUl1H9gFg" base_StructuralFeature="_5WZhUiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5WZhVCq1Eemz8qUl1H9gFg" base_Property="_5WZhUiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5WaIYyq1Eemz8qUl1H9gFg" base_StructuralFeature="_5WaIYiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5WaIZCq1Eemz8qUl1H9gFg" base_Property="_5WaIYiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6Tk7Qyq1Eemz8qUl1H9gFg" base_StructuralFeature="_6Tk7Qiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6TliUCq1Eemz8qUl1H9gFg" base_Property="_6Tk7Qiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6TliVCq1Eemz8qUl1H9gFg" base_StructuralFeature="_6TliUyq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6TmJYCq1Eemz8qUl1H9gFg" base_Property="_6TliUyq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7d29ECq1Eemz8qUl1H9gFg" base_StructuralFeature="_7d2WAiq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7d3kICq1Eemz8qUl1H9gFg" base_Property="_7d2WAiq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7d4LMCq1Eemz8qUl1H9gFg" base_StructuralFeature="_7d3kIyq1Eemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7d4LMSq1Eemz8qUl1H9gFg" base_Property="_7d3kIyq1Eemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ULjaUyrAEemz8qUl1H9gFg" base_StructuralFeature="_ULjaUirAEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ULkBYCrAEemz8qUl1H9gFg" base_Property="_ULjaUirAEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ULkocSrAEemz8qUl1H9gFg" base_StructuralFeature="_ULkocCrAEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ULkocirAEemz8qUl1H9gFg" base_Property="_ULkocCrAEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_VSf0QCrAEemz8qUl1H9gFg" base_Association="_ULiMMCrAEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:Specify xmi:id="_m27pcCrCEemz8qUl1H9gFg" base_Abstraction="_keOssCrCEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:Specify xmi:id="_tlxgACrCEemz8qUl1H9gFg" base_Abstraction="_sgTswCrCEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jSFa8yrIEemz8qUl1H9gFg" base_StructuralFeature="_jSFa8irIEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jSFa9CrIEemz8qUl1H9gFg" base_Property="_jSFa8irIEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jSGpECrIEemz8qUl1H9gFg" base_StructuralFeature="_jSGCAirIEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jSGpESrIEemz8qUl1H9gFg" base_Property="_jSGCAirIEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WdYAECrNEemz8qUl1H9gFg" base_StructuralFeature="_WdXZAirNEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_WdYAESrNEemz8qUl1H9gFg" base_Property="_WdXZAirNEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WdYnIyrNEemz8qUl1H9gFg" base_StructuralFeature="_WdYnIirNEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_WdYnJCrNEemz8qUl1H9gFg" base_Property="_WdYnIirNEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XIc9YyrNEemz8qUl1H9gFg" base_StructuralFeature="_XIc9YirNEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_XIdkcCrNEemz8qUl1H9gFg" base_Property="_XIc9YirNEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XIeLgyrNEemz8qUl1H9gFg" base_StructuralFeature="_XIeLgirNEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_XIeykCrNEemz8qUl1H9gFg" base_Property="_XIeLgirNEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Xz4gAirNEemz8qUl1H9gFg" base_StructuralFeature="_Xz4gASrNEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Xz4gAyrNEemz8qUl1H9gFg" base_Property="_Xz4gASrNEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Xz5HEyrNEemz8qUl1H9gFg" base_StructuralFeature="_Xz5HEirNEemz8qUl1H9gFg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Xz5HFCrNEemz8qUl1H9gFg" base_Property="_Xz5HEirNEemz8qUl1H9gFg"/>
+  <OpenModel_Profile:Reference xmi:id="_CAMigCrTEemz8qUl1H9gFg" base_Element="_hEfg1iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.6.1.4"/>
+  <OpenModel_Profile:Reference xmi:id="_FVVSUCrTEemz8qUl1H9gFg" base_Element="_hEfg0iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.6.1.3"/>
+  <OpenModel_Profile:Reference xmi:id="_YiiuECrTEemz8qUl1H9gFg" base_Element="_hEfg3iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.6.1.5"/>
+  <OpenModel_Profile:Reference xmi:id="_kkdn0CrTEemz8qUl1H9gFg" base_Element="_hEdEkiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.7.7.1"/>
+  <OpenModel_Profile:Reference xmi:id="_m6lKoCrTEemz8qUl1H9gFg" base_Element="_hEdEliquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.7.7.1"/>
+  <OpenModel_Profile:Reference xmi:id="_1_O1kCrTEemz8qUl1H9gFg" base_Element="_hEW98iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.3"/>
+  <OpenModel_Profile:Reference xmi:id="_4KKcECrTEemz8qUl1H9gFg" base_Element="_hEW99iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.4"/>
+  <OpenModel_Profile:Reference xmi:id="_6P29QCrTEemz8qUl1H9gFg" base_Element="_hEW9-iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.5"/>
+  <OpenModel_Profile:Reference xmi:id="_8lG9YCrTEemz8qUl1H9gFg" base_Element="_hEW9_iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.6"/>
+  <OpenModel_Profile:Reference xmi:id="_POR38CrUEemz8qUl1H9gFg" base_Element="_hEN0CCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.2.2"/>
+  <OpenModel_Profile:Reference xmi:id="_RffFkCrUEemz8qUl1H9gFg" base_Element="_hEN0DCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.2.3"/>
+  <OpenModel_Profile:Reference xmi:id="_T1xAcCrUEemz8qUl1H9gFg" base_Element="_hEN0ECquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.3.2"/>
+  <OpenModel_Profile:Reference xmi:id="_V2eT8CrUEemz8qUl1H9gFg" base_Element="_hEN0FCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.3.3"/>
+  <OpenModel_Profile:Reference xmi:id="_X-l3ACrUEemz8qUl1H9gFg" base_Element="_hEN0GCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.5.2"/>
+  <OpenModel_Profile:Reference xmi:id="_d-hZICrUEemz8qUl1H9gFg" base_Element="_hEN0HCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.6.2"/>
+  <OpenModel_Profile:Reference xmi:id="_g-FhkCrUEemz8qUl1H9gFg" base_Element="_hEN0ICquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.7.2"/>
+  <OpenModel_Profile:Reference xmi:id="_jEkF4CrUEemz8qUl1H9gFg" base_Element="_hEN0JCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.8.1"/>
+  <OpenModel_Profile:Reference xmi:id="_lGYzsCrUEemz8qUl1H9gFg" base_Element="_hEN0KCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.8.2"/>
+  <OpenModel_Profile:Reference xmi:id="_Ft_YACrVEemz8qUl1H9gFg" base_Element="_hEJikiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.1"/>
+  <OpenModel_Profile:Reference xmi:id="_IBgSwCrVEemz8qUl1H9gFg" base_Element="_hEJiliquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.2"/>
+  <OpenModel_Profile:Reference xmi:id="_KS-mICrVEemz8qUl1H9gFg" base_Element="_hEJimiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.3"/>
+  <OpenModel_Profile:Reference xmi:id="_MuRj4CrVEemz8qUl1H9gFg" base_Element="_hEJiniquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.4"/>
+  <OpenModel_Profile:Reference xmi:id="_O3c24CrVEemz8qUl1H9gFg" base_Element="_hEJioiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.5"/>
+  <OpenModel_Profile:Reference xmi:id="_RE9QQCrVEemz8qUl1H9gFg" base_Element="_hEJipiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.6"/>
+  <OpenModel_Profile:Reference xmi:id="_swnfACrVEemz8qUl1H9gFg" base_Element="_hEGfQiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.6.5"/>
+  <OpenModel_Profile:Reference xmi:id="_vV--wCrVEemz8qUl1H9gFg" base_Element="_hEGfRiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.7.2"/>
+  <OpenModel_Profile:Reference xmi:id="_5t7C8CrVEemz8qUl1H9gFg" base_Element="_hEAYoiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016 8.5.9.3"/>
+  <OpenModel_Profile:Reference xmi:id="_8Gy-0CrVEemz8qUl1H9gFg" base_Element="_hEAYpiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016 8.5.9.4"/>
+  <OpenModel_Profile:Reference xmi:id="_-c0bACrVEemz8qUl1H9gFg" base_Element="_hEAYqiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016 9.1.2.1"/>
+  <OpenModel_Profile:Reference xmi:id="_A_yuECrWEemz8qUl1H9gFg" base_Element="_hEAYryquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.2"/>
+  <OpenModel_Profile:Reference xmi:id="_DH3N0CrWEemz8qUl1H9gFg" base_Element="_hEAYsyquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.5"/>
+  <OpenModel_Profile:Reference xmi:id="_FZIF0CrWEemz8qUl1H9gFg" base_Element="_hEAYtyquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.9.6"/>
+  <OpenModel_Profile:Reference xmi:id="_oRi2MCrWEemz8qUl1H9gFg" base_Element="_hDv58iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.2.2"/>
+  <OpenModel_Profile:Reference xmi:id="_qQZvkCrWEemz8qUl1H9gFg" base_Element="_hDv59iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.2.3"/>
+  <OpenModel_Profile:Reference xmi:id="_suCPoCrWEemz8qUl1H9gFg" base_Element="_hDv5-iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.6.2"/>
+  <OpenModel_Profile:Reference xmi:id="_uzPBkCrWEemz8qUl1H9gFg" base_Element="_hDv5_iquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.7.2"/>
+  <OpenModel_Profile:Reference xmi:id="_xFq-QCrWEemz8qUl1H9gFg" base_Element="_hDv6AiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.8.1"/>
+  <OpenModel_Profile:Reference xmi:id="_zQmkwCrWEemz8qUl1H9gFg" base_Element="_hDv6BiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.8.2"/>
+  <OpenModel_Profile:Reference xmi:id="_DOTXkCrXEemz8qUl1H9gFg" base_Element="_hD0LaiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.1"/>
+  <OpenModel_Profile:Reference xmi:id="_GoQ9ACrXEemz8qUl1H9gFg" base_Element="_hD0LdCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016 9.1.2.1"/>
+  <OpenModel_Profile:Reference xmi:id="_IwsCECrXEemz8qUl1H9gFg" base_Element="_hD0LfiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.3.2"/>
+  <OpenModel_Profile:Reference xmi:id="_K7z10CrXEemz8qUl1H9gFg" base_Element="_hD0LgiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.3.3"/>
+  <OpenModel_Profile:Reference xmi:id="_NTb0gCrXEemz8qUl1H9gFg" base_Element="_hD0LhiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 8.5.5.2"/>
+  <OpenModel_Profile:Reference xmi:id="_WKDP4CrXEemz8qUl1H9gFg" base_Element="_hDh3giquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.5"/>
+  <OpenModel_Profile:Reference xmi:id="_YR9XkCrXEemz8qUl1H9gFg" base_Element="_hDh3hyquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.6"/>
+  <OpenModel_Profile:Reference xmi:id="_afT_8CrXEemz8qUl1H9gFg" base_Element="_hDh3jCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.7"/>
+  <OpenModel_Profile:Reference xmi:id="_cnQj4CrXEemz8qUl1H9gFg" base_Element="_hDh3jiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.10"/>
+  <OpenModel_Profile:Reference xmi:id="_egyRUCrXEemz8qUl1H9gFg" base_Element="_hDh3kCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.17"/>
+  <OpenModel_Profile:Reference xmi:id="_giVSUCrXEemz8qUl1H9gFg" base_Element="_hDh3kiquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.19"/>
+  <OpenModel_Profile:Reference xmi:id="_ik-fgCrXEemz8qUl1H9gFg" base_Element="_hDh3lCquEemz8qUl1H9gFg" reference="IEEE Std 802.1AB-2016: 9.2.5.7"/>
 </xmi:XMI>


### PR DESCRIPTION
LLDP as defined in
https://github.com/YangModels/yang/blob/master/standard/ieee/802.1/draft/ieee802-dot1ab-lldp.yang
revision 2018-11-11

Additional comments:
- ModelLibrary ImplementationCommonDataTypes added
- Reference stereotype need to be suppressed in front of attributes (update of style sheet)
- Bit typed attributes cannot be modelled because of old profiles
- name attribute of Port not modeled (is using localId)
- ZeroBasedCounter32 and Counter32 modelled by profile properties (bitLength = LENGTH_32_BIT, counter = ZERO_COUNTER/COUNTER); i.e., type could be changed to Integer
- Modeling of Binary typed attributes to be discussed
- readOnly attribute property just set to show in diagrams; already defined by property writeAllowed = WRITE_NOT_ALLOWED