### PR TITLE
LLDP model added to Tapi

### DIFF
--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -2042,7 +2042,7 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HLnN1Yt6Eeiu6boZkiJHCA" x="358" y="-12"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_-RwAgU0WEeaqn4OIuRCwEg" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_-RwAgU0WEeaqn4OIuRCwEg" name="diagram_compatibility_version" stringValue="1.3.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_-R5KcE0WEeaqn4OIuRCwEg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_47Tw8It5Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
       <owner xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -626,6 +626,28 @@ Examples:&#xD;
 </body>
         </ownedComment>
       </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_6-ftUC7jEem3g99vIRtESQ" name="MacAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_D10TUC7kEem3g99vIRtESQ" annotatedElement="_6-ftUC7jEem3g99vIRtESQ">
+          <body>pattern &quot;[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){5}&quot;&#xD;
+&#xD;
+description&#xD;
+      &quot;The mac-address type represents a MAC address in the canonical&#xD;
+      format and hexadecimal format specified by IEEE Std 802. The&#xD;
+      hexidecimal representation uses uppercase characters.&quot;</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_SR47UC7kEem3g99vIRtESQ" name="Binary">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_pRcnUC7kEem3g99vIRtESQ" annotatedElement="_SR47UC7kEem3g99vIRtESQ">
+          <body>Represents any binary data, i.e., a sequence of octets.&#xD;
+A binary type can be restricted by a length which defines the number of octets it contains.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_vK1_AC9lEem3g99vIRtESQ" name="Timeticks">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KT6eEC9mEem3g99vIRtESQ" annotatedElement="_vK1_AC9lEem3g99vIRtESQ">
+          <body>type uint32&#xD;
+The timeticks type represents a non-negative integer that represents the time, modulo 2^32 (4294967296 decimal), in hundredths of a second between two epochs.</body>
+        </ownedComment>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_FhzwMHrqEeavcODnuX7FyA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_JSfMgHrqEeavcODnuX7FyA" name="TapiService">
@@ -822,4 +844,6 @@ Examples:&#xD;
   <OpenModel_Profile:Experimental xmi:id="_aTAKEIk4Eeil5oKL3Vgl-g" base_Element="_-eq88Ik2Eeil5oKL3Vgl-g"/>
   <OpenModel_Profile:Experimental xmi:id="_lnBfMIk8Eeil5oKL3Vgl-g" base_Element="_i92HIL6PEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:Experimental xmi:id="_sghtoIk8Eeil5oKL3Vgl-g" base_Element="_2wdyENnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Reference xmi:id="_E081EC7kEem3g99vIRtESQ" base_Element="_6-ftUC7jEem3g99vIRtESQ" reference="3.1 and 8.1 of IEEE Std 802-2014"/>
+  <OpenModel_Profile:Reference xmi:id="_U9wKkC9mEem3g99vIRtESQ" base_Element="_vK1_AC9lEem3g99vIRtESQ" reference="RFC 2578"/>
 </xmi:XMI>

--- a/UML/TapiLldp.di
+++ b/UML/TapiLldp.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/UML/TapiLldp.notation
+++ b/UML/TapiLldp.notation
@@ -1,0 +1,8380 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:css="http://www.eclipse.org/papyrus/infra/gmfdiag/css" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <notation:Diagram xmi:id="_nPWNYHkhEeiQ1uqYFXu0Kg" type="PapyrusUMLClassDiagram" name="ieee802-dot1ab-lldp detailed Class Diagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_4VAOEOyhEeiDgrJNY0AUOg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4VRT0OyhEeiDgrJNY0AUOg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4VR64OyhEeiDgrJNY0AUOg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4VR64eyhEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4VTJAOyhEeiDgrJNY0AUOg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_GOE2sOyiEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#_8ZNqYOyhEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GOE2seyiEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GOGr4OyiEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#__Dam0OyhEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GOGr4eyiEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GOH6AOyiEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#_EEVjAOyiEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GOH6AeyiEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4VTJAeyhEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4VTJAuyhEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4VTJA-yhEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4VTJBOyhEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="ieee802-dot1ab-lldp.uml#_2TDkcOyhEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4VAOEeyhEeiDgrJNY0AUOg" x="-80" y="904"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NTjroOyiEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NTjroeyiEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NTkSsOyiEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="ieee802-dot1ab-lldp.uml#_2TDkcOyhEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NTjrouyiEeiDgrJNY0AUOg" x="465" y="363"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WM0yYOyiEeiDgrJNY0AUOg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WM1ZcOyiEeiDgrJNY0AUOg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WM1ZceyiEeiDgrJNY0AUOg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WM1ZcuyiEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_WM1Zc-yiEeiDgrJNY0AUOg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Xh_OgOyiEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_XhgtYOyiEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xh_OgeyiEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_WM1ZdOyiEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_WM1ZdeyiEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_WM1ZduyiEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WM1Zd-yiEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_WM1ZeOyiEeiDgrJNY0AUOg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_WM1ZeeyiEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_WM1ZeuyiEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_WM1Ze-yiEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WM1ZfOyiEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_Ui3yAOyiEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WM0yYeyiEeiDgrJNY0AUOg" x="72" y="904"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LvmwIOyjEeiDgrJNY0AUOg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_LvnXMOyjEeiDgrJNY0AUOg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_LvnXMeyjEeiDgrJNY0AUOg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvnXMuyjEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LvnXM-yjEeiDgrJNY0AUOg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_QVRTsOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_4zHbgOyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Fh9ssOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Fh-TwOykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_4zHbgeyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_4zHbguyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4zHbg-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_QU9xsOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QVRTseyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Rf1CUOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_6KWUM-yjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_E_B-wOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_E_B-weykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_6KWUNOyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_6KWUNeyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6KWUNuyjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_RflKsOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rf1CUeyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SpGXgOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_61os4OyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ETdSMOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ETdSMeykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_61os4eyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_61os4uyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61os4-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_So0DoOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SpGXgeyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UFOXQOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_7gDi4OyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_D_bi8OykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_D_bi8eykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_7gDi4eyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_7gDi4uyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gDi4-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_UE5AEOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UFOXQeyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_WheXQOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_8KrNMOyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_DrfTQOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_DrfTQeykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_8KrNMeyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_8KrNMuyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8KrNM-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_WhF8wOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_WheXQeyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_XbAAQOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_87LdEOyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_DRKuwOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_DRKuweykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_87LdEeyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_87LdEuyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_87LdE-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_XajUUOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XbAAQeyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Yq_BcOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_9mBw4OyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_C3EMsOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_C3EMseykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_9mBw4eyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_9mBw4uyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9mBw4-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_YqfSMOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Yq_BceyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_a2vHUOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_-MHggOyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CgKvoOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CgKvoeykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_-MHggeyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_-MHgguyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-MHgg-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_a129kOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_a2vHUeyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cscrwOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_-wdjsOyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CJ6LwOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CJ6LweykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_-wdjseyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_-wdjsuyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-wdjs-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_cru6EOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cscrweyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_fN574OyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="__XJwQOyjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_BzZJMOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_BzZJMeykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="__XJwQeyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="__XJwQuyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__XJwQ-yjEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_fNBLEOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_fN574eyjEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_hFWlsOyjEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="__-CKE-yjEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_BYadYOykEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_BYadYeykEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="__-CKFOyjEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="__-CKFeyjEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__-CKFuyjEeiDgrJNY0AUOg"/>
+          </children>
+          <styles xmi:type="notation:IntValueStyle" xmi:id="_A4BGEOykEeiDgrJNY0AUOg" name="shapeDirection" intValue="1"/>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_hEuTkOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hFWlseyjEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LvnXNOyjEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LvnXNeyjEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LvnXNuyjEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LvnXN-yjEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_LvnXOOyjEeiDgrJNY0AUOg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_LvnXOeyjEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_LvnXOuyjEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_LvnXO-yjEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LvnXPOyjEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_InDDwOyjEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LvmwIeyjEeiDgrJNY0AUOg" x="248" y="904"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OQc8QOyjEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OQc8QeyjEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OQc8Q-yjEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_InDDwOyjEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OQc8QuyjEeiDgrJNY0AUOg" x="824" y="360"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Wfi9QOymEeiDgrJNY0AUOg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WfjkUOymEeiDgrJNY0AUOg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WfjkUeymEeiDgrJNY0AUOg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WfjkUuymEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_WfjkU-ymEeiDgrJNY0AUOg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Xh-DkOymEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_Xg-lEOymEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Xh-DkeymEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_WfjkVOymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_WfjkVeymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_WfjkVuymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WfjkV-ymEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_WfjkWOymEeiDgrJNY0AUOg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_WfjkWeymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_WfjkWuymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_WfjkW-ymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WfjkXOymEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_VSwaAOymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wfi9QeymEeiDgrJNY0AUOg" x="-80" y="1200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d99PluymEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d99Pl-ymEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d99PmeymEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_VSwaAOymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d99PmOymEeiDgrJNY0AUOg" x="1112" y="360"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_kzs_YOymEeiDgrJNY0AUOg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_kzs_YuymEeiDgrJNY0AUOg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_kzs_Y-ymEeiDgrJNY0AUOg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kzs_ZOymEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_kztmcOymEeiDgrJNY0AUOg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_nUSs0OymEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_nTQLAOymEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nUSs0eymEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_kztmceymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_kztmcuymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_kztmc-ymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kztmdOymEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_kztmdeymEeiDgrJNY0AUOg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_kztmduymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_kztmd-ymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_kztmeOymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kztmeeymEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_i0034OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kzs_YeymEeiDgrJNY0AUOg" x="64" y="1200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7hhbIOymEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7hiCMOymEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7hiCMeymEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7hiCMuymEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7hiCM-ymEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_-jewQOymEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_-iIFYOymEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-jewQeymEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_VlONkOynEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_VkFlIOynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_VlONkeynEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_nDxvIOynEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_nB6G4OynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nDxvIeynEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_pXhTYOynEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_pWKBcOynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_pXhTYeynEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_r9LHAOynEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_r7x_4OynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_r9LHAeynEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uZ5BEOynEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_uYlZgOynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uZ5BEeynEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wwfsEOynEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_wu8z8OynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wwfsEeynEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7hiCNOymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7hiCNeymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7hiCNuymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7hiCN-ymEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7hiCOOymEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7hiCOeymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7hiCOuymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7hiCO-ymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7hiCPOymEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7hiCPeymEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7hiCPuymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7hiCP-ymEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7hiCQOymEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7hiCQeymEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7hhbIeymEeiDgrJNY0AUOg" x="1320" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7hsaQOymEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7hsaQeymEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7hsaQ-ymEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7hsaQuymEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-jeB0OypEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-jeB0uypEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-jeB0-ypEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-jeB1OypEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-jeo4OypEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-jeo4eypEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-jeo4uypEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-jeo4-ypEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-jeo5OypEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-jeo5eypEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-jeo5uypEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-jeo5-ypEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-jeo6OypEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-jeo6eypEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-jeo6uypEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-jeo6-ypEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-jeo7OypEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-jeo7eypEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-jeo7uypEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-jeB0eypEeiDgrJNY0AUOg" x="696" y="112"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-jny0-ypEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-jny1OypEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-joZ4OypEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-jny1eypEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MjkDAOyrEeiDgrJNY0AUOg" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_S-k-oeyrEeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_S-k-ouyrEeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MjkDAuyrEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MjkDA-yrEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MjkDBOyrEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MjkqEOyrEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MjkqEeyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MjkqEuyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MjkqE-yrEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MjkqFOyrEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MjkqFeyrEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MjkqFuyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MjkqF-yrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MjkqGOyrEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MjkqGeyrEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MjkqGuyrEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MjkqG-yrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MjkqHOyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MjkqHeyrEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MjkqHuyrEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_K1ObINLmEeeL3MNXamQjRA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MjkDAeyrEeiDgrJNY0AUOg" x="240" y="-40" width="233"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Mjz6oOyrEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Mjz6oeyrEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mjz6o-yrEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_K1ObINLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mjz6ouyrEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_N8kdUOyrEeiDgrJNY0AUOg" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_S-kXkOyrEeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_S-k-oOyrEeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N8kdUuyrEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_N8kdU-yrEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_N8kdVOyrEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_N8kdVeyrEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_QloxUOyrEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1q-bridge.uml#_Zn8okNLmEeeL3MNXamQjRA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QloxUeyrEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_N8kdVuyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_N8kdV-yrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_N8kdWOyrEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N8kdWeyrEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_N8kdWuyrEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_N8kdW-yrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_N8kdXOyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_N8kdXeyrEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N8kdXuyrEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_N8kdX-yrEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_N8kdYOyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_N8kdYeyrEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_N8kdYuyrEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N8kdY-yrEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_RDTG8NLmEeeL3MNXamQjRA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N8kdUeyrEeiDgrJNY0AUOg" x="629" y="-40" width="233"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_N8vccOyrEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_N8vcceyrEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_N8vcc-yrEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_RDTG8NLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N8vccuyrEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O_xmwOyrEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_O_xmweyrEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O_xmw-yrEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1q-bridge.uml#_S9SucNLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O_xmwuyrEeiDgrJNY0AUOg" x="597" y="7"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CD8NAOysEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CD8NAeysEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CD8NA-ysEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD8NAuysEeiDgrJNY0AUOg" x="952" y="-4"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HAqlsOysEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_HAqlsuysEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HAqls-ysEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HAqltOysEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HAqlteysEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_S0icYOysEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_QVWAoOytEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_Syq0IOysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_S0icYeysEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_c3RFkOysEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_QyB8oOytEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_c1aEYOysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_c3RFkeysEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_qVUmIOysEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_RJxuQOytEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_qTTz8OysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_qVUmIeysEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_zer-YOysEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_RfjJ8OytEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_zbeSUOysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zer-YeysEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8F0zUOysEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_R1Q7QOytEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_8C2-4OysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8F0zUeysEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HAqltuysEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HAqlt-ysEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HAqluOysEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HAqlueysEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HAqluuysEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HAqlu-ysEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HAqlvOysEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HAqlveysEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HAqlvuysEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HAqlv-ysEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HAqlwOysEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HAqlweysEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HAqlwuysEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HAqlw-ysEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HAqlseysEeiDgrJNY0AUOg" x="-80" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HAzvoOysEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HAzvoeysEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HAzvo-ysEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HAzvouysEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E6yB0OytEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_E6yB0uytEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_E6yB0-ytEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_E6yB1OytEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_E6yB1eytEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_a08zEOytEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_cy6fIOyuEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_ay_EMOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_a08zEeytEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_dCuSMOytEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_dLIK0OyuEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_dAongOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_dCuSMeytEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ewWRoOytEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_dhGa0OyuEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_ethAEOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ewWRoeytEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_goiiUOytEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_d3lBIOyuEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_gmO1MOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_goiiUeytEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_igdtQOytEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_eTlAoOyuEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_ieQGwOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_igdtQeytEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_lCjPgOytEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_eseo0OyuEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_k_ulAOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lCjPgeytEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_E6yB1uytEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_E6yB1-ytEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_E6yB2OytEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6yB2eytEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_E6yB2uytEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_E6yB2-ytEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_E6yB3OytEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_E6yB3eytEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6yB3uytEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_E6yo4OytEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_E6yo4eytEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_E6yo4uytEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_E6yo4-ytEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6yo5OytEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6yB0eytEeiDgrJNY0AUOg" x="304" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E7ArU-ytEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E7ArVOytEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7ArVuytEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7ArVeytEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pdAMIOyuEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pdAMIuyuEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pdAMI-yuEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pdAMJOyuEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pdAMJeyuEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_0ErQQOzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_0HTGc-zAEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__0UuQOzAEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__0UuQezAEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTGeezAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTGeuzAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTtgOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTtgezAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTtguzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTtg-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTthOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTthezAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTthuzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTth-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTtiOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTtiezAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTtiuzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTti-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HTtjOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HTtjezAEeiDgrJNY0AUOg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_0HTGdOzAEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_0HTGdezAEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HTGduzAEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_ONnNMeyvEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0ErQQezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0Er3UOzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_0HYmAOzAEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-S7M8OzAEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_-S7M8ezAEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmBuzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmB-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmCOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmCezAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmCuzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmC-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmDOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmDezAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmDuzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmD-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmEOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmEezAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HYmEuzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HYmE-zAEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_0HZNEOzAEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_0HZNEezAEeiDgrJNY0AUOg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_0HYmAezAEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_0HYmAuzAEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HYmA-zAEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_vcvrkOyvEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Er3UezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0Er3UuzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_37HmEOyvEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Er3U-zAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0Er3VOzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_loTgkOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Er3VezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0EseYOzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_tcbkMOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0EseYezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0EseZuzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_3zxYMOzAEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_hptbsOy-EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0EseZ-zAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0EtFcOzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_4TrnUOzAEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_mMgcAOy_EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0EtFcezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0EuTkOzAEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_4wjJgOzAEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_sPn1AOy_EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0EuTkezAEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pdAMJuyuEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pdAMJ-yuEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pdAMKOyuEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdAMKeyuEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pdAMKuyuEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pdAMK-yuEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pdAMLOyuEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pdAMLeyuEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdAMLuyuEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pdAzMOyuEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pdAzMeyuEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pdAzMuyuEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pdAzM-yuEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdAzNOyuEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdAMIeyuEeiDgrJNY0AUOg" x="768" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pdIvA-yuEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_pdIvBOyuEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pdIvBuyuEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdIvBeyuEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CFUlsOyvEeiDgrJNY0AUOg" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_EUcIoeyvEeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_EUcIouyvEeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CFUlsuyvEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CFUls-yvEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CFUltOyvEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_CFUlteyvEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_CFUltuyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_CFUlt-yvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_CFUluOyvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CFUlueyvEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_CFUluuyvEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_CFUlu-yvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_CFUlvOyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_CFUlveyvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CFUlvuyvEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_CFUlv-yvEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_CFUlwOyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_CFUlweyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_CFUlwuyvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CFUlw-yvEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_P9ZNcGJZEeeFIY-vT21IyA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CFUlseyvEeiDgrJNY0AUOg" x="1296" y="-40" width="187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CFfk0-yvEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CFfk1OyvEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CFfk1uyvEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_P9ZNcGJZEeeFIY-vT21IyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CFfk1eyvEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CIaV8OyvEeiDgrJNY0AUOg" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_EUbhkOyvEeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_EUcIoOyvEeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CIa9AOyvEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CIa9AeyvEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CIa9AuyvEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_CIa9A-yvEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_NU9G4OyvEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="platform:/resource/IetfModels/IetfInterfaces.uml#_kVlOkGJZEeeFIY-vT21IyA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_NU9G4eyvEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_CIa9BOyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_CIa9BeyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_CIa9BuyvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CIa9B-yvEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_CIa9COyvEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_CIa9CeyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_CIa9CuyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_CIa9C-yvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CIa9DOyvEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_CIa9DeyvEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_CIa9DuyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_CIa9D-yvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_CIa9EOyvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CIa9EeyvEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_ZqsZMGJZEeeFIY-vT21IyA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CIaV8eyvEeiDgrJNY0AUOg" x="960" y="-40" width="187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CIi40OyvEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CIi40eyvEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CIi40-yvEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_ZqsZMGJZEeeFIY-vT21IyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CIi40uyvEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_lP6EIOyvEeiDgrJNY0AUOg" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_lP6EIuyvEeiDgrJNY0AUOg" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="ieee802-dot1ab-lldp.uml#_klZHgOyvEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lP6EIeyvEeiDgrJNY0AUOg" x="1080" y="152"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7gZDoOyvEeiDgrJNY0AUOg" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7gZqsOyvEeiDgrJNY0AUOg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7gZqseyvEeiDgrJNY0AUOg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7gZqsuyvEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7gZqs-yvEeiDgrJNY0AUOg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_CsznAOywEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#_Cm_S4OywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_CsznAeywEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cCVr4OywEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#_H1IywOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cCVr4eywEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cCWS8OywEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#_KNuawOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cCWS8eywEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_cCWS8uywEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-lldp.uml#_MW9_MOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cCWS8-ywEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7gZqtOyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7gZqteyvEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7gZqtuyvEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gZqt-yvEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="ieee802-dot1ab-lldp.uml#_6OfW4OyvEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gZDoeyvEeiDgrJNY0AUOg" x="288" y="1200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SgDdUuywEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SgDdU-ywEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SgDdVeywEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="ieee802-dot1ab-lldp.uml#_6OfW4OyvEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SgDdVOywEeiDgrJNY0AUOg" x="1256" y="800"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yBqC4OywEeiDgrJNY0AUOg" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yBqC4uywEeiDgrJNY0AUOg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yBqC4-ywEeiDgrJNY0AUOg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yBqC5OywEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yBqC5eywEeiDgrJNY0AUOg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_B3-bUOyxEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_UXrQ0-yxEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_VGv9UOyxEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_VGv9UeyxEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_UXrQ1OyxEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_UXrQ1eyxEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UXrQ1uyxEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_BwmoAOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B3-bUeyxEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_D9RT4OyxEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_TnS8wOyxEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ve-QEOyxEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ve-QEeyxEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_TnS8weyxEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_TnS8wuyxEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TnS8w-yxEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_D05bAOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_D9RT4eyxEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_F1ZTIOyxEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_Svd84OyxEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_V3AVkOyxEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_V3AVkeyxEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_Svd84eyxEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_Svd84uyxEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Svd84-yxEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_Fvk_AOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_F1ZTIeyxEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_HlxEkOyxEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_SBXgw-yxEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WPuXkOyxEeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WPuXkeyxEeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_SBXgxOyxEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_SBXgxeyxEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenInterfaceModel_Profile::Bit"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_LZyzoK9XEeiZQbvX_nm67A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SBXgxuyxEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_HfyYYOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_HlxEkeyxEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yBqC5uywEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yBqC5-ywEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yBqC6OywEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yBqC6eywEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yBqC6uywEeiDgrJNY0AUOg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yBqC6-ywEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yBqC7OywEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yBqC7eywEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yBqC7uywEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_wcTOoOywEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yBqC4eywEeiDgrJNY0AUOg" x="400" y="1200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_z4mWZOywEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_z4mWZeywEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_z4mWZ-ywEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_wcTOoOywEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z4mWZuywEeiDgrJNY0AUOg" x="1376" y="800"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_o9xyI-yxEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_o9xyJOyxEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_o9xyJuyxEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o9xyJeyxEeiDgrJNY0AUOg" x="1664" y="180"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zmKtIOyxEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_zmKtIuyxEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zmKtI-yxEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zmKtJOyxEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zmKtJeyxEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_P2CmwOyzEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_P8EWQ-yzEeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_NJ8y8Oy-EeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_NJ8y8ey-EeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9UuyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9U-yzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9VOyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9VeyzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9VuyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9V-yzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9WOyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9WeyzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9WuyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9W-yzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9XOyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9XeyzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9XuyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9X-yzEeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_P8E9YOyzEeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_P8E9YeyzEeiDgrJNY0AUOg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_P8EWROyzEeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_P8EWReyzEeiDgrJNY0AUOg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P8EWRuyzEeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_Pvgg8OyzEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_P2CmweyzEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LkrTsOy9EeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_LrXKg-y9EeiDgrJNY0AUOg" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_O4W1gOy-EeiDgrJNY0AUOg" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_O4W1gey-EeiDgrJNY0AUOg" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxkOy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxkey9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxkuy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxk-y9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxlOy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxley9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxluy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxl-y9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxmOy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxmey9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxmuy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxm-y9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxnOy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxney9EeiDgrJNY0AUOg"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_LrXxnuy9EeiDgrJNY0AUOg" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LrXxn-y9EeiDgrJNY0AUOg"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_LrXKhOy9EeiDgrJNY0AUOg"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_LrXKhey9EeiDgrJNY0AUOg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LrXKhuy9EeiDgrJNY0AUOg"/>
+          </children>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_LeTl8Oy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LkrTsey9EeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Nus7QOy9EeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_NobUIOy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Nus7Qey9EeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_P-BSgOy9EeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_TGPyQOy-EeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_P3xgkOy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_P-BSgey9EeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_SmNcwOy9EeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_T6w_cOy-EeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_SfqI0Oy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SmNcwey9EeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UKhIIOy9EeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_UeQuEOy-EeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_UED60Oy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UKhIIey9EeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zmKtJuyxEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zmKtJ-yxEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zmKtKOyxEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zmKtKeyxEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zmKtKuyxEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zmKtK-yxEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zmKtLOyxEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zmKtLeyxEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zmKtLuyxEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zmKtL-yxEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zmKtMOyxEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zmKtMeyxEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zmKtMuyxEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zmKtM-yxEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zmKtIeyxEeiDgrJNY0AUOg" x="-32" y="656"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zmSo8-yxEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zmSo9OyxEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zmTQAOyxEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zmSo9eyxEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-pgdwOy8EeiDgrJNY0AUOg" type="Enumeration_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B1G3EOy9EeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B1HeIOy9EeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-piS8Oy8EeiDgrJNY0AUOg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-piS8ey8EeiDgrJNY0AUOg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-piS8uy8EeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-piS8-y8EeiDgrJNY0AUOg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_AgQkAOy9EeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="platform:/resource/IetfModels/IetfRouting.uml#_5g04QOyyEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AgQkAey9EeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AgRyIOy9EeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="platform:/resource/IetfModels/IetfRouting.uml#_6TwKAOyyEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AgRyIey9EeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-piS9Oy8EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-piS9ey8EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-piS9uy8EeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-piS9-y8EeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="platform:/resource/IetfModels/IetfRouting.uml#_0-n4YOyyEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-pgdwey8EeiDgrJNY0AUOg" x="640" y="1200" width="161"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xbMiAOy_EeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_xbMiAuy_EeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xbMiA-y_EeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xbMiBOy_EeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xbMiBey_EeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_OZwGkOzBEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_3PHWgOzBEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_OSzxEOzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OZwGkezBEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QgWmsOzBEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_2mM8YOzBEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_QZCdwOzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QgWmsezBEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xbMiBuy_EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xbMiB-y_EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbMiCOy_EeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbMiCey_EeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xbMiCuy_EeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xbMiC-y_EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xbMiDOy_EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbMiDey_EeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbMiDuy_EeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xbNJEOy_EeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xbNJEey_EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xbNJEuy_EeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xbNJE-y_EeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbNJFOy_EeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbMiAey_EeiDgrJNY0AUOg" x="320" y="656"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xbVr8-y_EeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_xbVr9Oy_EeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbVr9uy_EeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbVr9ey_EeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JzpTkOzAEeiDgrJNY0AUOg" type="DataType_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_M-e34OzAEeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_M-e34ezAEeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Jzp6oOzAEeiDgrJNY0AUOg" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Jzp6oezAEeiDgrJNY0AUOg" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Jzp6ouzAEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Jzp6o-zAEeiDgrJNY0AUOg" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_LaTIUOzAEeiDgrJNY0AUOg" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-types.uml#_Y5NdZXkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LaTIUezAEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Jzp6pOzAEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Jzp6pezAEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Jzp6puzAEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jzp6p-zAEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Jzp6qOzAEeiDgrJNY0AUOg" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Jzp6qezAEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Jzp6quzAEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Jzp6q-zAEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jzp6rOzAEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-types.uml#_Y5NdY3kmEeiQ1uqYFXu0Kg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JzpTkezAEeiDgrJNY0AUOg" x="1280" y="1200" width="218"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YV41AOzAEeiDgrJNY0AUOg" type="Enumeration_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cN950OzAEeiDgrJNY0AUOg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cN-g4OzAEeiDgrJNY0AUOg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_YV41AuzAEeiDgrJNY0AUOg" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_YV41A-zAEeiDgrJNY0AUOg" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YV41BOzAEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_YV5cEOzAEeiDgrJNY0AUOg" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_bA97MOzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdS3kmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA97MezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bA_JUOzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdTnkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA_JUezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bA_JUuzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdUXkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA_JU-zAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bA_JVOzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdVHkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA_JVezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bA_JVuzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdV3kmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA_JV-zAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bA_wYOzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdWnkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA_wYezAEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bA_wYuzAEeiDgrJNY0AUOg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdXXkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bA_wY-zAEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_YV5cEezAEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_YV5cEuzAEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_YV5cE-zAEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YV5cFOzAEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="ieee802-dot1ab-types.uml#_Y5NdSXkmEeiQ1uqYFXu0Kg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YV41AezAEeiDgrJNY0AUOg" x="1512" y="1200" width="217"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_kf76kOzBEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_kf76kuzBEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_kf76k-zBEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kf76lOzBEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_kf76lezBEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_okc44OzBEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_5k0poOzBEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_j-O7suzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_okc44ezBEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_okc44uzBEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_5-fG0OzBEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_j-O7tOzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_okc44-zBEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RvjvUOzCEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_wAEgcOzCEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_RoIRoOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RvjvUezCEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UF-NEOzCEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_wY0XoOzCEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_T8jLUOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UF-NEezCEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_WL5-0OzCEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_wvrYcOzCEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_WEjZoOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_WL5-0ezCEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Yz_bYOzCEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_xIhWQOzCEeiDgrJNY0AUOg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_YshhcOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Yz_bYezCEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_kf76luzBEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_kf76l-zBEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_kf76mOzBEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kf76mezBEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_kf76muzBEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_kf76m-zBEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_kf76nOzBEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_kf76nezBEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kf76nuzBEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_kf76n-zBEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_kf76oOzBEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_kf76oezBEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_kf76ouzBEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kf76o-zBEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kf76kezBEeiDgrJNY0AUOg" x="656" y="656"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_kgFEg-zBEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_kgFEhOzBEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kgFEhuzBEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kgFEhezBEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5FGLQOzCEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5FGyUOzCEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5FGyUezCEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5FGyUuzCEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5FGyU-zCEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_G8Be0OzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_ojOc8OzZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JsrTMO1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JsrTMe1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPEAuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPEA-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPEBOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPEBezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPEBuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPEB-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPECOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPECezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPECuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPEC-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPrEOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPrEezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPrEuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPrE-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojPrFOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojPrFezZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_ojOc8ezZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_ojOc8uzZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ojOc8-zZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_wfxwcO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_G0WJgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_G8Be0ezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JB93oOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_ojdGc-zZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_H-hvUO1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_H-iWYO1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojdtguzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojdtg-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojdthOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojdthezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojdthuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojdth-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojdtiOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojdtiezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojdtiuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojdti-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojdtjOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojdtjezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojeUkOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojeUkezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ojeUkuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ojeUk-zZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_ojdGdOzZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_ojdGdezZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ojdGduzZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_w9bVwO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_I6Xa0OzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JB93oezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LH5CUOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_xX2A4O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_K_8nQOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LH5CUezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_NfZsQOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_xzsPYO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_NWSMgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_NfZsQezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Pg97YOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_yNMUgO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_PYi_MOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Pg97YezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TfwFIOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_yqBacO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_TX9bEOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TfwFIezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_VeGBIOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_zHxGYO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_VWSwAOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_VeGBIezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_XTDXoOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_zk1c4O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_XLNqQOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XTDXoezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ZPnK8OzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_z_upIO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_ZHiNAOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZPnK8ezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bmimEOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_0ZdXwO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_bedoIOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bmimEezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gnWNgOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_02xl4O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_gc20wOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gnWNgezDEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5FGyVOzCEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5FGyVezCEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5FGyVuzCEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5FGyV-zCEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5FGyWOzCEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5FGyWezCEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5FGyWuzCEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5FGyW-zCEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5FGyXOzCEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5FGyXezCEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5FGyXuzCEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5FGyX-zCEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5FGyYOzCEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5FGyYezCEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5FGLQezCEeiDgrJNY0AUOg" x="1023" y="656"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5FPVM-zCEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5FPVNOzCEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5FPVNuzCEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5FPVNezCEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_n8UP8OzDEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_n8U3AOzDEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_n8U3AezDEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_n8U3AuzDEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n8U3A-zDEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_zX4UUOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_omInAOzZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OkXa4O1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OkXa4e1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omJ1IOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omJ1IezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omJ1IuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omJ1I-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omJ1JOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omJ1JezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omJ1JuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omJ1J-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omKcMOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omKcMezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omKcMuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omKcM-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omKcNOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omKcNezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omLDQOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omLDQezZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_omInAezZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_omInAuzZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_omInA-zZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_1YCf4O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_zPhpkOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zX4UUezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_1O1O4OzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_omSYAOzZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QaqOIO1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QaqOIe1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omS_EuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omS_E-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omS_FOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omS_FezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omS_FuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omS_F-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omTmIOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omTmIezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omTmIuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omTmI-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omTmJOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omTmJezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omTmJuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omTmJ-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_omTmKOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_omTmKezZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_omSYAezZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_omSYAuzZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_omSYA-zZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_12GU4O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_1G1wgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1O1O4ezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_3nCcYOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_2P5U8O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_3eYPoOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_3nCcYezDEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5DE8kOzDEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_2nFs8O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_46-wgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5DE8kezDEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n8U3BOzDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n8U3BezDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n8U3BuzDEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n8U3B-zDEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n8U3COzDEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n8U3CezDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n8U3CuzDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n8U3C-zDEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n8U3DOzDEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n8U3DezDEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n8U3DuzDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n8U3D-zDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n8U3EOzDEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n8U3EezDEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n8UP8ezDEeiDgrJNY0AUOg" x="616" y="984"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_n8fPEOzDEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n8fPEezDEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n8fPE-zDEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n8fPEuzDEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-2ynoOzDEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-2ynouzDEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-2yno-zDEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-2ynpOzDEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-2ynpezDEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_HWQHQOzEEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_oneDw-zZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TgYB4O1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TgYB4e1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onfR4uzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onfR4-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onfR5OzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onfR5ezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onfR5uzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onfR5-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onfR6OzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onfR6ezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onfR6uzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onfR6-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onfR7OzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onfR7ezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onf48OzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onf48ezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_onf48uzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_onf48-zZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_oneDxOzZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_oneDxezZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oneDxuzZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_3e3CcO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_HN6DkOzEEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_HWQHQezEEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_KKz5kOzEEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_34fDYO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_KCr4UOzEEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_KKz5kezEEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-2ynpuzDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-2ynp-zDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-2ynqOzDEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2ynqezDEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-2ynquzDEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-2ynq-zDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-2ynrOzDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-2ynrezDEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2ynruzDEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_-2ynr-zDEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_-2ynsOzDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_-2ynsezDEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_-2ynsuzDEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2yns-zDEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2ynoezDEeiDgrJNY0AUOg" x="1072" y="984"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-27Kg-zDEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-27KhOzDEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-27KhuzDEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-27KhezDEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Q9xbIOzEEeiDgrJNY0AUOg" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q9xbIuzEEeiDgrJNY0AUOg" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q9xbI-zEEeiDgrJNY0AUOg" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Q9xbJOzEEeiDgrJNY0AUOg" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q9xbJezEEeiDgrJNY0AUOg" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_d0NsoOzFEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_oofXcOzZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZVL5IO1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ZVL5Ie1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oof-guzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oof-g-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oof-hOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oof-hezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ooglkOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ooglkezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ooglkuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ooglk-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oogllOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oogllezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ooglluzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oogll-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ooglmOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ooglmezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oohMoOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oohMoezZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_oofXcezZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_oofXcuzZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oofXc-zZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_5JIy8O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_dpIeAOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_d0NsoezFEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gBT2UOzFEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_oopIcOzZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bNqdsO1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bNqdse1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oopvguzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oopvg-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oorksOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oorksezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oorksuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oorks-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oosLwOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oosLwezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oosLwuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oosLw-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oosLxOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oosLxezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oosy0OzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_a5dvUO1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+                <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_a5dvUe1gEeig48nFftVy3w" key="visible" value="true"/>
+              </eAnnotations>
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oosy0ezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_oosy0uzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_oosy0-zZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_oopIcezZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_oopIcuzZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oopIc-zZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_5lv2cO1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_f1PJMOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gBT2UezFEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jCRF4OzFEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_opDYIOzZEeig48nFftVy3w" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ePoZ4O1gEeig48nFftVy3w" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ePoZ4e1gEeig48nFftVy3w" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opDYJuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opDYJ-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_MOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_MezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_MuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_M-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_NOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_NezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_NuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_N-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_OOzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_OezZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_OuzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_O-zZEeig48nFftVy3w"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_opD_POzZEeig48nFftVy3w" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_opD_PezZEeig48nFftVy3w"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_opDYIezZEeig48nFftVy3w"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_opDYIuzZEeig48nFftVy3w" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_opDYI-zZEeig48nFftVy3w"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_6BvO4O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_iy3_AOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jCRF4ezFEeiDgrJNY0AUOg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_lRPe4OzFEeiDgrJNY0AUOg" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_6dNp8O1gEeig48nFftVy3w" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-lldp.uml#_lF5KgOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lRPe4ezFEeiDgrJNY0AUOg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q9xbJuzEEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q9xbJ-zEEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q9xbKOzEEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q9xbKezEEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q9xbKuzEEeiDgrJNY0AUOg" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q9xbK-zEEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q9xbLOzEEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q9xbLezEEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q9xbLuzEEeiDgrJNY0AUOg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q9xbL-zEEeiDgrJNY0AUOg" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q9xbMOzEEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q9xbMezEEeiDgrJNY0AUOg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q9xbMuzEEeiDgrJNY0AUOg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q9xbM-zEEeiDgrJNY0AUOg"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q9xbIezEEeiDgrJNY0AUOg" x="1448" y="984"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Q96lE-zEEeiDgrJNY0AUOg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Q96lFOzEEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Q97MIOzEEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q96lFezEEeiDgrJNY0AUOg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_y0L4gO1fEeig48nFftVy3w" type="Enumeration_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4AtnwO1fEeig48nFftVy3w" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4AuO0O1fEeig48nFftVy3w" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_y0NGoO1fEeig48nFftVy3w" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_y0NGoe1fEeig48nFftVy3w" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_y0NGou1fEeig48nFftVy3w" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_y0NGo-1fEeig48nFftVy3w" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_2PdFgO1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdNHkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2PdFge1fEeig48nFftVy3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2PdskO1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdN3kmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2Pdske1fEeig48nFftVy3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2PfhwO1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdOnkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2Pfhwe1fEeig48nFftVy3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2Ph-AO1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdPXkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2Ph-Ae1fEeig48nFftVy3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2Ph-Au1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdQHkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2Ph-A-1fEeig48nFftVy3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2PilEO1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdQ3kmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2PilEe1fEeig48nFftVy3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2PjMIO1fEeig48nFftVy3w" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="ieee802-dot1ab-types.uml#_Y5NdRnkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2PjMIe1fEeig48nFftVy3w"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_y0NGpO1fEeig48nFftVy3w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_y0NGpe1fEeig48nFftVy3w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_y0NGpu1fEeig48nFftVy3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y0NGp-1fEeig48nFftVy3w"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="ieee802-dot1ab-types.uml#_Y5NdMnkmEeiQ1uqYFXu0Kg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y0L4ge1fEeig48nFftVy3w" x="1048" y="1200" width="217"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_y0jr8-1fEeig48nFftVy3w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_y0jr9O1fEeig48nFftVy3w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y0jr9u1fEeig48nFftVy3w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="ieee802-dot1ab-types.uml#_Y5NdMnkmEeiQ1uqYFXu0Kg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y0jr9e1fEeig48nFftVy3w" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zB6LcO1fEeig48nFftVy3w" type="DataType_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4AuO0e1fEeig48nFftVy3w" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4AuO0u1fEeig48nFftVy3w" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zB6Lcu1fEeig48nFftVy3w" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zB6ygO1fEeig48nFftVy3w" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zB6yge1fEeig48nFftVy3w" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zB6ygu1fEeig48nFftVy3w" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_1dljsO1fEeig48nFftVy3w" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="ieee802-dot1ab-types.uml#_Y5NdYnkmEeiQ1uqYFXu0Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1dljse1fEeig48nFftVy3w"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zB6yg-1fEeig48nFftVy3w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zB6yhO1fEeig48nFftVy3w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zB6yhe1fEeig48nFftVy3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zB6yhu1fEeig48nFftVy3w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zB6yh-1fEeig48nFftVy3w" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zB6yiO1fEeig48nFftVy3w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zB6yie1fEeig48nFftVy3w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zB6yiu1fEeig48nFftVy3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zB6yi-1fEeig48nFftVy3w"/>
+      </children>
+      <element xmi:type="uml:DataType" href="ieee802-dot1ab-types.uml#_Y5NdYHkmEeiQ1uqYFXu0Kg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zB6Lce1fEeig48nFftVy3w" x="816" y="1200" width="217"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zCD8cO1fEeig48nFftVy3w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zCD8ce1fEeig48nFftVy3w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zCD8c-1fEeig48nFftVy3w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-types.uml#_Y5NdYHkmEeiQ1uqYFXu0Kg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zCD8cu1fEeig48nFftVy3w" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v99AUO1hEeig48nFftVy3w" type="Signal_Shape" fillColor="10011046">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v99nYO1hEeig48nFftVy3w" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v99nYe1hEeig48nFftVy3w" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v99nYu1hEeig48nFftVy3w" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v99nY-1hEeig48nFftVy3w" type="Signal_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v99nZO1hEeig48nFftVy3w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v99nZe1hEeig48nFftVy3w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v99nZu1hEeig48nFftVy3w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v99nZ-1hEeig48nFftVy3w"/>
+      </children>
+      <element xmi:type="uml:Signal" href="ieee802-dot1ab-lldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v99AUe1hEeig48nFftVy3w" x="40" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v-Va0-1hEeig48nFftVy3w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v-Va1O1hEeig48nFftVy3w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v-WB4O1hEeig48nFftVy3w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="ieee802-dot1ab-lldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v-Va1e1hEeig48nFftVy3w" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EvzP0O4sEeiM3Nv4z8tz-w" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EvzP0u4sEeiM3Nv4z8tz-w" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="ieee802-dot1ab-lldp.uml#_D3jZMO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EvzP0e4sEeiM3Nv4z8tz-w" x="448" y="80" height="26"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_jSfWEO4sEeiM3Nv4z8tz-w" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_jSf9IO4sEeiM3Nv4z8tz-w" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="ieee802-dot1ab-lldp.uml#_cS1cUO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jSfWEe4sEeiM3Nv4z8tz-w" x="376" y="448" height="21"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pwc4AO4sEeiM3Nv4z8tz-w" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pwdfEO4sEeiM3Nv4z8tz-w" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="ieee802-dot1ab-lldp.uml#_o0TY0O4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwc4Ae4sEeiM3Nv4z8tz-w" x="376" y="480" height="25"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_wNSYkO4sEeiM3Nv4z8tz-w" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_wNSYku4sEeiM3Nv4z8tz-w" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="ieee802-dot1ab-lldp.uml#_u5ZHwO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wNSYke4sEeiM3Nv4z8tz-w" x="376" y="512" height="25"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1rP2EO4sEeiM3Nv4z8tz-w" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1rQdIO4sEeiM3Nv4z8tz-w" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="ieee802-dot1ab-lldp.uml#_0_VLQO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1rP2Ee4sEeiM3Nv4z8tz-w" x="376" y="544" height="25"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_nPWNYXkhEeiQ1uqYFXu0Kg" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_nPWNYnkhEeiQ1uqYFXu0Kg"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_nPWNY3khEeiQ1uqYFXu0Kg" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="ieee802-dot1ab-lldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    </styles>
+    <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ko7qwH38EeiXCeRGbC8RLQ" name="rulergrid.viewgrid"/>
+    <styles xmi:type="notation:DoubleValueStyle" xmi:id="_LYiiwH38EeiXCeRGbC8RLQ" name="rulergrid.gridspacing" doubleValue="0.20000000298023224"/>
+    <styles xmi:type="notation:IntValueStyle" xmi:id="_Ldvy4H38EeiXCeRGbC8RLQ" name="rulergrid.rulerunit" intValue="1"/>
+    <element xmi:type="uml:Model" href="ieee802-dot1ab-lldp.uml#_nPCrYHkhEeiQ1uqYFXu0Kg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_NTk5wOyiEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_4VAOEOyhEeiDgrJNY0AUOg" target="_NTjroOyiEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NTk5weyiEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NTlg0uyiEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="ieee802-dot1ab-lldp.uml#_2TDkcOyhEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NTk5wuyiEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NTlg0OyiEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NTlg0eyiEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OQc8ROyjEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_LvmwIOyjEeiDgrJNY0AUOg" target="_OQc8QOyjEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OQc8ReyjEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OQdjUuyjEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_InDDwOyjEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OQc8RuyjEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OQdjUOyjEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OQdjUeyjEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d99PmuymEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_Wfi9QOymEeiDgrJNY0AUOg" target="_d99PluymEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d99Pm-ymEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d992oOymEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_VSwaAOymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d99PnOymEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d99PneymEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d99PnuymEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7hsaROymEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_7hhbIOymEeiDgrJNY0AUOg" target="_7hsaQOymEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7hsaReymEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7hsaSeymEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7hsaRuymEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7hsaR-ymEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7hsaSOymEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-joZ4eypEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_-jeB0OypEeiDgrJNY0AUOg" target="_-jny0-ypEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-joZ4uypEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-joZ5uypEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-joZ4-ypEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-joZ5OypEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-joZ5eypEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Mjz6pOyrEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_MjkDAOyrEeiDgrJNY0AUOg" target="_Mjz6oOyrEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Mjz6peyrEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mj0hsuyrEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_K1ObINLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mjz6puyrEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mj0hsOyrEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mj0hseyrEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_N8vcdOyrEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_N8kdUOyrEeiDgrJNY0AUOg" target="_N8vccOyrEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_N8vcdeyrEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_N8vceeyrEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_RDTG8NLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N8vcduyrEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_N8vcd-yrEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_N8vceOyrEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O-AsMOyrEeiDgrJNY0AUOg" type="Association_Edge" source="_MjkDAOyrEeiDgrJNY0AUOg" target="_N8kdUOyrEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-AsM-yrEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Tmq5YOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O-AsNOyrEeiDgrJNY0AUOg" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-BTQOyrEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TovV8OyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O-BTQeyrEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-BTQuyrEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TqpacOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O-BTQ-yrEeiDgrJNY0AUOg" x="14" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-BTROyrEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ts4PEOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O-BTReyrEeiDgrJNY0AUOg" x="-29" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-BTRuyrEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TvCyQOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O-BTR-yrEeiDgrJNY0AUOg" x="12" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-BTSOyrEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TxEykOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O-BTSeyrEeiDgrJNY0AUOg" x="-12" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_O-AsMeyrEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1q-bridge.uml#_S9SucNLmEeeL3MNXamQjRA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O-AsMuyrEeiDgrJNY0AUOg" points="[441, 8, -643984, -643984]$[520, 8, -643984, -643984]$[520, 16, -643984, -643984]$[600, 16, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U9rIkOyrEeiDgrJNY0AUOg" id="(1.0,0.5333333333333333)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U9rvoOyrEeiDgrJNY0AUOg" id="(0.0,0.56)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O_xmxOyrEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_O-AsMOyrEeiDgrJNY0AUOg" target="_O_xmwOyrEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_O_xmxeyrEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O_xmyeyrEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1q-bridge.uml#_S9SucNLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O_xmxuyrEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O_xmx-yrEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O_xmyOyrEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_m4JxIOyrEeiDgrJNY0AUOg" type="Association_Edge" source="_-jeB0OypEeiDgrJNY0AUOg" target="_N8kdUOyrEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_m4JxI-yrEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_p6ikEOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m4JxJOyrEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_m4JxJeyrEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_p8nnsOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m4JxJuyrEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_m4JxJ-yrEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_p-U34OyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m4JxKOyrEeiDgrJNY0AUOg" x="35" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_m4JxKeyrEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qAD9QOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m4JxKuyrEeiDgrJNY0AUOg" x="-11" y="53"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_m4JxK-yrEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qB8zoOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m4JxLOyrEeiDgrJNY0AUOg" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_m4JxLeyrEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qDqq4OyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_m4JxLuyrEeiDgrJNY0AUOg" x="-11" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_m4JxIeyrEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_m2XBYOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_m4JxIuyrEeiDgrJNY0AUOg" points="[744, 104, -643984, -643984]$[744, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m8VGgOyrEeiDgrJNY0AUOg" id="(0.48,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m8VGgeyrEeiDgrJNY0AUOg" id="(0.49356223175965663,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7y9XIOyrEeiDgrJNY0AUOg" type="Association_Edge" source="_-jeB0OypEeiDgrJNY0AUOg" target="_7hhbIOymEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y9XI-yrEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-iKIUOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y9XJOyrEeiDgrJNY0AUOg" x="46" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y9XJeyrEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-j2xcOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y9XJuyrEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y9XJ-yrEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-lvAwOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y9XKOyrEeiDgrJNY0AUOg" x="59" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y9-MOyrEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-nc4AOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y9-MeyrEeiDgrJNY0AUOg" x="-9" y="30"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y9-MuyrEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-pITAOyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y9-M-yrEeiDgrJNY0AUOg" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y9-NOyrEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-q838OyrEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y9-NeyrEeiDgrJNY0AUOg" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_7y9XIeyrEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7y9XIuyrEeiDgrJNY0AUOg" points="[796, 120, -643984, -643984]$[1448, 120, -643984, -643984]$[1448, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_72kr0OyrEeiDgrJNY0AUOg" id="(1.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_72kr0eyrEeiDgrJNY0AUOg" id="(0.48854961832061067,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CD8NBOysEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_7y9XIOyrEeiDgrJNY0AUOg" target="_CD8NAOysEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CD8NBeysEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CD8NCeysEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CD8NBuysEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CD8NB-ysEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CD8NCOysEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HAzvpOysEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_HAqlsOysEeiDgrJNY0AUOg" target="_HAzvoOysEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HAzvpeysEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HA0WseysEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HAzvpuysEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HAzvp-ysEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HA0WsOysEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HjMD8OysEeiDgrJNY0AUOg" type="Association_Edge" source="_-jeB0OypEeiDgrJNY0AUOg" target="_HAqlsOysEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjMD8-ysEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IYi-oOysEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjMD9OysEeiDgrJNY0AUOg" x="624" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjMD9eysEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IahUkOysEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjMD9uysEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjMD9-ysEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IcRoEOysEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjMD-OysEeiDgrJNY0AUOg" x="10" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjMD-eysEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IeDwwOysEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjMD-uysEeiDgrJNY0AUOg" x="-9" y="60"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjMD--ysEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_If_qcOysEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjMD_OysEeiDgrJNY0AUOg" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjMD_eysEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ih2EkOysEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjMD_uysEeiDgrJNY0AUOg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_HjMD8eysEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_HhWQ4OysEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HjMD8uysEeiDgrJNY0AUOg" points="[696, 120, -643984, -643984]$[80, 120, -643984, -643984]$[80, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HnHhsOysEeiDgrJNY0AUOg" id="(0.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HnHhseysEeiDgrJNY0AUOg" id="(0.43956043956043955,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E7ArV-ytEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_E6yB0OytEeiDgrJNY0AUOg" target="_E7ArU-ytEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E7ArWOytEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7BSYuytEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E7ArWeytEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7BSYOytEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7BSYeytEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GBbg0OytEeiDgrJNY0AUOg" type="Association_Edge" source="_-jeB0OypEeiDgrJNY0AUOg" target="_E6yB0OytEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_GBcH4OytEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LHusQOytEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GBcH4eytEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GBcH4uytEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LKRC4OytEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GBcH4-ytEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GBcH5OytEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LMjh4OytEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GBcH5eytEeiDgrJNY0AUOg" x="55" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GBcH5uytEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LO8HgOytEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GBcH5-ytEeiDgrJNY0AUOg" x="-9" y="59"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GBcH6OytEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LRBLIOytEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GBcH6eytEeiDgrJNY0AUOg" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GBcH6uytEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LTFnsOytEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GBcH6-ytEeiDgrJNY0AUOg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_GBbg0eytEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_F9jtcOytEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GBbg0uytEeiDgrJNY0AUOg" points="[696, 160, -643984, -643984]$[528, 160, -643984, -643984]$[528, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GH8YgOytEeiDgrJNY0AUOg" id="(0.0,0.72)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GH8YgeytEeiDgrJNY0AUOg" id="(0.5,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pdIvB-yuEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_pdIvA-yuEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_pdIvCOyuEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pdJWEuyuEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pdIvCeyuEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdJWEOyuEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdJWEeyuEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qwsooOyuEeiDgrJNY0AUOg" type="Association_Edge" source="_-jeB0OypEeiDgrJNY0AUOg" target="_pdAMIOyuEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_qwsoo-yuEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rvHYsOyuEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qwsopOyuEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qwsopeyuEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rxkPwOyuEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qwsopuyuEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qwsop-yuEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rz0SgOyuEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qwsoqOyuEeiDgrJNY0AUOg" x="29" y="-17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qwsoqeyuEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_r2PUYOyuEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qwsoquyuEeiDgrJNY0AUOg" x="-9" y="27"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qwsoq-yuEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_r4eJAOyuEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qwsorOyuEeiDgrJNY0AUOg" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qwsoreyuEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_r68OMOyuEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qwsoruyuEeiDgrJNY0AUOg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_qwsooeyuEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_qub-0OyuEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qwsoouyuEeiDgrJNY0AUOg" points="[796, 160, -643984, -643984]$[944, 160, -643984, -643984]$[944, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q1heQOyuEeiDgrJNY0AUOg" id="(1.0,0.72)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q1heQeyuEeiDgrJNY0AUOg" id="(0.5072046109510087,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CFfk1-yvEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_CFUlsOyvEeiDgrJNY0AUOg" target="_CFfk0-yvEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CFfk2OyvEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CFfk3OyvEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_P9ZNcGJZEeeFIY-vT21IyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CFfk2eyvEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFfk2uyvEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFfk2-yvEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CIi41OyvEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_CIaV8OyvEeiDgrJNY0AUOg" target="_CIi40OyvEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CIi41eyvEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CIi42eyvEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_ZqsZMGJZEeeFIY-vT21IyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CIi41uyvEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CIi41-yvEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CIi42OyvEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CLWVMOyvEeiDgrJNY0AUOg" type="Association_Edge" source="_CFUlsOyvEeiDgrJNY0AUOg" target="_CIaV8OyvEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_CLWVM-yvEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CgkXQOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CLWVNOyvEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CLWVNeyvEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CjH8AOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CLWVNuyvEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CLWVN-yvEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ClhIsOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CLWVOOyvEeiDgrJNY0AUOg" x="38" y="-17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CLW8QOyvEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CoC4QOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CLW8QeyvEeiDgrJNY0AUOg" x="-39" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CLW8QuyvEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CqlO4OyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CLW8Q-yvEeiDgrJNY0AUOg" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CLW8ROyvEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CtAQwOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CLW8ReyvEeiDgrJNY0AUOg" x="-12" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_CLWVMeyvEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="platform:/resource/IetfModels/IetfInterfaces.uml#_s-CSIGJZEeeFIY-vT21IyA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CLWVMuyvEeiDgrJNY0AUOg" points="[1464, 8, -643984, -643984]$[1147, 8, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cvnf4OyvEeiDgrJNY0AUOg" id="(0.0,0.45714285714285713)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cvnf4eyvEeiDgrJNY0AUOg" id="(1.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OQAZ4OyvEeiDgrJNY0AUOg" type="Association_Edge" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_CIaV8OyvEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OQAZ4-yvEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YdzDkOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OQAZ5OyvEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OQAZ5eyvEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YgM3UOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OQAZ5uyvEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OQAZ5-yvEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YjGaUOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OQAZ6OyvEeiDgrJNY0AUOg" x="34" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OQAZ6eyvEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Yldx0OyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OQAZ6uyvEeiDgrJNY0AUOg" x="-8" y="33"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OQAZ6-yvEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Yn-6UOyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OQAZ7OyvEeiDgrJNY0AUOg" x="17" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OQAZ7eyvEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YqXf8OyvEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OQAZ7uyvEeiDgrJNY0AUOg" x="-11" y="-11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_OQAZ4eyvEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_ONmmIOyvEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OQAZ4uyvEeiDgrJNY0AUOg" points="[1056, 280, -643984, -643984]$[1056, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OVIKcOyvEeiDgrJNY0AUOg" id="(0.829971181556196,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OVIKceyvEeiDgrJNY0AUOg" id="(0.5133689839572193,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_l64TwOyvEeiDgrJNY0AUOg" type="Comment_AnnotatedElementEdge" source="_lP6EIOyvEeiDgrJNY0AUOg" target="_OQAZ4OyvEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_l64TweyvEeiDgrJNY0AUOg"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l64TwuyvEeiDgrJNY0AUOg" points="[1252, 195, -643984, -643984]$[1145, 172, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mmVEgOyvEeiDgrJNY0AUOg" id="(0.0,0.5470085470085471)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l6460OyvEeiDgrJNY0AUOg" id="(0.416,0.6194331983805668)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SgDdVuywEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_7gZDoOyvEeiDgrJNY0AUOg" target="_SgDdUuywEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SgDdV-ywEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SgDdW-ywEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="ieee802-dot1ab-lldp.uml#_6OfW4OyvEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SgDdWOywEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SgDdWeywEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SgDdWuywEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_z4m9cOywEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_yBqC4OywEeiDgrJNY0AUOg" target="_z4mWZOywEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_z4m9ceywEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_z4m9deywEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-lldp.uml#_wcTOoOywEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z4m9cuywEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z4m9c-ywEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z4m9dOywEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nVxSgOyxEeiDgrJNY0AUOg" type="Association_Edge" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_7hhbIOymEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nVx5kOyxEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pMlDIOyxEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nVx5keyxEeiDgrJNY0AUOg" x="1" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nVx5kuyxEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pSk9cOyxEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nVx5k-yxEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nVx5lOyxEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pZhS8OyxEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nVx5leyxEeiDgrJNY0AUOg" x="13" y="-37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nVx5luyxEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pgW6wOyxEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nVx5l-yxEeiDgrJNY0AUOg" x="-36" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nVx5mOyxEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pmkQcOyxEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nVx5meyxEeiDgrJNY0AUOg" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nVx5muyxEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pskx0OyxEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nVx5m-yxEeiDgrJNY0AUOg" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nVxSgeyxEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nVxSguyxEeiDgrJNY0AUOg" points="[1115, 352, -643984, -643984]$[1272, 352, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nkE0QOyxEeiDgrJNY0AUOg" id="(1.0,0.3711340206185567)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nkE0QeyxEeiDgrJNY0AUOg" id="(0.0,0.4044943820224719)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_o9yZMOyxEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_nVxSgOyxEeiDgrJNY0AUOg" target="_o9xyI-yxEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_o9yZMeyxEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_o9yZNeyxEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_o9yZMuyxEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o9yZM-yxEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o9yZNOyxEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zmTQAeyxEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_zmKtIOyxEeiDgrJNY0AUOg" target="_zmSo8-yxEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zmTQAuyxEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zmTQBuyxEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zmTQA-yxEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zmTQBOyxEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zmTQBeyxEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1s2FwOyxEeiDgrJNY0AUOg" type="Association_Edge" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_zmKtIOyxEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1s2Fw-yxEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fmSMYOyzEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1s2FxOyxEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1s2FxeyxEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fsfiEOyzEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1s2FxuyxEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1s2Fx-yxEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fz2HQOyzEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1s2FyOyxEeiDgrJNY0AUOg" x="24" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1s2FyeyxEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_f7EJkOyzEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1s2FyuyxEeiDgrJNY0AUOg" x="-9" y="93"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1s2Fy-yxEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gBHuQOyzEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1s2FzOyxEeiDgrJNY0AUOg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1s2FzeyxEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gHSAoOyzEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1s2FzuyxEeiDgrJNY0AUOg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_1s2FweyxEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_1m4AoOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1s2FwuyxEeiDgrJNY0AUOg" points="[824, 474, -643984, -643984]$[824, 584, -643984, -643984]$[200, 584, -643984, -643984]$[200, 656, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_17Y4EOyxEeiDgrJNY0AUOg" id="(0.16138328530259366,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_17Y4EeyxEeiDgrJNY0AUOg" id="(0.6946107784431138,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_xbVr9-y_EeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_xbMiAOy_EeiDgrJNY0AUOg" target="_xbVr8-y_EeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_xbVr-Oy_EeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbWTAuy_EeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbVr-ey_EeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbWTAOy_EeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbWTAey_EeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gzPb0OzAEeiDgrJNY0AUOg" type="Association_Edge" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_xbMiAOy_EeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gzPb0-zAEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8RB7wOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gzPb1OzAEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gzQC4OzAEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8YufMOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gzQC4ezAEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gzQC4uzAEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8gOOUOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gzQC4-zAEeiDgrJNY0AUOg" x="51" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gzQC5OzAEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8p7j8OzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gzQC5ezAEeiDgrJNY0AUOg" x="-9" y="43"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gzQC5uzAEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8xin0OzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gzQC5-zAEeiDgrJNY0AUOg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gzQC6OzAEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_848QUOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gzQC6ezAEeiDgrJNY0AUOg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_gzPb0ezAEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_gsQqEOzAEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gzPb0uzAEeiDgrJNY0AUOg" points="[888, 474, -643984, -643984]$[888, 600, -643984, -643984]$[480, 600, -643984, -643984]$[480, 656, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hDgscOzAEeiDgrJNY0AUOg" id="(0.345821325648415,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hDgscezAEeiDgrJNY0AUOg" id="(0.5031446540880503,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_kgFEh-zBEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_kf76kOzBEeiDgrJNY0AUOg" target="_kgFEg-zBEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_kgFEiOzBEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kgFEjOzBEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kgFEiezBEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kgFEiuzBEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kgFEi-zBEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uiOe4OzBEeiDgrJNY0AUOg" type="Association_Edge" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_kf76kOzBEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uiOe4-zBEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_32Q2EOzBEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uiOe5OzBEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uiOe5ezBEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_39Z_4OzBEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uiOe5uzBEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uiOe5-zBEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4G2PwOzBEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uiOe6OzBEeiDgrJNY0AUOg" x="103" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uiOe6ezBEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4N8WQOzBEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uiOe6uzBEeiDgrJNY0AUOg" x="-9" y="43"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uiOe6-zBEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4VBOoOzBEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uiOe7OzBEeiDgrJNY0AUOg" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uiOe7ezBEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4eodoOzBEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uiOe7uzBEeiDgrJNY0AUOg" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_uiOe4ezBEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_ua-AUOzBEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uiOe4uzBEeiDgrJNY0AUOg" points="[968, 474, -643984, -643984]$[968, 616, -643984, -643984]$[832, 616, -643984, -643984]$[832, 656, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uzFlYOzBEeiDgrJNY0AUOg" id="(0.5763688760806917,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uzGMcOzBEeiDgrJNY0AUOg" id="(0.5028571428571429,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5FPVN-zCEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_5FGLQOzCEeiDgrJNY0AUOg" target="_5FPVM-zCEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5FPVOOzCEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5FPVPOzCEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5FPVOezCEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5FPVOuzCEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5FPVO-zCEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7CJt0OzCEeiDgrJNY0AUOg" type="Association_Edge" source="_pdAMIOyuEeiDgrJNY0AUOg" target="_5FGLQOzCEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7CJt0-zCEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_91QuoOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7CJt1OzCEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7CJt1ezCEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_985AoOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7CJt1uzCEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7CJt1-zCEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-EqckOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7CJt2OzCEeiDgrJNY0AUOg" x="31" y="-25"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7CJt2ezCEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-OuXgOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7CJt2uzCEeiDgrJNY0AUOg" x="-9" y="69"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7CJt2-zCEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-WInEOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7CJt3OzCEeiDgrJNY0AUOg" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7CJt3ezCEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-d9GUOzCEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7CJt3uzCEeiDgrJNY0AUOg" x="-9" y="-24"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_7CJt0ezCEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_64-jsOzCEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7CJt0uzCEeiDgrJNY0AUOg" points="[1048, 474, -643984, -643984]$[1048, 528, -643984, -643984]$[1531, 528, -643984, -643984]$[1531, 592, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7SEZIOzCEeiDgrJNY0AUOg" id="(0.8069164265129684,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7SEZIezCEeiDgrJNY0AUOg" id="(0.49107142857142855,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_n8fPFOzDEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_n8UP8OzDEeiDgrJNY0AUOg" target="_n8fPEOzDEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n8fPFezDEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n8fPGezDEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n8fPFuzDEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n8fPF-zDEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n8fPGOzDEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_orMvMOzDEeiDgrJNY0AUOg" type="Association_Edge" source="_5FGLQOzCEeiDgrJNY0AUOg" target="_n8UP8OzDEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_orMvM-zDEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wWAewOzDEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_orMvNOzDEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_orMvNezDEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_weUtQOzDEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_orMvNuzDEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_orMvN-zDEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wovNgOzDEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_orMvOOzDEeiDgrJNY0AUOg" x="14" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_orMvOezDEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wwmwEOzDEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_orMvOuzDEeiDgrJNY0AUOg" x="-9" y="70"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_orMvO-zDEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_w7DskOzDEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_orMvPOzDEeiDgrJNY0AUOg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_orMvPezDEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_xC-ScOzDEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_orMvPuzDEeiDgrJNY0AUOg" x="-7" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_orMvMezDEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_oixzAOzDEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_orMvMuzDEeiDgrJNY0AUOg" points="[1119, 898, -643984, -643984]$[1119, 936, -643984, -643984]$[832, 936, -643984, -643984]$[832, 984, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o9n78OzDEeiDgrJNY0AUOg" id="(0.21428571428571427,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o9n78ezDEeiDgrJNY0AUOg" id="(0.4954128440366973,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-27Kh-zDEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_-2ynoOzDEeiDgrJNY0AUOg" target="_-27Kg-zDEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-27KiOzDEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-27KjOzDEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-27KiezDEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-27KiuzDEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-27Ki-zDEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_AuAn8OzEEeiDgrJNY0AUOg" type="Association_Edge" source="_5FGLQOzCEeiDgrJNY0AUOg" target="_-2ynoOzDEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_AuAn8-zEEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NV4ucOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AuAn9OzEEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AuAn9ezEEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NeaYUOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AuAn9uzEEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AuAn9-zEEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NnteQOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AuBPAOzEEeiDgrJNY0AUOg" x="37" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AuBPAezEEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NyntwOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AuBPAuzEEeiDgrJNY0AUOg" x="-10" y="66"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AuBPA-zEEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_N7FGMOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AuBPBOzEEeiDgrJNY0AUOg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AuBPBezEEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_OGHRgOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AuBPBuzEEeiDgrJNY0AUOg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_AuAn8ezEEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_AkdqYOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AuAn8uzEEeiDgrJNY0AUOg" points="[1248, 898, -643984, -643984]$[1248, 984, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A_8sgOzEEeiDgrJNY0AUOg" id="(0.5022321428571429,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A_8sgezEEeiDgrJNY0AUOg" id="(0.5014245014245015,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Q97MIezEEeiDgrJNY0AUOg" type="StereotypeCommentLink" source="_Q9xbIOzEEeiDgrJNY0AUOg" target="_Q96lE-zEEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Q97MIuzEEeiDgrJNY0AUOg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Q97MJuzEEeiDgrJNY0AUOg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Q97MI-zEEeiDgrJNY0AUOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q97MJOzEEeiDgrJNY0AUOg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q97MJezEEeiDgrJNY0AUOg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SonzYOzEEeiDgrJNY0AUOg" type="Association_Edge" source="_5FGLQOzCEeiDgrJNY0AUOg" target="_Q9xbIOzEEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SonzY-zEEeiDgrJNY0AUOg" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bcD-8OzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SonzZOzEEeiDgrJNY0AUOg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SonzZezEEeiDgrJNY0AUOg" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bke7IOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SonzZuzEEeiDgrJNY0AUOg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SonzZ-zEEeiDgrJNY0AUOg" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_buXP4OzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SonzaOzEEeiDgrJNY0AUOg" x="19" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SonzaezEEeiDgrJNY0AUOg" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_b3mEYOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SonzauzEEeiDgrJNY0AUOg" x="-9" y="74"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Sonza-zEEeiDgrJNY0AUOg" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cA-p4OzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SonzbOzEEeiDgrJNY0AUOg" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SonzbezEEeiDgrJNY0AUOg" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cK3lsOzEEeiDgrJNY0AUOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SonzbuzEEeiDgrJNY0AUOg" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_SonzYezEEeiDgrJNY0AUOg"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_Se9hEOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SonzYuzEEeiDgrJNY0AUOg" points="[1376, 898, -643984, -643984]$[1376, 944, -643984, -643984]$[1632, 944, -643984, -643984]$[1632, 984, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S757wOzEEeiDgrJNY0AUOg" id="(0.7879464285714286,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S757wezEEeiDgrJNY0AUOg" id="(0.4880636604774536,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_y0kTAO1fEeig48nFftVy3w" type="StereotypeCommentLink" source="_y0L4gO1fEeig48nFftVy3w" target="_y0jr8-1fEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_y0kTAe1fEeig48nFftVy3w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y0kTBe1fEeig48nFftVy3w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="ieee802-dot1ab-types.uml#_Y5NdMnkmEeiQ1uqYFXu0Kg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_y0kTAu1fEeig48nFftVy3w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y0kTA-1fEeig48nFftVy3w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y0kTBO1fEeig48nFftVy3w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zCD8dO1fEeig48nFftVy3w" type="StereotypeCommentLink" source="_zB6LcO1fEeig48nFftVy3w" target="_zCD8cO1fEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zCD8de1fEeig48nFftVy3w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zCEjgO1fEeig48nFftVy3w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="ieee802-dot1ab-types.uml#_Y5NdYHkmEeiQ1uqYFXu0Kg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zCD8du1fEeig48nFftVy3w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zCD8d-1fEeig48nFftVy3w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zCD8eO1fEeig48nFftVy3w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v-WB4e1hEeig48nFftVy3w" type="StereotypeCommentLink" source="_v99AUO1hEeig48nFftVy3w" target="_v-Va0-1hEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v-WB4u1hEeig48nFftVy3w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v-WB5u1hEeig48nFftVy3w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="ieee802-dot1ab-lldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v-WB4-1hEeig48nFftVy3w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v-WB5O1hEeig48nFftVy3w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v-WB5e1hEeig48nFftVy3w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5AafUO1hEeig48nFftVy3w" type="Association_Edge" source="_v99AUO1hEeig48nFftVy3w" target="_HAqlsOysEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5AafU-1hEeig48nFftVy3w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_r_g_YO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5AafVO1hEeig48nFftVy3w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5AafVe1hEeig48nFftVy3w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_sITvAO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5AafVu1hEeig48nFftVy3w" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5AafV-1hEeig48nFftVy3w" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_sRAYAO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5AafWO1hEeig48nFftVy3w" x="12" y="-73"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5AafWe1hEeig48nFftVy3w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_saBxIO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5AafWu1hEeig48nFftVy3w" x="-9" y="54"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5AafW-1hEeig48nFftVy3w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_sixdcO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5AafXO1hEeig48nFftVy3w" x="12" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5AafXe1hEeig48nFftVy3w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_srhJwO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5AafXu1hEeig48nFftVy3w" x="-9" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5AafUe1hEeig48nFftVy3w"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_43WC4O1hEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5AafUu1hEeig48nFftVy3w" points="[40, 544, -643984, -643984]$[-56, 544, -643984, -643984]$[-56, 426, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Sd4oO1hEeig48nFftVy3w" id="(0.0,0.16)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Sd4oe1hEeig48nFftVy3w" id="(0.06593406593406594,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MuArUO1iEeig48nFftVy3w" type="Association_Edge" source="_v99AUO1hEeig48nFftVy3w" target="_HAqlsOysEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MuArU-1iEeig48nFftVy3w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RZXAIO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MuBSYO1iEeig48nFftVy3w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MuBSYe1iEeig48nFftVy3w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RiLk8O1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MuBSYu1iEeig48nFftVy3w" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MuBSY-1iEeig48nFftVy3w" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RrFCQO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MuBSZO1iEeig48nFftVy3w" x="17" y="-65"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MuBSZe1iEeig48nFftVy3w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Rz61MO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MuBSZu1iEeig48nFftVy3w" x="-29" y="53"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MuBSZ-1iEeig48nFftVy3w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_R-AlUO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MuBSaO1iEeig48nFftVy3w" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MuBSae1iEeig48nFftVy3w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SG2YQO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MuBSau1iEeig48nFftVy3w" x="-29" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_MuArUe1iEeig48nFftVy3w"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_MlJDMO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MuArUu1iEeig48nFftVy3w" points="[64, 528, -643984, -643984]$[64, 488, -643984, -643984]$[56, 488, -643984, -643984]$[56, 426, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M_n_wO1iEeig48nFftVy3w" id="(0.12121212121212122,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M_n_we1iEeig48nFftVy3w" id="(0.37362637362637363,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Z_r8wO1iEeig48nFftVy3w" type="Association_Edge" source="_v99AUO1hEeig48nFftVy3w" target="_HAqlsOysEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z_sj0O1iEeig48nFftVy3w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_erSJMO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z_sj0e1iEeig48nFftVy3w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z_sj0u1iEeig48nFftVy3w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e0HVEO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z_sj0-1iEeig48nFftVy3w" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z_sj1O1iEeig48nFftVy3w" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e83ocO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z_sj1e1iEeig48nFftVy3w" x="73" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z_sj1u1iEeig48nFftVy3w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fFmGoO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z_sj1-1iEeig48nFftVy3w" x="-13" y="52"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z_sj2O1iEeig48nFftVy3w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fObSgO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z_sj2e1iEeig48nFftVy3w" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z_sj2u1iEeig48nFftVy3w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fXLl4O1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z_sj2-1iEeig48nFftVy3w" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Z_r8we1iEeig48nFftVy3w"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_Z23_AO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z_r8wu1iEeig48nFftVy3w" points="[160, 632, -643984, -643984]$[160, 426, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aRKHQO1iEeig48nFftVy3w" id="(0.9090909090909091,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aRKHQe1iEeig48nFftVy3w" id="(0.6593406593406593,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nBg0UO1iEeig48nFftVy3w" type="Association_Edge" source="_v99AUO1hEeig48nFftVy3w" target="_HAqlsOysEeiDgrJNY0AUOg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nBhbYO1iEeig48nFftVy3w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_t9o48O1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nBhbYe1iEeig48nFftVy3w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nBhbYu1iEeig48nFftVy3w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uGghEO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nBhbY-1iEeig48nFftVy3w" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nBhbZO1iEeig48nFftVy3w" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uPbzkO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nBhbZe1iEeig48nFftVy3w" x="9" y="-73"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nBhbZu1iEeig48nFftVy3w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uYdzwO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nBhbZ-1iEeig48nFftVy3w" x="-29" y="51"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nBhbaO1iEeig48nFftVy3w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_uhLD0O1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nBhbae1iEeig48nFftVy3w" x="13" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nBhbau1iEeig48nFftVy3w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_up13oO1iEeig48nFftVy3w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nBhba-1iEeig48nFftVy3w" x="-29" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nBg0Ue1iEeig48nFftVy3w"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_m4olIO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nBg0Uu1iEeig48nFftVy3w" points="[172, 544, -643984, -643984]$[264, 544, -643984, -643984]$[264, 426, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nTHhsO1iEeig48nFftVy3w" id="(1.0,0.16)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nTHhse1iEeig48nFftVy3w" id="(0.945054945054945,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GAHBIO4sEeiM3Nv4z8tz-w" type="Comment_AnnotatedElementEdge" source="_EvzP0O4sEeiM3Nv4z8tz-w" target="_m4JxIOyrEeiDgrJNY0AUOg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_GAHBIe4sEeiM3Nv4z8tz-w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GAHBIu4sEeiM3Nv4z8tz-w" points="[390, 135, -643984, -643984]$[499, 100, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G0RB8O4sEeiM3Nv4z8tz-w" id="(1.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GAI2UO4sEeiM3Nv4z8tz-w" id="(0.32727272727272727,0.45569620253164556)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ktnQQO4sEeiM3Nv4z8tz-w" type="Comment_AnnotatedElementEdge" source="_jSfWEO4sEeiM3Nv4z8tz-w" target="_5AafUO1hEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ktnQQe4sEeiM3Nv4z8tz-w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ktnQQu4sEeiM3Nv4z8tz-w" points="[419, 301, -643984, -643984]$[68, 317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l-wIAO4sEeiM3Nv4z8tz-w" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ktoeYO4sEeiM3Nv4z8tz-w" id="(0.21844660194174756,0.44776119402985076)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rgkx0O4sEeiM3Nv4z8tz-w" type="Comment_AnnotatedElementEdge" source="_pwc4AO4sEeiM3Nv4z8tz-w" target="_MuArUO1iEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rgkx0e4sEeiM3Nv4z8tz-w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rgkx0u4sEeiM3Nv4z8tz-w" points="[477, 294, -643984, -643984]$[157, 262, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BBU9gO4tEeiM3Nv4z8tz-w" id="(0.0,0.25925925925925924)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rgl_8O4sEeiM3Nv4z8tz-w" id="(0.5612648221343873,0.6190476190476191)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_x6ObgO4sEeiM3Nv4z8tz-w" type="Comment_AnnotatedElementEdge" source="_wNSYkO4sEeiM3Nv4z8tz-w" target="_Z_r8wO1iEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_x6Obge4sEeiM3Nv4z8tz-w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_x6Obgu4sEeiM3Nv4z8tz-w" points="[477, 313, -643984, -643984]$[261, 262, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CQSrAO4tEeiM3Nv4z8tz-w" id="(0.0,0.2962962962962963)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x6PpoO4sEeiM3Nv4z8tz-w" id="(0.44776119402985076,0.7663551401869159)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3VJzIO4sEeiM3Nv4z8tz-w" type="Comment_AnnotatedElementEdge" source="_1rP2EO4sEeiM3Nv4z8tz-w" target="_nBg0UO1iEeig48nFftVy3w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3VJzIe4sEeiM3Nv4z8tz-w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3VJzIu4sEeiM3Nv4z8tz-w" points="[511, 341, -643984, -643984]$[275, 317, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_95CW4O4sEeiM3Nv4z8tz-w" id="(0.0,0.2962962962962963)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VKaMO4sEeiM3Nv4z8tz-w" id="(0.5766423357664233,0.7412587412587412)"/>
+    </edges>
+  </notation:Diagram>
+  <css:ModelStyleSheets xmi:id="_6HBeAHkhEeiQ1uqYFXu0Kg">
+    <stylesheets xmi:type="css:StyleSheetReference" xmi:id="_Gw7HcLwCEei3lMc99QHJoQ" path="/IeeeModels/UmlProfiles/ClassDiagramStyleSheet.css"/>
+  </css:ModelStyleSheets>
+  <notation:Diagram xmi:id="_mX3GgBioEemJ-vhcqELtkQ" type="PapyrusUMLClassDiagram" name="ieee802-dot1ab-lldp skeleton Class Diagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_mX4VGRioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX4VGhioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX4VGxioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX4VHBioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4VHRioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4WgxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4WhBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4WhRioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4WhhioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4WhxioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4WiBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4WiRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4WihioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4WixioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4WjBioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4WjRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4WjhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4WjxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4WkBioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4WuhioEemJ-vhcqELtkQ" x="824" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX4WuxioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX4WvBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX4WvRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4WzhioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX4WzxioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX4W0BioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX4W0RioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX4W0hioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4W0xioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4W1BioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4W1RioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4W1hioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4W1xioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4W2BioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4W2RioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4W2hioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4W2xioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4W3BioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4W3RioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4W3hioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4W3xioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4W4BioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4W4RioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4XCxioEemJ-vhcqELtkQ" x="448" y="112"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX4XDBioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX4XDRioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX4XDhioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4XHxioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX47vRioEemJ-vhcqELtkQ" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_mX47vhioEemJ-vhcqELtkQ" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_mX47vxioEemJ-vhcqELtkQ" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX47wBioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX47wRioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX47whioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX47wxioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX479xioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX47-BioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX47-RioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX47-hioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX47-xioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX47_BioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX47_RioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX47_hioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX47_xioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX48ABioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX48ARioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX48AhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX48AxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX48BBioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_RDTG8NLmEeeL3MNXamQjRA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX48LhioEemJ-vhcqELtkQ" x="373" y="-40" width="233"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX48LxioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX48MBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX48MRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_RDTG8NLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX48QhioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX48SxioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX48TBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX48TRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX48UhioEemJ-vhcqELtkQ" x="952" y="-4"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX48UxioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX48VBioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX48VRioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX48VhioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX48VxioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX49LxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX49MBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX49MRioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX49MhioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX49MxioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX49NBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX49NRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX49NhioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX49NxioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX49OBioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX49ORioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX49OhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX49OxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX49PBioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX49ZhioEemJ-vhcqELtkQ" x="-80" y="280" width="369"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX49ZxioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX49aBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX49aRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX49ehioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX49exioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX49fBioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX49fRioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX49fhioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX49fxioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4-uBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4-uRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4-uhioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4-uxioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4-vBioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4-vRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4-vhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4-vxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4-wBioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX4-wRioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX4-whioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX4-wxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX4-xBioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4-xRioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX4-7xioEemJ-vhcqELtkQ" x="344" y="280" width="137"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX4-8BioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX4-8RioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX4-8hioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5ixBioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX5ixRioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX5ixhioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX5ixxioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX5iyBioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX5iyRioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX5kThioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX5kTxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX5kUBioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5kURioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX5kUhioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX5kUxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX5kVBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX5kVRioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5kVhioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX5kVxioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX5kWBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX5kWRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX5kWhioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5kWxioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5khRioEemJ-vhcqELtkQ" x="536" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX5khhioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX5khxioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX5kiBioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5kmRioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX5lDhioEemJ-vhcqELtkQ" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_mX5lDxioEemJ-vhcqELtkQ" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_mX5lEBioEemJ-vhcqELtkQ" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX5lERioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX5lEhioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX5lExioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX5lFBioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX5lPxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX5lQBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX5lQRioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5lQhioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX5lQxioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX5lRBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX5lRRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX5lRhioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5lRxioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX5lSBioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX5lSRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX5lShioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX5lSxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5lTBioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_ZqsZMGJZEeeFIY-vT21IyA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5ldhioEemJ-vhcqELtkQ" x="704" y="-40" width="187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX5ldxioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX5leBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX5leRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_ZqsZMGJZEeeFIY-vT21IyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX5lihioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6KxhioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX6KxxioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX6KyBioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6KzRioEemJ-vhcqELtkQ" x="1664" y="180"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6KzhioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6KzxioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6K0BioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX6K0RioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6K0hioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6MDBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6MDRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6MDhioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6MDxioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6MEBioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6MERioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6MEhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6MExioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6MFBioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6MFRioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6MFhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6MFxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6MGBioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6MGRioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6MQxioEemJ-vhcqELtkQ" x="296" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6MRBioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX6MRRioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX6MRhioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6MVxioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6MaxioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6MbBioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6MbRioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX6MbhioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6MbxioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6M2BioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6M2RioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6M2hioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6M2xioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6M3BioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6M3RioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6M3hioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6M3xioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6M4BioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6M4RioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6M4hioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6M4xioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6M5BioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6M5RioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6NDxioEemJ-vhcqELtkQ" x="480" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6NEBioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX6NERioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX6NEhioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6NIxioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6NfxioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6NgBioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6NgRioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX6NghioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6NgxioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6xoRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6xohioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6xoxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6xpBioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6xpRioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6xphioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6xpxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6xqBioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6xqRioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6xqhioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX6xqxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX6xrBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX6xrRioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6xrhioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6x2BioEemJ-vhcqELtkQ" x="592" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6x2RioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX6x2hioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX6x2xioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX6x7BioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX6x7RioEemJ-vhcqELtkQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6x7hioEemJ-vhcqELtkQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX6x7xioEemJ-vhcqELtkQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX6x8BioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX6x8RioEemJ-vhcqELtkQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX60IBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX60IRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX60IhioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX60IxioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX60JBioEemJ-vhcqELtkQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX60JRioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX60JhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX60JxioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX60KBioEemJ-vhcqELtkQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX60KRioEemJ-vhcqELtkQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX60KhioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX60KxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX60LBioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX60LRioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX60VxioEemJ-vhcqELtkQ" x="704" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX60WBioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX60WRioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX60WhioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX60axioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX8mxhioEemJ-vhcqELtkQ" type="Signal_Shape" fillColor="10011046">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8mxxioEemJ-vhcqELtkQ" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8myBioEemJ-vhcqELtkQ" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8myRioEemJ-vhcqELtkQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mX8myhioEemJ-vhcqELtkQ" type="Signal_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mX8myxioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mX8mzBioEemJ-vhcqELtkQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mX8mzRioEemJ-vhcqELtkQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX8mzhioEemJ-vhcqELtkQ"/>
+      </children>
+      <element xmi:type="uml:Signal" href="ieee802-dot1ab-lldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX8m6RioEemJ-vhcqELtkQ" x="40" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mX8m6hioEemJ-vhcqELtkQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mX8m6xioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8m7BioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="ieee802-dot1ab-lldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mX8m9xioEemJ-vhcqELtkQ" x="200"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_mX8nBxioEemJ-vhcqELtkQ" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_mX8nCBioEemJ-vhcqELtkQ"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_mX8nCRioEemJ-vhcqELtkQ" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="ieee802-dot1ab-lldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    </styles>
+    <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nChioEemJ-vhcqELtkQ" name="rulergrid.viewgrid"/>
+    <styles xmi:type="notation:DoubleValueStyle" xmi:id="_mX8nCxioEemJ-vhcqELtkQ" name="rulergrid.gridspacing" doubleValue="0.20000000298023224"/>
+    <styles xmi:type="notation:IntValueStyle" xmi:id="_mX8nDBioEemJ-vhcqELtkQ" name="rulergrid.rulerunit" intValue="1"/>
+    <element xmi:type="uml:Model" href="ieee802-dot1ab-lldp.uml#_nPCrYHkhEeiQ1uqYFXu0Kg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nHxioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX4VGRioEemJ-vhcqELtkQ" target="_mX4WuxioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nIBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nIRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nIhioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nIxioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nJBioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nJRioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX4WzxioEemJ-vhcqELtkQ" target="_mX4XDBioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nJhioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nJxioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nKBioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nKRioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nKhioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nMRioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX47vRioEemJ-vhcqELtkQ" target="_mX48LxioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nMhioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nMxioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1q-bridge.uml#_RDTG8NLmEeeL3MNXamQjRA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nNBioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nNRioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nNhioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nVxioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX4WzxioEemJ-vhcqELtkQ" target="_mX47vRioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nWBioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nWRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nWhioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nWxioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nXBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nXRioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nXhioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nXxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nYBioEemJ-vhcqELtkQ" x="35" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nYRioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nYhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nYxioEemJ-vhcqELtkQ" x="-11" y="53"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nZBioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nZRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nZhioEemJ-vhcqELtkQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nZxioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8naBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8naRioEemJ-vhcqELtkQ" x="-11" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nahioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_m2XBYOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8naxioEemJ-vhcqELtkQ" points="[496, 112, -643984, -643984]$[496, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nbBioEemJ-vhcqELtkQ" id="(0.48,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nbRioEemJ-vhcqELtkQ" id="(0.5278969957081545,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nbhioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX4WzxioEemJ-vhcqELtkQ" target="_mX4VGRioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nbxioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ncBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ncRioEemJ-vhcqELtkQ" x="-79" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nchioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ncxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ndBioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ndRioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ndhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ndxioEemJ-vhcqELtkQ" x="59" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8neBioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8neRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nehioEemJ-vhcqELtkQ" x="-9" y="30"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nexioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nfBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nfRioEemJ-vhcqELtkQ" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nfhioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nfxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ngBioEemJ-vhcqELtkQ" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8ngRioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nhRioEemJ-vhcqELtkQ" points="[796, 144, -643984, -643984]$[1368, 144, -643984, -643984]$[1368, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nhhioEemJ-vhcqELtkQ" id="(1.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nhxioEemJ-vhcqELtkQ" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8niBioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX8nbhioEemJ-vhcqELtkQ" target="_mX48SxioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8niRioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nihioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nixioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8njBioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8njRioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8njhioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX48UxioEemJ-vhcqELtkQ" target="_mX49ZxioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8njxioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nkBioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nkRioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nkhioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nkxioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nlBioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX4WzxioEemJ-vhcqELtkQ" target="_mX48UxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nlRioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nlhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nlxioEemJ-vhcqELtkQ" x="624" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nmBioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nmRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nmhioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nmxioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nnBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nnRioEemJ-vhcqELtkQ" x="10" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nnhioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nnxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8noBioEemJ-vhcqELtkQ" x="-9" y="60"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8noRioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nohioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8noxioEemJ-vhcqELtkQ" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8npBioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8npRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nphioEemJ-vhcqELtkQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8npxioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_HhWQ4OysEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nqBioEemJ-vhcqELtkQ" points="[696, 144, -643984, -643984]$[112, 144, -643984, -643984]$[112, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nqRioEemJ-vhcqELtkQ" id="(0.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nqhioEemJ-vhcqELtkQ" id="(0.5203252032520326,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nqxioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX49exioEemJ-vhcqELtkQ" target="_mX4-8BioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nrBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nrRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nrhioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nrxioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nsBioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nsRioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX4WzxioEemJ-vhcqELtkQ" target="_mX49exioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nshioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nsxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ntBioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ntRioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nthioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ntxioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nuBioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nuRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nuhioEemJ-vhcqELtkQ" x="55" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nuxioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nvBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nvRioEemJ-vhcqELtkQ" x="-9" y="59"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nvhioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nvxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nwBioEemJ-vhcqELtkQ" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nwRioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8nwhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8nwxioEemJ-vhcqELtkQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nxBioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_F9jtcOytEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nxRioEemJ-vhcqELtkQ" points="[696, 184, -643984, -643984]$[376, 184, -643984, -643984]$[376, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nxhioEemJ-vhcqELtkQ" id="(0.0,0.72)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nxxioEemJ-vhcqELtkQ" id="(0.46715328467153283,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nyBioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX5khhioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8nyRioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8nyhioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8nyxioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nzBioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8nzRioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8nzhioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX4WzxioEemJ-vhcqELtkQ" target="_mX5ixRioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8nzxioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8n0BioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8n0RioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8n0hioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8n0xioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8n1BioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8n1RioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8n1hioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8n1xioEemJ-vhcqELtkQ" x="29" y="-17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8n2BioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8n2RioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8n2hioEemJ-vhcqELtkQ" x="-9" y="27"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8n2xioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8n3BioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8n3RioEemJ-vhcqELtkQ" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8n3hioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8n3xioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8n4BioEemJ-vhcqELtkQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8n4RioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_qub-0OyuEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8n4hioEemJ-vhcqELtkQ" points="[548, 184, -643984, -643984]$[584, 184, -643984, -643984]$[584, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8n4xioEemJ-vhcqELtkQ" id="(1.0,0.72)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8n5BioEemJ-vhcqELtkQ" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8n6xioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX5lDhioEemJ-vhcqELtkQ" target="_mX5ldxioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8n7BioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8n7RioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="platform:/resource/IetfModels/IetfInterfaces.uml#_ZqsZMGJZEeeFIY-vT21IyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8n7hioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8n7xioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8n8BioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8oCBioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX5lDhioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oCRioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oChioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oCxioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oDBioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oDRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oDhioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oDxioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oEBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oERioEemJ-vhcqELtkQ" x="34" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oEhioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oExioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oFBioEemJ-vhcqELtkQ" x="-8" y="33"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oFRioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oFhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oFxioEemJ-vhcqELtkQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oGBioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oGRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oGhioEemJ-vhcqELtkQ" x="-11" y="-11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oGxioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_ONmmIOyvEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8oHBioEemJ-vhcqELtkQ" points="[616, 280, -643984, -643984]$[616, 184, -643984, -643984]$[800, 184, -643984, -643984]$[800, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oHRioEemJ-vhcqELtkQ" id="(0.8,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oHhioEemJ-vhcqELtkQ" id="(0.5133689839572193,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8oMBioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX4VGRioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oMRioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oMhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oMxioEemJ-vhcqELtkQ" x="1" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oNBioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oNRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oNhioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oNxioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oOBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oORioEemJ-vhcqELtkQ" x="13" y="-37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oOhioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oOxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oPBioEemJ-vhcqELtkQ" x="-36" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oPRioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oPhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oPxioEemJ-vhcqELtkQ" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oQBioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oQRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oQhioEemJ-vhcqELtkQ" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oQxioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8oRxioEemJ-vhcqELtkQ" points="[636, 320, -643984, -643984]$[728, 320, -643984, -643984]$[728, 312, -643984, -643984]$[824, 312, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oSBioEemJ-vhcqELtkQ" id="(1.0,0.4)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oSRioEemJ-vhcqELtkQ" id="(0.0,0.4)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8oShioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX8oMBioEemJ-vhcqELtkQ" target="_mX6KxhioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oSxioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8oTBioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8oTRioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oThioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oTxioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8oUBioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX6KzhioEemJ-vhcqELtkQ" target="_mX6MRBioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oURioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8oUhioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8oUxioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oVBioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oVRioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8oVhioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX6KzhioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oVxioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oWBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oWRioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oWhioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oWxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oXBioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oXRioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oXhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oXxioEemJ-vhcqELtkQ" x="24" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oYBioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oYRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oYhioEemJ-vhcqELtkQ" x="-9" y="93"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oYxioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oZBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oZRioEemJ-vhcqELtkQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oZhioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oZxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oaBioEemJ-vhcqELtkQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oaRioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_1m4AoOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8oahioEemJ-vhcqELtkQ" points="[552, 380, -643984, -643984]$[552, 432, -643984, -643984]$[440, 432, -643984, -643984]$[440, 504, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oaxioEemJ-vhcqELtkQ" id="(0.16,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8obBioEemJ-vhcqELtkQ" id="(0.8571428571428571,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8obRioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX6MaxioEemJ-vhcqELtkQ" target="_mX6NEBioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8obhioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8obxioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8ocBioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8ocRioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8ochioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8ocxioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX6MaxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8odBioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8odRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8odhioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8odxioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oeBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oeRioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8oehioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oexioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ofBioEemJ-vhcqELtkQ" x="51" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ofRioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ofhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ofxioEemJ-vhcqELtkQ" x="-9" y="43"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ogBioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ogRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oghioEemJ-vhcqELtkQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ogxioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ohBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ohRioEemJ-vhcqELtkQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8ohhioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_gsQqEOzAEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8ohxioEemJ-vhcqELtkQ" points="[576, 380, -643984, -643984]$[576, 448, -643984, -643984]$[544, 448, -643984, -643984]$[544, 504, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oiBioEemJ-vhcqELtkQ" id="(0.4,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oiRioEemJ-vhcqELtkQ" id="(0.64,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8oihioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX6NfxioEemJ-vhcqELtkQ" target="_mX6x2RioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oixioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8ojBioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8ojRioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8ojhioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8ojxioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8okBioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX6NfxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8okRioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8okhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8okxioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8olBioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8olRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8olhioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8olxioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8omBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8omRioEemJ-vhcqELtkQ" x="103" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8omhioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8omxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8onBioEemJ-vhcqELtkQ" x="-9" y="43"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8onRioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8onhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8onxioEemJ-vhcqELtkQ" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ooBioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ooRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8oohioEemJ-vhcqELtkQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8ooxioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_ua-AUOzBEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8opBioEemJ-vhcqELtkQ" points="[600, 380, -643984, -643984]$[600, 448, -643984, -643984]$[648, 448, -643984, -643984]$[648, 504, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8opRioEemJ-vhcqELtkQ" id="(0.64,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8ophioEemJ-vhcqELtkQ" id="(0.56,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8opxioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX6x7RioEemJ-vhcqELtkQ" target="_mX60WBioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8oqBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8oqRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="ieee802-dot1ab-lldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8oqhioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8oqxioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8orBioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8orRioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX5ixRioEemJ-vhcqELtkQ" target="_mX6x7RioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8orhioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8orxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8osBioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8osRioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8oshioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8osxioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8otBioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8otRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8othioEemJ-vhcqELtkQ" x="31" y="-25"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8otxioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ouBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ouRioEemJ-vhcqELtkQ" x="-9" y="69"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ouhioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ouxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ovBioEemJ-vhcqELtkQ" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8ovRioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8ovhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8ovxioEemJ-vhcqELtkQ" x="-9" y="-24"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8owBioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_64-jsOzCEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8owRioEemJ-vhcqELtkQ" points="[616, 380, -643984, -643984]$[616, 432, -643984, -643984]$[808, 432, -643984, -643984]$[808, 504, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8owhioEemJ-vhcqELtkQ" id="(0.88,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8owxioEemJ-vhcqELtkQ" id="(0.8,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8pJxioEemJ-vhcqELtkQ" type="StereotypeCommentLink" source="_mX8mxhioEemJ-vhcqELtkQ" target="_mX8m6hioEemJ-vhcqELtkQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8pKBioEemJ-vhcqELtkQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mX8pKRioEemJ-vhcqELtkQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="ieee802-dot1ab-lldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8pKhioEemJ-vhcqELtkQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pKxioEemJ-vhcqELtkQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pLBioEemJ-vhcqELtkQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8pLRioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX8mxhioEemJ-vhcqELtkQ" target="_mX48UxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pLhioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pLxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pMBioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pMRioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pMhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pMxioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pNBioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pNRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pNhioEemJ-vhcqELtkQ" x="12" y="-73"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pNxioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pOBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pORioEemJ-vhcqELtkQ" x="-9" y="54"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pOhioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pOxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pPBioEemJ-vhcqELtkQ" x="12" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pPRioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pPhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pPxioEemJ-vhcqELtkQ" x="-9" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8pQBioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_43WC4O1hEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8pQRioEemJ-vhcqELtkQ" points="[40, 520, -643984, -643984]$[-56, 520, -643984, -643984]$[-56, 380, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pQhioEemJ-vhcqELtkQ" id="(0.0,0.16)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pQxioEemJ-vhcqELtkQ" id="(0.06504065040650407,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8pRBioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX8mxhioEemJ-vhcqELtkQ" target="_mX48UxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pRRioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pRhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pRxioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pSBioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pSRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pShioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pSxioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pTBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pTRioEemJ-vhcqELtkQ" x="17" y="-65"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pThioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pTxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pUBioEemJ-vhcqELtkQ" x="-29" y="53"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pURioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pUhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pUxioEemJ-vhcqELtkQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pVBioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pVRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pVhioEemJ-vhcqELtkQ" x="-29" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8pVxioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_MlJDMO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8pWBioEemJ-vhcqELtkQ" points="[56, 504, -643984, -643984]$[56, 488, -643984, -643984]$[48, 488, -643984, -643984]$[48, 380, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pWRioEemJ-vhcqELtkQ" id="(0.12121212121212122,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pWhioEemJ-vhcqELtkQ" id="(0.3685636856368564,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8pWxioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX8mxhioEemJ-vhcqELtkQ" target="_mX48UxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pXBioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pXRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pXhioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pXxioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pYBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pYRioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pYhioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pYxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pZBioEemJ-vhcqELtkQ" x="73" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pZRioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pZhioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pZxioEemJ-vhcqELtkQ" x="-13" y="52"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8paBioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8paRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pahioEemJ-vhcqELtkQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8paxioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pbBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pbRioEemJ-vhcqELtkQ" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8pbhioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_Z23_AO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8pbxioEemJ-vhcqELtkQ" points="[160, 504, -643984, -643984]$[160, 380, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pcBioEemJ-vhcqELtkQ" id="(0.9090909090909091,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8pcRioEemJ-vhcqELtkQ" id="(0.6504065040650406,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mX8pchioEemJ-vhcqELtkQ" type="Association_Edge" source="_mX8mxhioEemJ-vhcqELtkQ" target="_mX48UxioEemJ-vhcqELtkQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pcxioEemJ-vhcqELtkQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pdBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pdRioEemJ-vhcqELtkQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pdhioEemJ-vhcqELtkQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pdxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8peBioEemJ-vhcqELtkQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8peRioEemJ-vhcqELtkQ" visible="false" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pehioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pexioEemJ-vhcqELtkQ" x="9" y="-73"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pfBioEemJ-vhcqELtkQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pfRioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pfhioEemJ-vhcqELtkQ" x="-27" y="59"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pfxioEemJ-vhcqELtkQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pgBioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8pgRioEemJ-vhcqELtkQ" x="13" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mX8pghioEemJ-vhcqELtkQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mX8pgxioEemJ-vhcqELtkQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mX8phBioEemJ-vhcqELtkQ" x="-29" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mX8phRioEemJ-vhcqELtkQ"/>
+      <element xmi:type="uml:Association" href="ieee802-dot1ab-lldp.uml#_m4olIO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX8phhioEemJ-vhcqELtkQ" points="[172, 520, -643984, -643984]$[264, 520, -643984, -643984]$[264, 380, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8phxioEemJ-vhcqELtkQ" id="(1.0,0.16)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX8piBioEemJ-vhcqELtkQ" id="(0.9322493224932249,1.0)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_rFweYDOWEemmfYv-bFFYSw" type="PapyrusUMLClassDiagram" name="LldpDetails" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_v25SIDOWEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v255MDOWEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v255MTOWEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v255MjOWEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v255MzOWEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_r26fADQZEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_7w-aIeyrEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_r26fATQZEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_r27GEDQZEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_6fFCQDQZEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_HhW38uysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_r27GETQZEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_r27tIDQZEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_5tZGoDQZEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_F9k7kuytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_r27tITQZEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_r27tIjQZEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_qucl4uyuEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_r27tIzQZEemgQ-i8ZByeIA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v255NDOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v255NTOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v255NjOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v255NzOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v26gQDOWEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v26gQTOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v26gQjOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v26gQzOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v26gRDOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v26gRTOWEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v26gRjOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v26gRzOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v26gSDOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v26gSTOWEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v25SITOWEemmfYv-bFFYSw" x="696" y="-16"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v3GGczOWEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v3GGdDOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v3GGdjOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3GGdTOWEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v3XzQDOWEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3XzQjOWEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3XzQzOWEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3XzRDOWEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v3XzRTOWEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_yQaHMDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_-iIFYOymEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQaHMTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yQauQDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_VkFlIOynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQauQTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yQbVUDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_nB6G4OynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQbVUTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yQbVUjOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_pWKBcOynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQbVUzOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yQb8YDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_r7x_4OynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQb8YTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yQb8YjOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_uYlZgOynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQb8YzOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yQeYoDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_wu8z8OynEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yQeYoTOWEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v3YaUDOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v3YaUTOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v3YaUjOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3YaUzOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v3YaVDOWEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v3YaVTOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v3YaVjOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v3YaVzOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3YaWDOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v3YaWTOWEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v3YaWjOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v3YaWzOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v3YaXDOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3YaXTOWEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3XzQTOWEemmfYv-bFFYSw" x="1464" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v3knkzOWEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v3knlDOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v3knljOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3knlTOWEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v32UYDOWEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v32UYTOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v32UYzOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v32UYjOWEemmfYv-bFFYSw" x="542" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_527MoDOWEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_527MojOWEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_527MozOWEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_527MpDOWEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_527zsDOWEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_61On8DOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ecLK4DOaEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_ay_EMOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_61On8TOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_61PPADOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_e5dj0DOaEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_dAongOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_61PPATOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_61P2EDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_fTi3wDOaEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_ethAEOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_61P2ETOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_61P2EjOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_fsKzIDOaEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_gmO1MOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_61P2EzOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_61P2FDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_gHzmQDOaEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_ieQGwOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_61P2FTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_61P2FjOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_gin6ADOaEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_k_ulAOytEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_61P2FzOWEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_527zsTOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_527zsjOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_527zszOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_527ztDOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_527ztTOWEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_527ztjOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_527ztzOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_527zuDOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_527zuTOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_527zujOWEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_527zuzOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_527zvDOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_527zvTOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_527zvjOWEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_527MoTOWEemmfYv-bFFYSw" x="344" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_53OuoDOWEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_53OuoTOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_53OuozOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_53OuojOWEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7y2t0DOWEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y2t0jOWEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7y2t0zOWEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7y2t1DOWEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7y2t1TOWEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_8gaXYDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel" fontColor="255">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_bBkhsDOZEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_Syq0IOysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8gaXYTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8gcMkDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_blqGMDOZEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_c1aEYOysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8gcMkTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8gczoDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_cBYY4DOZEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_qTTz8OysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8gczoTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8gdasDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_caT2QDOZEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_zbeSUOysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8gdasTOWEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8gdasjOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_cztNsDOZEemmfYv-bFFYSw" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_8C2-4OysEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8gdaszOWEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7y2t1jOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7y2t1zOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7y2t2DOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t2TOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7y2t2jOWEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7y2t2zOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7y2t3DOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7y2t3TOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t3jOWEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_7y2t3zOWEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_7y2t4DOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_7y2t4TOWEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_7y2t4jOWEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t4zOWEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t0TOWEemmfYv-bFFYSw" x="16" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7zAe0DOWEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7zAe0TOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7zAe0zOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7zAe0jOWEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_k9ChwDOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_k9ChwjOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_k9ChwzOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k9ChxDOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_k9ChxTOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_6Df2UDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel" fontColor="255">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_6FpycDQVEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AbxnADQWEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AbxnATQWEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FpydjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FpydzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FpyeDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FpyeTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FpyejQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FpyezQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FqZgDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FqZgTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FqZgjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FqZgzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FqZhDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FqZhTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FqZhjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FqZhzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FrAkDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FrAkTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_6FpycTQVEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_6FpycjQVEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6FpyczQVEemgQ-i8ZByeIA"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_k0IVkDQVEemgQ-i8ZByeIA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6Df2UTQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6Di5oDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_6FwgIDQVEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B-L08DQWEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B-L08TQWEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FwgJjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FwgJzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FxHMDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FxHMTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FxHMjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FxHMzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FyVUDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FyVUTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6FyVUjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6FyVUzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6Fy8YDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6Fy8YTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6Fy8YjQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6Fy8YzQVEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_6Fy8ZDQVEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_6Fy8ZTQVEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_6FwgITQVEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_6FwgIjQVEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6FwgIzQVEemgQ-i8ZByeIA"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_vcvrkOyvEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6Di5oTQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6Dku0DQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_37HmEOyvEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dku0TQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DlV4DQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_loTgkOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DlV4TQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6Dl88DQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_tcbkMOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dl88TQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6Dl88jQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_nP3e0OyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dl88zQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DmkADQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_1m4nsOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DmkATQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DnLEDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_QtSGoDQWEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_hptbsOy-EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DnLETQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DnLEjQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_R1g6ADQWEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_mMgcAOy_EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DnLEzQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DnyIDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_SQdJkDQWEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_sPn1AOy_EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DnyITQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DoZMDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_agqsQDQWEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_gsR4MuzAEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DoZMTQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6DpnUDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_dA4mQDQWEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_ua-nYuzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6DpnUTQVEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6Dq1cDQVEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_e-jz4DQWEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_64_KwuzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dq1cTQVEemgQ-i8ZByeIA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_k9ChxjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_k9ChxzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_k9ChyDOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k9ChyTOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_k9ChyjOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_k9ChyzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_k9ChzDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_k9ChzTOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k9ChzjOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_k9ChzzOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_k9Ch0DOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_k9Ch0TOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_k9Ch0jOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k9Ch0zOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k9ChwTOYEemmfYv-bFFYSw" x="880" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_k9M50DOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_k9M50TOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_k9M50zOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k9M50jOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_paKNUDOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_paK0YDOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_paK0YTOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_paK0YjOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_paK0YzOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_sbScADOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QQ5XgDQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_pb5DgDQYEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pb5DgTQYEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ5-kjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ5-kzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ5-lDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ5-lTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ5-ljQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ5-lzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ5-mDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ5-mTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ6loDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ6loTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ6lojQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ6lozQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ6lpDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ6lpTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QQ6lpjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QQ6lpzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QQ5XgTQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QQ5XgjQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QQ5XgzQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_tZStMDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_G0WJgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbScATOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbTDEDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QRChcDQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_r4FZIDQYEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_r4FZITQYEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRChdjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRChdzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRCheDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRCheTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRChejQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRChezQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRChfDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRChfTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRDIgDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRDIgTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRDIgjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRDIgzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRDIhDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRDIhTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QRDIhjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QRDIhzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QRChcTQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QRChcjQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QRChczQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_t7vS8DQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_I6Xa0OzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbTDETOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbTqIDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_u223YDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_K_8nQOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbTqITOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbTqIjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_vRiBMDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_NWSMgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbTqIzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbTqJDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_vrR98DQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_PYi_MOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbTqJTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbURMDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_wDAhcDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_TX9bEOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbURMTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbURMjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_we5MMDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_VWSwAOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbURMzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbURNDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_w3AxQDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_XLNqQOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbURNTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbU4QDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_xOv70DQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_ZHiNAOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbU4QTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbU4QjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_xqDXwDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_bedoIOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbU4QzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbU4RDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_yE9LEDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_gc20wOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbU4RTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbVfUDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_yhogADQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_oiyaEuzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbVfUTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbVfUjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_y8U38DQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_AkeRcezEEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbVfUzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_sbXUgDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_zUh8kDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_Se-IIuzEEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sbXUgTOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_paK0ZDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_paK0ZTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_paK0ZjOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_paK0ZzOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_paK0aDOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_paK0aTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_paK0ajOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_paK0azOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_paK0bDOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_paK0bTOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_paK0bjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_paK0bzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_paK0cDOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_paK0cTOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_paKNUTOYEemmfYv-bFFYSw" x="1232" y="584"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_paUlYDOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_paUlYTOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_paUlYzOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_paUlYjOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pdLsIDOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pdMTMDOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pdMTMTOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pdMTMjOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pdMTMzOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_tK1poDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QTh0wDQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ld43UDQbEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ld43UTQbEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib0TQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib0jQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib0zQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib1DQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib1TQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib1jQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib1zQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib2DQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib2TQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib2jQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib2zQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib3DQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib3TQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib3jQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTib3zQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTib4DQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QTh0wTQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QTh0wjQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QTh0wzQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_EvQcIDQbEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <styles xmi:type="notation:IntValueStyle" xmi:id="_J_sbADQbEemgQ-i8ZByeIA" name="shapeDirection" intValue="1"/>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_zPhpkOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tK1poTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tK2QsDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QTn7YDQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_NSHOADQbEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_NSHOATQbEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7ZjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7ZzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7aDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7aTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7ajQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7azQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7bDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7bTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7bjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7bzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7cDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7cTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7cjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7czQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QTn7dDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QTn7dTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QTn7YTQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QTn7YjQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QTn7YzQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_FLqEQDQbEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_1G1wgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tK2QsTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tK23wDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_FmbUsDQbEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_3eYPoOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tK23wTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tK23wjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_GBKI4DQbEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_46-wgOzDEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tK23wzOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pdMTNDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pdMTNTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pdMTNjOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdMTNzOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pdMTODOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pdMTOTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pdMTOjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pdMTOzOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdMTPDOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_pdMTPTOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_pdMTPjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_pdMTPzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_pdMTQDOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdMTQTOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdLsITOYEemmfYv-bFFYSw" x="760" y="960"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pdWEMzOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_pdWENDOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pdWrQDOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pdWENTOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ufa28DOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ufa28jOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ufbeADOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ufbeATOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ufbeAjOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_vwy_QDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QUVtEDQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fHWuEDQXEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fHWuETQXEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtFjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtFzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtGDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtGTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtGjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtGzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtHDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtHTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtHjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtHzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtIDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtITQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtIjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtIzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUVtJDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUVtJTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QUVtETQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QUVtEjQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QUVtEzQUEemgQ-i8ZByeIA"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_Pvgg8OyzEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vwy_QTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vw00cDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QUcawzQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gdxucDQXEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gdxucTQXEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB0jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB0zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB1DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB1TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB1jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB1zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB2DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB2TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB2jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB2zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB3DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB3TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB3jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB3zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QUdB4DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QUdB4TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QUcaxDQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QUcaxTQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QUcaxjQUEemgQ-i8ZByeIA"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_LeTl8Oy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vw00cTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vw00cjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_NobUIOy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vw00czOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vw1bgDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_jSi8IDQXEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_P3xgkOy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vw1bgTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vw1bgjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_kA0XYDQXEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_SfqI0Oy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vw1bgzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vw1bhDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ki7l8DQXEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_UED60Oy9EeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vw1bhTOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ufbeAzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ufbeBDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ufbeBTOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufbeBjOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ufbeBzOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ufbeCDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ufbeCTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ufbeCjOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufbeCzOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ufbeDDOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ufbeDTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ufbeDjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ufbeDzOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufbeEDOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufa28TOYEemmfYv-bFFYSw" x="16" y="584"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uflPAzOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uflPBDOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uflPBjOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uflPBTOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yLL-EDOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yLL-EjOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yLL-EzOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yLL-FDOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yLMlIDOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_zNz4sDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QVduczQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_w40dMDQaEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_w40dMTQaEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVdueTQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVduejQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVduezQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVdufDQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVdufTQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVdufjQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVdufzQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVdugDQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVdugTQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVdugjQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVeVgDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVeVgTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVeVgjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVeVgzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVeVhDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVeVhTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QVdudDQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QVdudTQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVdudjQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_t6ZkQDQaEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_dpIeAOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zNz4sTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_zN0fwDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QVj1EjQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_yK7lUDQaEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_yK7lUTQaEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1GDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1GTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1GjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1GzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1HDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1HTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1HjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1HzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1IDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1ITQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1IjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1IzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1JDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1JTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVj1JjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVj1JzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QVj1EzQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QVj1FDQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVj1FTQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_tiO74DQaEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_f1PJMOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN0fwTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_zN0fwjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QVp7sDQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_zc48cDQaEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_zc48cTQaEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7tjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7tzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7uDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7uTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7ujQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7uzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7vDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7vTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7vjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7vzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7wDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7wTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7wjQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7wzQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QVp7xDQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QVp7xTQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QVp7sTQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QVp7sjQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVp7szQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_tIJA4DQaEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_iy3_AOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN0fwzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_zN0fxDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_sqajEDQaEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_lF5KgOzFEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zN0fxTOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yLMlITOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yLMlIjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yLMlIzOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yLMlJDOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yLMlJTOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yLMlJjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yLMlJzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yLMlKDOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yLMlKTOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yLMlKjOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yLMlKzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yLMlLDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yLMlLTOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yLMlLjOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yLL-ETOYEemmfYv-bFFYSw" x="1712" y="960"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yLYLUDOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yLYLUTOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yLYLUzOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yLYLUjOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_2YxY0DOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_2YxY0jOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2YxY0zOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2YxY1DOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2YxY1TOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_4fGzMDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_QWSN0DQUEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QSHQwDQaEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QSH30DQaEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN1jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN1zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN2DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN2TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN2jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN2zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN3DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN3TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN3jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN3zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN4DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN4TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN4jQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN4zQUEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_QWSN5DQUEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_QWSN5TQUEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_QWSN0TQUEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_QWSN0jQUEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWSN0zQUEemgQ-i8ZByeIA"/>
+          </children>
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_RKUEEDQaEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_HN6DkOzEEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4fGzMTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_4fHaQDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_SyaDQDQaEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_KCr4UOzEEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4fHaQTOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2YxY1jOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2YxY1zOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2YxY2DOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2YxY2TOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2Yx_4DOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2Yx_4TOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2Yx_4jOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2Yx_4zOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Yx_5DOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2Yx_5TOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2Yx_5jOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2Yx_5zOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2Yx_6DOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Yx_6TOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2YxY0TOYEemmfYv-bFFYSw" x="1280" y="960"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_2Y7J0zOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_2Y7J1DOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2Y7J1jOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Y7J1TOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5a00kDOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5a1boDOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5a1boTOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5a1bojOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5a1bozOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_8kJV8DOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_L2RpgDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_j-O7suzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8kJV8TOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8kKkEDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_MWmIUDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_j-O7tOzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8kKkETOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8kMZQDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_MwBU8DQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_RoIRoOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8kMZQTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8kNAUDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_NKmYIDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_T8jLUOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8kNAUTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8kNAUjOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_NkoowDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_WEjZoOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8kNAUzOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8kNnYDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_N-zcQDQYEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_YshhcOzCEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8kNnYTOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5a1bpDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5a1bpTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5a1bpjOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5a1bpzOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5a1bqDOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5a1bqTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5a1bqjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5a1bqzOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5a1brDOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5a1brTOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5a1brjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5a1brzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5a1bsDOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5a1bsTOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5a00kTOYEemmfYv-bFFYSw" x="816" y="584"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5bBo4DOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5bBo4TOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5bBo4zOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5bBo4jOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9UJPgDOYEemmfYv-bFFYSw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9UJ2kDOYEemmfYv-bFFYSw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9UJ2kTOYEemmfYv-bFFYSw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9UJ2kjOYEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9UJ2kzOYEemmfYv-bFFYSw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_-NX9kDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_-Zf7UDQXEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_OSzxEOzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-NX9kTOYEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-NZLsDOYEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_95x5cDQXEemgQ-i8ZByeIA" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>modifiers</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_QZCdwOzBEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-NZLsTOYEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9UJ2lDOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9UJ2lTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9UJ2ljOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9UJ2lzOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9UJ2mDOYEemmfYv-bFFYSw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9UJ2mTOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9UJ2mjOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9UJ2mzOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9UJ2nDOYEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9UJ2nTOYEemmfYv-bFFYSw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9UJ2njOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9UJ2nzOYEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9UJ2oDOYEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9UJ2oTOYEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9UJPgTOYEemmfYv-bFFYSw" x="432" y="584"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9UWD0DOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9UWD0TOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9UWD0zOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9UWD0jOYEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-y2CIzOYEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-y2CJDOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-y2CJjOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-y2CJTOYEemmfYv-bFFYSw" x="1139" y="234"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BEX_4DOZEemmfYv-bFFYSw" type="Signal_Shape" fillColor="10011046">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BEYm8DOZEemmfYv-bFFYSw" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BEYm8TOZEemmfYv-bFFYSw" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BEYm8jOZEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BEYm8zOZEemmfYv-bFFYSw" type="Signal_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_9nfFADQWEemgQ-i8ZByeIA" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_43YfIO1hEeig48nFftVy3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9nfFATQWEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_9nfsEDQWEemgQ-i8ZByeIA" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_MlJqQu1iEeig48nFftVy3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9nfsETQWEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_9ngTIDQWEemgQ-i8ZByeIA" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_Z24mEu1iEeig48nFftVy3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9ngTITQWEemgQ-i8ZByeIA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_9ngTIjQWEemgQ-i8ZByeIA" type="Property_SignalAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_m4pMMu1iEeig48nFftVy3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9ngTIzQWEemgQ-i8ZByeIA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BEYm9DOZEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BEYm9TOZEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BEYm9jOZEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BEYm9zOZEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BEX_4TOZEemmfYv-bFFYSw" x="39" y="408"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BEhJ0DOZEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BEhJ0TOZEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BEhJ0zOZEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BEhJ0jOZEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_qZXVoDOaEemmfYv-bFFYSw" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_qZXVojOaEemmfYv-bFFYSw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qZXVozOaEemmfYv-bFFYSw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qZXVpDOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_qZXVpTOaEemmfYv-bFFYSw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_yR274DOaEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_8ZNqYOyhEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yR274TOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yR3i8DOaEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#__Dam0OyhEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yR3i8TOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_yR4KADOaEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_EEVjAOyiEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_yR4KATOaEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_qZXVpjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_qZXVpzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_qZXVqDOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qZXVqTOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiLldp.uml#_2TDkcOyhEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qZXVoTOaEemmfYv-bFFYSw" x="16" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_qZhGozOaEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qZhGpDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qZhGpjOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="TapiLldp.uml#_2TDkcOyhEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qZhGpTOaEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rTbxMDOaEemmfYv-bFFYSw" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rTcYQDOaEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rTcYQTOaEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rTcYQjOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rTcYQzOaEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_0yWisDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_XhgtYOyiEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0yWisTOaEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rTcYRDOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rTcYRTOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rTcYRjOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rTcYRzOaEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rTcYSDOaEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rTcYSTOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rTcYSjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rTcYSzOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rTcYTDOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_Ui3yAOyiEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rTbxMTOaEemmfYv-bFFYSw" x="176" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_siPGoDOaEemmfYv-bFFYSw" type="DataType_Shape" fontColor="255" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_siPGojOaEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_siPGozOaEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_siPGpDOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_siPGpTOaEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_5SrTQDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_QU9xsOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5SrTQTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5Sr6UDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_RflKsOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5Sr6UTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5SshYDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_So0DoOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5SshYTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5SshYjOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_UE5AEOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5SshYzOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5SshZDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_WhF8wOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5SshZTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5SshZjOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_XajUUOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5SshZzOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5SshaDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_YqfSMOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5SshaTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5StIcDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_a129kOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5StIcTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5StIcjOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_cru6EOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5StIczOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5StIdDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_fNBLEOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5StIdTOaEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5StIdjOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_hEuTkOyjEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5StIdzOaEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_siPGpjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_siPGpzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_siPGqDOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_siPGqTOaEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_siPGqjOaEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_siPGqzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_siPGrDOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_siPGrTOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_siPGrjOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_InDDwOyjEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_siPGoTOaEemmfYv-bFFYSw" x="392" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_siZeszOaEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_siZetDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_siZetjOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiLldp.uml#_InDDwOyjEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_siZetTOaEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_s7LyIDOaEemmfYv-bFFYSw" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_s7LyIjOaEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_s7LyIzOaEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_s7LyJDOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s7LyJTOaEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_-Q0BMDOaEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_Xg-lEOymEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-Q0BMTOaEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s7LyJjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s7LyJzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s7LyKDOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s7LyKTOaEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s7LyKjOaEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s7LyKzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s7LyLDOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s7LyLTOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s7LyLjOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_VSwaAOymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s7LyITOaEemmfYv-bFFYSw" x="608" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_s7U8EzOaEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_s7U8FDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s7U8FjOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiLldp.uml#_VSwaAOymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s7U8FTOaEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tTXooDOaEemmfYv-bFFYSw" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_tTXoojOaEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_tTXoozOaEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTXopDOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_tTXopTOaEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_B8C80DObEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_nTQLAOymEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B8C80TObEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_tTXopjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_tTXopzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_tTXoqDOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTXoqTOaEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_tTXoqjOaEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_tTXoqzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_tTXorDOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_tTXorTOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTXorjOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_i0034OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTXooTOaEemmfYv-bFFYSw" x="728" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tpMusDOaEemmfYv-bFFYSw" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_tpMusjOaEemmfYv-bFFYSw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_tpMuszOaEemmfYv-bFFYSw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tpMutDOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_tpMutTOaEemmfYv-bFFYSw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_EaPdkDObEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_Cm_S4OywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EaPdkTObEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EaQEoDObEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_H1IywOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EaQEoTObEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EaQEojObEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_KNuawOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EaQEozObEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EaQEpDObEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_MW9_MOywEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EaQEpTObEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_tpMutjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_tpMutzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_tpMuuDOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tpMuuTOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiLldp.uml#_6OfW4OyvEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tpMusTOaEemmfYv-bFFYSw" x="960" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tpV4ozOaEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tpV4pDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tpV4pjOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="TapiLldp.uml#_6OfW4OyvEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tpV4pTOaEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uBc2oDOaEemmfYv-bFFYSw" type="DataType_Shape" fontColor="255" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uBc2ojOaEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uBc2ozOaEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uBc2pDOaEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_uBc2pTOaEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_HVYZADObEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_BwmoAOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_HVYZATObEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_HVZAEDObEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_D05bAOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_HVZAETObEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_HVZAEjObEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_Fvk_AOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_HVZAEzObEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_HVZnIDObEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_HfyYYOyxEeiDgrJNY0AUOg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_HVZnITObEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_uBc2pjOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_uBc2pzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_uBc2qDOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uBc2qTOaEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_uBc2qjOaEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_uBc2qzOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_uBc2rDOaEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_uBc2rTOaEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uBc2rjOaEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_wcTOoOywEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uBc2oTOaEemmfYv-bFFYSw" x="1080" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uBmAkzOaEemmfYv-bFFYSw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uBmAlDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uBmnoDOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiLldp.uml#_wcTOoOywEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uBmAlTOaEemmfYv-bFFYSw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DOWcwDOcEemmfYv-bFFYSw" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DOXD0DOcEemmfYv-bFFYSw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DOXD0TOcEemmfYv-bFFYSw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DOXD0jOcEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DOXD0zOcEemmfYv-bFFYSw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_RHYCEDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMUjObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHYCETOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHYpIDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMVTObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHYpITOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHZQMDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMWDObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHZQMTOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHZQMjOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMWzObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHZQMzOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHZ3QDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMXjObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHZ3QTOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHZ3QjOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMYTObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHZ3QzOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RHZ3RDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_wCaMZDObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RHZ3RTOcEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DOXD1DOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DOXD1TOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DOXD1jOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DOXD1zOcEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiLldp.uml#_wCaMUDObEemmfYv-bFFYSw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DOWcwTOcEemmfYv-bFFYSw" x="1520" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DZ17EDOcEemmfYv-bFFYSw" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DZ17EjOcEemmfYv-bFFYSw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DZ17EzOcEemmfYv-bFFYSw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DZ17FDOcEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DZ17FTOcEemmfYv-bFFYSw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_T4GdQDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUoGkjObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4GdQTOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T4HEUDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUotoDObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4HEUTOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T4HrYDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUotozObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4HrYTOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T4HrYjOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUotpjObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4HrYzOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T4IScDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUotqTObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4IScTOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T4IScjOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUotrDObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4ISczOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T4I5gDOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_yUotrzObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T4I5gTOcEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DZ17FjOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DZ17FzOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DZ17GDOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZ17GTOcEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiLldp.uml#_yUoGkDObEemmfYv-bFFYSw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZ17ETOcEemmfYv-bFFYSw" x="1808" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DjdxIDOcEemmfYv-bFFYSw" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DjdxIjOcEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DjdxIzOcEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DjdxJDOcEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DjdxJTOcEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_O8RccDOcEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_2NWrojObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_O8RccTOcEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DjdxJjOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DjdxJzOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DjdxKDOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DjdxKTOcEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_DjeYMDOcEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_DjeYMTOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_DjeYMjOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_DjeYMzOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DjeYNDOcEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_2NWroDObEemmfYv-bFFYSw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DjdxITOcEemmfYv-bFFYSw" x="1368" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ds9EUDOcEemmfYv-bFFYSw" type="DataType_Shape" fillColor="8905185">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ds9EUjOcEemmfYv-bFFYSw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ds9EUzOcEemmfYv-bFFYSw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ds9EVDOcEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Ds9EVTOcEemmfYv-bFFYSw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_SyECQDOcEemmfYv-bFFYSw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_5Ec0kjObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SyECQTOcEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Ds9EVjOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Ds9EVzOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Ds9EWDOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ds9EWTOcEemmfYv-bFFYSw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Ds9EWjOcEemmfYv-bFFYSw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Ds9EWzOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Ds9EXDOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Ds9EXTOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ds9EXjOcEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiLldp.uml#_5Ec0kDObEemmfYv-bFFYSw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ds9EUTOcEemmfYv-bFFYSw" x="1672" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D3uJ4DOcEemmfYv-bFFYSw" type="Enumeration_Shape" fillColor="8047085">
+      <children xmi:type="notation:DecorationNode" xmi:id="_D3uw8DOcEemmfYv-bFFYSw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_D3uw8TOcEemmfYv-bFFYSw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_D3uw8jOcEemmfYv-bFFYSw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_D3uw8zOcEemmfYv-bFFYSw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Mlkq0DOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_757M4jObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mlkq0TOcEemmfYv-bFFYSw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Mll48DOcEemmfYv-bFFYSw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_757M5DObEemmfYv-bFFYSw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Mll48TOcEemmfYv-bFFYSw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_D3uw9DOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_D3uw9TOcEemmfYv-bFFYSw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_D3uw9jOcEemmfYv-bFFYSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D3uw9zOcEemmfYv-bFFYSw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiLldp.uml#_757M4DObEemmfYv-bFFYSw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D3uJ4TOcEemmfYv-bFFYSw" x="1248" y="1136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XImyADQbEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_XInZEDQbEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_cS1cUO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XImyATQbEemgQ-i8ZByeIA" x="384" y="344" height="28"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_a742YDQbEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_a75dcDQbEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_o0TY0O4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a742YTQbEemgQ-i8ZByeIA" x="384" y="376" height="27"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dsIwcDQbEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dsIwcjQbEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_u5ZHwO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dsIwcTQbEemgQ-i8ZByeIA" x="384" y="408" height="23"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gQ_54DQbEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gQ_54jQbEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_0_VLQO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gQ_54TQbEemgQ-i8ZByeIA" x="384" y="440" height="21"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_IhGgoDQcEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_IhHHsDQcEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_HSvQEDQcEemgQ-i8ZByeIA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IhGgoTQcEemgQ-i8ZByeIA" x="1104" y="32"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_lI6RwDQgEemgQ-i8ZByeIA" type="PrimitiveType_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rLnbEDQgEemgQ-i8ZByeIA" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rLoCIDQgEemgQ-i8ZByeIA" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lI640DQgEemgQ-i8ZByeIA" type="PrimitiveType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lI640TQgEemgQ-i8ZByeIA" type="PrimitiveType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lI640jQgEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_lI7f4DQgEemgQ-i8ZByeIA" type="PrimitiveType_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_lI7f4TQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_lI7f4jQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_lI7f4zQgEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lI7f5DQgEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_lI7f5TQgEemgQ-i8ZByeIA" type="PrimitiveType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_lI7f5jQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_lI7f5zQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_lI7f6DQgEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lI7f6TQgEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_6-ftUC7jEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lI6RwTQgEemgQ-i8ZByeIA" x="220" y="1024" width="185" height="73"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_lJOa0DQgEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_lJOa0TQgEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lJOa0zQgEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_6-ftUC7jEem3g99vIRtESQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lJOa0jQgEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_l3XTMDQgEemgQ-i8ZByeIA" type="PrimitiveType_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rLopMTQgEemgQ-i8ZByeIA" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rLopMjQgEemgQ-i8ZByeIA" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_l3X6QDQgEemgQ-i8ZByeIA" type="PrimitiveType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_l3X6QTQgEemgQ-i8ZByeIA" type="PrimitiveType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l3X6QjQgEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_l3X6QzQgEemgQ-i8ZByeIA" type="PrimitiveType_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_l3X6RDQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_l3X6RTQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_l3X6RjQgEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l3X6RzQgEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_l3X6SDQgEemgQ-i8ZByeIA" type="PrimitiveType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_l3X6STQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_l3X6SjQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_l3X6SzQgEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l3X6TDQgEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l3XTMTQgEemgQ-i8ZByeIA" x="20" y="1024" width="185" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mmBwADQgEemgQ-i8ZByeIA" type="PrimitiveType_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rLoCITQgEemgQ-i8ZByeIA" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rLopMDQgEemgQ-i8ZByeIA" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mmBwAjQgEemgQ-i8ZByeIA" type="PrimitiveType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mmBwAzQgEemgQ-i8ZByeIA" type="PrimitiveType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mmCXEDQgEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mmCXETQgEemgQ-i8ZByeIA" type="PrimitiveType_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mmCXEjQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mmCXEzQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mmCXFDQgEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmCXFTQgEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mmCXFjQgEemgQ-i8ZByeIA" type="PrimitiveType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mmCXFzQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mmCXGDQgEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mmCXGTQgEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmCXGjQgEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_vK1_AC9lEem3g99vIRtESQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmBwATQgEemgQ-i8ZByeIA" x="420" y="1024" width="185" height="73"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mmMvIDQgEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mmMvITQgEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mmMvIzQgEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_vK1_AC9lEem3g99vIRtESQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mmMvIjQgEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_rFweYTOWEemmfYv-bFFYSw" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_rFweYjOWEemmfYv-bFFYSw"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_rFweYzOWEemmfYv-bFFYSw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiLldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiLldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_v3GGdzOWEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_v25SIDOWEemmfYv-bFFYSw" target="_v3GGczOWEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v3GGeDOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v3GGfDOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v3GGeTOWEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v3GGejOWEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v3GGezOWEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v3knlzOWEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_v3XzQDOWEemmfYv-bFFYSw" target="_v3knkzOWEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v3knmDOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v3knnDOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v3knmTOWEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v3knmjOWEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v3knmzOWEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v3yqADOWEemmfYv-bFFYSw" type="Association_Edge" source="_v25SIDOWEemmfYv-bFFYSw" target="_v3XzQDOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3yqAzOWEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wpPVEDOWEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3yqBDOWEemmfYv-bFFYSw" x="-23" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3yqBTOWEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wpcwcDOWEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3yqBjOWEemmfYv-bFFYSw" x="-21" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3yqBzOWEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wpoWoDOWEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3yqCDOWEemmfYv-bFFYSw" x="12" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3yqCTOWEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wpz80DOWEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3yqCjOWEemmfYv-bFFYSw" x="-13" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3yqCzOWEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wp-78DOWEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3yqDDOWEemmfYv-bFFYSw" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3zREDOWEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wqLJMDOWEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v3zRETOWEemmfYv-bFFYSw" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_v3yqATOWEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v3yqAjOWEemmfYv-bFFYSw" points="[1050, 16, -643984, -643984]$[1608, 16, -643984, -643984]$[1608, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wqaZwDOWEemmfYv-bFFYSw" id="(1.0,0.24615384615384617)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wqaZwTOWEemmfYv-bFFYSw" id="(0.5106382978723404,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v32UZDOWEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_v3yqADOWEemmfYv-bFFYSw" target="_v32UYDOWEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v32UZTOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v32UaTOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v32UZjOWEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v32UZzOWEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v32UaDOWEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_53OupDOWEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_527MoDOWEemmfYv-bFFYSw" target="_53OuoDOWEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_53OupTOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_53PVsTOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_53OupjOWEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_53OupzOWEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_53PVsDOWEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_56casDOWEemmfYv-bFFYSw" type="Association_Edge" source="_v25SIDOWEemmfYv-bFFYSw" target="_527MoDOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_56dBwDOWEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l58ZcDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_56dBwTOWEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_56dBwjOWEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l_-wADOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_56dBwzOWEemmfYv-bFFYSw" x="2" y="4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_56do0DOWEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mGKQgDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_56do0TOWEemmfYv-bFFYSw" x="51" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_56do0jOWEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mOMLIDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_56do0zOWEemmfYv-bFFYSw" x="-51" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_56do1DOWEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mUUBQDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_56do1TOWEemmfYv-bFFYSw" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_56do1jOWEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_maVJsDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_56do1zOWEemmfYv-bFFYSw" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_56casTOWEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_F9jtcOytEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_56casjOWEemmfYv-bFFYSw" points="[768, 122, -643984, -643984]$[768, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mg8IADOZEemmfYv-bFFYSw" id="(0.2033898305084746,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mg8vEDOZEemmfYv-bFFYSw" id="(0.8233009708737864,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7zAe1DOWEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_7y2t0DOWEemmfYv-bFFYSw" target="_7zAe0DOWEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7zAe1TOWEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7zAe2TOWEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7zAe1jOWEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7zAe1zOWEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7zAe2DOWEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_70o2gDOWEemmfYv-bFFYSw" type="Association_Edge" source="_v25SIDOWEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_70o2gzOWEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Dkw5ADOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70o2hDOWEemmfYv-bFFYSw" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_70pdkDOWEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Dqj_ADOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70pdkTOWEemmfYv-bFFYSw" x="-94" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_70pdkjOWEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DwjSQDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70pdkzOWEemmfYv-bFFYSw" x="42" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_70pdlDOWEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D2WYQDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70pdlTOWEemmfYv-bFFYSw" x="-42" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_70pdljOWEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D77b0DOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70pdlzOWEemmfYv-bFFYSw" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_70pdmDOWEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EB12kDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70pdmTOWEemmfYv-bFFYSw" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_70o2gTOWEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_HhWQ4OysEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_70o2gjOWEemmfYv-bFFYSw" points="[696, 16, -643984, -643984]$[160, 16, -643984, -643984]$[160, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIssgDOZEemmfYv-bFFYSw" id="(0.0,0.24615384615384617)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIssgTOZEemmfYv-bFFYSw" id="(0.4948453608247423,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_k9M51DOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_k9ChwDOYEemmfYv-bFFYSw" target="_k9M50DOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_k9M51TOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_k9M52TOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_k9M51jOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_k9M51zOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_k9M52DOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_k_djoDOYEemmfYv-bFFYSw" type="Association_Edge" source="_v25SIDOWEemmfYv-bFFYSw" target="_k9ChwDOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_k_djozOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hJxHoDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k_eKsDOYEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_k_eKsTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hU9D8DOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k_eKsjOYEemmfYv-bFFYSw" x="-2" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_k_eKszOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hcXTgDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k_eKtDOYEemmfYv-bFFYSw" x="63" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_k_eKtTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hj-XYDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k_eKtjOYEemmfYv-bFFYSw" x="-63" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_k_eKtzOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ht69kDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k_eKuDOYEemmfYv-bFFYSw" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_k_eKuTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_h2cAYDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_k_eKujOYEemmfYv-bFFYSw" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_k_djoTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_qub-0OyuEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_k_djojOYEemmfYv-bFFYSw" points="[992, 114, -643984, -643984]$[992, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h-HVsDOcEemmfYv-bFFYSw" id="(0.8361581920903954,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h-HVsTOcEemmfYv-bFFYSw" id="(0.27053140096618356,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_paUlZDOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_paKNUDOYEemmfYv-bFFYSw" target="_paUlYDOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_paUlZTOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_paUlaTOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_paUlZjOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_paUlZzOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_paUlaDOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pdWrQTOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_pdLsIDOYEemmfYv-bFFYSw" target="_pdWEMzOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_pdWrQjOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pdWrRjOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pdWrQzOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdWrRDOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdWrRTOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pg02ADOYEemmfYv-bFFYSw" type="Association_Edge" source="_paKNUDOYEemmfYv-bFFYSw" target="_pdLsIDOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pg1dEDOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qgPEkDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pg1dETOYEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pg1dEjOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qjP8UDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pg1dEzOYEemmfYv-bFFYSw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pg1dFDOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ql4ZkDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pg1dFTOYEemmfYv-bFFYSw" x="15" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pg1dFjOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qoYT8DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pg1dFzOYEemmfYv-bFFYSw" x="-18" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pg2EIDOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qrggcDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pg2EITOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pg2EIjOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_quKy4DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pg2EIzOYEemmfYv-bFFYSw" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_pg02ATOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_oixzAOzDEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pg02AjOYEemmfYv-bFFYSw" points="[1344, 874, -643984, -643984]$[1344, 912, -643984, -643984]$[960, 912, -643984, -643984]$[960, 960, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qwrUUDOYEemmfYv-bFFYSw" id="(0.2174757281553398,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qwr7YDOYEemmfYv-bFFYSw" id="(0.5049701789264414,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ufl2EDOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_ufa28DOYEemmfYv-bFFYSw" target="_uflPAzOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ufl2ETOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ufl2FTOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ufl2EjOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ufl2EzOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ufl2FDOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ukarsDOYEemmfYv-bFFYSw" type="Association_Edge" source="_k9ChwDOYEemmfYv-bFFYSw" target="_ufa28DOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ukarszOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_waHCADOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ukartDOYEemmfYv-bFFYSw" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ukartTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_we6CcDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ukartjOYEemmfYv-bFFYSw" x="-13" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ukartzOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wjeZYDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ukaruDOYEemmfYv-bFFYSw" x="55" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ukaruTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wop0UDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ukarujOYEemmfYv-bFFYSw" x="-55" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ukaruzOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wutZADOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ukarvDOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ukarvTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_w3Ob0DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ukarvjOYEemmfYv-bFFYSw" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ukarsTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_1m4AoOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ukarsjOYEemmfYv-bFFYSw" points="[936, 450, -643984, -643984]$[936, 528, -643984, -643984]$[336, 528, -643984, -643984]$[336, 584, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w7t6QDOYEemmfYv-bFFYSw" id="(0.1641025641025641,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w7uhUDOYEemmfYv-bFFYSw" id="(0.7980049875311721,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yLYLVDOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_yLL-EDOYEemmfYv-bFFYSw" target="_yLYLUDOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yLYLVTOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yLYLWTOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yLYLVjOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yLYLVzOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yLYLWDOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yQPdMDOYEemmfYv-bFFYSw" type="Association_Edge" source="_paKNUDOYEemmfYv-bFFYSw" target="_yLL-EDOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yQPdMzOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0xKh0DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yQPdNDOYEemmfYv-bFFYSw" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yQPdNTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_02hi8DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yQPdNjOYEemmfYv-bFFYSw" x="-2" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yQPdNzOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_09ZnADOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yQPdODOYEemmfYv-bFFYSw" x="29" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yQPdOTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1D1mMDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yQPdOjOYEemmfYv-bFFYSw" x="-30" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yQPdOzOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1ItfIDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yQPdPDOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yQPdPTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1N0BkDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yQPdPjOYEemmfYv-bFFYSw" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_yQPdMTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_Se9hEOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yQPdMjOYEemmfYv-bFFYSw" points="[1624, 874, -643984, -643984]$[1624, 912, -643984, -643984]$[1936, 912, -643984, -643984]$[1936, 960, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1S9nUDOYEemmfYv-bFFYSw" id="(0.7611650485436893,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1S9nUTOYEemmfYv-bFFYSw" id="(0.5045045045045045,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1qBccDOYEemmfYv-bFFYSw" type="Association_Edge" source="_k9ChwDOYEemmfYv-bFFYSw" target="_paKNUDOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1qBcczOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fkNfEDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1qBcdDOYEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1qBcdTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_frzU0DOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1qBcdjOYEemmfYv-bFFYSw" x="8" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1qBcdzOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fz79IDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1qBceDOYEemmfYv-bFFYSw" x="28" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1qBceTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_f9Dc4DOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1qBcejOYEemmfYv-bFFYSw" x="-28" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1qBcezOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gHiOkDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1qBcfDOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1qBcfTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gO_hcDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1qBcfjOYEemmfYv-bFFYSw" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_1qBccTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_64-jsOzCEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1qBccjOYEemmfYv-bFFYSw" points="[1200, 450, -643984, -643984]$[1200, 528, -643984, -643984]$[1416, 528, -643984, -643984]$[1416, 584, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h-HVtDOcEemmfYv-bFFYSw" id="(0.8205128205128205,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h-HVtTOcEemmfYv-bFFYSw" id="(0.5036319612590799,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_2Y7J1zOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_2YxY0DOYEemmfYv-bFFYSw" target="_2Y7J0zOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_2Y7J2DOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2Y7w4jOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2Y7J2TOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Y7w4DOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Y7w4TOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_2eTZEDOYEemmfYv-bFFYSw" type="Association_Edge" source="_paKNUDOYEemmfYv-bFFYSw" target="_2YxY0DOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_2eTZEzOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3Wp9YDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2eTZFDOYEemmfYv-bFFYSw" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2eTZFTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3bZTcDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2eTZFjOYEemmfYv-bFFYSw" x="-1" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2eTZFzOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3gICcDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2eTZGDOYEemmfYv-bFFYSw" x="32" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2eTZGTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3ksZYDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2eTZGjOYEemmfYv-bFFYSw" x="-33" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2eTZGzOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3phPADOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2eTZHDOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2eTZHTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3uRzMDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2eTZHjOYEemmfYv-bFFYSw" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_2eTZETOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_AkdqYOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2eTZEjOYEemmfYv-bFFYSw" points="[1488, 874, -643984, -643984]$[1488, 960, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3zBwUDOYEemmfYv-bFFYSw" id="(0.4970873786407767,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3zBwUTOYEemmfYv-bFFYSw" id="(0.49760765550239233,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5bBo5DOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_5a00kDOYEemmfYv-bFFYSw" target="_5bBo4DOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5bBo5TOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5bBo6TOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5bBo5jOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5bBo5zOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5bBo6DOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5hkVwDOYEemmfYv-bFFYSw" type="Association_Edge" source="_k9ChwDOYEemmfYv-bFFYSw" target="_5a00kDOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hkVwzOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7b8-0DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5hkVxDOYEemmfYv-bFFYSw" x="-1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hkVxTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7pZk8DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5hkVxjOYEemmfYv-bFFYSw" x="2" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hkVxzOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7zJW0DOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5hkVyDOYEemmfYv-bFFYSw" x="48" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hkVyTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_739lYDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5hkVyjOYEemmfYv-bFFYSw" x="-48" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hkVyzOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_788MADOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5hkVzDOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5hkVzTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8B5kgDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5hkVzjOYEemmfYv-bFFYSw" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5hkVwTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_ua-AUOzBEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5hkVwjOYEemmfYv-bFFYSw" points="[1120, 450, -643984, -643984]$[1120, 584, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8G5ZQDOYEemmfYv-bFFYSw" id="(0.5797101449275363,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8G5ZQTOYEemmfYv-bFFYSw" id="(0.7715736040609137,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9UWD1DOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_9UJPgDOYEemmfYv-bFFYSw" target="_9UWD0DOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9UWD1TOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9UWD2TOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9UWD1jOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9UWD1zOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9UWD2DOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9b5dUDOYEemmfYv-bFFYSw" type="Association_Edge" source="_k9ChwDOYEemmfYv-bFFYSw" target="_9UJPgDOYEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9b6EYDOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gXNCQDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9b6EYTOYEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9b6EYjOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gheYkDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9b6EYzOYEemmfYv-bFFYSw" x="1" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9b6EZDOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_go-uwDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9b6EZTOYEemmfYv-bFFYSw" x="14" y="-52"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9b6EZjOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_gwY-UDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9b6EZzOYEemmfYv-bFFYSw" x="-46" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9b6EaDOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_g7T04DOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9b6EaTOYEemmfYv-bFFYSw" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9b6EajOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hCc-sDOcEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9b6EazOYEemmfYv-bFFYSw" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_9b5dUTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_gsQqEOzAEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9b5dUjOYEemmfYv-bFFYSw" points="[1016, 450, -643984, -643984]$[1016, 552, -643984, -643984]$[616, 552, -643984, -643984]$[616, 584, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h-HVsjOcEemmfYv-bFFYSw" id="(0.3487179487179487,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h-HVszOcEemmfYv-bFFYSw" id="(0.5013623978201635,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-xCrUDOYEemmfYv-bFFYSw" type="Association_Edge" source="_k9ChwDOYEemmfYv-bFFYSw" target="_v3XzQDOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xCrUzOYEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__4eNcDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xCrVDOYEemmfYv-bFFYSw" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xCrVTOYEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__9-YgDOYEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xCrVjOYEemmfYv-bFFYSw" x="2" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xCrVzOYEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ADrX4DOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xCrWDOYEemmfYv-bFFYSw" x="61" y="-79"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xCrWTOYEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AJgTEDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xCrWjOYEemmfYv-bFFYSw" x="-66" y="-39"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xCrWzOYEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_APJBADOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xCrXDOYEemmfYv-bFFYSw" x="7" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-xCrXTOYEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AVKwgDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xCrXjOYEemmfYv-bFFYSw" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_-xCrUTOYEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-xCrUjOYEemmfYv-bFFYSw" points="[1270, 264, -643984, -643984]$[1440, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AbI1oDOZEemmfYv-bFFYSw" id="(1.0,0.32116788321167883)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AbI1oTOZEemmfYv-bFFYSw" id="(0.0,0.4943820224719101)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-y2CJzOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_-xCrUDOYEemmfYv-bFFYSw" target="_-y2CIzOYEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-y2CKDOYEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-y2CLDOYEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-y2CKTOYEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-y2CKjOYEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-y2CKzOYEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BEhJ1DOZEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_BEX_4DOZEemmfYv-bFFYSw" target="_BEhJ0DOZEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BEhJ1TOZEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BEhJ2TOZEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BEhJ1jOZEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEhJ1zOZEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEhJ2DOZEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BK_lQDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BLAMUjOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ca01cDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BLAMUzOZEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BLAMVDOZEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ChnZ8DOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BLAMVTOZEemmfYv-bFFYSw" x="-10" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BLAMVjOZEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CpNPsDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BLAMVzOZEemmfYv-bFFYSw" x="16" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BLAMWDOZEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CxisUDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BLAMWTOZEemmfYv-bFFYSw" x="-16" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BLAMWjOZEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_C4JqoDOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BLAMWzOZEemmfYv-bFFYSw" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BLAMXDOZEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_C9_z8DOZEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BLAMXTOZEemmfYv-bFFYSw" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BLAMUDOZEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_m4olIO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BLAMUTOZEemmfYv-bFFYSw" points="[264, 408, -643984, -643984]$[264, 322, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DDuogDOZEemmfYv-bFFYSw" id="(0.9221311475409836,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DDvPkDOZEemmfYv-bFFYSw" id="(0.852233676975945,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EsWzMDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EsXaQDOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DO2WIDQXEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EsXaQTOZEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EsXaQjOZEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DV1u8DQXEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EsXaQzOZEemmfYv-bFFYSw" x="-10" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EsXaRDOZEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DcphkDQXEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EsXaRTOZEemmfYv-bFFYSw" x="13" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EsXaRjOZEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DnQ2IDQXEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EsXaRzOZEemmfYv-bFFYSw" x="-13" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EsXaSDOZEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DuWVkDQXEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EsXaSTOZEemmfYv-bFFYSw" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EsXaSjOZEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D1I6EDQXEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EsXaSzOZEemmfYv-bFFYSw" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_EsWzMTOZEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_MlJDMO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EsWzMjOZEemmfYv-bFFYSw" points="[120, 408, -643984, -643984]$[120, 322, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHr-MDQXEemgQ-i8ZByeIA" id="(0.3319672131147541,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHslQDQXEemgQ-i8ZByeIA" id="(0.35738831615120276,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FGl4IDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FGl4IzOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MVOzoDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FGl4JDOZEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FGl4JTOZEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MdZ4MDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FGl4JjOZEemmfYv-bFFYSw" x="6" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FGl4JzOZEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MlVFIDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FGl4KDOZEemmfYv-bFFYSw" x="30" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FGmfMDOZEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MuMGMDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FGmfMTOZEemmfYv-bFFYSw" y="51"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FGmfMjOZEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_M2GsEDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FGmfMzOZEemmfYv-bFFYSw" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FGmfNDOZEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_M8dLsDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FGmfNTOZEemmfYv-bFFYSw" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_FGl4ITOZEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_Z23_AO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FGl4IjOZEemmfYv-bFFYSw" points="[200, 408, -643984, -643984]$[200, 322, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOItIDOaEemmfYv-bFFYSw" id="(0.6598360655737705,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOJUMDOaEemmfYv-bFFYSw" id="(0.6323024054982818,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FfDbcDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FfECgDOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LD2rUDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FfECgTOZEemmfYv-bFFYSw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FfECgjOZEemmfYv-bFFYSw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LJZ5sDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FfECgzOZEemmfYv-bFFYSw" x="6" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FfEChDOZEemmfYv-bFFYSw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LRxLgDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FfEChTOZEemmfYv-bFFYSw" x="49" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FfEChjOZEemmfYv-bFFYSw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LYqdsDOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FfEChzOZEemmfYv-bFFYSw" x="-18" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FfECiDOZEemmfYv-bFFYSw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Leex0DOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FfECiTOZEemmfYv-bFFYSw" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FfECijOZEemmfYv-bFFYSw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LkJ8ADOaEemmfYv-bFFYSw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FfECizOZEemmfYv-bFFYSw" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_FfDbcTOZEemmfYv-bFFYSw"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_43WC4O1hEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FfDbcjOZEemmfYv-bFFYSw" points="[48, 408, -643984, -643984]$[48, 322, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K9p8sDOaEemmfYv-bFFYSw" id="(0.036885245901639344,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K9p8sTOaEemmfYv-bFFYSw" id="(0.10996563573883161,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qZhtsDOaEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_qZXVoDOaEemmfYv-bFFYSw" target="_qZhGozOaEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qZhtsTOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qZhttTOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="TapiLldp.uml#_2TDkcOyhEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qZhtsjOaEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZhtszOaEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZhttDOaEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_siZetzOaEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_siPGoDOaEemmfYv-bFFYSw" target="_siZeszOaEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_siZeuDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_siZevDOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiLldp.uml#_InDDwOyjEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_siZeuTOaEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_siZeujOaEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_siZeuzOaEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_s7U8FzOaEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_s7LyIDOaEemmfYv-bFFYSw" target="_s7U8EzOaEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_s7U8GDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s7U8HDOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiLldp.uml#_VSwaAOymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_s7U8GTOaEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s7U8GjOaEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s7U8GzOaEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tpV4pzOaEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_tpMusDOaEemmfYv-bFFYSw" target="_tpV4ozOaEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tpV4qDOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tpV4rDOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Enumeration" href="TapiLldp.uml#_6OfW4OyvEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tpV4qTOaEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tpV4qjOaEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tpV4qzOaEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uBmnoTOaEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_uBc2oDOaEemmfYv-bFFYSw" target="_uBmAkzOaEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uBmnojOaEemmfYv-bFFYSw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uBmnpjOaEemmfYv-bFFYSw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiLldp.uml#_wcTOoOywEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uBmnozOaEemmfYv-bFFYSw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uBmnpDOaEemmfYv-bFFYSw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uBmnpTOaEemmfYv-bFFYSw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_X9kEEDQbEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_XImyADQbEemgQ-i8ZByeIA" target="_FfDbcDOZEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X9kEETQbEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X9kEEjQbEemgQ-i8ZByeIA" points="[527, 315, -643984, -643984]$[96, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y7lykDQbEemgQ-i8ZByeIA" id="(0.0,0.5714285714285714)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X9lSMDQbEemgQ-i8ZByeIA" id="(0.5672514619883041,0.26548672566371684)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bwb4wDQbEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_a742YDQbEemgQ-i8ZByeIA" target="_EsWzMDOZEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bwb4wTQbEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bwb4wjQbEemgQ-i8ZByeIA" points="[474, 325, -643984, -643984]$[168, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ccLkcDQbEemgQ-i8ZByeIA" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bwdt8DQbEemgQ-i8ZByeIA" id="(0.5245901639344263,0.4690265486725664)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e-XNUDQbEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_dsIwcDQbEemgQ-i8ZByeIA" target="_FGl4IDOZEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e-XNUTQbEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e-XNUjQbEemgQ-i8ZByeIA" points="[562, 357, -643984, -643984]$[248, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j115oDQbEemgQ-i8ZByeIA" id="(0.0,0.2962962962962963)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-YbcDQbEemgQ-i8ZByeIA" id="(0.47317073170731705,0.675)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hQHNgDQbEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_gQ_54DQbEemgQ-i8ZByeIA" target="_BK_lQDOZEemmfYv-bFFYSw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hQHNgTQbEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hQHNgjQbEemgQ-i8ZByeIA" points="[528, 399, -643984, -643984]$[312, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTO3YDQbEemgQ-i8ZByeIA" id="(0.0,0.2962962962962963)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hQH0kDQbEemgQ-i8ZByeIA" id="(0.49238578680203043,0.8407079646017699)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_lJOa1DQgEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_lI6RwDQgEemgQ-i8ZByeIA" target="_lJOa0DQgEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_lJOa1TQgEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lJOa2TQgEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_6-ftUC7jEem3g99vIRtESQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lJOa1jQgEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lJOa1zQgEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lJOa2DQgEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mmMvJDQgEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_mmBwADQgEemgQ-i8ZByeIA" target="_mmMvIDQgEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mmMvJTQgEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mmMvKTQgEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_vK1_AC9lEem3g99vIRtESQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mmMvJjQgEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mmMvJzQgEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mmMvKDQgEemgQ-i8ZByeIA"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_Bb7tYDQfEemgQ-i8ZByeIA" type="PapyrusUMLClassDiagram" name="LldpSkeleton" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_Bb7tYTQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb7tYjQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb7tYzQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb7tZDQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb7tZTQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb7uGDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb7uGTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb7uGjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb7uGzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb7uHDQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb7uHTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb7uHjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb7uHzQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb7uIDQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb7uITQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb7uIjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb7uIzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb7uJDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb7uJTQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb7uTzQfEemgQ-i8ZByeIA" x="786" y="-16"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb7uUDQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb7uUTQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb7uUjQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8UfDQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb8UfTQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb8UfjQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb8UfzQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb8UgDQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb8UgTQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8V9TQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb8V9jQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb8V9zQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8V-DQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb8V-TQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8V-jQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb8V-zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb8V_DQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8V_TQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb8V_jQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8V_zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb8WADQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb8WATQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8WAjQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8WLDQfEemgQ-i8ZByeIA" x="1184" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb8WLTQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8WLjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb8WLzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8WQDQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb8WQTQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8WQjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb8WQzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8WSDQfEemgQ-i8ZByeIA" x="542" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb8WSTQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb8WSjQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb8WSzQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb8WTDQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb8WTTQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8XkjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb8XkzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb8XlDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8XlTQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb8XljQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8XlzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb8XmDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb8XmTQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8XmjQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb8XmzQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8XnDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb8XnTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb8XnjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8XnzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8XyTQfEemgQ-i8ZByeIA" x="424" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb8XyjQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb8XyzQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb8XzDQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb8X3TQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb87gDQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb87gTQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb87gjQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb87gzQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb87hDQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb88ZjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb88ZzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb88aDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb88aTQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb88ajQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb88azQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb88bDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb88bTQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb88bjQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb88bzQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb88cDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb88cTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb88cjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb88czQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb88nTQfEemgQ-i8ZByeIA" x="144" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb88njQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb88nzQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb88oDQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb88sTQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb88sjQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb88szQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb88tDQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88tTQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb88tjQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Bb88tzQfEemgQ-i8ZByeIA" type="Property_ClassAttributeLabel" fontColor="255">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_Bb88uDQfEemgQ-i8ZByeIA" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Bb88uTQfEemgQ-i8ZByeIA" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Bb88ujQfEemgQ-i8ZByeIA" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88uzQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88vDQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88vTQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88vjQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88vzQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88wDQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88wTQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88wjQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88wzQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88xDQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88xTQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88xjQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88xzQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88yDQfEemgQ-i8ZByeIA"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_Bb88yTQfEemgQ-i8ZByeIA" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb88yjQfEemgQ-i8ZByeIA"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_Bb88yzQfEemgQ-i8ZByeIA"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_Bb88zDQfEemgQ-i8ZByeIA" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb88zzQfEemgQ-i8ZByeIA"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_k0IVkDQVEemgQ-i8ZByeIA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb885DQfEemgQ-i8ZByeIA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9i1zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb9i2DQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb9i2TQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9i2jQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb9i2zQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9i3DQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb9i3TQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb9i3jQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9i3zQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb9i4DQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9i4TQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb9i4jQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb9i4zQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9i5DQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9jDjQfEemgQ-i8ZByeIA" x="696" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb9jDzQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9jEDQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb9jETQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9jIjQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb9jIzQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb9jJDQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb9jJTQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb9jJjQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb9jJzQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9l8zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb9l9DQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb9l9TQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9l9jQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb9l9zQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9l-DQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb9l-TQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb9l-jQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9l-zQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb9l_DQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb9l_TQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb9l_jQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb9l_zQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb9mADQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-JwjQfEemgQ-i8ZByeIA" x="968" y="464"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb-JwzQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb-JxDQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb-JxTQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-wvzQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb-wwDQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb-wwTQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb-wwjQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb-wwzQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb-wxDQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb-xojQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb-xozQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb-xpDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-xpTQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb-xpjQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb-xpzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb-xqDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb-xqTQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-xqjQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb-xqzQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb-xrDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb-xrTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb-xrjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-xrzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-x2TQfEemgQ-i8ZByeIA" x="824" y="640"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb-x2jQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb-x2zQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb-x3DQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb-x7TQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb-x7jQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb-x7zQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb-x8DQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb-x8TQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb-x8jQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_YBDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_YBTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_YBjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_YBzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_YCDQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_YCTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_YCjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_YCzQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_YDDQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_YDTQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_YDjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_YDzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_YEDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_YETQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_YOzQfEemgQ-i8ZByeIA" x="560" y="464"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb_YPDQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_YPTQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb_YPjQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_YTzQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb_YUDQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb_YUTQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb_YUjQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb_YUzQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_YVDQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_ZKjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_ZKzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_ZLDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_ZLTQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_ZLjQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_ZLzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_ZMDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_ZMTQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_ZMjQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_ZMzQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_ZNDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_ZNTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_ZNjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_ZNzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_ZYTQfEemgQ-i8ZByeIA" x="1112" y="640"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb_ZYjQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_ZYzQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb_ZZDQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_ZdTQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb_ZdjQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb_ZdzQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb_ZeDQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb_ZeTQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_ZejQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_Z6TQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_Z6jQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_Z6zQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_Z7DQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_Z7TQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_Z7jQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_Z7zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_Z8DQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_Z8TQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_Z8jQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_Z8zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb_Z9DQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb_Z9TQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_Z9jQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_aIDQfEemgQ-i8ZByeIA" x="969" y="640"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb_aITQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_aIjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb_aIzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb_aNDQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb_aNTQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb_aNjQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb_aNzQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb_aODQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb_aOTQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb_-_zQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb__ADQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb__ATQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__AjQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb__AzQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__BDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb__BTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb__BjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__BzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb__CDQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__CTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb__CjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb__CzQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__DDQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__NjQfEemgQ-i8ZByeIA" x="856" y="464"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb__NzQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__ODQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb__OTQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__SjQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb__SzQfEemgQ-i8ZByeIA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb__TDQfEemgQ-i8ZByeIA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Bb__TTQfEemgQ-i8ZByeIA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bb__TjQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb__TzQfEemgQ-i8ZByeIA" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__vDQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb__vTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb__vjQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__vzQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb__wDQfEemgQ-i8ZByeIA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__wTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb__wjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb__wzQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__xDQfEemgQ-i8ZByeIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Bb__xTQfEemgQ-i8ZByeIA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__xjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Bb__xzQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bb__yDQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__yTQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bb__8zQfEemgQ-i8ZByeIA" x="744" y="464"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Bb__9DQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Bb__9TQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bb__9jQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAABzQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAACDQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BcAACTQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAACjQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAADzQfEemgQ-i8ZByeIA" x="1139" y="234"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAAEDQfEemgQ-i8ZByeIA" type="Signal_Shape" fillColor="10011046">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAAETQfEemgQ-i8ZByeIA" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAAEjQfEemgQ-i8ZByeIA" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAAEzQfEemgQ-i8ZByeIA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BcAAFDQfEemgQ-i8ZByeIA" type="Signal_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BcAAxTQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BcAAxjQfEemgQ-i8ZByeIA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BcAAxzQfEemgQ-i8ZByeIA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAAyDQfEemgQ-i8ZByeIA"/>
+      </children>
+      <element xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAA4zQfEemgQ-i8ZByeIA" x="133" y="408"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAA5DQfEemgQ-i8ZByeIA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BcAA5TQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAA5jQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAA8TQfEemgQ-i8ZByeIA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAoRTQfEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoRjQfEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_cS1cUO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAoRzQfEemgQ-i8ZByeIA" x="400" y="288" height="28"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAoSDQfEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoSTQfEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_o0TY0O4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAoSjQfEemgQ-i8ZByeIA" x="400" y="320" height="27"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAoSzQfEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoTDQfEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_u5ZHwO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAoTTQfEemgQ-i8ZByeIA" x="400" y="352" height="23"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAoTjQfEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoTzQfEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_0_VLQO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAoUDQfEemgQ-i8ZByeIA" x="400" y="384" height="21"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BcAoUTQfEemgQ-i8ZByeIA" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoUjQfEemgQ-i8ZByeIA" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_HSvQEDQcEemgQ-i8ZByeIA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BcAoUzQfEemgQ-i8ZByeIA" x="920" y="32"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_BcAoVDQfEemgQ-i8ZByeIA" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_BcAoVTQfEemgQ-i8ZByeIA"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_BcAoVjQfEemgQ-i8ZByeIA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiLldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiLldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAoVzQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb7tYTQfEemgQ-i8ZByeIA" target="_Bb7uUDQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAoWDQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAoWTQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAoWjQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAoWzQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAoXDQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAoXTQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb8UfTQfEemgQ-i8ZByeIA" target="_Bb8WLTQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAoXjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAoXzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAoYDQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAoYTQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAoYjQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAoYzQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb7tYTQfEemgQ-i8ZByeIA" target="_Bb8UfTQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoZDQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoZTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAoZjQfEemgQ-i8ZByeIA" x="-23" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoZzQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoaDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAoaTQfEemgQ-i8ZByeIA" x="-21" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoajQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoazQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAobDQfEemgQ-i8ZByeIA" x="12" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAobTQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAobjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAobzQfEemgQ-i8ZByeIA" x="-13" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAocDQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAocTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAocjQfEemgQ-i8ZByeIA" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoczQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAodDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAodTQfEemgQ-i8ZByeIA" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAodjQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAoejQfEemgQ-i8ZByeIA" points="[886, 8, -643984, -643984]$[1232, 8, -643984, -643984]$[1232, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAoezQfEemgQ-i8ZByeIA" id="(1.0,0.24)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAofDQfEemgQ-i8ZByeIA" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAofTQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_BcAoYzQfEemgQ-i8ZByeIA" target="_Bb8WQTQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAofjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAofzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAogDQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAogTQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAogjQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAogzQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb8WSTQfEemgQ-i8ZByeIA" target="_Bb8XyjQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAohDQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAohTQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAohjQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAohzQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAoiDQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAoiTQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb7tYTQfEemgQ-i8ZByeIA" target="_Bb8WSTQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoijQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoizQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAojDQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAojTQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAojjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAojzQfEemgQ-i8ZByeIA" x="-52" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAokDQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAokTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAokjQfEemgQ-i8ZByeIA" x="51" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAokzQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAolDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAolTQfEemgQ-i8ZByeIA" x="-51" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoljQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAolzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAomDQfEemgQ-i8ZByeIA" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAomTQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAomjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAomzQfEemgQ-i8ZByeIA" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAonDQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_F9jtcOytEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAonTQfEemgQ-i8ZByeIA" points="[696, 64, -643984, -643984]$[488, 64, -643984, -643984]$[488, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAonjQfEemgQ-i8ZByeIA" id="(0.0,0.8)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAonzQfEemgQ-i8ZByeIA" id="(0.5714285714285714,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAooDQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb87gDQfEemgQ-i8ZByeIA" target="_Bb88njQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAooTQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAoojQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAoozQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAopDQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAopTQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAopjQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb7tYTQfEemgQ-i8ZByeIA" target="_Bb87gDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAopzQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoqDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAoqTQfEemgQ-i8ZByeIA" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoqjQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoqzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAorDQfEemgQ-i8ZByeIA" x="-94" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAorTQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAorjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAorzQfEemgQ-i8ZByeIA" x="42" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAosDQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAosTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAosjQfEemgQ-i8ZByeIA" x="-42" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoszQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAotDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAotTQfEemgQ-i8ZByeIA" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAotjQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAotzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAouDQfEemgQ-i8ZByeIA" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAouTQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_HhWQ4OysEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAoujQfEemgQ-i8ZByeIA" points="[696, 8, -643984, -643984]$[200, 8, -643984, -643984]$[200, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAouzQfEemgQ-i8ZByeIA" id="(0.0,0.24)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAovDQfEemgQ-i8ZByeIA" id="(0.5137614678899083,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAovTQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb88sjQfEemgQ-i8ZByeIA" target="_Bb9jDzQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAovjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAovzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAowDQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAowTQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAowjQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAowzQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb7tYTQfEemgQ-i8ZByeIA" target="_Bb88sjQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoxDQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoxTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAoxjQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoxzQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoyDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAoyTQfEemgQ-i8ZByeIA" x="-2" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAoyjQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAoyzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAozDQfEemgQ-i8ZByeIA" x="63" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAozTQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAozjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAozzQfEemgQ-i8ZByeIA" x="-63" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo0DQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo0TQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo0jQfEemgQ-i8ZByeIA" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo0zQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo1DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo1TQfEemgQ-i8ZByeIA" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAo1jQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_qub-0OyuEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAo1zQfEemgQ-i8ZByeIA" points="[840, 84, -643984, -643984]$[840, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo2DQfEemgQ-i8ZByeIA" id="(0.54,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo2TQfEemgQ-i8ZByeIA" id="(0.5142857142857142,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAo2jQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb9jIzQfEemgQ-i8ZByeIA" target="_Bb-JwzQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAo2zQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAo3DQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAo3TQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo3jQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo3zQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAo4DQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb-wwDQfEemgQ-i8ZByeIA" target="_Bb-x2jQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAo4TQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAo4jQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAo4zQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo5DQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo5TQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAo5jQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb9jIzQfEemgQ-i8ZByeIA" target="_Bb-wwDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo5zQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo6DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo6TQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo6jQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo6zQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo7DQfEemgQ-i8ZByeIA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo7TQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo7jQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo7zQfEemgQ-i8ZByeIA" x="15" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo8DQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo8TQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo8jQfEemgQ-i8ZByeIA" x="-18" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo8zQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo9DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo9TQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAo9jQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAo9zQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAo-DQfEemgQ-i8ZByeIA" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAo-TQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_oixzAOzDEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAo-jQfEemgQ-i8ZByeIA" points="[1000, 564, -643984, -643984]$[1000, 608, -643984, -643984]$[848, 608, -643984, -643984]$[848, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo-zQfEemgQ-i8ZByeIA" id="(0.24615384615384617,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAo_DQfEemgQ-i8ZByeIA" id="(0.4740740740740741,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAo_TQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb-x7jQfEemgQ-i8ZByeIA" target="_Bb_YPDQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAo_jQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcAo_zQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApADQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApATQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApAjQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApAzQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb88sjQfEemgQ-i8ZByeIA" target="_Bb-x7jQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApBDQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApBTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApBjQfEemgQ-i8ZByeIA" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApBzQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApCDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApCTQfEemgQ-i8ZByeIA" x="5" y="72"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApCjQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApCzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApDDQfEemgQ-i8ZByeIA" x="55" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApDTQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApDjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApDzQfEemgQ-i8ZByeIA" x="-55" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApEDQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApETQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApEjQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApEzQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApFDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApFTQfEemgQ-i8ZByeIA" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApFjQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_1m4AoOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApFzQfEemgQ-i8ZByeIA" points="[744, 276, -643984, -643984]$[744, 432, -643984, -643984]$[648, 432, -643984, -643984]$[648, 464, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApGDQfEemgQ-i8ZByeIA" id="(0.17142857142857143,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApGTQfEemgQ-i8ZByeIA" id="(0.5238095238095238,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApGjQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb_YUDQfEemgQ-i8ZByeIA" target="_Bb_ZYjQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApGzQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcApHDQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApHTQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApHjQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApHzQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApIDQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb9jIzQfEemgQ-i8ZByeIA" target="_Bb_YUDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApITQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApIjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApIzQfEemgQ-i8ZByeIA" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApJDQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApJTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApJjQfEemgQ-i8ZByeIA" x="-2" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApJzQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApKDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApKTQfEemgQ-i8ZByeIA" x="29" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApKjQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApKzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApLDQfEemgQ-i8ZByeIA" x="-30" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApLTQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApLjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApLzQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApMDQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApMTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApMjQfEemgQ-i8ZByeIA" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApMzQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_Se9hEOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApNDQfEemgQ-i8ZByeIA" points="[1064, 564, -643984, -643984]$[1064, 608, -643984, -643984]$[1184, 608, -643984, -643984]$[1184, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApNTQfEemgQ-i8ZByeIA" id="(0.7384615384615385,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApNjQfEemgQ-i8ZByeIA" id="(0.496551724137931,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApNzQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb88sjQfEemgQ-i8ZByeIA" target="_Bb9jIzQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApODQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApOTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApOjQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApOzQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApPDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApPTQfEemgQ-i8ZByeIA" x="13" y="-81"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApPjQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApPzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApQDQfEemgQ-i8ZByeIA" x="28" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApQTQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApQjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApQzQfEemgQ-i8ZByeIA" x="-28" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApRDQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApRTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApRjQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApRzQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApSDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApSTQfEemgQ-i8ZByeIA" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApSjQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_64-jsOzCEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApSzQfEemgQ-i8ZByeIA" points="[952, 276, -643984, -643984]$[952, 432, -643984, -643984]$[1032, 432, -643984, -643984]$[1032, 464, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApTDQfEemgQ-i8ZByeIA" id="(0.9142857142857143,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApTTQfEemgQ-i8ZByeIA" id="(0.49230769230769234,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApTjQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb_ZdjQfEemgQ-i8ZByeIA" target="_Bb_aITQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApTzQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcApUDQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApUTQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApUjQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApUzQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApVDQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb9jIzQfEemgQ-i8ZByeIA" target="_Bb_ZdjQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApVTQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApVjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApVzQfEemgQ-i8ZByeIA" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApWDQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApWTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApWjQfEemgQ-i8ZByeIA" x="-1" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApWzQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApXDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApXTQfEemgQ-i8ZByeIA" x="32" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApXjQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApXzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApYDQfEemgQ-i8ZByeIA" x="-33" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApYTQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApYjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApYzQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApZDQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApZTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApZjQfEemgQ-i8ZByeIA" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApZzQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_AkdqYOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApaDQfEemgQ-i8ZByeIA" points="[1032, 564, -643984, -643984]$[1032, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApaTQfEemgQ-i8ZByeIA" id="(0.49230769230769234,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApajQfEemgQ-i8ZByeIA" id="(0.4883720930232558,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApazQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb_aNTQfEemgQ-i8ZByeIA" target="_Bb__NzQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApbDQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcApbTQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApbjQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApbzQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApcDQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApcTQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb88sjQfEemgQ-i8ZByeIA" target="_Bb_aNTQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApcjQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApczQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApdDQfEemgQ-i8ZByeIA" x="-1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApdTQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApdjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApdzQfEemgQ-i8ZByeIA" x="13" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApeDQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApeTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApejQfEemgQ-i8ZByeIA" x="48" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApezQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApfDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApfTQfEemgQ-i8ZByeIA" x="-48" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApfjQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApfzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApgDQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApgTQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApgjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApgzQfEemgQ-i8ZByeIA" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAphDQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_ua-AUOzBEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAphTQfEemgQ-i8ZByeIA" points="[912, 276, -643984, -643984]$[912, 464, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAphjQfEemgQ-i8ZByeIA" id="(0.7714285714285715,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAphzQfEemgQ-i8ZByeIA" id="(0.56,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApiDQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_Bb__SzQfEemgQ-i8ZByeIA" target="_Bb__9DQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApiTQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcApijQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApizQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApjDQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApjTQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApjjQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb88sjQfEemgQ-i8ZByeIA" target="_Bb__SzQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApjzQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApkDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApkTQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApkjQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApkzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAplDQfEemgQ-i8ZByeIA" x="-3" y="-10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAplTQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApljQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAplzQfEemgQ-i8ZByeIA" x="14" y="-52"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApmDQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApmTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApmjQfEemgQ-i8ZByeIA" x="-46" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApmzQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApnDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApnTQfEemgQ-i8ZByeIA" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApnjQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApnzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApoDQfEemgQ-i8ZByeIA" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApoTQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_gsQqEOzAEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApojQfEemgQ-i8ZByeIA" points="[792, 276, -643984, -643984]$[792, 464, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApozQfEemgQ-i8ZByeIA" id="(0.34285714285714286,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAppDQfEemgQ-i8ZByeIA" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAppTQfEemgQ-i8ZByeIA" type="Association_Edge" source="_Bb88sjQfEemgQ-i8ZByeIA" target="_Bb8UfTQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAppjQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAppzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApqDQfEemgQ-i8ZByeIA" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApqTQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApqjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApqzQfEemgQ-i8ZByeIA" x="2" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAprDQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAprTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAprjQfEemgQ-i8ZByeIA" x="61" y="-79"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAprzQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApsDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApsTQfEemgQ-i8ZByeIA" x="-66" y="-39"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApsjQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApszQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAptDQfEemgQ-i8ZByeIA" x="7" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAptTQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAptjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAptzQfEemgQ-i8ZByeIA" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApuDQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApvDQfEemgQ-i8ZByeIA" points="[976, 208, -643984, -643984]$[1184, 208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApvTQfEemgQ-i8ZByeIA" id="(1.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApvjQfEemgQ-i8ZByeIA" id="(0.0,0.32)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApvzQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_BcAppTQfEemgQ-i8ZByeIA" target="_BcAACDQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApwDQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcApwTQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApwjQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApwzQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApxDQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApxTQfEemgQ-i8ZByeIA" type="StereotypeCommentLink" source="_BcAAEDQfEemgQ-i8ZByeIA" target="_BcAA5DQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcApxjQfEemgQ-i8ZByeIA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BcApxzQfEemgQ-i8ZByeIA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcApyDQfEemgQ-i8ZByeIA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApyTQfEemgQ-i8ZByeIA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcApyjQfEemgQ-i8ZByeIA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcApyzQfEemgQ-i8ZByeIA" type="Association_Edge" source="_BcAAEDQfEemgQ-i8ZByeIA" target="_Bb87gDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApzDQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcApzTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcApzjQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcApzzQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp0DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp0TQfEemgQ-i8ZByeIA" x="-25" y="8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp0jQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp0zQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp1DQfEemgQ-i8ZByeIA" x="16" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp1TQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp1jQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp1zQfEemgQ-i8ZByeIA" x="-16" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp2DQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp2TQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp2jQfEemgQ-i8ZByeIA" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp2zQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp3DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp3TQfEemgQ-i8ZByeIA" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAp3jQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_m4olIO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAp3zQfEemgQ-i8ZByeIA" points="[265, 456, -643984, -643984]$[312, 456, -643984, -643984]$[312, 224, -643984, -643984]$[253, 224, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAp4DQfEemgQ-i8ZByeIA" id="(1.0,0.48)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAp4TQfEemgQ-i8ZByeIA" id="(1.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAp4jQfEemgQ-i8ZByeIA" type="Association_Edge" source="_BcAAEDQfEemgQ-i8ZByeIA" target="_Bb87gDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp4zQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp5DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp5TQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp5jQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp5zQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp6DQfEemgQ-i8ZByeIA" x="-17" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp6TQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp6jQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp6zQfEemgQ-i8ZByeIA" x="13" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp7DQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp7TQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp7jQfEemgQ-i8ZByeIA" x="-13" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp7zQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp8DQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp8TQfEemgQ-i8ZByeIA" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp8jQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp8zQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp9DQfEemgQ-i8ZByeIA" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAp9TQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_MlJDMO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAp9jQfEemgQ-i8ZByeIA" points="[160, 408, -643984, -643984]$[160, 276, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAp9zQfEemgQ-i8ZByeIA" id="(0.20454545454545456,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAp-DQfEemgQ-i8ZByeIA" id="(0.14678899082568808,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAp-TQfEemgQ-i8ZByeIA" type="Association_Edge" source="_BcAAEDQfEemgQ-i8ZByeIA" target="_Bb87gDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp-jQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp-zQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp_DQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAp_TQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAp_jQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAp_zQfEemgQ-i8ZByeIA" x="6" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqADQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqATQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqAjQfEemgQ-i8ZByeIA" x="30" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqAzQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqBDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqBTQfEemgQ-i8ZByeIA" y="51"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqBjQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqBzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqCDQfEemgQ-i8ZByeIA" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqCTQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqCjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqCzQfEemgQ-i8ZByeIA" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAqDDQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_Z23_AO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqDTQfEemgQ-i8ZByeIA" points="[240, 408, -643984, -643984]$[240, 276, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqDjQfEemgQ-i8ZByeIA" id="(0.8106060606060606,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqDzQfEemgQ-i8ZByeIA" id="(0.8807339449541285,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAqEDQfEemgQ-i8ZByeIA" type="Association_Edge" source="_BcAAEDQfEemgQ-i8ZByeIA" target="_Bb87gDQfEemgQ-i8ZByeIA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqETQfEemgQ-i8ZByeIA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqEjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqEzQfEemgQ-i8ZByeIA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqFDQfEemgQ-i8ZByeIA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqFTQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqFjQfEemgQ-i8ZByeIA" x="6" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqFzQfEemgQ-i8ZByeIA" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqGDQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqGTQfEemgQ-i8ZByeIA" x="49" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqGjQfEemgQ-i8ZByeIA" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqGzQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqHDQfEemgQ-i8ZByeIA" x="-18" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqHTQfEemgQ-i8ZByeIA" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqHjQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqHzQfEemgQ-i8ZByeIA" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BcAqIDQfEemgQ-i8ZByeIA" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BcAqITQfEemgQ-i8ZByeIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BcAqIjQfEemgQ-i8ZByeIA" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAqIzQfEemgQ-i8ZByeIA"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_43WC4O1hEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqJDQfEemgQ-i8ZByeIA" points="[133, 456, -643984, -643984]$[88, 456, -643984, -643984]$[88, 224, -643984, -643984]$[144, 224, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqJTQfEemgQ-i8ZByeIA" id="(0.0,0.48)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqJjQfEemgQ-i8ZByeIA" id="(0.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAqRTQfEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_BcAoRTQfEemgQ-i8ZByeIA" target="_BcAqEDQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAqRjQfEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqRzQfEemgQ-i8ZByeIA" points="[527, 315, -643984, -643984]$[96, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqSDQfEemgQ-i8ZByeIA" id="(0.0,0.5714285714285714)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqSTQfEemgQ-i8ZByeIA" id="(0.5028248587570622,0.35668789808917195)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAqSjQfEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_BcAoSDQfEemgQ-i8ZByeIA" target="_BcAp4jQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAqSzQfEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqTDQfEemgQ-i8ZByeIA" points="[474, 325, -643984, -643984]$[168, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqTTQfEemgQ-i8ZByeIA" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqTjQfEemgQ-i8ZByeIA" id="(0.5191256830601093,0.3081761006289308)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAqTzQfEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_BcAoSzQfEemgQ-i8ZByeIA" target="_BcAp-TQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAqUDQfEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqUTQfEemgQ-i8ZByeIA" points="[562, 357, -643984, -643984]$[248, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqUjQfEemgQ-i8ZByeIA" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqUzQfEemgQ-i8ZByeIA" id="(0.4634146341463415,0.8192771084337349)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BcAqVDQfEemgQ-i8ZByeIA" type="Comment_AnnotatedElementEdge" source="_BcAoTjQfEemgQ-i8ZByeIA" target="_BcApyzQfEemgQ-i8ZByeIA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BcAqVTQfEemgQ-i8ZByeIA"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqVjQfEemgQ-i8ZByeIA" points="[528, 399, -643984, -643984]$[312, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqVzQfEemgQ-i8ZByeIA" id="(0.0,0.2962962962962963)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqWDQfEemgQ-i8ZByeIA" id="(0.49238578680203043,0.8407079646017699)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/UML/TapiLldp.notation
+++ b/UML/TapiLldp.notation
@@ -4511,7 +4511,10 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7y2t1DOWEemmfYv-bFFYSw" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_7y2t1TOWEemmfYv-bFFYSw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_8gaXYDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_8gaXYDOWEemmfYv-bFFYSw" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iMzjkDT9Eem7cZ08OBDNGQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iMzjkTT9Eem7cZ08OBDNGQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <styles xmi:type="notation:StringListValueStyle" xmi:id="_bBkhsDOZEemmfYv-bFFYSw" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
             <stringListValue>defaultValue</stringListValue>
@@ -4584,7 +4587,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t4zOWEemmfYv-bFFYSw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t0TOWEemmfYv-bFFYSw" x="16" y="176"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7y2t0TOWEemmfYv-bFFYSw" x="-5" y="176"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_7zAe0DOWEemmfYv-bFFYSw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_7zAe0TOWEemmfYv-bFFYSw"/>
@@ -6575,7 +6578,7 @@
       <element xmi:type="uml:Association" href="TapiLldp.uml#_HhWQ4OysEeiDgrJNY0AUOg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_70o2gjOWEemmfYv-bFFYSw" points="[696, 16, -643984, -643984]$[160, 16, -643984, -643984]$[160, 176, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIssgDOZEemmfYv-bFFYSw" id="(0.0,0.24615384615384617)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIssgTOZEemmfYv-bFFYSw" id="(0.4948453608247423,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIssgTOZEemmfYv-bFFYSw" id="(0.48338368580060426,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_k9M51DOYEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_k9ChwDOYEemmfYv-bFFYSw" target="_k9M50DOYEemmfYv-bFFYSw">
       <styles xmi:type="notation:FontStyle" xmi:id="_k9M51TOYEemmfYv-bFFYSw"/>
@@ -6985,7 +6988,7 @@
       <element xmi:type="uml:Association" href="TapiLldp.uml#_m4olIO1iEeig48nFftVy3w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BLAMUTOZEemmfYv-bFFYSw" points="[264, 408, -643984, -643984]$[264, 322, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DDuogDOZEemmfYv-bFFYSw" id="(0.9221311475409836,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DDvPkDOZEemmfYv-bFFYSw" id="(0.852233676975945,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DDvPkDOZEemmfYv-bFFYSw" id="(0.8126888217522659,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EsWzMDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_EsXaQDOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
@@ -7016,7 +7019,7 @@
       <element xmi:type="uml:Association" href="TapiLldp.uml#_MlJDMO1iEeig48nFftVy3w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EsWzMjOZEemmfYv-bFFYSw" points="[120, 408, -643984, -643984]$[120, 322, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHr-MDQXEemgQ-i8ZByeIA" id="(0.3319672131147541,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHslQDQXEemgQ-i8ZByeIA" id="(0.35738831615120276,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHslQDQXEemgQ-i8ZByeIA" id="(0.3776435045317221,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_FGl4IDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_FGl4IzOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
@@ -7045,9 +7048,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_FGl4ITOZEemmfYv-bFFYSw"/>
       <element xmi:type="uml:Association" href="TapiLldp.uml#_Z23_AO1iEeig48nFftVy3w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FGl4IjOZEemmfYv-bFFYSw" points="[200, 408, -643984, -643984]$[200, 322, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FGl4IjOZEemmfYv-bFFYSw" points="[200, 408, -643984, -643984]$[200, 368, -643984, -643984]$[224, 368, -643984, -643984]$[224, 322, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOItIDOaEemmfYv-bFFYSw" id="(0.6598360655737705,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOJUMDOaEemmfYv-bFFYSw" id="(0.6323024054982818,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOJUMDOaEemmfYv-bFFYSw" id="(0.6283987915407855,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_FfDbcDOZEemmfYv-bFFYSw" type="Association_Edge" source="_BEX_4DOZEemmfYv-bFFYSw" target="_7y2t0DOWEemmfYv-bFFYSw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_FfECgDOZEemmfYv-bFFYSw" type="Association_StereotypeLabel">
@@ -7078,7 +7081,7 @@
       <element xmi:type="uml:Association" href="TapiLldp.uml#_43WC4O1hEeig48nFftVy3w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FfDbcjOZEemmfYv-bFFYSw" points="[48, 408, -643984, -643984]$[48, 322, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K9p8sDOaEemmfYv-bFFYSw" id="(0.036885245901639344,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K9p8sTOaEemmfYv-bFFYSw" id="(0.10996563573883161,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K9p8sTOaEemmfYv-bFFYSw" id="(0.16012084592145015,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qZhtsDOaEemmfYv-bFFYSw" type="StereotypeCommentLink" source="_qZXVoDOaEemmfYv-bFFYSw" target="_qZhGozOaEemmfYv-bFFYSw">
       <styles xmi:type="notation:FontStyle" xmi:id="_qZhtsTOaEemmfYv-bFFYSw"/>
@@ -8375,6 +8378,1769 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BcAqVjQfEemgQ-i8ZByeIA" points="[528, 399, -643984, -643984]$[312, 264, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqVzQfEemgQ-i8ZByeIA" id="(0.0,0.2962962962962963)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcAqWDQfEemgQ-i8ZByeIA" id="(0.49238578680203043,0.8407079646017699)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_5D1IADTkEem7cZ08OBDNGQ" type="PapyrusUMLClassDiagram" name="LldpTouchPoints" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_J0li4DT6Eem7cZ08OBDNGQ" type="rectangle" fontName="Segoe UI" fillColor="13369343" transparency="0" lineColor="255" lineWidth="1">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_J0mxADT6Eem7cZ08OBDNGQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_J0mxATT6Eem7cZ08OBDNGQ" key="lineColor" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_J0n_IDT6Eem7cZ08OBDNGQ" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_J0n_ITT6Eem7cZ08OBDNGQ" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_J0n_IjT6Eem7cZ08OBDNGQ" key="italic" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_J0n_IzT6Eem7cZ08OBDNGQ" key="fontColor" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_J0n_JDT6Eem7cZ08OBDNGQ" key="fillColor" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_KvS3oDT6Eem7cZ08OBDNGQ" key="description" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:BasicDecorationNode" xmi:id="_J0n_JTT6Eem7cZ08OBDNGQ" type="DiagramName">
+        <element xsi:nil="true"/>
+      </children>
+      <children xmi:type="notation:BasicDecorationNode" xmi:id="_J0n_JjT6Eem7cZ08OBDNGQ" type="Description">
+        <element xsi:nil="true"/>
+      </children>
+      <styles xmi:type="notation:TextStyle" xmi:id="_J0li4TT6Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:LineTypeStyle" xmi:id="_J0li4jT6Eem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J0li4zT6Eem7cZ08OBDNGQ" y="536" width="657" height="161"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1IATTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1IAjTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1IAzTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1IBDTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IBTTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IBjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IBzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1ICDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1ICTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1ICjTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1ICzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IDDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IDTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IDjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IDzTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IEDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IETTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IEjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IEzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IPTTkEem7cZ08OBDNGQ" x="784" y="-104"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1IPjTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IPzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1IQDTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IUTTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1IUjTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1IUzTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1IVDTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1IVTTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IVjTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IVzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IWDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IWTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IWjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IWzTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IXDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IXTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IXjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IXzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IYDTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IYTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IYjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IYzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IZDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IjjTkEem7cZ08OBDNGQ" x="1184" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1IjzTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IkDTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1IkTTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IojTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1IozTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IpDTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1IpTTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IqjTkEem7cZ08OBDNGQ" x="542" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1IqzTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1IrDTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1IrTTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1IrjTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IrzTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IsDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IsTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IsjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IszTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1ItDTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1ItTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1ItjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1ItzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IuDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1IuTTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1IujTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1IuzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1IvDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1IvTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1I5zTkEem7cZ08OBDNGQ" x="416" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1I6DTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1I6TTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1I6jTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1I-zTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1I_DTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1I_TTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1I_jTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1I_zTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JADTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JATTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1JAjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1JAzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JBDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JBTTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JBjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1JBzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1JCDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JCTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JCjTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JCzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1JDDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1JDTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JDjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JODTkEem7cZ08OBDNGQ" x="32" y="568"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1JOTTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JOjTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1JOzTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JTDTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1JTTTkEem7cZ08OBDNGQ" type="Class_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1JTjTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1JTzTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JUDTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JUTTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_5D1JUjTkEem7cZ08OBDNGQ" type="Property_ClassAttributeLabel" fontColor="255">
+          <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JUzTkEem7cZ08OBDNGQ" type="StereotypeBrace">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5D1JVDTkEem7cZ08OBDNGQ" source="PapyrusCSSForceValue">
+              <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5D1JVTTkEem7cZ08OBDNGQ" key="visible" value="true"/>
+            </eAnnotations>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JVjTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_R-0eQNjTEea1wr7GsSffog"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JVzTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JWDTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JWTTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JWjTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JWzTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JXDTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JXTTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JXjTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JXzTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JYDTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JYTTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JYjTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JYzTkEem7cZ08OBDNGQ"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_5D1JZDTkEem7cZ08OBDNGQ" visible="false" type="StereotypePropertyBrace">
+              <element xmi:type="uml:Property" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JZTTkEem7cZ08OBDNGQ"/>
+            </children>
+            <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JZjTkEem7cZ08OBDNGQ"/>
+            <styles xmi:type="notation:StringValueStyle" xmi:id="_5D1JZzTkEem7cZ08OBDNGQ" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
+            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JajTkEem7cZ08OBDNGQ"/>
+          </children>
+          <element xmi:type="uml:Property" href="TapiLldp.uml#_k0IVkDQVEemgQ-i8ZByeIA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1JfzTkEem7cZ08OBDNGQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JgDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1JgTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1JgjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JgzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JhDTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JhTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1JhjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1JhzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JiDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1JiTTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JijTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1JizTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1JjDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JjTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1JtzTkEem7cZ08OBDNGQ" x="696" y="176"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1JuDTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1JuTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1JujTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vEjTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1vEzTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1vFDTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1vFTTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1vFjTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vFzTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vGDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vGTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vGjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vGzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vHDTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vHTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vHjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vHzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vIDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vITTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vIjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vIzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vJDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vJTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vTzTkEem7cZ08OBDNGQ" x="968" y="464"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1vUDTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vUTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1vUjTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vYzTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1vZDTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1vZTTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1vZjTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1vZzTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vaDTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vaTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vajTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vazTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vbDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vbTTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vbjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vbzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vcDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vcTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vcjTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vczTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vdDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vdTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vdjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1voDTkEem7cZ08OBDNGQ" x="824" y="640"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1voTTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vojTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1vozTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vtDTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1vtTTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1vtjTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1vtzTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1vuDTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vuTTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vujTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vuzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vvDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vvTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vvjTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vvzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vwDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vwTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vwjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1vwzTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1vxDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1vxTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1vxjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1vxzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1v8TTkEem7cZ08OBDNGQ" x="784" y="464"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1v8jTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1v8zTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1v9DTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wBTTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1wBjTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1wBzTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1wCDTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1wCTTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wCjTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wCzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wDDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wDTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wDjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wDzTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wEDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wETTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wEjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wEzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wFDTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wFTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wFjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wFzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wGDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wQjTkEem7cZ08OBDNGQ" x="1112" y="640"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1wQzTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wRDTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1wRTTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wVjTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1wVzTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1wWDTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1wWTTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1wWjTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wWzTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wXDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wXTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wXjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wXzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wYDTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wYTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wYjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wYzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wZDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wZTTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wZjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wZzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1waDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1waTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wkzTkEem7cZ08OBDNGQ" x="969" y="640"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1wlDTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wlTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1wljTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wpzTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1wqDTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1wqTTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1wqjTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1wqzTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wrDTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wrTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wrjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wrzTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wsDTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wsTTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wsjTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wszTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wtDTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wtTTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1wtjTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1wtzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1wuDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1wuTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1wujTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1w5DTkEem7cZ08OBDNGQ" x="528" y="568"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1w5TTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1w5jTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1w5zTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1w-DTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1w-TTkEem7cZ08OBDNGQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1w-jTkEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1w-zTkEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1w_DTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1w_TTkEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1w_jTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1w_zTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1xADTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xATTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1xAjTkEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1xAzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1xBDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1xBTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xBjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1xBzTkEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1xCDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1xCTTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1xCjTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xCzTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xNTTkEem7cZ08OBDNGQ" x="416" y="568"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xNjTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1xNzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xODTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xSTTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xSjTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1xSzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xTDTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xUTTkEem7cZ08OBDNGQ" x="1139" y="234"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xUjTkEem7cZ08OBDNGQ" type="Signal_Shape" fillColor="10011046">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xUzTkEem7cZ08OBDNGQ" type="Signal_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xVDTkEem7cZ08OBDNGQ" type="Signal_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xVTTkEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5D1xVjTkEem7cZ08OBDNGQ" type="Signal_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5D1xVzTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5D1xWDTkEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5D1xWTTkEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xWjTkEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xdTTkEem7cZ08OBDNGQ" x="21" y="824"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xdjTkEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5D1xdzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xeDTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xgzTkEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xhDTkEem7cZ08OBDNGQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xhTTkEem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_cS1cUO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xhjTkEem7cZ08OBDNGQ" x="288" y="704" height="28"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xhzTkEem7cZ08OBDNGQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xiDTkEem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_o0TY0O4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xiTTkEem7cZ08OBDNGQ" x="288" y="736" height="27"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xijTkEem7cZ08OBDNGQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xizTkEem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_u5ZHwO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xjDTkEem7cZ08OBDNGQ" x="288" y="768" height="23"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xjTTkEem7cZ08OBDNGQ" type="Comment_Shape" fontColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xjjTkEem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_0_VLQO4sEeiM3Nv4z8tz-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xjzTkEem7cZ08OBDNGQ" x="288" y="800" height="21"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5D1xkDTkEem7cZ08OBDNGQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xkTTkEem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_HSvQEDQcEemgQ-i8ZByeIA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5D1xkjTkEem7cZ08OBDNGQ" x="984" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rEi68DTqEem7cZ08OBDNGQ" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjtzIDTrEem7cZ08OBDNGQ" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjuaMDTrEem7cZ08OBDNGQ" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rEq2wDTqEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rErd0DTqEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rErd0TTqEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rEsE4DTqEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_YcJnADTrEem7cZ08OBDNGQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_5cYg0F3eEeit4-HSxnZlvw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YcJnATTrEem7cZ08OBDNGQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rEsE4TTqEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rEsE4jTqEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rEsE4zTqEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rEsE5DTqEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rEsE5TTqEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rEsE5jTqEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rEsE5zTqEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rEsE6DTqEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rEsE6TTqEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rEsr8DTqEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rEsr8TTqEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rEsr8jTqEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rEsr8zTqEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rEsr9DTqEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rEi68TTqEem7cZ08OBDNGQ" x="112" y="48"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rFTI4DTqEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rFTI4TTqEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rFTI4zTqEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rFTI4jTqEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AoZd8DTrEem7cZ08OBDNGQ" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjuaMTTrEem7cZ08OBDNGQ" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjuaMjTrEem7cZ08OBDNGQ" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AoasEDTrEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AoasETTrEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AoasEjTrEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AoasEzTrEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AoasFDTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AoasFTTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AoasFjTrEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AoasFzTrEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AoasGDTrEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AoasGTTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AoasGjTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AoasGzTrEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AoasHDTrEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AoasHTTrEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AoasHjTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AoasHzTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AoasIDTrEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AobTIDTrEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AoZd8TTrEem7cZ08OBDNGQ" x="142" y="232"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AongYzTrEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_AongZDTrEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AooHcDTrEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AongZTTrEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EixBwDTrEem7cZ08OBDNGQ" type="Class_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjuaMzTrEem7cZ08OBDNGQ" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjuaNDTrEem7cZ08OBDNGQ" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Eixo0DTrEem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Eixo0TTrEem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Eixo0jTrEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Eixo0zTrEem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Eixo1DTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Eixo1TTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Eixo1jTrEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eixo1zTrEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Eixo2DTrEem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Eixo2TTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Eixo2jTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Eixo2zTrEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eixo3DTrEem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_EiyP4DTrEem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_EiyP4TTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_EiyP4jTrEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_EiyP4zTrEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EiyP5DTrEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EixBwTTrEem7cZ08OBDNGQ" x="142" y="401"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ei-dIDTrEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ei-dITTrEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ei-dIzTrEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ei-dIjTrEem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zQjoMDTsEem7cZ08OBDNGQ" type="Enumeration_Shape" fillColor="12632256">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1yQv8DTsEem7cZ08OBDNGQ" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1yR-EDTsEem7cZ08OBDNGQ" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zQkPQDTsEem7cZ08OBDNGQ" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zQkPQTTsEem7cZ08OBDNGQ" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zQkPQjTsEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zQkPQzTsEem7cZ08OBDNGQ" type="Enumeration_LiteralCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zQkPRDTsEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zQkPRTTsEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zQkPRjTsEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zQkPRzTsEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_tqiDYF3eEeit4-HSxnZlvw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zQjoMTTsEem7cZ08OBDNGQ" x="-72" y="56" width="152"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__Q08IDTsEem7cZ08OBDNGQ" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="__Q08IjTsEem7cZ08OBDNGQ" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="__Q08IzTsEem7cZ08OBDNGQ" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__Q08JDTsEem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__Q1jMDTsEem7cZ08OBDNGQ" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_NbVTADTtEem7cZ08OBDNGQ" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiLldp.uml#_NChKYDTtEem7cZ08OBDNGQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_NbVTATTtEem7cZ08OBDNGQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="__Q1jMTTsEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__Q1jMjTsEem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__Q1jMzTsEem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Q1jNDTsEem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiLldp.uml#_7xBNYDTsEem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Q08ITTsEem7cZ08OBDNGQ" x="-320" y="56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FKQ0sDTtEem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FKQ0sTTtEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKQ0szTtEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_CFT18DTtEem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKQ0sjTtEem7cZ08OBDNGQ" x="-88" y="-36"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ctJEoDT3Eem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ctJEoTT3Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ctJEozT3Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_YCD1kDT3Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ctJEojT3Eem7cZ08OBDNGQ" x="1384" y="76"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KiW5wDT4Eem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KiW5wTT4Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KiW5wzT4Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_CMgpIDT4Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KiW5wjT4Eem7cZ08OBDNGQ" x="896" y="76"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MBDFUDT4Eem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MBDFUTT4Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MBDFUzT4Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_EhXnsDT4Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MBDFUjT4Eem7cZ08OBDNGQ" x="896" y="76"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9y2EwDT4Eem7cZ08OBDNGQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9y2EwjT4Eem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_8xBbYDT4Eem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9y2EwTT4Eem7cZ08OBDNGQ" x="384" y="248" width="297" height="29"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QoOZ4DT6Eem7cZ08OBDNGQ" type="Text" fontName="Segoe UI" description="&quot;job results&quot; / CurrentData; do we need these metrics in TAPI?">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QoPoADT6Eem7cZ08OBDNGQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QoPoATT6Eem7cZ08OBDNGQ" key="lineColor" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QoPoAjT6Eem7cZ08OBDNGQ" key="fontHeight" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QoPoAzT6Eem7cZ08OBDNGQ" key="bold" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QoPoBDT6Eem7cZ08OBDNGQ" key="italic" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QoPoBTT6Eem7cZ08OBDNGQ" key="fontColor" value="true"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QoPoBjT6Eem7cZ08OBDNGQ" key="fillColor" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:BasicDecorationNode" xmi:id="_QoPoBzT6Eem7cZ08OBDNGQ" type="DiagramName">
+        <element xsi:nil="true"/>
+      </children>
+      <children xmi:type="notation:BasicDecorationNode" xmi:id="_QoPoCDT6Eem7cZ08OBDNGQ" type="Description">
+        <element xsi:nil="true"/>
+      </children>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QoOZ4TT6Eem7cZ08OBDNGQ" x="128" y="544"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v-BYEDT6Eem7cZ08OBDNGQ" type="Class_Shape" fontColor="255" fillColor="12632256" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v-B_IDT6Eem7cZ08OBDNGQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v-B_ITT6Eem7cZ08OBDNGQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v-B_IjT6Eem7cZ08OBDNGQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v-B_IzT6Eem7cZ08OBDNGQ" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v-B_JDT6Eem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v-B_JTT6Eem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v-B_JjT6Eem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v-B_JzT6Eem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v-B_KDT6Eem7cZ08OBDNGQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v-B_KTT6Eem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v-B_KjT6Eem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v-B_KzT6Eem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v-B_LDT6Eem7cZ08OBDNGQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v-B_LTT6Eem7cZ08OBDNGQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v-B_LjT6Eem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v-B_LzT6Eem7cZ08OBDNGQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v-B_MDT6Eem7cZ08OBDNGQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v-B_MTT6Eem7cZ08OBDNGQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiLldp.uml#_oetG0DT6Eem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v-BYETT6Eem7cZ08OBDNGQ" x="-8" y="-64"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v-M-QzT6Eem7cZ08OBDNGQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v-M-RDT6Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v-M-RjT6Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oetG0DT6Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v-M-RTT6Eem7cZ08OBDNGQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xYej4DT6Eem7cZ08OBDNGQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_xYej4jT6Eem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_vfHOgDT6Eem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xYej4TT6Eem7cZ08OBDNGQ" x="-280" y="-56" height="25"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ObPvgDT7Eem7cZ08OBDNGQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ObQWkDT7Eem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_L9prsDT7Eem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ObPvgTT7Eem7cZ08OBDNGQ" x="240" y="8" height="17"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_GHIu0DT8Eem7cZ08OBDNGQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_GHIu0jT8Eem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_DlYjwDT8Eem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GHIu0TT8Eem7cZ08OBDNGQ" x="1120" y="448" width="337"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_38eVADT9Eem7cZ08OBDNGQ" type="Comment_Shape" fontColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_38eVAjT9Eem7cZ08OBDNGQ" type="Comment_BodyLabel"/>
+      <element xmi:type="uml:Comment" href="TapiLldp.uml#_1JjhcDT9Eem7cZ08OBDNGQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_38eVATT9Eem7cZ08OBDNGQ" x="328" y="-184" width="396"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_5D1xkzTkEem7cZ08OBDNGQ" name="diagram_compatibility_version" stringValue="1.3.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_5D1xlDTkEem7cZ08OBDNGQ"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_5D1xlTTkEem7cZ08OBDNGQ" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiLldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiLldp.uml#_q7K-4HkhEeiQ1uqYFXu0Kg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1xljTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1IATTkEem7cZ08OBDNGQ" target="_5D1IPjTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1xlzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xmDTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_9oJCAOypEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1xmTTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xmjTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xmzTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1xnDTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1IUjTkEem7cZ08OBDNGQ" target="_5D1IjzTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1xnTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xnjTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_5-xO8OymEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1xnzTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xoDTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xoTTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1xojTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1IATTkEem7cZ08OBDNGQ" target="_5D1IUjTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xozTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xpDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xpTTkEem7cZ08OBDNGQ" x="-111" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xpjTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xpzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xqDTkEem7cZ08OBDNGQ" x="-109" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xqTTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xqjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xqzTkEem7cZ08OBDNGQ" x="12" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xrDTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xrTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xrjTkEem7cZ08OBDNGQ" x="-13" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xrzTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xsDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xsTTkEem7cZ08OBDNGQ" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xsjTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xszTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xtDTkEem7cZ08OBDNGQ" x="-9" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1xtTTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1xuTTkEem7cZ08OBDNGQ" points="[886, 8, -643984, -643984]$[1232, 8, -643984, -643984]$[1232, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xujTkEem7cZ08OBDNGQ" id="(1.0,0.24)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xuzTkEem7cZ08OBDNGQ" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1xvDTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1xojTkEem7cZ08OBDNGQ" target="_5D1IozTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1xvTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xvjTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1xvzTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xwDTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xwTTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1xwjTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1IqzTkEem7cZ08OBDNGQ" target="_5D1I6DTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1xwzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1xxDTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_DR3jQOytEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1xxTTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xxjTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1xxzTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1xyDTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1IATTkEem7cZ08OBDNGQ" target="_5D1IqzTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xyTTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xyjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xyzTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xzDTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1xzTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1xzjTkEem7cZ08OBDNGQ" x="-4" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1xzzTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x0DTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x0TTkEem7cZ08OBDNGQ" x="51" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x0jTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x0zTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x1DTkEem7cZ08OBDNGQ" x="-51" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x1TTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x1jTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x1zTkEem7cZ08OBDNGQ" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x2DTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x2TTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x2jTkEem7cZ08OBDNGQ" x="-19" y="-15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1x2zTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_F9jtcOytEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1x3DTkEem7cZ08OBDNGQ" points="[784, -24, -643984, -643984]$[528, -24, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1x3TTkEem7cZ08OBDNGQ" id="(0.0,0.8)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1x3jTkEem7cZ08OBDNGQ" id="(1.0,0.32)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1x3zTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1I_DTkEem7cZ08OBDNGQ" target="_5D1JOTTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1x4DTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1x4TTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_FZdXUOysEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1x4jTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1x4zTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1x5DTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1x5TTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1IATTkEem7cZ08OBDNGQ" target="_5D1I_DTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x5jTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x5zTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x6DTkEem7cZ08OBDNGQ" x="96" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x6TTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x6jTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x6zTkEem7cZ08OBDNGQ" x="-522" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x7DTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x7TTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x7jTkEem7cZ08OBDNGQ" x="42" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x7zTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x8DTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x8TTkEem7cZ08OBDNGQ" x="-42" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x8jTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x8zTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x9DTkEem7cZ08OBDNGQ" x="11" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D1x9TTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D1x9jTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D1x9zTkEem7cZ08OBDNGQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1x-DTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_HhWQ4OysEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1x-TTkEem7cZ08OBDNGQ" points="[784, -80, -643984, -643984]$[-336, -80, -643984, -643984]$[-336, 440, -643984, -643984]$[88, 440, -643984, -643984]$[88, 568, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1x-jTkEem7cZ08OBDNGQ" id="(0.0,0.24)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1x-zTkEem7cZ08OBDNGQ" id="(0.5137614678899083,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D1x_DTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1JuDTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D1x_TTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D1x_jTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oeHiAOyuEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D1x_zTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D1yADTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29MDTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29MTTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1IATTkEem7cZ08OBDNGQ" target="_5D1JTTTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29MjTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29MzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29NDTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29NTTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29NjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29NzTkEem7cZ08OBDNGQ" x="-31" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29ODTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29OTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29OjTkEem7cZ08OBDNGQ" x="63" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29OzTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29PDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29PTTkEem7cZ08OBDNGQ" x="-63" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29PjTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29PzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29QDTkEem7cZ08OBDNGQ" x="9" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29QTTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29QjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29QzTkEem7cZ08OBDNGQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29RDTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_qub-0OyuEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29RTTkEem7cZ08OBDNGQ" points="[840, 84, -643984, -643984]$[840, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29RjTkEem7cZ08OBDNGQ" id="(0.56,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29RzTkEem7cZ08OBDNGQ" id="(0.5142857142857142,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29SDTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1vEzTkEem7cZ08OBDNGQ" target="_5D1vUDTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29STTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D29SjTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_2OmfQOzCEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29SzTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29TDTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29TTTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29TjTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1vZDTkEem7cZ08OBDNGQ" target="_5D1voTTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29TzTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D29UDTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_mE2_EOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29UTTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29UjTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29UzTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29VDTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1vEzTkEem7cZ08OBDNGQ" target="_5D1vZDTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29VTTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29VjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29VzTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29WDTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29WTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29WjTkEem7cZ08OBDNGQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29WzTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29XDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29XTTkEem7cZ08OBDNGQ" x="15" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29XjTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29XzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29YDTkEem7cZ08OBDNGQ" x="-18" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29YTTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29YjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29YzTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29ZDTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29ZTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29ZjTkEem7cZ08OBDNGQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29ZzTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_oixzAOzDEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29aDTkEem7cZ08OBDNGQ" points="[1000, 564, -643984, -643984]$[1000, 608, -643984, -643984]$[848, 608, -643984, -643984]$[848, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29aTTkEem7cZ08OBDNGQ" id="(0.24615384615384617,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29ajTkEem7cZ08OBDNGQ" id="(0.4740740740740741,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29azTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1vtTTkEem7cZ08OBDNGQ" target="_5D1v8jTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29bDTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D29bTTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_xfvzMOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29bjTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29bzTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29cDTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29cTTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1vtTTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29cjTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29czTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29dDTkEem7cZ08OBDNGQ" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29dTTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29djTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29dzTkEem7cZ08OBDNGQ" x="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29eDTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29eTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29ejTkEem7cZ08OBDNGQ" x="55" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29ezTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29fDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29fTTkEem7cZ08OBDNGQ" x="-55" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29fjTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29fzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29gDTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29gTTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29gjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29gzTkEem7cZ08OBDNGQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29hDTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_1m4AoOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29hTTkEem7cZ08OBDNGQ" points="[872, 276, -643984, -643984]$[872, 464, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29hjTkEem7cZ08OBDNGQ" id="(0.6285714285714286,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29hzTkEem7cZ08OBDNGQ" id="(0.5238095238095238,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29iDTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1wBjTkEem7cZ08OBDNGQ" target="_5D1wQzTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29iTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D29ijTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_OxoTsOzEEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29izTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29jDTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29jTTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29jjTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1vEzTkEem7cZ08OBDNGQ" target="_5D1wBjTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29jzTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29kDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29kTTkEem7cZ08OBDNGQ" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29kjTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29kzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29lDTkEem7cZ08OBDNGQ" x="-2" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29lTTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29ljTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29lzTkEem7cZ08OBDNGQ" x="29" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29mDTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29mTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29mjTkEem7cZ08OBDNGQ" x="-30" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29mzTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29nDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29nTTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29njTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29nzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29oDTkEem7cZ08OBDNGQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29oTTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_Se9hEOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29ojTkEem7cZ08OBDNGQ" points="[1064, 564, -643984, -643984]$[1064, 608, -643984, -643984]$[1184, 608, -643984, -643984]$[1184, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29ozTkEem7cZ08OBDNGQ" id="(0.7384615384615385,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29pDTkEem7cZ08OBDNGQ" id="(0.496551724137931,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29pTTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1vEzTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29pjTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29pzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29qDTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29qTTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29qjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29qzTkEem7cZ08OBDNGQ" x="13" y="-81"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29rDTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29rTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29rjTkEem7cZ08OBDNGQ" x="28" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29rzTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29sDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29sTTkEem7cZ08OBDNGQ" x="-28" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29sjTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29szTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29tDTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29tTTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29tjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29tzTkEem7cZ08OBDNGQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29uDTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_64-jsOzCEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29uTTkEem7cZ08OBDNGQ" points="[952, 276, -643984, -643984]$[952, 432, -643984, -643984]$[1032, 432, -643984, -643984]$[1032, 464, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29ujTkEem7cZ08OBDNGQ" id="(0.9142857142857143,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29uzTkEem7cZ08OBDNGQ" id="(0.49230769230769234,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29vDTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1wVzTkEem7cZ08OBDNGQ" target="_5D1wlDTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D29vTTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D29vjTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_8LSDoOzDEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29vzTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29wDTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29wTTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29wjTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1vEzTkEem7cZ08OBDNGQ" target="_5D1wVzTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29wzTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29xDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29xTTkEem7cZ08OBDNGQ" x="1" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29xjTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29xzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29yDTkEem7cZ08OBDNGQ" x="-1" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29yTTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29yjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29yzTkEem7cZ08OBDNGQ" x="32" y="-19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29zDTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29zTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29zjTkEem7cZ08OBDNGQ" x="-33" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29zzTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D290DTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D290TTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D290jTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D290zTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D291DTkEem7cZ08OBDNGQ" x="-9" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D291TTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_AkdqYOzEEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D291jTkEem7cZ08OBDNGQ" points="[1032, 564, -643984, -643984]$[1032, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D291zTkEem7cZ08OBDNGQ" id="(0.49230769230769234,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D292DTkEem7cZ08OBDNGQ" id="(0.4883720930232558,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D292TTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1wqDTkEem7cZ08OBDNGQ" target="_5D1w5TTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D292jTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D292zTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_j-O7sOzBEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D293DTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D293TTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D293jTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D293zTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1wqDTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D294DTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D294TTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D294jTkEem7cZ08OBDNGQ" x="-1" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D294zTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D295DTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D295TTkEem7cZ08OBDNGQ" x="8" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D295jTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D295zTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D296DTkEem7cZ08OBDNGQ" x="48" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D296TTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D296jTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D296zTkEem7cZ08OBDNGQ" x="-48" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D297DTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D297TTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D297jTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D297zTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D298DTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D298TTkEem7cZ08OBDNGQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D298jTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_ua-AUOzBEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D298zTkEem7cZ08OBDNGQ" points="[784, 276, -643984, -643984]$[784, 432, -643984, -643984]$[584, 432, -643984, -643984]$[584, 576, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D299DTkEem7cZ08OBDNGQ" id="(0.3142857142857143,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D299TTkEem7cZ08OBDNGQ" id="(0.56,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D299jTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1w-TTkEem7cZ08OBDNGQ" target="_5D1xNjTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D299zTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D29-DTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_vzXBgOy_EeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D29-TTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29-jTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D29-zTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D29_DTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1w-TTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D29_TTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D29_jTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D29_zTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-ADTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-ATTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-AjTkEem7cZ08OBDNGQ" x="-48" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-AzTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-BDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-BTTkEem7cZ08OBDNGQ" x="14" y="-52"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-BjTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-BzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-CDTkEem7cZ08OBDNGQ" x="-46" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-CTTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-CjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-CzTkEem7cZ08OBDNGQ" x="13" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-DDTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-DTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-DjTkEem7cZ08OBDNGQ" x="-9" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-DzTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_gsQqEOzAEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-EDTkEem7cZ08OBDNGQ" points="[728, 276, -643984, -643984]$[728, 392, -643984, -643984]$[464, 392, -643984, -643984]$[464, 576, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-ETTkEem7cZ08OBDNGQ" id="(0.11428571428571428,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-EjTkEem7cZ08OBDNGQ" id="(0.48,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-EzTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1IUjTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-FDTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-FTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-FjTkEem7cZ08OBDNGQ" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-FzTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-GDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-GTTkEem7cZ08OBDNGQ" x="2" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-GjTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-GzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-HDTkEem7cZ08OBDNGQ" x="61" y="-79"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-HTTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-HjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-HzTkEem7cZ08OBDNGQ" x="-66" y="-39"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-IDTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-ITTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-IjTkEem7cZ08OBDNGQ" x="7" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-IzTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-JDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-JTTkEem7cZ08OBDNGQ" x="-11" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-JjTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-KjTkEem7cZ08OBDNGQ" points="[976, 208, -643984, -643984]$[1184, 208, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-KzTkEem7cZ08OBDNGQ" id="(1.0,0.32)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-LDTkEem7cZ08OBDNGQ" id="(0.0,0.32)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-LTTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D2-EzTkEem7cZ08OBDNGQ" target="_5D1xSjTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-LjTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D2-LzTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiLldp.uml#_nP1poOyxEeiDgrJNY0AUOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-MDTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-MTTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-MjTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-MzTkEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_5D1xUjTkEem7cZ08OBDNGQ" target="_5D1xdjTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-NDTkEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5D2-NTTkEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Signal" href="TapiLldp.uml#_tiylcO1hEeig48nFftVy3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-NjTkEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-NzTkEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-ODTkEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-OTTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1xUjTkEem7cZ08OBDNGQ" target="_5D1I_DTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-OjTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-OzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-PDTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-PTTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-PjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-PzTkEem7cZ08OBDNGQ" x="-25" y="8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-QDTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-QTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-QjTkEem7cZ08OBDNGQ" x="16" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-QzTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-RDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-RTTkEem7cZ08OBDNGQ" x="-16" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-RjTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-RzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-SDTkEem7cZ08OBDNGQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-STTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-SjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-SzTkEem7cZ08OBDNGQ" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-TDTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_m4olIO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-TTTkEem7cZ08OBDNGQ" points="[153, 872, -643984, -643984]$[200, 872, -643984, -643984]$[200, 640, -643984, -643984]$[141, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-TjTkEem7cZ08OBDNGQ" id="(1.0,0.48)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-TzTkEem7cZ08OBDNGQ" id="(1.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-UDTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1xUjTkEem7cZ08OBDNGQ" target="_5D1I_DTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-UTTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-UjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-UzTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-VDTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-VTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-VjTkEem7cZ08OBDNGQ" x="-17" y="5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-VzTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-WDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-WTTkEem7cZ08OBDNGQ" x="13" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-WjTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-WzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-XDTkEem7cZ08OBDNGQ" x="-13" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-XTTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-XjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-XzTkEem7cZ08OBDNGQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-YDTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-YTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-YjTkEem7cZ08OBDNGQ" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-YzTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_MlJDMO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-ZDTkEem7cZ08OBDNGQ" points="[48, 824, -643984, -643984]$[48, 692, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-ZTTkEem7cZ08OBDNGQ" id="(0.20454545454545456,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-ZjTkEem7cZ08OBDNGQ" id="(0.14678899082568808,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-ZzTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1xUjTkEem7cZ08OBDNGQ" target="_5D1I_DTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-aDTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-aTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-ajTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-azTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-bDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-bTTkEem7cZ08OBDNGQ" x="6" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-bjTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-bzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-cDTkEem7cZ08OBDNGQ" x="30" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-cTTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-cjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-czTkEem7cZ08OBDNGQ" y="51"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-dDTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-dTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-djTkEem7cZ08OBDNGQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-dzTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-eDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-eTTkEem7cZ08OBDNGQ" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-ejTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_Z23_AO1iEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-ezTkEem7cZ08OBDNGQ" points="[128, 824, -643984, -643984]$[128, 692, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-fDTkEem7cZ08OBDNGQ" id="(0.8106060606060606,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-fTTkEem7cZ08OBDNGQ" id="(0.8807339449541285,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-fjTkEem7cZ08OBDNGQ" type="Association_Edge" source="_5D1xUjTkEem7cZ08OBDNGQ" target="_5D1I_DTkEem7cZ08OBDNGQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-fzTkEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-gDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-gTTkEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-gjTkEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-gzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-hDTkEem7cZ08OBDNGQ" x="6" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-hTTkEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-hjTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-hzTkEem7cZ08OBDNGQ" x="49" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-iDTkEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-iTTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-ijTkEem7cZ08OBDNGQ" x="-18" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-izTkEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-jDTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-jTTkEem7cZ08OBDNGQ" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5D2-jjTkEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5D2-jzTkEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5D2-kDTkEem7cZ08OBDNGQ" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-kTTkEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_43WC4O1hEeig48nFftVy3w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-kjTkEem7cZ08OBDNGQ" points="[21, 872, -643984, -643984]$[-24, 872, -643984, -643984]$[-24, 640, -643984, -643984]$[32, 640, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-kzTkEem7cZ08OBDNGQ" id="(0.0,0.48)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-lDTkEem7cZ08OBDNGQ" id="(0.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-lTTkEem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_5D1xhDTkEem7cZ08OBDNGQ" target="_5D2-fjTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-ljTkEem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-lzTkEem7cZ08OBDNGQ" points="[527, 315, -643984, -643984]$[96, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-mDTkEem7cZ08OBDNGQ" id="(0.0,0.5714285714285714)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-mTTkEem7cZ08OBDNGQ" id="(0.5028248587570622,0.35668789808917195)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-mjTkEem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_5D1xhzTkEem7cZ08OBDNGQ" target="_5D2-UDTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-mzTkEem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-nDTkEem7cZ08OBDNGQ" points="[474, 325, -643984, -643984]$[168, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-nTTkEem7cZ08OBDNGQ" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-njTkEem7cZ08OBDNGQ" id="(0.5191256830601093,0.3081761006289308)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-nzTkEem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_5D1xijTkEem7cZ08OBDNGQ" target="_5D2-ZzTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-oDTkEem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-oTTkEem7cZ08OBDNGQ" points="[562, 357, -643984, -643984]$[248, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-ojTkEem7cZ08OBDNGQ" id="(0.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-ozTkEem7cZ08OBDNGQ" id="(0.4634146341463415,0.8192771084337349)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5D2-pDTkEem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_5D1xjTTkEem7cZ08OBDNGQ" target="_5D2-OTTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5D2-pTTkEem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5D2-pjTkEem7cZ08OBDNGQ" points="[528, 399, -643984, -643984]$[312, 264, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-pzTkEem7cZ08OBDNGQ" id="(0.0,0.2962962962962963)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5D2-qDTkEem7cZ08OBDNGQ" id="(0.49238578680203043,0.8407079646017699)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rFU-EDTqEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_rEi68DTqEem7cZ08OBDNGQ" target="_rFTI4DTqEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rFU-ETTqEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rFVlITTqEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rFU-EjTqEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rFU-EzTqEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rFVlIDTqEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_AooHcTTrEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_AoZd8DTrEem7cZ08OBDNGQ" target="_AongYzTrEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_AooHcjTrEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AooHdjTrEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AooHczTrEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AooHdDTrEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AooHdTTrEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BWdd0DTrEem7cZ08OBDNGQ" type="Association_Edge" source="_rEi68DTqEem7cZ08OBDNGQ" target="_AoZd8DTrEem7cZ08OBDNGQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BWdd0zTrEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MBEmYDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BWdd1DTrEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BWdd1TTrEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MXgJYDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BWdd1jTrEem7cZ08OBDNGQ" x="3" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BWdd1zTrEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ms0SEDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BWdd2DTrEem7cZ08OBDNGQ" x="10" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BWdd2TTrEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_NFkwUDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BWdd2jTrEem7cZ08OBDNGQ" x="-10" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BWdd2zTrEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Nd6-4DTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BWdd3DTrEem7cZ08OBDNGQ" x="10" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BWdd3TTrEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_N0K7sDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BWdd3jTrEem7cZ08OBDNGQ" x="-10" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BWdd0TTrEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_wd3s4JsXEeid4dfn4JFJZg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BWdd0jTrEem7cZ08OBDNGQ" points="[162, 48, -643984, -643984]$[107, -38, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1GjYDTrEem7cZ08OBDNGQ" id="(0.4962962962962963,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1GjYTTrEem7cZ08OBDNGQ" id="(0.4962962962962963,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ei-dJDTrEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_EixBwDTrEem7cZ08OBDNGQ" target="_Ei-dIDTrEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ei-dJTTrEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ei-dKTTrEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ei-dJjTrEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ei-dJzTrEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ei-dKDTrEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FOzBUDTrEem7cZ08OBDNGQ" type="Association_Edge" source="_AoZd8DTrEem7cZ08OBDNGQ" target="_EixBwDTrEem7cZ08OBDNGQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FOzoYDTrEem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_OK7O0DTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FOzoYTTrEem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FOzoYjTrEem7cZ08OBDNGQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_OhX_8DTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FOzoYzTrEem7cZ08OBDNGQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FOzoZDTrEem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_O4Gd4DTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FOzoZTTrEem7cZ08OBDNGQ" x="12" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FOzoZjTrEem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PPXuYDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FOzoZzTrEem7cZ08OBDNGQ" x="-12" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FOzoaDTrEem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PlS7EDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FOzoaTTrEem7cZ08OBDNGQ" x="12" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FOzoajTrEem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P-uHsDTrEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FOzoazTrEem7cZ08OBDNGQ" x="-12" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_FOzBUTTrEem7cZ08OBDNGQ"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_-sPnoHMgEeeSiaQ95-6r9w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FOzBUjTrEem7cZ08OBDNGQ" points="[173, 218, -643984, -643984]$[107, -38, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1F8UDTrEem7cZ08OBDNGQ" id="(0.4962962962962963,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1F8UTTrEem7cZ08OBDNGQ" id="(0.4962962962962963,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CFXgUDTtEem7cZ08OBDNGQ" type="Abstraction_Edge" source="__Q08IDTsEem7cZ08OBDNGQ" target="_zQjoMDTsEem7cZ08OBDNGQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_CFXgUzTtEem7cZ08OBDNGQ" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GXI3gDTtEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CFYHYDTtEem7cZ08OBDNGQ" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CFYHYTTtEem7cZ08OBDNGQ" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GsrpsDTtEem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CFYHYjTtEem7cZ08OBDNGQ" x="1" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_CFXgUTTtEem7cZ08OBDNGQ" fontColor="255"/>
+      <element xmi:type="uml:Abstraction" href="TapiLldp.uml#_CFT18DTtEem7cZ08OBDNGQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CFXgUjTtEem7cZ08OBDNGQ" points="[-190, 112, -643984, -643984]$[-128, 112, -643984, -643984]$[-128, 104, -643984, -643984]$[-72, 104, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CxAeUDTtEem7cZ08OBDNGQ" id="(1.0,0.48)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CxAeUTTtEem7cZ08OBDNGQ" id="(0.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FKQ0tDTtEem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_CFXgUDTtEem7cZ08OBDNGQ" target="_FKQ0sDTtEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FKRbwDTtEem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKRbxDTtEem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_CFT18DTtEem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FKRbwTTtEem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKRbwjTtEem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKRbwzTtEem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YCG44DT3Eem7cZ08OBDNGQ" type="Abstraction_Edge" source="_5D1IUjTkEem7cZ08OBDNGQ" target="_rEi68DTqEem7cZ08OBDNGQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_YCHf8DT3Eem7cZ08OBDNGQ" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dS5dEDT3Eem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YCHf8TT3Eem7cZ08OBDNGQ" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_YCIHADT3Eem7cZ08OBDNGQ" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_doYk4DT3Eem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YCIHATT3Eem7cZ08OBDNGQ" x="-157" y="9"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_YCG44TT3Eem7cZ08OBDNGQ" fontColor="255"/>
+      <element xmi:type="uml:Abstraction" href="TapiLldp.uml#_YCD1kDT3Eem7cZ08OBDNGQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YCG44jT3Eem7cZ08OBDNGQ" points="[1200, 176, -643984, -643984]$[1200, 104, -643984, -643984]$[306, 104, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YveVMDT3Eem7cZ08OBDNGQ" id="(0.16,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YveVMTT3Eem7cZ08OBDNGQ" id="(1.0,0.5)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ctJrsDT3Eem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_YCG44DT3Eem7cZ08OBDNGQ" target="_ctJEoDT3Eem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ctJrsTT3Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ctJrtTT3Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_YCD1kDT3Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ctJrsjT3Eem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ctJrszT3Eem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ctJrtDT3Eem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CMjscDT4Eem7cZ08OBDNGQ" type="Abstraction_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_AoZd8DTrEem7cZ08OBDNGQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_CMkTgDT4Eem7cZ08OBDNGQ" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UhDXgDT4Eem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CMkTgTT4Eem7cZ08OBDNGQ" x="-91" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CMkTgjT4Eem7cZ08OBDNGQ" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_U3jL8DT4Eem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CMkTgzT4Eem7cZ08OBDNGQ" x="-92" y="9"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_CMjscTT4Eem7cZ08OBDNGQ" fontColor="255"/>
+      <element xmi:type="uml:Abstraction" href="TapiLldp.uml#_CMgpIDT4Eem7cZ08OBDNGQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CMjscjT4Eem7cZ08OBDNGQ" points="[696, 184, -643984, -643984]$[352, 184, -643984, -643984]$[352, 280, -643984, -643984]$[277, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C66nQDT4Eem7cZ08OBDNGQ" id="(0.0,0.08)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C67OUDT4Eem7cZ08OBDNGQ" id="(1.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EhaD8DT4Eem7cZ08OBDNGQ" type="Abstraction_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_EixBwDTrEem7cZ08OBDNGQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EhaD8zT4Eem7cZ08OBDNGQ" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_We9OoDT4Eem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EharADT4Eem7cZ08OBDNGQ" x="-151" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_EharATT4Eem7cZ08OBDNGQ" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_W6cQwDT4Eem7cZ08OBDNGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EharAjT4Eem7cZ08OBDNGQ" x="-156" y="9"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_EhaD8TT4Eem7cZ08OBDNGQ" fontColor="255"/>
+      <element xmi:type="uml:Abstraction" href="TapiLldp.uml#_EhXnsDT4Eem7cZ08OBDNGQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EhaD8jT4Eem7cZ08OBDNGQ" points="[696, 224, -643984, -643984]$[368, 224, -643984, -643984]$[368, 448, -643984, -643984]$[277, 448, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FOX3oDT4Eem7cZ08OBDNGQ" id="(0.0,0.48)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FOYesDT4Eem7cZ08OBDNGQ" id="(1.0,0.47)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KiXg0DT4Eem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_CMjscDT4Eem7cZ08OBDNGQ" target="_KiW5wDT4Eem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KiXg0TT4Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KiXg1TT4Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_CMgpIDT4Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KiXg0jT4Eem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KiXg0zT4Eem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KiXg1DT4Eem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MBDFVDT4Eem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_EhaD8DT4Eem7cZ08OBDNGQ" target="_MBDFUDT4Eem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MBDFVTT4Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MBDFWTT4Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiLldp.uml#_EhXnsDT4Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MBDFVjT4Eem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MBDFVzT4Eem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MBDFWDT4Eem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__LocoDT4Eem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_9y2EwDT4Eem7cZ08OBDNGQ" target="_5D1JTTTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="__LocoTT4Eem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__LocojT4Eem7cZ08OBDNGQ" points="[706, 308, -643984, -643984]$[756, 276, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AmJ54DT5Eem7cZ08OBDNGQ" id="(1.0,0.20512820512820512)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CqhlYDT5Eem7cZ08OBDNGQ" id="(0.0,0.72)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_M1Y24DT5Eem7cZ08OBDNGQ" type="Association_Edge" source="_5D1JTTTkEem7cZ08OBDNGQ" target="_5D1IqzTkEem7cZ08OBDNGQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_M1Zd8DT5Eem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M1Zd8TT5Eem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_M1Zd8jT5Eem7cZ08OBDNGQ" type="Association_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M1Zd8zT5Eem7cZ08OBDNGQ" x="60" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_M1Zd9DT5Eem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M1Zd9TT5Eem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_M1aFADT5Eem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M1aFATT5Eem7cZ08OBDNGQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_M1aFAjT5Eem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M1aFAzT5Eem7cZ08OBDNGQ" x="-46" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_M1aFBDT5Eem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M1aFBTT5Eem7cZ08OBDNGQ" x="36" y="-15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_M1Y24TT5Eem7cZ08OBDNGQ" fontColor="255"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_McRzUDT5Eem7cZ08OBDNGQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M1Y24jT5Eem7cZ08OBDNGQ" points="[736, 176, -643984, -643984]$[528, 16, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NonqoDT5Eem7cZ08OBDNGQ" id="(0.14285714285714285,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NonqoTT5Eem7cZ08OBDNGQ" id="(1.0,0.72)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v-M-RzT6Eem7cZ08OBDNGQ" type="StereotypeCommentLink" source="_v-BYEDT6Eem7cZ08OBDNGQ" target="_v-M-QzT6Eem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v-M-SDT6Eem7cZ08OBDNGQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v-M-TDT6Eem7cZ08OBDNGQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiLldp.uml#_oetG0DT6Eem7cZ08OBDNGQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v-M-STT6Eem7cZ08OBDNGQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v-M-SjT6Eem7cZ08OBDNGQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v-M-SzT6Eem7cZ08OBDNGQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zDIH0DT6Eem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_xYej4DT6Eem7cZ08OBDNGQ" target="_v-BYEDT6Eem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zDIH0TT6Eem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zDIH0jT6Eem7cZ08OBDNGQ" points="[-125, 3, -643984, -643984]$[-203, 5, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1kw-IDT6Eem7cZ08OBDNGQ" id="(1.0,0.5925925925925926)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1kw-ITT6Eem7cZ08OBDNGQ" id="(0.0,0.4)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BkYKwDT7Eem7cZ08OBDNGQ" type="Association_Edge" source="_v-BYEDT6Eem7cZ08OBDNGQ" target="_5D1IqzTkEem7cZ08OBDNGQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BkYKwzT7Eem7cZ08OBDNGQ" type="Association_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BkYKxDT7Eem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BkYKxTT7Eem7cZ08OBDNGQ" type="Association_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BkYKxjT7Eem7cZ08OBDNGQ" x="-5" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BkYKxzT7Eem7cZ08OBDNGQ" type="Association_TargetRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BkYKyDT7Eem7cZ08OBDNGQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BkYKyTT7Eem7cZ08OBDNGQ" type="Association_SourceRoleLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BkYKyjT7Eem7cZ08OBDNGQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BkYKyzT7Eem7cZ08OBDNGQ" type="Association_SourceMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BkYKzDT7Eem7cZ08OBDNGQ" x="-24" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BkYKzTT7Eem7cZ08OBDNGQ" type="Association_TargetMultiplicityLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BkYKzjT7Eem7cZ08OBDNGQ" x="25" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BkYKwTT7Eem7cZ08OBDNGQ" fontColor="255"/>
+      <element xmi:type="uml:Association" href="TapiLldp.uml#_BHdlQDT7Eem7cZ08OBDNGQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BkYKwjT7Eem7cZ08OBDNGQ" points="[168, -8, -643984, -643984]$[416, -8, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CfRswDT7Eem7cZ08OBDNGQ" id="(1.0,0.56)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CfRswTT7Eem7cZ08OBDNGQ" id="(0.0,0.48)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PxBPoDT7Eem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_ObPvgDT7Eem7cZ08OBDNGQ" target="_BkYKwDT7Eem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PxBPoTT7Eem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxBPojT7Eem7cZ08OBDNGQ" points="[583, 100, -643984, -643984]$[509, 110, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VzfvcDT7Eem7cZ08OBDNGQ" id="(0.384,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxCdwDT7Eem7cZ08OBDNGQ" id="(0.5335365853658537,0.49382716049382713)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_M_K9oDT8Eem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_GHIu0DT8Eem7cZ08OBDNGQ" target="_5D1vEzTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_M_K9oTT8Eem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M_K9ojT8Eem7cZ08OBDNGQ" points="[1144, 514, -643984, -643984]$[1098, 506, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q3suYDT8Eem7cZ08OBDNGQ" id="(0.0,0.41025641025641024)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uh5vQDT8Eem7cZ08OBDNGQ" id="(1.0,0.36)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__nCM8DT9Eem7cZ08OBDNGQ" type="Comment_AnnotatedElementEdge" source="_38eVADT9Eem7cZ08OBDNGQ" target="_5D1IqzTkEem7cZ08OBDNGQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="__nCM8TT9Eem7cZ08OBDNGQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__nCM8jT9Eem7cZ08OBDNGQ" points="[508, -97, -643984, -643984]$[492, -56, -643984, -643984]"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiLldp.uml
+++ b/UML/TapiLldp.uml
@@ -1,0 +1,1949 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenInterfaceModel_Profile="http:///schemas/OpenInterfaceModel_Profile/_3NKYsD78EeiIisB6uOvKFA/8" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_S30WUD8HEeiIisB6uOvKFA/26" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenInterfaceModel_Profile/_3NKYsD78EeiIisB6uOvKFA/8 UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_3NPRMD78EeiIisB6uOvKFA http:///schemas/OpenModel_Profile/_S30WUD8HEeiIisB6uOvKFA/26 UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S32LgD8HEeiIisB6uOvKFA">
+  <uml:Model xmi:id="_nPCrYHkhEeiQ1uqYFXu0Kg" name="TapiLldp">
+    <ownedComment xmi:type="uml:Comment" xmi:id="_s1zl8HkpEeiQ1uqYFXu0Kg" annotatedElement="_nPCrYHkhEeiQ1uqYFXu0Kg">
+      <body>https://github.com/YangModels/yang/blob/master/standard/ieee/802.1/draft/ieee802-dot1ab-lldp.yang&#xD;
+2018-11-15&#xD;
+&#xD;
+revision 2018-11-11 {&#xD;
+    description&#xD;
+      &quot;Separated out the lldp-types.&quot;;&#xD;
+    reference&#xD;
+      &quot;IEEE Std 802.1AB-2016&quot;;&#xD;
+  }</body>
+    </ownedComment>
+    <packageImport xmi:type="uml:PackageImport" xmi:id="_nVw-cHkhEeiQ1uqYFXu0Kg">
+      <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+    </packageImport>
+    <packagedElement xmi:type="uml:Package" xmi:id="_pq5p0HkhEeiQ1uqYFXu0Kg" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_7w9zEOyrEeiDgrJNY0AUOg" name="LldpHasBasicConfig" memberEnd="_7w-aIeyrEeiDgrJNY0AUOg _7xG9AOyrEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7w9zEeyrEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7w-aIOyrEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_7xG9AOyrEeiDgrJNY0AUOg" name="_lldp" type="_9oJCAOypEeiDgrJNY0AUOg" association="_7w9zEOyrEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_F9jtcOytEeiDgrJNY0AUOg" name="LldpHas LocalSystemData" memberEnd="_F9k7kuytEeiDgrJNY0AUOg _F9mJsuytEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_F9k7kOytEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_F9k7keytEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_F9mJsuytEeiDgrJNY0AUOg" name="_lldp" type="_9oJCAOypEeiDgrJNY0AUOg" association="_F9jtcOytEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_HhWQ4OysEeiDgrJNY0AUOg" name="LldpProvidesRemoteStatistics" memberEnd="_HhW38uysEeiDgrJNY0AUOg _HhYGEeysEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_HhW38OysEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_HhW38eysEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_HhYGEeysEeiDgrJNY0AUOg" name="_lldp" type="_9oJCAOypEeiDgrJNY0AUOg" association="_HhWQ4OysEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_qub-0OyuEeiDgrJNY0AUOg" name="LldpHasPortConfigData" memberEnd="_qucl4uyuEeiDgrJNY0AUOg _qudM8eyuEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qucl4OyuEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qucl4eyuEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_qudM8eyuEeiDgrJNY0AUOg" name="_lldp" type="_9oJCAOypEeiDgrJNY0AUOg" association="_qub-0OyuEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_oixzAOzDEeiDgrJNY0AUOg" memberEnd="_oiyaEuzDEeiDgrJNY0AUOg _oizBIuzDEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oiyaEOzDEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oiyaEezDEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_oizBIuzDEeiDgrJNY0AUOg" name="_remoteSystemsData" type="_2OmfQOzCEeiDgrJNY0AUOg" association="_oixzAOzDEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_1m4AoOyxEeiDgrJNY0AUOg" name="PortHasMgmtAddresses" memberEnd="_1m4nsOyxEeiDgrJNY0AUOg _1m5OweyxEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1m4AoeyxEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1m4AouyxEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_1m5OweyxEeiDgrJNY0AUOg" name="_port" type="_oeHiAOyuEeiDgrJNY0AUOg" association="_1m4AoOyxEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_Se9hEOzEEeiDgrJNY0AUOg" memberEnd="_Se-IIuzEEeiDgrJNY0AUOg _Se_WQuzEEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Se-IIOzEEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Se-IIezEEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Se_WQuzEEeiDgrJNY0AUOg" name="_remoteSystemsData" type="_2OmfQOzCEeiDgrJNY0AUOg" association="_Se9hEOzEEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_64-jsOzCEeiDgrJNY0AUOg" name="PortHasRemoteSystemData" memberEnd="_64_KwuzCEeiDgrJNY0AUOg _64_x0uzCEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_64_KwOzCEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_64_KwezCEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_64_x0uzCEeiDgrJNY0AUOg" name="_port" type="_oeHiAOyuEeiDgrJNY0AUOg" association="_64-jsOzCEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_AkdqYOzEEeiDgrJNY0AUOg" memberEnd="_AkeRcezEEeiDgrJNY0AUOg _Ake4guzEEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AkdqYezEEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AkeRcOzEEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Ake4guzEEeiDgrJNY0AUOg" name="_remoteSystemsData" type="_2OmfQOzCEeiDgrJNY0AUOg" association="_AkdqYOzEEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ua-AUOzBEeiDgrJNY0AUOg" name="PortHasRxStatistics" memberEnd="_ua-nYuzBEeiDgrJNY0AUOg _ua_1gOzBEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ua-nYOzBEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ua-nYezBEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ua_1gOzBEeiDgrJNY0AUOg" name="_port" type="_oeHiAOyuEeiDgrJNY0AUOg" association="_ua-AUOzBEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_gsQqEOzAEeiDgrJNY0AUOg" name="PortHasTxStatistics" memberEnd="_gsR4MuzAEeiDgrJNY0AUOg _gsSfQ-zAEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gsR4MOzAEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gsR4MezAEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_gsSfQ-zAEeiDgrJNY0AUOg" name="_port" type="_oeHiAOyuEeiDgrJNY0AUOg" association="_gsQqEOzAEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nP1poOyxEeiDgrJNY0AUOg" name="PortHasBasicConfig" memberEnd="_nP3e0OyxEeiDgrJNY0AUOg _nP5UAeyxEeiDgrJNY0AUOg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nP2QsOyxEeiDgrJNY0AUOg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nP23wOyxEeiDgrJNY0AUOg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nP5UAeyxEeiDgrJNY0AUOg" name="_port" type="_oeHiAOyuEeiDgrJNY0AUOg" association="_nP1poOyxEeiDgrJNY0AUOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_m4olIO1iEeig48nFftVy3w" name="RtcNotifiesRemoteAgeouts" memberEnd="_m4pMMu1iEeig48nFftVy3w _m4roc-1iEeig48nFftVy3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_m4pMMO1iEeig48nFftVy3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_m4pMMe1iEeig48nFftVy3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_0_VLQO4sEeiM3Nv4z8tz-w" annotatedElement="_m4olIO1iEeig48nFftVy3w">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-ageouts&quot;</body>
+        </ownedComment>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_m4roc-1iEeig48nFftVy3w" name="_remoteTableChange" type="_tiylcO1hEeig48nFftVy3w" association="_m4olIO1iEeig48nFftVy3w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_MlJDMO1iEeig48nFftVy3w" name="RtcNotifiesRemoteDeletes" memberEnd="_MlJqQu1iEeig48nFftVy3w _MlK4YO1iEeig48nFftVy3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MlJqQO1iEeig48nFftVy3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MlJqQe1iEeig48nFftVy3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_o0TY0O4sEeiM3Nv4z8tz-w" annotatedElement="_MlJDMO1iEeig48nFftVy3w">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-deletes&quot;</body>
+        </ownedComment>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MlK4YO1iEeig48nFftVy3w" name="_remoteTableChange" type="_tiylcO1hEeig48nFftVy3w" association="_MlJDMO1iEeig48nFftVy3w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_Z23_AO1iEeig48nFftVy3w" name="RtcNotifiesRemoteDrops" memberEnd="_Z24mEu1iEeig48nFftVy3w _Z25NI-1iEeig48nFftVy3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Z24mEO1iEeig48nFftVy3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Z24mEe1iEeig48nFftVy3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_u5ZHwO4sEeiM3Nv4z8tz-w" annotatedElement="_Z23_AO1iEeig48nFftVy3w">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-drops&quot;</body>
+        </ownedComment>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Z25NI-1iEeig48nFftVy3w" name="_remoteTableChange" type="_tiylcO1hEeig48nFftVy3w" association="_Z23_AO1iEeig48nFftVy3w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_43WC4O1hEeig48nFftVy3w" name="RtcNotifiesRemoteInserts" memberEnd="_43YfIO1hEeig48nFftVy3w _43fz4O1hEeig48nFftVy3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_43X4EO1hEeig48nFftVy3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_43X4Ee1hEeig48nFftVy3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_cS1cUO4sEeiM3Nv4z8tz-w" annotatedElement="_43WC4O1hEeig48nFftVy3w">
+          <body>path &quot;/lldp:lldp/lldp:remote-statistics/lldp:remote-inserts&quot;</body>
+        </ownedComment>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_43fz4O1hEeig48nFftVy3w" name="_remoteTableChange" type="_tiylcO1hEeig48nFftVy3w" association="_43WC4O1hEeig48nFftVy3w"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_q7K-4HkhEeiQ1uqYFXu0Kg" name="ClassDiagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_tE_yIHkhEeiQ1uqYFXu0Kg" name="Interfaces"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_ucUxcHkhEeiQ1uqYFXu0Kg" name="Notifications">
+      <packagedElement xmi:type="uml:Signal" xmi:id="_tiylcO1hEeig48nFftVy3w" name="RemoteTableChange">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_2mlrwO1iEeig48nFftVy3w" annotatedElement="_tiylcO1hEeig48nFftVy3w">
+          <body>A rem-table-change notification is sent when the value&#xD;
+       of remote-table-last-change-time changes.  It can be&#xD;
+       utilized by an NMS to trigger LLDP remote systems table&#xD;
+       maintenance polls.&#xD;
+&#xD;
+       Note that transmission of remote-table-change&#xD;
+       notifications are throttled by the agent, as specified by the&#xD;
+      'notification-interval' object.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_43YfIO1hEeig48nFftVy3w" name="_remoteInserts" type="_FZdXUOysEeiDgrJNY0AUOg" association="_43WC4O1hEeig48nFftVy3w">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_DxO9kO1iEeig48nFftVy3w" annotatedElement="_43YfIO1hEeig48nFftVy3w">
+            <body>The number of times the complete set of information&#xD;
+         advertised by a particular MSAP has been inserted into tables&#xD;
+         contained in remote-systems-data and lldpExtensions objects.&#xD;
+&#xD;
+         The complete set of information received from a particular&#xD;
+         MSAP should be inserted into related tables. If partial&#xD;
+         information cannot be inserted for a reason such as lack&#xD;
+         of resources, all of the complete set of information should&#xD;
+         be removed.&#xD;
+&#xD;
+         This counter should be incremented only once after the&#xD;
+         complete set of information is successfully recorded&#xD;
+         in all related tables.  Any failures during inserting&#xD;
+         information set which result in deletion of previously&#xD;
+         inserted information should not trigger any changes in&#xD;
+         inserts since the insert is not completed&#xD;
+         yet or or in deletes, since the deletion&#xD;
+         would only be a partial deletion. If the failure was the&#xD;
+         result of lack of resources, the drops&#xD;
+         counter should be incremented once.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_43aUUO1hEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_43dXoO1hEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MlJqQu1iEeig48nFftVy3w" name="_remoteDelete" type="_FZdXUOysEeiDgrJNY0AUOg" association="_MlJDMO1iEeig48nFftVy3w">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_W-dAYO1iEeig48nFftVy3w" annotatedElement="_MlJqQu1iEeig48nFftVy3w">
+            <body>The number of times the complete set of information&#xD;
+        advertised by a particular MSAP has been deleted from&#xD;
+        tables contained in remote-systems-data and lldpExtensions&#xD;
+        objects.&#xD;
+&#xD;
+        This counter should be incremented only once when the&#xD;
+        complete set of information is completely deleted from all&#xD;
+        related tables.  Partial deletions, such as deletion of&#xD;
+        rows associated with a particular MSAP from some tables,&#xD;
+        but not from all tables are not allowed, thus should not&#xD;
+        change the value of this counter.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MlKRUe1iEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MlKRUu1iEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Z24mEu1iEeig48nFftVy3w" name="_remoteDrops" type="_FZdXUOysEeiDgrJNY0AUOg" association="_Z23_AO1iEeig48nFftVy3w">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_izDP0O1iEeig48nFftVy3w" annotatedElement="_Z24mEu1iEeig48nFftVy3w">
+            <body>The number of times the complete set of information&#xD;
+         advertised by a particular MSAP could not be entered into&#xD;
+         tables contained in remote-systems-data and lldpExtensions&#xD;
+         objects because of insufficient resources.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Z25NIe1iEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Z25NIu1iEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_m4pMMu1iEeig48nFftVy3w" name="_remoteAgeouts" type="_FZdXUOysEeiDgrJNY0AUOg" association="_m4olIO1iEeig48nFftVy3w">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0iBL8O1iEeig48nFftVy3w" annotatedElement="_m4pMMu1iEeig48nFftVy3w">
+            <body>The number of times the complete set of information&#xD;
+         advertised by a particular MSAP has been deleted from tables&#xD;
+         contained in remote-systems-data and lldpExtensions objects&#xD;
+         because the information timeliness interval has expired.&#xD;
+&#xD;
+         This counter should be incremented only once when the complete&#xD;
+         set of information is completely invalidated (aged out)&#xD;
+         from all related tables.  Partial aging, similar to deletion&#xD;
+         case, is not allowed, and thus, should not change the value&#xD;
+         of this counter.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_m4roce1iEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_m4rocu1iEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_v9zLQHkhEeiQ1uqYFXu0Kg" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_5-xO8OymEeiDgrJNY0AUOg" name="LldpCfg">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_9W-g4OymEeiDgrJNY0AUOg" annotatedElement="_5-xO8OymEeiDgrJNY0AUOg">
+          <body>LLDP basic configuration group.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-iIFYOymEeiDgrJNY0AUOg" name="messageFastTx">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_SBRlsOynEeiDgrJNY0AUOg" annotatedElement="_-iIFYOymEeiDgrJNY0AUOg">
+            <body>This node indicates the time interval in timer&#xD;
+         ticks between transmissions during fast transmission&#xD;
+         periods(i.e., txFast is non-zero). &#xD;
+         &#xD;
+         The recommended default value of msgFastTx is 1;&#xD;
+         this value can be changed by management to any &#xD;
+         value in the range 1 through 3600.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DMzr0OynEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DM9c0OynEeiDgrJNY0AUOg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_QWp28OynEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VkFlIOynEeiDgrJNY0AUOg" name="messageTxHoldMultiplier">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_beGFcOynEeiDgrJNY0AUOg" annotatedElement="_VkFlIOynEeiDgrJNY0AUOg">
+            <body>This node is used, as a multiplier of msg-tx-interval, &#xD;
+         to determine the value of txTTL that is carried in LLDP &#xD;
+         frames transmitted by the LLDP agent. &#xD;
+&#xD;
+         The recommended default value of msgTxHold is 4; &#xD;
+         this value can be changed by management to any value in&#xD;
+         the range 2 through 10.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fPcQIOynEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fPpEcOynEeiDgrJNY0AUOg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_ej8cEOynEeiDgrJNY0AUOg" value="4"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nB6G4OynEeiDgrJNY0AUOg" name="messageTxInterval">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_mAHAwOypEeiDgrJNY0AUOg" value="30"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pWKBcOynEeiDgrJNY0AUOg" name="reinitDelay">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_n8DJAOypEeiDgrJNY0AUOg" value="2"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_r7x_4OynEeiDgrJNY0AUOg" name="txCreditMax">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_ps6psOypEeiDgrJNY0AUOg" value="5"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_uYlZgOynEeiDgrJNY0AUOg" name="txFastInit">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_rdEYsOypEeiDgrJNY0AUOg" value="4"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wu8z8OynEeiDgrJNY0AUOg" name="notificationInterval">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_tV2fQOypEeiDgrJNY0AUOg" value="30"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_9oJCAOypEeiDgrJNY0AUOg" name="Lldp">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_BcjHwOyqEeiDgrJNY0AUOg" annotatedElement="_9oJCAOypEeiDgrJNY0AUOg">
+          <body>Link Layer Discovery Protocol configuration and&#xD;
+  		 operational information.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7w-aIeyrEeiDgrJNY0AUOg" name="_lldpCfg" type="_5-xO8OymEeiDgrJNY0AUOg" aggregation="composite" association="_7w9zEOyrEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7w_oQOyrEeiDgrJNY0AUOg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7xDSoOyrEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HhW38uysEeiDgrJNY0AUOg" name="_remoteStatistics" type="_FZdXUOysEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_HhWQ4OysEeiDgrJNY0AUOg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_PySMUOysEeiDgrJNY0AUOg" annotatedElement="_HhW38uysEeiDgrJNY0AUOg">
+            <body>LLDP remote operational statistics data.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HhXfAeysEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HhYGEOysEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_F9k7kuytEeiDgrJNY0AUOg" name="_localSystemData" type="_DR3jQOytEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_F9jtcOytEeiDgrJNY0AUOg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_XI5YEOytEeiDgrJNY0AUOg" annotatedElement="_F9k7kuytEeiDgrJNY0AUOg">
+            <body>LLDP local system operational data.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_F9mJsOytEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_F9mJseytEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qucl4uyuEeiDgrJNY0AUOg" name="_port" type="_oeHiAOyuEeiDgrJNY0AUOg" aggregation="composite" association="_qub-0OyuEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qucl5eyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qudM8OyuEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_FZdXUOysEeiDgrJNY0AUOg" name="RemoteStatistics">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Q2jswOysEeiDgrJNY0AUOg" annotatedElement="_FZdXUOysEeiDgrJNY0AUOg">
+          <body>LLDP remote operational statistics data.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Syq0IOysEeiDgrJNY0AUOg" name="lastChangeTime" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_beR5YOysEeiDgrJNY0AUOg" annotatedElement="_Syq0IOysEeiDgrJNY0AUOg">
+            <body>The value of sysUpTime object (defined in IETF RFC 3418)&#xD;
+           at the time an entry is created, modified, or deleted in the&#xD;
+           in tables associated with the remote-systems-data objects&#xD;
+           and all LLDP extension objects associated with remote systems.&#xD;
+  &#xD;
+           An NMS can use this object to reduce polling of the&#xD;
+           remote-systems-data objects.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_iP8kI_ZaEeWhRf3FikFX5w"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nHrlcOysEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nH0vYOysEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_c1aEYOysEeiDgrJNY0AUOg" name="remoteInserts" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_izMRcOysEeiDgrJNY0AUOg" annotatedElement="_c1aEYOysEeiDgrJNY0AUOg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP has been inserted into tables&#xD;
+           contained in remote-systems-data and lldpExtensions objects.&#xD;
+  &#xD;
+           The complete set of information received from a particular&#xD;
+           MSAP should be inserted into related tables.  If partial&#xD;
+           information cannot be inserted for a reason such as lack&#xD;
+           of resources, all of the complete set of information should&#xD;
+           be removed.&#xD;
+  &#xD;
+           This counter should be incremented only once after the&#xD;
+           complete set of information is successfully recorded&#xD;
+           in all related tables.  Any failures during inserting&#xD;
+           information set which result in deletion of previously&#xD;
+           inserted information should not trigger any changes in&#xD;
+           inserts since the insert is not completed&#xD;
+           yet or or in deletes, since the deletion&#xD;
+           would only be a partial deletion. If the failure was the&#xD;
+           result of lack of resources, the drops&#xD;
+           counter should be incremented once.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_miemoOysEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_miueQOysEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qTTz8OysEeiDgrJNY0AUOg" name="remoteDeletes" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xTSd0OysEeiDgrJNY0AUOg" annotatedElement="_qTTz8OysEeiDgrJNY0AUOg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP has been deleted from&#xD;
+           tables contained in remote-systems-data and lldpExtensions&#xD;
+           objects.&#xD;
+  &#xD;
+           This counter should be incremented only once when the&#xD;
+           complete set of information is completely deleted from all&#xD;
+           related tables.  Partial deletions, such as deletion of&#xD;
+           rows associated with a particular MSAP from some tables,&#xD;
+           but not from all tables are not allowed, thus should not&#xD;
+           change the value of this counter.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sZdoIOysEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sZonQOysEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zbeSUOysEeiDgrJNY0AUOg" name="remoteDrops" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_19pUIOysEeiDgrJNY0AUOg" annotatedElement="_zbeSUOysEeiDgrJNY0AUOg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP could not be entered into&#xD;
+           tables contained in remote-systems-data and lldpExtensions&#xD;
+           objects because of insufficient resources.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5PffYOysEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5PzBYOysEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8C2-4OysEeiDgrJNY0AUOg" name="remoteAgeouts" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AqHd4OytEeiDgrJNY0AUOg" annotatedElement="_8C2-4OysEeiDgrJNY0AUOg">
+            <body>The number of times the complete set of information&#xD;
+           advertised by a particular MSAP has been deleted from tables&#xD;
+           contained in remote-systems-data and lldpExtensions objects&#xD;
+           because the information timeliness interval has expired.&#xD;
+  &#xD;
+           This counter should be incremented only once when the complete&#xD;
+           set of information is completely invalidated (aged out)&#xD;
+           from all related tables.  Partial aging, similar to deletion&#xD;
+           case, is not allowed, and thus, should not change the value&#xD;
+           of this counter.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-iHPkOysEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-iaKgOysEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_DR3jQOytEeiDgrJNY0AUOg" name="LocalSystemData">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Vr_8QOytEeiDgrJNY0AUOg" annotatedElement="_DR3jQOytEeiDgrJNY0AUOg">
+          <body>LLDP local system operational data.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ay_EMOytEeiDgrJNY0AUOg" name="chassisIdSubtype" type="_wCaMUDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_11GmsOytEeiDgrJNY0AUOg" annotatedElement="_ay_EMOytEeiDgrJNY0AUOg">
+            <body>The type of encoding used to identify the chassis&#xD;
+           associated with the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b9_pUOyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_b-HlIOyuEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dAongOytEeiDgrJNY0AUOg" name="chassisId" type="_2NWroDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3PLYAOytEeiDgrJNY0AUOg" annotatedElement="_dAongOytEeiDgrJNY0AUOg">
+            <body>The string value used to identify the chassis component&#xD;
+           associated with the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YoqsQOyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YozPIOyuEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ethAEOytEeiDgrJNY0AUOg" name="systemName" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4xSrAOytEeiDgrJNY0AUOg" annotatedElement="_ethAEOytEeiDgrJNY0AUOg">
+            <body>The string value used to identify the system name of the&#xD;
+           local system.  If the local agent supports IETF RFC 3418,&#xD;
+           system-name object should have the same value of sys-name&#xD;
+           object.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PiaSYOyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PiiOMOyuEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gmO1MOytEeiDgrJNY0AUOg" name="systemDescription" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6Kst8OytEeiDgrJNY0AUOg" annotatedElement="_gmO1MOytEeiDgrJNY0AUOg">
+            <body>The string value used to identify the system description&#xD;
+          of the local system.  If the local agent supports IETF RFC 3418,&#xD;
+          system-name object should have the same value of sys-desc&#xD;
+          object.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JE1yAOyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JE_jAOyuEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ieQGwOytEeiDgrJNY0AUOg" name="systemCapabilitiesSupported" type="_InDDwOyjEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7lppAOytEeiDgrJNY0AUOg" annotatedElement="_ieQGwOytEeiDgrJNY0AUOg">
+            <body>The bitmap value used to identify which system capabilities&#xD;
+           are supported on the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FMUBQOyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FMdLMOyuEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_k_ulAOytEeiDgrJNY0AUOg" name="systemCapabilitiesEnabled" type="_InDDwOyjEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_9E9foOytEeiDgrJNY0AUOg" annotatedElement="_k_ulAOytEeiDgrJNY0AUOg">
+            <body>The bitmap value used to identify which system capabilities&#xD;
+           are enabled on the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DDc3UOyuEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DDnPYOyuEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_oeHiAOyuEeiDgrJNY0AUOg" name="Port">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_0FQkQOyuEeiDgrJNY0AUOg" annotatedElement="_oeHiAOyuEeiDgrJNY0AUOg">
+          <body>LLDP configuration information for a particular port.&#xD;
+  &#xD;
+         This configuration parameter controls the transmission and&#xD;
+         the reception of LLDP frames on those ports whose rows are&#xD;
+         created in this table.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_k0IVkDQVEemgQ-i8ZByeIA" name="name?">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_HSvQEDQcEemgQ-i8ZByeIA" annotatedElement="_k0IVkDQVEemgQ-i8ZByeIA">
+            <body>name?&#xD;
+type if:interface-ref;&#xD;
+must &quot;deref(.)/../type = 'ianaift:ethernetCsmacd'&quot; &#xD;
++ &quot; or deref(.)/../type = 'ianaift:ieee8023adLag'&quot; {&#xD;
+error-message&#xD;
+&quot;The LLDP is only configured on Link Aggreagation&#xD;
+and Ethernet Port.&quot;;&#xD;
+}</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vcvrkOyvEeiDgrJNY0AUOg" name="destMacAddress">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0f_jAOyvEeiDgrJNY0AUOg" annotatedElement="_vcvrkOyvEeiDgrJNY0AUOg">
+            <body>The dest-mac-address specifies the destination MAC&#xD;
+           addresses.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_6-ftUC7jEem3g99vIRtESQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1da0kOyvEeiDgrJNY0AUOg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1dklkOyvEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_37HmEOyvEeiDgrJNY0AUOg" name="adminStatus" type="_6OfW4OyvEeiDgrJNY0AUOg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_PdrRcOywEeiDgrJNY0AUOg" annotatedElement="_37HmEOyvEeiDgrJNY0AUOg">
+            <body>The administratively desired status of the local LLDP agent.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AD314OywEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AEAYwOywEeiDgrJNY0AUOg" value="1"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_ZwSwwOywEeiDgrJNY0AUOg" type="_6OfW4OyvEeiDgrJNY0AUOg" instance="_KNuawOywEeiDgrJNY0AUOg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_loTgkOywEeiDgrJNY0AUOg" name="notificationEnable">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rpDiEOywEeiDgrJNY0AUOg" annotatedElement="_loTgkOywEeiDgrJNY0AUOg">
+            <body>The notification-enable controls, on a per&#xD;
+           port basis,  whether or not notifications from the agent&#xD;
+           are enabled. The value true(1) means that notifications are&#xD;
+           enabled; the value false(2) means that they are not.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_onf1kOywEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_onoYcOywEeiDgrJNY0AUOg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_p6pfgOywEeiDgrJNY0AUOg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tcbkMOywEeiDgrJNY0AUOg" name="tlvsTxEnable" type="_wcTOoOywEeiDgrJNY0AUOg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6fNeAOywEeiDgrJNY0AUOg" annotatedElement="_tcbkMOywEeiDgrJNY0AUOg">
+            <body>The tlvs-tx-enable, defined as a bitmap,&#xD;
+          includes the basic set of LLDP tlvs whose transmission is&#xD;
+          allowed on the local LLDP agent by the network management.&#xD;
+          Each bit in the bitmap corresponds to a tlv type associated&#xD;
+          with a specific optional tlv.&#xD;
+  &#xD;
+          It should be noted that the organizationally-specific tlvs&#xD;
+          are excluded from the lldptlvsTxEnable bitmap.&#xD;
+  &#xD;
+          LLDP Organization Specific Information Extension MIBs should&#xD;
+          have similar configuration object to control transmission&#xD;
+          of their organizationally defined tlvs.&#xD;
+  &#xD;
+          There is no bit reserved for the management address tlv type&#xD;
+          since transmission of management address tlvs are controlled&#xD;
+          by another object, man-addr-type.&#xD;
+  &#xD;
+          The default value for tlvs-tx-enable object is&#xD;
+          empty set, which means no enumerated values are set.&#xD;
+  &#xD;
+          The value of this object must be restored from non-volatile&#xD;
+          storage after a re-initialization of the management system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3ewkwOywEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3e35gOywEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nP3e0OyxEeiDgrJNY0AUOg" name="_lldpCfg" type="_5-xO8OymEeiDgrJNY0AUOg" aggregation="composite" association="_nP1poOyxEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nP4s8eyxEeiDgrJNY0AUOg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nP5UAOyxEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1m4nsOyxEeiDgrJNY0AUOg" name="_managementAddressTxPort" type="_xfvzMOyxEeiDgrJNY0AUOg" aggregation="composite" association="_1m4AoOyxEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1m4ns-yxEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1m5OwOyxEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hptbsOy-EeiDgrJNY0AUOg" name="portIdSubtype" type="_yUoGkDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8L1aEOy_EeiDgrJNY0AUOg" annotatedElement="_hptbsOy-EeiDgrJNY0AUOg">
+            <body>The type of port identifier encoding used in the associated&#xD;
+           'port-id' object.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_V0iSkOzAEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_V0q1cOzAEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_mMgcAOy_EeiDgrJNY0AUOg" name="portId" type="_5Ec0kDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_95OI8Oy_EeiDgrJNY0AUOg" annotatedElement="_mMgcAOy_EeiDgrJNY0AUOg">
+            <body>The string value used to identify the port component&#xD;
+           associated with a given port in the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Tzx7wOzAEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Tz7swOzAEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sPn1AOy_EeiDgrJNY0AUOg" name="portDesc" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__UHZoOy_EeiDgrJNY0AUOg" annotatedElement="_sPn1AOy_EeiDgrJNY0AUOg">
+            <body>The string value used to identify the 802 LAN station's port&#xD;
+           description associated with the local system.  If the local&#xD;
+           agent supports IETF RFC 2863, port-desc object should&#xD;
+           have the same value of ifDescr object.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AwR1oOzAEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Awdb0OzAEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gsR4MuzAEeiDgrJNY0AUOg" name="_txStatistics" type="_vzXBgOy_EeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_gsQqEOzAEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gsSfQezAEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gsSfQuzAEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ua-nYuzBEeiDgrJNY0AUOg" name="_rxStatistics" type="_j-O7sOzBEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_ua-AUOzBEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ua_OcezBEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ua_OcuzBEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_64_KwuzCEeiDgrJNY0AUOg" name="_remoteSystemsData" type="_2OmfQOzCEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_64-jsOzCEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_64_x0OzCEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_64_x0ezCEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_xfvzMOyxEeiDgrJNY0AUOg" name="ManagementAddressTxPort">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8rmAkOyxEeiDgrJNY0AUOg" annotatedElement="_xfvzMOyxEeiDgrJNY0AUOg">
+          <body>LLDP configuration information that specifies the set&#xD;
+           of ports (represented as a PortList) on which the local&#xD;
+           system management address instance will be transmitted.&#xD;
+      &#xD;
+           This configuration object augments the local-management-address,&#xD;
+           therefore it is only present along with the management&#xD;
+           address instance contained in the associated&#xD;
+           local-management-address entry.&#xD;
+      &#xD;
+           Each active man-address must be restored from&#xD;
+           non-volatile and re-created (along with the corresponding&#xD;
+           local-management-address) after a re-initialization of the&#xD;
+           management system.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Pvgg8OyzEeiDgrJNY0AUOg" name="addressSubtype" type="_757M4DObEemmfYv-bFFYSw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_S-QU4OyzEeiDgrJNY0AUOg" annotatedElement="_Pvgg8OyzEeiDgrJNY0AUOg">
+            <body>The management address subtype field shall contain an&#xD;
+             integer value indicating the type of address.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dabY0OyzEeiDgrJNY0AUOg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dam_AOyzEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LeTl8Oy9EeiDgrJNY0AUOg" name="manAddress" type="_Ui3yAOyiEeiDgrJNY0AUOg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_m-I_MOy9EeiDgrJNY0AUOg" annotatedElement="_LeTl8Oy9EeiDgrJNY0AUOg">
+            <body>The management address field shall contain an octet string&#xD;
+             indicating the particular management address associated&#xD;
+             with this TLV.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_D69T0Oy-EeiDgrJNY0AUOg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_D7F2sOy-EeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NobUIOy9EeiDgrJNY0AUOg" name="txEnable">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oig8AOy9EeiDgrJNY0AUOg" annotatedElement="_NobUIOy9EeiDgrJNY0AUOg">
+            <body>Specify to enable transmission of system&#xD;
+             management address instance on a particular port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_A4BuUOy-EeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_A4K4QOy-EeiDgrJNY0AUOg" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_Aa_NAOy-EeiDgrJNY0AUOg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_P3xgkOy9EeiDgrJNY0AUOg" name="addrLen" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qci_wOy9EeiDgrJNY0AUOg" annotatedElement="_P3xgkOy9EeiDgrJNY0AUOg">
+            <body>The total length of the management address subtype and the&#xD;
+             management address fields in LLDPDUs transmitted by the&#xD;
+             local LLDP agent.&#xD;
+        &#xD;
+             The management address length field is needed so that the&#xD;
+             receiving systems that do not implement SNMP will not be&#xD;
+             required to implement an iana family numbers/address length&#xD;
+             equivalency table in order to decode the management adress.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9HZVUOy9EeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9Hh4MOy9EeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_SfqI0Oy9EeiDgrJNY0AUOg" name="ifSubtype" type="_2TDkcOyhEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_r6j14Oy9EeiDgrJNY0AUOg" annotatedElement="_SfqI0Oy9EeiDgrJNY0AUOg">
+            <body>The enumeration value that identifies the interface numbering&#xD;
+             method used for defining the interface number, associated&#xD;
+             with the local system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6V7TQOy9EeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6WD2IOy9EeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UED60Oy9EeiDgrJNY0AUOg" name="ifId" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_teg78Oy9EeiDgrJNY0AUOg" annotatedElement="_UED60Oy9EeiDgrJNY0AUOg">
+            <body>The integer value used to identify the interface number&#xD;
+             regarding the management address component associated with&#xD;
+             the local system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYEE0Oy9EeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYNOwOy9EeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_vzXBgOy_EeiDgrJNY0AUOg" name="TxStatistics">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KQTk8OzBEeiDgrJNY0AUOg" annotatedElement="_vzXBgOy_EeiDgrJNY0AUOg">
+          <body>LLDP frame transmission statistics for a particular port.  &#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_OSzxEOzBEeiDgrJNY0AUOg" name="totalFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Y0Ae8OzBEeiDgrJNY0AUOg" annotatedElement="_OSzxEOzBEeiDgrJNY0AUOg">
+            <body>A count of all LLDP frames transmitted through the port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qp0p8OzBEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qqBeQOzBEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QZCdwOzBEeiDgrJNY0AUOg" name="totalLengthErrors" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_aFkNcOzBEeiDgrJNY0AUOg" annotatedElement="_QZCdwOzBEeiDgrJNY0AUOg">
+            <body>A count of all LLDP length errors detected when constructing&#xD;
+            LLPDU frames for transmission through the port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rOOXgOzBEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rOYIgOzBEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_j-O7sOzBEeiDgrJNY0AUOg" name="RxStatistics">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_j-O7sezBEeiDgrJNY0AUOg" annotatedElement="_j-O7sOzBEeiDgrJNY0AUOg">
+          <body>LLDP frame reception statistics for a particular port.&#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_j-O7suzBEeiDgrJNY0AUOg" name="totalAgeouts" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_j-O7s-zBEeiDgrJNY0AUOg" annotatedElement="_j-O7suzBEeiDgrJNY0AUOg">
+            <body>A count of the times that a neighbor’s information&#xD;
+             is deleted from the LLDP remote systems MIB because&#xD;
+             of rxInfoTTL timer expiration.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_srGlMOzBEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_srUAkOzBEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_j-O7tOzBEeiDgrJNY0AUOg" name="totalDiscardedFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_j-O7tezBEeiDgrJNY0AUOg" annotatedElement="_j-O7tOzBEeiDgrJNY0AUOg">
+            <body>A count of all LLDPDUs received and then discarded.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tR9J0OzBEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tSG60OzBEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RoIRoOzCEeiDgrJNY0AUOg" name="errorFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_k9uNUOzCEeiDgrJNY0AUOg" annotatedElement="_RoIRoOzCEeiDgrJNY0AUOg">
+            <body>A count of all LLDPDUs received at the port with one or more&#xD;
+             detectable errors.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vfQSYOzCEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vfaDYOzCEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_T8jLUOzCEeiDgrJNY0AUOg" name="totalFrames" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mDaDAOzCEeiDgrJNY0AUOg" annotatedElement="_T8jLUOzCEeiDgrJNY0AUOg">
+            <body>A count of all LLDP frames received at the port.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tG-zcOzCEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tHJykOzCEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WEjZoOzCEeiDgrJNY0AUOg" name="totalDiscardedTlvs" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_nL0ckOzCEeiDgrJNY0AUOg" annotatedElement="_WEjZoOzCEeiDgrJNY0AUOg">
+            <body>A count of all TLVs received at the port and discarded for any&#xD;
+             reason.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rmtTgOzCEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rm3EgOzCEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YshhcOzCEeiDgrJNY0AUOg" name="totalUnrecognizedTlvs" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_onctEOzCEeiDgrJNY0AUOg" annotatedElement="_YshhcOzCEeiDgrJNY0AUOg">
+            <body>This counter provides a count of all TLVs not recognized by&#xD;
+             the receiving LLDP local agent.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pjyZgOzCEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pj8KgOzCEeiDgrJNY0AUOg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_2OmfQOzCEeiDgrJNY0AUOg" name="RemoteSystemsData">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_EffyAOzDEeiDgrJNY0AUOg" annotatedElement="_2OmfQOzCEeiDgrJNY0AUOg">
+          <body>Information about a particular physical network connection.&#xD;
+           Entries may be created and deleted in this table by the agent,&#xD;
+           if a physical topology discovery process is active.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_G0WJgOzDEeiDgrJNY0AUOg" name="timeMark" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_huJscOziEeig48nFftVy3w" annotatedElement="_G0WJgOzDEeiDgrJNY0AUOg">
+            <body>A TimeFilter for this entry.  See the TimeFilter textual&#xD;
+             convention in IETF RFC 2021 and &#xD;
+             http://www.ietf.org/IESG/Implementations/RFC2021-Implementation.txt&#xD;
+             to see how TimeFilter works.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_vK1_AC9lEem3g99vIRtESQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_I6Xa0OzDEeiDgrJNY0AUOg" name="remoteIndex" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jSjecOziEeig48nFftVy3w" annotatedElement="_I6Xa0OzDEeiDgrJNY0AUOg">
+            <body>This object represents an arbitrary local integer value used&#xD;
+             by this agent to identify a particular connection instance,&#xD;
+             unique only for the indicated remote system.&#xD;
+            &#xD;
+             An agent is encouraged to assign monotonically increasing&#xD;
+             index values to new entries, starting with one, after each&#xD;
+             reboot.  It is considered unlikely that the index&#xD;
+             will wrap between reboots.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qHeAAO1fEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qHjfkO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_K_8nQOzDEeiDgrJNY0AUOg" name="chassisIdSubtype" type="_wCaMUDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_kv8pgOziEeig48nFftVy3w" annotatedElement="_K_8nQOzDEeiDgrJNY0AUOg">
+            <body>The type of encoding used to identify the chassis associated&#xD;
+             with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_n1_soO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_n2DXAO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NWSMgOzDEeiDgrJNY0AUOg" name="chassisId" type="_2NWroDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mm0EgOziEeig48nFftVy3w" annotatedElement="_NWSMgOzDEeiDgrJNY0AUOg">
+            <body>The string value used to identify the chassis component&#xD;
+             associated with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lhesUO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lhiWsO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PYi_MOzDEeiDgrJNY0AUOg" name="portIdSubtype" type="_yUoGkDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_n6tVUOziEeig48nFftVy3w" annotatedElement="_PYi_MOzDEeiDgrJNY0AUOg">
+            <body>The type of port identifier encoding used in the associated&#xD;
+            'port-id' object.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hUV9gO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hUZn4O1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TX9bEOzDEeiDgrJNY0AUOg" name="portId" type="_5Ec0kDObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pKpTMOziEeig48nFftVy3w" annotatedElement="_TX9bEOzDEeiDgrJNY0AUOg">
+            <body>The string value used to identify the port component&#xD;
+             associated with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eKoakO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eKtTEO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VWSwAOzDEeiDgrJNY0AUOg" name="portDesc" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qgz04OziEeig48nFftVy3w" annotatedElement="_VWSwAOzDEeiDgrJNY0AUOg">
+            <body>The string value used to identify the description of&#xD;
+             the given port associated with the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bAMe4O1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bAQwUO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XLNqQOzDEeiDgrJNY0AUOg" name="systemName" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sbmtoOziEeig48nFftVy3w" annotatedElement="_XLNqQOzDEeiDgrJNY0AUOg">
+            <body>The string value used to identify the system name of the&#xD;
+             remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZIDRgO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZIIKAO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZHiNAOzDEeiDgrJNY0AUOg" name="systemDescription" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_uZwcYOziEeig48nFftVy3w" annotatedElement="_ZHiNAOzDEeiDgrJNY0AUOg">
+            <body>The string value used to identify the system description&#xD;
+             of the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WqEzMO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WqMH8O1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_bedoIOzDEeiDgrJNY0AUOg" name="systemCapabilitiesSupported" type="_InDDwOyjEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wDMfYOziEeig48nFftVy3w" annotatedElement="_bedoIOzDEeiDgrJNY0AUOg">
+            <body>The bitmap value used to identify which system &#xD;
+              capabilities are supported on the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TxakAO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TxfcgO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gc20wOzDEeiDgrJNY0AUOg" name="systemCapabilitiesEnabled" type="_InDDwOyjEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xbVXAOziEeig48nFftVy3w" annotatedElement="_gc20wOzDEeiDgrJNY0AUOg">
+            <body>The bitmap value used to identify which system capabilities&#xD;
+             are enabled on the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rc5jsO1fEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RdARYO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oiyaEuzDEeiDgrJNY0AUOg" name="_managementAddress" type="_mE2_EOzDEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_oixzAOzDEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oizBIOzDEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oizBIezDEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AkeRcezEEeiDgrJNY0AUOg" name="_remoteUnknownTlv" type="_8LSDoOzDEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_AkdqYOzEEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ake4gOzEEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ake4gezEEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Se-IIuzEEeiDgrJNY0AUOg" name="_remoteOrgDefinedInfo" type="_OxoTsOzEEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_Se9hEOzEEeiDgrJNY0AUOg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Se_WQOzEEeiDgrJNY0AUOg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Se_WQezEEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+        <nestedClassifier xmi:type="uml:Class" xmi:id="_2itHAOzCEeiDgrJNY0AUOg" name="TxStatistics">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2itHAezCEeiDgrJNY0AUOg" annotatedElement="_2itHAOzCEeiDgrJNY0AUOg">
+            <body>LLDP frame transmission statistics for a particular port.  &#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_2itHAuzCEeiDgrJNY0AUOg" name="totalFrames">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_2itHA-zCEeiDgrJNY0AUOg" annotatedElement="_2itHAuzCEeiDgrJNY0AUOg">
+              <body>A count of all LLDP frames transmitted through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_2itHBOzCEeiDgrJNY0AUOg" name="totalLengthErrors">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_2itHBezCEeiDgrJNY0AUOg" annotatedElement="_2itHBOzCEeiDgrJNY0AUOg">
+              <body>A count of all LLDP length errors detected when constructing&#xD;
+            LLPDU frames for transmission through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+        </nestedClassifier>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_mE2_EOzDEeiDgrJNY0AUOg" name="ManagementAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_zhqKUOziEeig48nFftVy3w" annotatedElement="_mE2_EOzDEeiDgrJNY0AUOg">
+          <body>Management address information about a particular chassis&#xD;
+             component.  There may be multiple management addresses&#xD;
+             configured on the remote system identified by a particular&#xD;
+             index whose information is received on&#xD;
+             port-num of the local system.  Each management&#xD;
+             address should have distinct 'management address&#xD;
+             type' (subtype) and 'management address'&#xD;
+            (address.)&#xD;
+        &#xD;
+             Entries may be created and deleted in this table by the&#xD;
+             agent.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zPhpkOzDEeiDgrJNY0AUOg" name="addressSubtype" type="_757M4DObEemmfYv-bFFYSw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0-mCYOziEeig48nFftVy3w" annotatedElement="_zPhpkOzDEeiDgrJNY0AUOg">
+            <body>The type of management address identifier encoding used in&#xD;
+               the associated 'lldpRemManagmentAddr' object.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BakvkO1fEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BapoEO1fEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1G1wgOzDEeiDgrJNY0AUOg" name="address" type="_Ui3yAOyiEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2QP3gOziEeig48nFftVy3w" annotatedElement="_1G1wgOzDEeiDgrJNY0AUOg">
+            <body>The string value used to identify the management address&#xD;
+               component associated with the remote system.  The purpose&#xD;
+               of this address is to contact the management entity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-R_OAO1eEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-SDfcO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3eYPoOzDEeiDgrJNY0AUOg" name="ifSubtype" type="_2TDkcOyhEeiDgrJNY0AUOg" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4CFokOziEeig48nFftVy3w" annotatedElement="_3eYPoOzDEeiDgrJNY0AUOg">
+            <body>The enumeration value that identifies the interface numbering&#xD;
+               method used for defining the interface number, associated&#xD;
+               with the remote system.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ybCOIO1eEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ybHtsO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_46-wgOzDEeiDgrJNY0AUOg" name="ifId" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5ZIUAOziEeig48nFftVy3w" annotatedElement="_46-wgOzDEeiDgrJNY0AUOg">
+            <body>The integer value used to identify the interface number&#xD;
+               regarding the management address component associated with&#xD;
+               the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vWgGIO1eEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vWmMwO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <nestedClassifier xmi:type="uml:Class" xmi:id="_mYQcMOzDEeiDgrJNY0AUOg" name="TxStatistics">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mYQcMezDEeiDgrJNY0AUOg" annotatedElement="_mYQcMOzDEeiDgrJNY0AUOg">
+            <body>LLDP frame transmission statistics for a particular port.  &#xD;
+           The port must be contained in the same chassis as the&#xD;
+           LLDP agent.&#xD;
+  &#xD;
+           All counter values in a particular entry shall be&#xD;
+           maintained on a continuing basis and shall not be deleted&#xD;
+           upon expiration of rxInfoTTL timing counters in the LLDP&#xD;
+           remote systems MIB of the receipt of a shutdown frame from&#xD;
+           a remote LLDP agent.&#xD;
+  &#xD;
+           All statistical counters associated with a particular&#xD;
+           port on the local LLDP agent become frozen whenever the&#xD;
+           adminStatus is disabled for the same port.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_mYQcMuzDEeiDgrJNY0AUOg" name="totalFrames">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_mYQcM-zDEeiDgrJNY0AUOg" annotatedElement="_mYQcMuzDEeiDgrJNY0AUOg">
+              <body>A count of all LLDP frames transmitted through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_mYQcNOzDEeiDgrJNY0AUOg" name="totalLengthErrors">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_mYQcNezDEeiDgrJNY0AUOg" annotatedElement="_mYQcNOzDEeiDgrJNY0AUOg">
+              <body>A count of all LLDP length errors detected when constructing&#xD;
+            LLPDU frames for transmission through the port.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_gxc3U1DOEeWpFusmeDrF3w"/>
+          </ownedAttribute>
+        </nestedClassifier>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_8LSDoOzDEeiDgrJNY0AUOg" name="RemoteUnknownTlv">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_6-MNUOziEeig48nFftVy3w" annotatedElement="_8LSDoOzDEeiDgrJNY0AUOg">
+          <body>Information about an unrecognized tlv received from a&#xD;
+             physical network connection.  Entries may be created and&#xD;
+             deleted in this table by the agent, if a physical topology&#xD;
+             discovery process is active.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HN6DkOzEEeiDgrJNY0AUOg" name="tlvType" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8SaOQOziEeig48nFftVy3w" annotatedElement="_HN6DkOzEEeiDgrJNY0AUOg">
+            <body>This object represents the value extracted from the type&#xD;
+               field of the tlv.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_r8AVMO1eEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_r8F0wO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KCr4UOzEEeiDgrJNY0AUOg" name="tlvInfo" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_-AlnUOziEeig48nFftVy3w" annotatedElement="_KCr4UOzEEeiDgrJNY0AUOg">
+            <body>This object represents the value extracted from the value&#xD;
+               field of the tlv.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXICEO1eEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXOIsO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_OxoTsOzEEeiDgrJNY0AUOg" name="RemoteOrgDefinedInfo">
+        <ownedComment xmi:type="uml:Comment" xmi:id="__dgRQOziEeig48nFftVy3w" annotatedElement="_OxoTsOzEEeiDgrJNY0AUOg">
+          <body>Information about the unrecognized organizationally&#xD;
+             defined information advertised by the remote system.&#xD;
+             The time-mark, port-num, index,&#xD;
+             info-identifier, info-subtype, and&#xD;
+             info-index are indexes to this table.  If there is&#xD;
+             an remote-org-defined-info associated with a particular remote&#xD;
+             system identified by the port-num and index,&#xD;
+             there must be an remote associated with the same&#xD;
+             instance (i.e, using same indexes.)  When the remote&#xD;
+             for the same index is removed from the lldpRemTable, the&#xD;
+             associated remote-org-defined-info should be removed from&#xD;
+             the remote-org-defined-infoTable.&#xD;
+            &#xD;
+             Entries may be created and deleted in this table by the&#xD;
+             agent.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dpIeAOzFEeiDgrJNY0AUOg" name="infoIdentifier" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_A8f-0OzjEeig48nFftVy3w" annotatedElement="_dpIeAOzFEeiDgrJNY0AUOg">
+            <body>The Organizationally Unique Identifier (OUI), as defined&#xD;
+               in IEEE std 802-2001, is a 24 bit (three octets) globally&#xD;
+               unique assigned number referenced by various standards,&#xD;
+               of the information received from the remote system.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mh7SIO1eEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_miD1AO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_f1PJMOzFEeiDgrJNY0AUOg" name="infoSubtype" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_CuI7kOzjEeig48nFftVy3w" annotatedElement="_f1PJMOzFEeiDgrJNY0AUOg">
+            <body>The integer value used to identify the subtype of the&#xD;
+               organizationally defined information received from the&#xD;
+               remote system.&#xD;
+        &#xD;
+               The subtype value is required to identify different instances&#xD;
+               of organizationally defined information that could not be&#xD;
+               retrieved without a unique identifier that indicates the&#xD;
+               particular type of information contained in the information&#xD;
+               string.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kSQ8oO1eEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kSXDQO1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iy3_AOzFEeiDgrJNY0AUOg" name="infoIndex" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EEAiUOzjEeig48nFftVy3w" annotatedElement="_iy3_AOzFEeiDgrJNY0AUOg">
+            <body>This object represents an arbitrary local integer value&#xD;
+               used by this agent to identify a particular unrecognized&#xD;
+               organizationally defined information instance, unique only&#xD;
+               for the info-identifier and info-subtype&#xD;
+               from the same remote system.&#xD;
+        &#xD;
+               An agent is encouraged to assign monotonically increasing&#xD;
+               index values to new entries, starting with one, after each&#xD;
+               reboot.  It is considered unlikely that the&#xD;
+               info-index will wrap between reboots.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hwaq8O1eEeig48nFftVy3w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hwj04O1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lF5KgOzFEeiDgrJNY0AUOg" name="remoteInfo" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_FiYk0OzjEeig48nFftVy3w" annotatedElement="_lF5KgOzFEeiDgrJNY0AUOg">
+            <body>The string value used to identify the organizationally&#xD;
+               defined information of the remote system.  The encoding for&#xD;
+               this object should be as defined for SnmpAdminString TC.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ex_yAO1eEeig48nFftVy3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eyHt0O1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_Y5NcAHkmEeiQ1uqYFXu0Kg" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_2TDkcOyhEeiDgrJNY0AUOg" name="ManAddrIfSubtype" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Lj99UOyiEeiDgrJNY0AUOg" annotatedElement="_2TDkcOyhEeiDgrJNY0AUOg">
+          <body>This is the basis of a particular type of&#xD;
+       interface associated with the management address.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8ZNqYOyhEeiDgrJNY0AUOg" name="unknown">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KHuo0OyiEeiDgrJNY0AUOg" annotatedElement="_8ZNqYOyhEeiDgrJNY0AUOg">
+            <body>The subtype 'unknown(1)' represents the case where the&#xD;
+           interface is not known.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_8ZORcOyhEeiDgrJNY0AUOg" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__Dam0OyhEeiDgrJNY0AUOg" name="port-ref">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_IqG0QOyiEeiDgrJNY0AUOg" annotatedElement="__Dam0OyhEeiDgrJNY0AUOg">
+            <body>The subtype 'port-ref(2)' represents interface identifier&#xD;
+           based on the port-ref MIB object.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="__Dam0eyhEeiDgrJNY0AUOg" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_EEVjAOyiEeiDgrJNY0AUOg" name="system-port-number">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_HJgkMOyiEeiDgrJNY0AUOg" annotatedElement="_EEVjAOyiEeiDgrJNY0AUOg">
+            <body>The subtype 'system-port-number(3)' represents interface&#xD;
+           identifier based on the system port numbering convention.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_EEVjAeyiEeiDgrJNY0AUOg" value="3"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_Ui3yAOyiEeiDgrJNY0AUOg" name="ManAddrType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_D0degOyjEeiDgrJNY0AUOg" annotatedElement="_Ui3yAOyiEeiDgrJNY0AUOg">
+          <body>The value of a management address associated with the LLDP&#xD;
+       agent that may be used to reach higher layer entities to&#xD;
+       assist discovery by network management.&#xD;
+       &#xD;
+       It should be noted that appropriate security credentials,&#xD;
+       such as SNMP engineId, may be required to access the LLDP&#xD;
+       agent using a management address.  These necessary credentials&#xD;
+       should be known by the network management and the objects&#xD;
+       associated with the credentials are not included in the&#xD;
+       LLDP agent.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XhgtYOyiEeiDgrJNY0AUOg" name="manAddrType">
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_InDDwOyjEeiDgrJNY0AUOg" name="SystemCapabilitiesMap">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_k7tMMOyjEeiDgrJNY0AUOg" annotatedElement="_InDDwOyjEeiDgrJNY0AUOg">
+          <body>This describes system capabilities.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QU9xsOyjEeiDgrJNY0AUOg" name="other">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3wUhwOyjEeiDgrJNY0AUOg" annotatedElement="_QU9xsOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has capabilities&#xD;
+           other than those listed below.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RflKsOyjEeiDgrJNY0AUOg" name="repeater">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2Dt2AOyjEeiDgrJNY0AUOg" annotatedElement="_RflKsOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has repeater&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_So0DoOyjEeiDgrJNY0AUOg" name="bridge">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0zoHIOyjEeiDgrJNY0AUOg" annotatedElement="_So0DoOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has bridge&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UE5AEOyjEeiDgrJNY0AUOg" name="wlanAccessPoint">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_zbhEsOyjEeiDgrJNY0AUOg" annotatedElement="_UE5AEOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has&#xD;
+           WLAN access point capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WhF8wOyjEeiDgrJNY0AUOg" name="router">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wPktIOyjEeiDgrJNY0AUOg" annotatedElement="_WhF8wOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has router&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XajUUOyjEeiDgrJNY0AUOg" name="telephone">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vBLAUOyjEeiDgrJNY0AUOg" annotatedElement="_XajUUOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has telephone&#xD;
+           capability.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YqfSMOyjEeiDgrJNY0AUOg" name="docsisCableDevice">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_toyREOyjEeiDgrJNY0AUOg" annotatedElement="_YqfSMOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has&#xD;
+           DOCSIS Cable Device capability (IETF RFC 4639 &amp; 2670).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_a129kOyjEeiDgrJNY0AUOg" name="stationOnly">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_scKF4OyjEeiDgrJNY0AUOg" annotatedElement="_a129kOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has only&#xD;
+           station capability and nothing else.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cru6EOyjEeiDgrJNY0AUOg" name="cvlanComponent">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rLd6EOyjEeiDgrJNY0AUOg" annotatedElement="_cru6EOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has&#xD;
+           C-VLAN component functionality.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_fNBLEOyjEeiDgrJNY0AUOg" name="svlanComponent">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_prYnYOyjEeiDgrJNY0AUOg" annotatedElement="_fNBLEOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has&#xD;
+           S-VLAN component functionality.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hEuTkOyjEeiDgrJNY0AUOg" name="twoPortMacRelay">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oilMQOyjEeiDgrJNY0AUOg" annotatedElement="_hEuTkOyjEeiDgrJNY0AUOg">
+            <body>This bit indicates that the system has&#xD;
+           Two-port MAC Relay (TPMR) functionality.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_VSwaAOymEeiDgrJNY0AUOg" name="PortList">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_gEeQIOymEeiDgrJNY0AUOg" annotatedElement="_VSwaAOymEeiDgrJNY0AUOg">
+          <body>Each octet within this value specifies a set of eight ports,&#xD;
+       with the first octet specifying ports 1 through 8, the second&#xD;
+       octet specifying ports 9 through 16, etc.  Within each octet,&#xD;
+       the most significant bit represents the lowest numbered port,&#xD;
+       and the least significant bit represents the highest numbered&#xD;
+       port.  Thus, each port of the system is represented by a&#xD;
+       single bit within the value of this object.  If that bit has&#xD;
+       a value of '1' then that port is included in the set of ports;&#xD;
+       the port is not included if its bit has a value of '0'.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xg-lEOymEeiDgrJNY0AUOg" name="portList">
+          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_lMTSA1DOEeWpFusmeDrF3w"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_i0034OymEeiDgrJNY0AUOg" name="DestAddressIndexType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_x4tt0OymEeiDgrJNY0AUOg" annotatedElement="_i0034OymEeiDgrJNY0AUOg">
+          <body>An index value used as the key to the list of destination&#xD;
+       MAC addresses used both as the destination addresses on&#xD;
+       transmitted LLDPDUs and on received LLDPDUs. This index value&#xD;
+       is also used as a secondary key in lists that use interface&#xD;
+       as a primary key.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nTQLAOymEeiDgrJNY0AUOg" name="destAddressIndexType">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_6OfW4OyvEeiDgrJNY0AUOg" name="AdminStatus" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_QmO08OywEeiDgrJNY0AUOg" annotatedElement="_6OfW4OyvEeiDgrJNY0AUOg">
+          <body>The administratively desired status of the local LLDP agent.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Cm_S4OywEeiDgrJNY0AUOg" name="tx-only">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_g_xPMOywEeiDgrJNY0AUOg" annotatedElement="_Cm_S4OywEeiDgrJNY0AUOg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'tx-only(1)', then LLDP agent will transmit LLDP&#xD;
+               frames on this port and it will not store any information&#xD;
+               about the remote systems connected.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_Ee2zcOywEeiDgrJNY0AUOg" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_H1IywOywEeiDgrJNY0AUOg" name="rx-only">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_fqfeUOywEeiDgrJNY0AUOg" annotatedElement="_H1IywOywEeiDgrJNY0AUOg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'rx-only(2)', then the LLDP agent will receive,&#xD;
+               but it will not transmit LLDP frames on this port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_H1IyweywEeiDgrJNY0AUOg" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KNuawOywEeiDgrJNY0AUOg" name="tx-and-rx">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_egvA8OywEeiDgrJNY0AUOg" annotatedElement="_KNuawOywEeiDgrJNY0AUOg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'tx-and-rx(3)', then the LLDP agent will transmit&#xD;
+               and receive LLDP frames on this port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_KNuaweywEeiDgrJNY0AUOg" value="3"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MW9_MOywEeiDgrJNY0AUOg" name="disabled">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_c86dwOywEeiDgrJNY0AUOg" annotatedElement="_MW9_MOywEeiDgrJNY0AUOg">
+            <body>If the associated admin-status object has a&#xD;
+               value of 'disabled(4)', then LLDP agent will not transmit or&#xD;
+               receive LLDP frames on this port.  If there is remote systems&#xD;
+               information which is received on this port and stored in&#xD;
+               other tables, before the port's admin-status&#xD;
+               becomes disabled, then the information will naturally age out.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_MW9_MeywEeiDgrJNY0AUOg" value="4"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_wcTOoOywEeiDgrJNY0AUOg" name="TlvsTxEnable">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_7TcXUOywEeiDgrJNY0AUOg" annotatedElement="_wcTOoOywEeiDgrJNY0AUOg">
+          <body>The tlvs-tx-enable, defined as a bitmap,&#xD;
+          includes the basic set of LLDP tlvs whose transmission is&#xD;
+          allowed on the local LLDP agent by the network management.&#xD;
+          Each bit in the bitmap corresponds to a tlv type associated&#xD;
+          with a specific optional tlv.&#xD;
+  &#xD;
+          It should be noted that the organizationally-specific tlvs&#xD;
+          are excluded from the lldptlvsTxEnable bitmap.&#xD;
+  &#xD;
+          LLDP Organization Specific Information Extension MIBs should&#xD;
+          have similar configuration object to control transmission&#xD;
+          of their organizationally defined tlvs.&#xD;
+  &#xD;
+          There is no bit reserved for the management address tlv type&#xD;
+          since transmission of management address tlvs are controlled&#xD;
+          by another object, man-addr-type.&#xD;
+  &#xD;
+          The default value for tlvs-tx-enable object is&#xD;
+          empty set, which means no enumerated values are set.&#xD;
+  &#xD;
+          The value of this object must be restored from non-volatile&#xD;
+          storage after a re-initialization of the management system.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BwmoAOyxEeiDgrJNY0AUOg" name="portDesc">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Njr0gOyxEeiDgrJNY0AUOg" annotatedElement="_BwmoAOyxEeiDgrJNY0AUOg">
+            <body>The bit 'port-desc(0)' indicates that LLDP agent should&#xD;
+               transmit 'Port Description tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_D05bAOyxEeiDgrJNY0AUOg" name="sysName">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_MPTbgOyxEeiDgrJNY0AUOg" annotatedElement="_D05bAOyxEeiDgrJNY0AUOg">
+            <body>The bit 'sys-name(1)' indicates that LLDP agent should transmit&#xD;
+               'System Name tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Fvk_AOyxEeiDgrJNY0AUOg" name="sysDesc">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_K-pE4OyxEeiDgrJNY0AUOg" annotatedElement="_Fvk_AOyxEeiDgrJNY0AUOg">
+            <body>The bit 'sys-desc(2)' indicates that LLDP agent should transmit&#xD;
+               'System Description tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HfyYYOyxEeiDgrJNY0AUOg" name="sysCap">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Jv1vcOyxEeiDgrJNY0AUOg" annotatedElement="_HfyYYOyxEeiDgrJNY0AUOg">
+            <body>The bit 'sys-cap(3)' indicates that LLDP agent should transmit&#xD;
+               'System Capabilities tlv'.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_wCaMUDObEemmfYv-bFFYSw" name="ChassisIdSubtypeType" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMUTObEemmfYv-bFFYSw" annotatedElement="_wCaMUDObEemmfYv-bFFYSw">
+          <body>The source of a chassis identifier.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMUjObEemmfYv-bFFYSw" name="chassis-component">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMUzObEemmfYv-bFFYSw" annotatedElement="_wCaMUjObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				entPhysicalAlias object (defined in IETF RFC 2737) for a&#xD;
+  				chassis component (i.e., an entPhysicalClass value of&#xD;
+  				chassis(3))</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMVDObEemmfYv-bFFYSw" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMVTObEemmfYv-bFFYSw" name="interface-alias">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMVjObEemmfYv-bFFYSw" annotatedElement="_wCaMVTObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				ifAlias object (defined in IETF RFC 2863) for an interface&#xD;
+  				on the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMVzObEemmfYv-bFFYSw" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMWDObEemmfYv-bFFYSw" name="port-component">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMWTObEemmfYv-bFFYSw" annotatedElement="_wCaMWDObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				entPhysicalAlias object (defined in IETF RFC 2737) for a&#xD;
+  				port or backplane component (i.e., entPhysicalClass value of&#xD;
+  				port(10) or backplane(4)), within the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMWjObEemmfYv-bFFYSw" value="3"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMWzObEemmfYv-bFFYSw" name="mac-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMXDObEemmfYv-bFFYSw" annotatedElement="_wCaMWzObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on the value of a&#xD;
+  				unicast source address (encoded in network byte order and&#xD;
+  				IEEE 802.3 canonical bit order), of a port on the containing&#xD;
+  				chassis as defined in IEEE Std 802-2001.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMXTObEemmfYv-bFFYSw" value="4"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMXjObEemmfYv-bFFYSw" name="network-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMXzObEemmfYv-bFFYSw" annotatedElement="_wCaMXjObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on a network address,&#xD;
+  				associated with a particular chassis.  The encoded address is&#xD;
+  				actually composed of two fields.  The first field is a&#xD;
+  				single octet, representing the IANA AddressFamilyNumbers&#xD;
+  				value for the specific address type, and the second field is&#xD;
+  				the network address value.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMYDObEemmfYv-bFFYSw" value="5"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMYTObEemmfYv-bFFYSw" name="interface-name">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMYjObEemmfYv-bFFYSw" annotatedElement="_wCaMYTObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on the value of&#xD;
+  				ifName object (defined in IETF RFC 2863) for an interface&#xD;
+  				on the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMYzObEemmfYv-bFFYSw" value="6"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wCaMZDObEemmfYv-bFFYSw" name="local">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wCaMZTObEemmfYv-bFFYSw" annotatedElement="_wCaMZDObEemmfYv-bFFYSw">
+            <body>Represents a chassis identifier based on a locally defined&#xD;
+  				value.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_wCaMZjObEemmfYv-bFFYSw" value="7"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_yUoGkDObEemmfYv-bFFYSw" name="PortIdSubtypeType" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_yUoGkTObEemmfYv-bFFYSw" annotatedElement="_yUoGkDObEemmfYv-bFFYSw">
+          <body>The source of a particular type of port identifier used&#xD;
+  		in the LLDP YANG module.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUoGkjObEemmfYv-bFFYSw" name="interface-alias">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUoGkzObEemmfYv-bFFYSw" annotatedElement="_yUoGkjObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on the ifAlias&#xD;
+  				MIB object, defined in IETF RFC 2863.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUoGlDObEemmfYv-bFFYSw" value="1"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUotoDObEemmfYv-bFFYSw" name="port-component">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUotoTObEemmfYv-bFFYSw" annotatedElement="_yUotoDObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on the value of&#xD;
+  				entPhysicalAlias (defined in IETF RFC 2737) for a port&#xD;
+  				component (i.e., entPhysicalClass value of port(10)), &#xD;
+  				within the containing chassis.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUotojObEemmfYv-bFFYSw" value="2"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUotozObEemmfYv-bFFYSw" name="mac-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUotpDObEemmfYv-bFFYSw" annotatedElement="_yUotozObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on a unicast source&#xD;
+  				address (encoded in network byte order and IEEE 802.3&#xD;
+  				canonical bit order), which has been detected by the agent&#xD;
+  				and associated with a particular port (IEEE Std 802-2001).</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUotpTObEemmfYv-bFFYSw" value="3"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUotpjObEemmfYv-bFFYSw" name="network-address">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUotpzObEemmfYv-bFFYSw" annotatedElement="_yUotpjObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on a network address,&#xD;
+  				detected by the agent and associated with a particular &#xD;
+  				port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUotqDObEemmfYv-bFFYSw" value="4"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUotqTObEemmfYv-bFFYSw" name="interface-name">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUotqjObEemmfYv-bFFYSw" annotatedElement="_yUotqTObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on the ifName MIB object,&#xD;
+  				defined in IETF RFC 2863.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUotqzObEemmfYv-bFFYSw" value="5"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUotrDObEemmfYv-bFFYSw" name="agent-circuit-id">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUotrTObEemmfYv-bFFYSw" annotatedElement="_yUotrDObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on the agent-local&#xD;
+  				identifier of the circuit (defined in RFC 3046), detected by&#xD;
+  				the agent and associated with a particular port.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUotrjObEemmfYv-bFFYSw" value="6"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yUotrzObEemmfYv-bFFYSw" name="local">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yUotsDObEemmfYv-bFFYSw" annotatedElement="_yUotrzObEemmfYv-bFFYSw">
+            <body>Represents a port identifier based on a value locally&#xD;
+  				assigned.</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralInteger" xmi:id="_yUotsTObEemmfYv-bFFYSw" value="7"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_2NWroDObEemmfYv-bFFYSw" name="ChassisIdType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_2NWroTObEemmfYv-bFFYSw" annotatedElement="_2NWroDObEemmfYv-bFFYSw">
+          <body>The format of a chassis identifier string. Objects of this type&#xD;
+  		are always used with an associated lldp-chassis-is-subtype&#xD;
+  		object, which identifies the format of the particular&#xD;
+  		lldp-chassis-id object instance.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      chassis-component, then the octet string identifies&#xD;
+      a particular instance of the entPhysicalAlias object&#xD;
+      (defined in IETF RFC 2737) for a chassis component (i.e.,&#xD;
+      an entPhysicalClass value of chassis(3)).&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value&#xD;
+      of interface-alias, then the octet string identifies&#xD;
+      a particular instance of the ifAlias object (defined in&#xD;
+      IETF RFC 2863) for an interface on the containing chassis.&#xD;
+      If the particular ifAlias object does not contain any values,&#xD;
+      another chassis identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value&#xD;
+      of port-component, then the octet string identifies a&#xD;
+      particular instance of the entPhysicalAlias object (defined&#xD;
+      in IETF RFC 2737) for a port or backplane component within&#xD;
+      the containing chassis.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      mac-address, then this string identifies a particular&#xD;
+      unicast source address (encoded in network byte order and&#xD;
+      IEEE 802.3 canonical bit order), of a port on the containing&#xD;
+      chassis as defined in IEEE Std 802-2001.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      network-address, then this string identifies a particular&#xD;
+      network address, encoded in network byte order, associated&#xD;
+      with one or more ports on the containing chassis.  The first&#xD;
+      octet contains the IANA Address Family Numbers enumeration&#xD;
+      value for the specific address type, and octets 2 through&#xD;
+      N contain the network address value in network byte order.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value&#xD;
+      of interface-name, then the octet string identifies&#xD;
+      a particular instance of the ifName object (defined in&#xD;
+      IETF RFC 2863) for an interface on the containing chassis.&#xD;
+      If the particular ifName object does not contain any values,&#xD;
+      another chassis identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-chassis-id-subtype object has a value of&#xD;
+      local, then this string identifies a locally assigned&#xD;
+      Chassis ID.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2NWrojObEemmfYv-bFFYSw" name="chassisId">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_5Ec0kDObEemmfYv-bFFYSw" name="PortIdType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_5Ec0kTObEemmfYv-bFFYSw" annotatedElement="_5Ec0kDObEemmfYv-bFFYSw">
+          <body>The format of a port identifier string. Objects of this type&#xD;
+  		are always used with an associated lldp-port-id-subtype object,&#xD;
+  		which identifies the format of the particular lldp-port-id&#xD;
+  		object instance.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      interface-alias, then the octet string identifies a&#xD;
+      particular instance of the ifAlias object (defined in IETF&#xD;
+      RFC 2863).  If the particular ifAlias object does not contain&#xD;
+      any values, another port identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      port-component, then the octet string identifies a&#xD;
+      particular instance of the entPhysicalAlias object (defined&#xD;
+      in IETF RFC 2737) for a port or backplane component.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      mac-address, then this string identifies a particular&#xD;
+      unicast source address (encoded in network byte order&#xD;
+      and IEEE 802.3 canonical bit order) associated with the port&#xD;
+      (IEEE Std 802-2001).&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      network-address, then this string identifies a network&#xD;
+      address associated with the port.  The first octet contains&#xD;
+      the IANA AddressFamilyNumbers enumeration value for the&#xD;
+      specific address type, and octets 2 through N contain the&#xD;
+      networkAddress address value in network byte order.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      interface-name, then the octet string identifies a&#xD;
+      particular instance of the ifName object (defined in IETF&#xD;
+      RFC 2863).  If the particular ifName object does not contain&#xD;
+      any values, another port identifier type should be used.&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      agent-circuit-id, then this string identifies a agent-local&#xD;
+      identifier of the circuit (defined in RFC 3046).&#xD;
+&#xD;
+      If the associated lldp-port-id-subtype object has a value of&#xD;
+      local, then this string identifies a locally assigned port ID.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5Ec0kjObEemmfYv-bFFYSw" name="portId">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_757M4DObEemmfYv-bFFYSw" name="AddressFamily">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_757M4TObEemmfYv-bFFYSw" annotatedElement="_757M4DObEemmfYv-bFFYSw">
+          <body>Base identity from which identities describing address families are derived.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_757M4jObEemmfYv-bFFYSw" name="IP_V4">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_757M4zObEemmfYv-bFFYSw" annotatedElement="_757M4jObEemmfYv-bFFYSw">
+            <body>This identity represents an IPv4 address family.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_757M5DObEemmfYv-bFFYSw" name="IP_V6">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_757M5TObEemmfYv-bFFYSw" annotatedElement="_757M5DObEemmfYv-bFFYSw">
+            <body>This identity represents an IPv6 address family.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_3-ymMHkhEeiQ1uqYFXu0Kg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qzOO0DOUEemmfYv-bFFYSw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qzOO0TOUEemmfYv-bFFYSw" key="Version" value="0.0.9"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qzOO0jOUEemmfYv-bFFYSw" key="Comment" value="BITS encoding and bitsDefinition property added."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qzOO0zOUEemmfYv-bFFYSw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qzOO1DOUEemmfYv-bFFYSw" key="Date" value="2018-04-13"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qzOO1TOUEemmfYv-bFFYSw" key="Author" value="IISOMI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3-zNQHkhEeiQ1uqYFXu0Kg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_3NPRMD78EeiIisB6uOvKFA"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_UbM6ILbyEeaufdfMFhfy_A"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_4BmCkHkhEeiQ1uqYFXu0Kg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_q0CuMDOUEemmfYv-bFFYSw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_q0CuMTOUEemmfYv-bFFYSw" key="Version" value="0.2.14"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_q0CuMjOUEemmfYv-bFFYSw" key="Comment" value="New stereotype OpenModelStatement added. It contains the generic information of the model and extends the Metaclass &quot;Model&quot;."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_q0CuMzOUEemmfYv-bFFYSw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_q0CuNDOUEemmfYv-bFFYSw" key="Date" value="2018-04-13"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_q0CuNTOUEemmfYv-bFFYSw" key="Author" value="IISOMI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4BmpoHkhEeiQ1uqYFXu0Kg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S32LgD8HEeiIisB6uOvKFA"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_4Boe0HkhEeiQ1uqYFXu0Kg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4Bps8HkhEeiQ1uqYFXu0Kg" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Bps8XkhEeiQ1uqYFXu0Kg" key="Version" value="0.0.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Bps8nkhEeiQ1uqYFXu0Kg" key="Comment" value="Metaclasses Property and Stereotype added via &lt;Element Import>."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Bps83khEeiQ1uqYFXu0Kg" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Bps9HkhEeiQ1uqYFXu0Kg" key="Date" value="2017-08-08"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Bps9XkhEeiQ1uqYFXu0Kg" key="Author" value=""/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4BpF4HkhEeiQ1uqYFXu0Kg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="UmlProfiles/ProfileLifecycleProfile/ProfileLifecycle_Profile.profile.uml#_AL3HsHweEee8oZaf2rRQlg"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="UmlProfiles/ProfileLifecycleProfile/ProfileLifecycle_Profile.profile.uml#_CBpGoEdZEearpawF38eisA"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelStatement xmi:id="_B2BDoH38EeiXCeRGbC8RLQ" base_Model="_nPCrYHkhEeiQ1uqYFXu0Kg" namespace="urn:ieee:std:802.1Q:yang:ieee802-dot1q-cfm-types" organization="IEEE 802.1 Working Group">
+    <contact xmi:type="OpenModel_Profile:Contact" xmi:id="_ldOagTOUEemmfYv-bFFYSw" projectWeb="http://www.ieee802.org/1/" projectEmail="stds-802-1-L@ieee.org" editorName="IEEE 802.1 Working Group Chair" editorEmail="STDS-802-1-L@IEEE.ORG"/>
+    <revision xmi:type="OpenModel_Profile:Revision" xmi:id="_ldOagjOUEemmfYv-bFFYSw" date="2018-06-25" description="Creation for Task Group review." reference="IEEE Std 802.1Q-2018, Bridges and Bridged Networks."/>
+  </OpenModel_Profile:OpenModelStatement>
+  <OpenModel_Profile:Reference xmi:id="_NS8AkOyiEeiDgrJNY0AUOg" base_Element="_2TDkcOyhEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.5"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XhhUcOyiEeiDgrJNY0AUOg" base_StructuralFeature="_XhgtYOyiEeiDgrJNY0AUOg" valueRange="1..31"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Xhh7gOyiEeiDgrJNY0AUOg" base_Property="_XhgtYOyiEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_7uT2wOyiEeiDgrJNY0AUOg" base_Element="_XhgtYOyiEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.4"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QU-YwOyjEeiDgrJNY0AUOg" base_StructuralFeature="_QU9xsOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_QU-YweyjEeiDgrJNY0AUOg" base_Property="_QU9xsOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RflKseyjEeiDgrJNY0AUOg" base_StructuralFeature="_RflKsOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_RflxwOyjEeiDgrJNY0AUOg" base_Property="_RflKsOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_So0DoeyjEeiDgrJNY0AUOg" base_StructuralFeature="_So0DoOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_So0DouyjEeiDgrJNY0AUOg" base_Property="_So0DoOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UE5AEeyjEeiDgrJNY0AUOg" base_StructuralFeature="_UE5AEOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UE5AEuyjEeiDgrJNY0AUOg" base_Property="_UE5AEOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WhGj0OyjEeiDgrJNY0AUOg" base_StructuralFeature="_WhF8wOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_WhGj0eyjEeiDgrJNY0AUOg" base_Property="_WhF8wOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XajUUeyjEeiDgrJNY0AUOg" base_StructuralFeature="_XajUUOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Xaj7YOyjEeiDgrJNY0AUOg" base_Property="_XajUUOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YqfSMeyjEeiDgrJNY0AUOg" base_StructuralFeature="_YqfSMOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_YqfSMuyjEeiDgrJNY0AUOg" base_Property="_YqfSMOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_a13koOyjEeiDgrJNY0AUOg" base_StructuralFeature="_a129kOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_a13koeyjEeiDgrJNY0AUOg" base_Property="_a129kOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cru6EeyjEeiDgrJNY0AUOg" base_StructuralFeature="_cru6EOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cru6EuyjEeiDgrJNY0AUOg" base_Property="_cru6EOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_fNByIOyjEeiDgrJNY0AUOg" base_StructuralFeature="_fNBLEOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_fNByIeyjEeiDgrJNY0AUOg" base_Property="_fNBLEOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hEu6oOyjEeiDgrJNY0AUOg" base_StructuralFeature="_hEuTkOyjEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hEu6oeyjEeiDgrJNY0AUOg" base_Property="_hEuTkOyjEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_mOmXcOyjEeiDgrJNY0AUOg" base_Element="_InDDwOyjEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.8.1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Xg-lEeymEeiDgrJNY0AUOg" base_StructuralFeature="_Xg-lEOymEeiDgrJNY0AUOg" valueRange="0..512"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Xg_MIOymEeiDgrJNY0AUOg" base_Property="_Xg-lEOymEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_d8yx8OymEeiDgrJNY0AUOg" base_Element="_VSwaAOymEeiDgrJNY0AUOg" reference="IETF RFC 2674 section 5"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nTQLAeymEeiDgrJNY0AUOg" base_StructuralFeature="_nTQLAOymEeiDgrJNY0AUOg" valueRange="1..4096" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nTQLAuymEeiDgrJNY0AUOg" base_Property="_nTQLAOymEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_5-xO8eymEeiDgrJNY0AUOg" base_Class="_5-xO8OymEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_5-xO8uymEeiDgrJNY0AUOg" base_Class="_5-xO8OymEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-iIscOymEeiDgrJNY0AUOg" base_StructuralFeature="_-iIFYOymEeiDgrJNY0AUOg" valueRange="1..3600" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_-iIsceymEeiDgrJNY0AUOg" base_Property="_-iIFYOymEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Reference xmi:id="_TuiYwOynEeiDgrJNY0AUOg" base_Element="_-iIFYOymEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.5"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VkGMMOynEeiDgrJNY0AUOg" base_StructuralFeature="_VkFlIOynEeiDgrJNY0AUOg" valueRange="2..10" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_VkGMMeynEeiDgrJNY0AUOg" base_Property="_VkFlIOynEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Reference xmi:id="_ZSSVMOynEeiDgrJNY0AUOg" base_Element="_VkFlIOynEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.6"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nB6G4eynEeiDgrJNY0AUOg" base_StructuralFeature="_nB6G4OynEeiDgrJNY0AUOg" valueRange="1..3600" unsigned="true" unit="second"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nB6t8OynEeiDgrJNY0AUOg" base_Property="_nB6G4OynEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pWKBceynEeiDgrJNY0AUOg" base_StructuralFeature="_pWKBcOynEeiDgrJNY0AUOg" valueRange="1..10" unsigned="true" unit="second"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_pWKBcuynEeiDgrJNY0AUOg" base_Property="_pWKBcOynEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_r7x_4eynEeiDgrJNY0AUOg" base_StructuralFeature="_r7x_4OynEeiDgrJNY0AUOg" valueRange="1..10" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_r7x_4uynEeiDgrJNY0AUOg" base_Property="_r7x_4OynEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_uYlZgeynEeiDgrJNY0AUOg" base_StructuralFeature="_uYlZgOynEeiDgrJNY0AUOg" valueRange="1..8" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_uYmAkOynEeiDgrJNY0AUOg" base_Property="_uYlZgOynEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wu8z8eynEeiDgrJNY0AUOg" base_StructuralFeature="_wu8z8OynEeiDgrJNY0AUOg" valueRange="1..3600" unsigned="true" unit="second"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_wu8z8uynEeiDgrJNY0AUOg" base_Property="_wu8z8OynEeiDgrJNY0AUOg" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Reference xmi:id="_01B4gOynEeiDgrJNY0AUOg" base_Element="_wu8z8OynEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.7"/>
+  <OpenModel_Profile:Reference xmi:id="_3FEBcOynEeiDgrJNY0AUOg" base_Element="_uYlZgOynEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.19"/>
+  <OpenModel_Profile:Reference xmi:id="_5rvIwOynEeiDgrJNY0AUOg" base_Element="_r7x_4OynEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.17"/>
+  <OpenModel_Profile:Reference xmi:id="_8L70oOynEeiDgrJNY0AUOg" base_Element="_pWKBcOynEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.10"/>
+  <OpenModel_Profile:Reference xmi:id="_-dWdoOynEeiDgrJNY0AUOg" base_Element="_nB6G4OynEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.7"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_9oJCAeypEeiDgrJNY0AUOg" base_Class="_9oJCAOypEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_9oJpEOypEeiDgrJNY0AUOg" base_Class="_9oJCAOypEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7w-aIuyrEeiDgrJNY0AUOg" base_StructuralFeature="_7w-aIeyrEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7w-aI-yrEeiDgrJNY0AUOg" base_Property="_7w-aIeyrEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7xG9AeyrEeiDgrJNY0AUOg" base_StructuralFeature="_7xG9AOyrEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7xG9AuyrEeiDgrJNY0AUOg" base_Property="_7xG9AOyrEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_CBxCwOysEeiDgrJNY0AUOg" base_Association="_7w9zEOyrEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FZdXUeysEeiDgrJNY0AUOg" base_Class="_FZdXUOysEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_FZdXUuysEeiDgrJNY0AUOg" base_Class="_FZdXUOysEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HhW38-ysEeiDgrJNY0AUOg" base_StructuralFeature="_HhW38uysEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HhXfAOysEeiDgrJNY0AUOg" base_Property="_HhW38uysEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HhYGEuysEeiDgrJNY0AUOg" base_StructuralFeature="_HhYGEeysEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HhYGE-ysEeiDgrJNY0AUOg" base_Property="_HhYGEeysEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_SyrbMOysEeiDgrJNY0AUOg" base_StructuralFeature="_Syq0IOysEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_SyrbMeysEeiDgrJNY0AUOg" base_Property="_Syq0IOysEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_c1aEYeysEeiDgrJNY0AUOg" base_StructuralFeature="_c1aEYOysEeiDgrJNY0AUOg" unit="table entries"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_c1aEYuysEeiDgrJNY0AUOg" base_Property="_c1aEYOysEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qTTz8eysEeiDgrJNY0AUOg" base_StructuralFeature="_qTTz8OysEeiDgrJNY0AUOg" unit="table entries"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qTTz8uysEeiDgrJNY0AUOg" base_Property="_qTTz8OysEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zbeSUeysEeiDgrJNY0AUOg" base_StructuralFeature="_zbeSUOysEeiDgrJNY0AUOg" unit="table entries"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zbeSUuysEeiDgrJNY0AUOg" base_Property="_zbeSUOysEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8C2-4eysEeiDgrJNY0AUOg" base_StructuralFeature="_8C2-4OysEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8C3l8OysEeiDgrJNY0AUOg" base_Property="_8C2-4OysEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_DR3jQeytEeiDgrJNY0AUOg" base_Class="_DR3jQOytEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_DR3jQuytEeiDgrJNY0AUOg" base_Class="_DR3jQOytEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_F9k7k-ytEeiDgrJNY0AUOg" base_StructuralFeature="_F9k7kuytEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F9lioOytEeiDgrJNY0AUOg" base_Property="_F9k7kuytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_F9mJs-ytEeiDgrJNY0AUOg" base_StructuralFeature="_F9mJsuytEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F9mwwOytEeiDgrJNY0AUOg" base_Property="_F9mJsuytEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ay_rQOytEeiDgrJNY0AUOg" base_StructuralFeature="_ay_EMOytEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ay_rQeytEeiDgrJNY0AUOg" base_Property="_ay_EMOytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dAongeytEeiDgrJNY0AUOg" base_StructuralFeature="_dAongOytEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_dApOkOytEeiDgrJNY0AUOg" base_Property="_dAongOytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ethnIOytEeiDgrJNY0AUOg" base_StructuralFeature="_ethAEOytEeiDgrJNY0AUOg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ethnIeytEeiDgrJNY0AUOg" base_Property="_ethAEOytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gmO1MeytEeiDgrJNY0AUOg" base_StructuralFeature="_gmO1MOytEeiDgrJNY0AUOg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gmO1MuytEeiDgrJNY0AUOg" base_Property="_gmO1MOytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ieQGweytEeiDgrJNY0AUOg" base_StructuralFeature="_ieQGwOytEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ieQt0OytEeiDgrJNY0AUOg" base_Property="_ieQGwOytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_k_vMEOytEeiDgrJNY0AUOg" base_StructuralFeature="_k_ulAOytEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_k_vMEeytEeiDgrJNY0AUOg" base_Property="_k_ulAOytEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Reference xmi:id="_oijykOytEeiDgrJNY0AUOg" base_Element="_k_ulAOytEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.8.2"/>
+  <OpenModel_Profile:Reference xmi:id="_qYmuMOytEeiDgrJNY0AUOg" base_Element="_ieQGwOytEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.8.1"/>
+  <OpenModel_Profile:Reference xmi:id="_sc_AwOytEeiDgrJNY0AUOg" base_Element="_gmO1MOytEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.7.2"/>
+  <OpenModel_Profile:Reference xmi:id="_vRtyMOytEeiDgrJNY0AUOg" base_Element="_ethAEOytEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.6.2"/>
+  <OpenModel_Profile:Reference xmi:id="_xenuoOytEeiDgrJNY0AUOg" base_Element="_dAongOytEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.2.3"/>
+  <OpenModel_Profile:Reference xmi:id="_zsNnkOytEeiDgrJNY0AUOg" base_Element="_ay_EMOytEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.2.2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_oeHiAeyuEeiDgrJNY0AUOg" base_Class="_oeHiAOyuEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oeHiAuyuEeiDgrJNY0AUOg" base_Class="_oeHiAOyuEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qucl4-yuEeiDgrJNY0AUOg" base_StructuralFeature="_qucl4uyuEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qucl5OyuEeiDgrJNY0AUOg" base_Property="_qucl4uyuEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qudM8uyuEeiDgrJNY0AUOg" base_StructuralFeature="_qudM8eyuEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qudM8-yuEeiDgrJNY0AUOg" base_Property="_qudM8eyuEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vcvrkeyvEeiDgrJNY0AUOg" base_StructuralFeature="_vcvrkOyvEeiDgrJNY0AUOg" partOfObjectKey="2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vcwSoOyvEeiDgrJNY0AUOg" base_Property="_vcvrkOyvEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_37HmEeyvEeiDgrJNY0AUOg" base_StructuralFeature="_37HmEOyvEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_37HmEuyvEeiDgrJNY0AUOg" base_Property="_37HmEOyvEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_SaHNYOywEeiDgrJNY0AUOg" base_Element="_6OfW4OyvEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.1"/>
+  <OpenModel_Profile:Reference xmi:id="_UHMaQOywEeiDgrJNY0AUOg" base_Element="_37HmEOyvEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.5.1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_loTgkeywEeiDgrJNY0AUOg" base_StructuralFeature="_loTgkOywEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_loTgkuywEeiDgrJNY0AUOg" base_Property="_loTgkOywEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tcbkMeywEeiDgrJNY0AUOg" base_StructuralFeature="_tcbkMOywEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tcbkMuywEeiDgrJNY0AUOg" base_Property="_tcbkMOywEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_9CO0YOywEeiDgrJNY0AUOg" base_Element="_wcTOoOywEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016 9.1.2.1"/>
+  <OpenModel_Profile:Reference xmi:id="_-vMFcOywEeiDgrJNY0AUOg" base_Element="_tcbkMOywEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016 9.1.2.1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BwmoAeyxEeiDgrJNY0AUOg" base_StructuralFeature="_BwmoAOyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BwnPEOyxEeiDgrJNY0AUOg" base_Property="_BwmoAOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_D05bAeyxEeiDgrJNY0AUOg" base_StructuralFeature="_D05bAOyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_D05bAuyxEeiDgrJNY0AUOg" base_Property="_D05bAOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FvlmEOyxEeiDgrJNY0AUOg" base_StructuralFeature="_Fvk_AOyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_FvlmEeyxEeiDgrJNY0AUOg" base_Property="_Fvk_AOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HfyYYeyxEeiDgrJNY0AUOg" base_StructuralFeature="_HfyYYOyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HfyYYuyxEeiDgrJNY0AUOg" base_Property="_HfyYYOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nP4F4OyxEeiDgrJNY0AUOg" base_StructuralFeature="_nP3e0OyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nP4s8OyxEeiDgrJNY0AUOg" base_Property="_nP3e0OyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nP5UAuyxEeiDgrJNY0AUOg" base_StructuralFeature="_nP5UAeyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nP5UA-yxEeiDgrJNY0AUOg" base_Property="_nP5UAeyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_o1ZSMOyxEeiDgrJNY0AUOg" base_Association="_nP1poOyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_xfwaQOyxEeiDgrJNY0AUOg" base_Class="_xfvzMOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_xfwaQeyxEeiDgrJNY0AUOg" base_Class="_xfvzMOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1m4nseyxEeiDgrJNY0AUOg" base_StructuralFeature="_1m4nsOyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1m4nsuyxEeiDgrJNY0AUOg" base_Property="_1m4nsOyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1m5OwuyxEeiDgrJNY0AUOg" base_StructuralFeature="_1m5OweyxEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1m5Ow-yxEeiDgrJNY0AUOg" base_Property="_1m5OweyxEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Pvgg8eyzEeiDgrJNY0AUOg" base_StructuralFeature="_Pvgg8OyzEeiDgrJNY0AUOg" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Pvgg8uyzEeiDgrJNY0AUOg" base_Property="_Pvgg8OyzEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_UsUZMOyzEeiDgrJNY0AUOg" base_Element="_Pvgg8OyzEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016 8.5.9.3"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LeTl8ey9EeiDgrJNY0AUOg" base_StructuralFeature="_LeTl8Oy9EeiDgrJNY0AUOg" partOfObjectKey="2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_LeUNAOy9EeiDgrJNY0AUOg" base_Property="_LeTl8Oy9EeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Nob7MOy9EeiDgrJNY0AUOg" base_StructuralFeature="_NobUIOy9EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Nob7Mey9EeiDgrJNY0AUOg" base_Property="_NobUIOy9EeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_P3yHoOy9EeiDgrJNY0AUOg" base_StructuralFeature="_P3xgkOy9EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_P3yHoey9EeiDgrJNY0AUOg" base_Property="_P3xgkOy9EeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_SfqI0ey9EeiDgrJNY0AUOg" base_StructuralFeature="_SfqI0Oy9EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_SfqI0uy9EeiDgrJNY0AUOg" base_Property="_SfqI0Oy9EeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UED60ey9EeiDgrJNY0AUOg" base_StructuralFeature="_UED60Oy9EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UED60uy9EeiDgrJNY0AUOg" base_Property="_UED60Oy9EeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Reference xmi:id="_ZZV9cOy9EeiDgrJNY0AUOg" base_Element="_UED60Oy9EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.6"/>
+  <OpenModel_Profile:Reference xmi:id="_blVT4Oy9EeiDgrJNY0AUOg" base_Element="_SfqI0Oy9EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.5"/>
+  <OpenModel_Profile:Reference xmi:id="_d7AKwOy9EeiDgrJNY0AUOg" base_Element="_P3xgkOy9EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.2"/>
+  <OpenModel_Profile:Reference xmi:id="_gTzOIOy9EeiDgrJNY0AUOg" base_Element="_NobUIOy9EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016 9.1.2.1"/>
+  <OpenModel_Profile:Reference xmi:id="_iyNxUOy9EeiDgrJNY0AUOg" base_Element="_LeTl8Oy9EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016 8.5.9.4"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hptbsey-EeiDgrJNY0AUOg" base_StructuralFeature="_hptbsOy-EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hptbsuy-EeiDgrJNY0AUOg" base_Property="_hptbsOy-EeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mMgcAey_EeiDgrJNY0AUOg" base_StructuralFeature="_mMgcAOy_EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_mMgcAuy_EeiDgrJNY0AUOg" base_Property="_mMgcAOy_EeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sPn1Aey_EeiDgrJNY0AUOg" base_StructuralFeature="_sPn1AOy_EeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_sPn1Auy_EeiDgrJNY0AUOg" base_Property="_sPn1AOy_EeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_vzXBgey_EeiDgrJNY0AUOg" base_Class="_vzXBgOy_EeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_vzXokOy_EeiDgrJNY0AUOg" base_Class="_vzXBgOy_EeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_0g2rYOy_EeiDgrJNY0AUOg" base_Element="_sPn1AOy_EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.5.2"/>
+  <OpenModel_Profile:Reference xmi:id="_2ibhkOy_EeiDgrJNY0AUOg" base_Element="_mMgcAOy_EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.3.3"/>
+  <OpenModel_Profile:Reference xmi:id="_4uV_gOy_EeiDgrJNY0AUOg" base_Element="_hptbsOy-EeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.3.2"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gsR4M-zAEeiDgrJNY0AUOg" base_StructuralFeature="_gsR4MuzAEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gsSfQOzAEeiDgrJNY0AUOg" base_Property="_gsR4MuzAEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gsSfROzAEeiDgrJNY0AUOg" base_StructuralFeature="_gsSfQ-zAEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gsTGUOzAEeiDgrJNY0AUOg" base_Property="_gsSfQ-zAEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_OSzxEezBEeiDgrJNY0AUOg" base_StructuralFeature="_OSzxEOzBEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_OS0YIOzBEeiDgrJNY0AUOg" base_Property="_OSzxEOzBEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QZCdwezBEeiDgrJNY0AUOg" base_StructuralFeature="_QZCdwOzBEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_QZDE0OzBEeiDgrJNY0AUOg" base_Property="_QZCdwOzBEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Reference xmi:id="_T9XgIOzBEeiDgrJNY0AUOg" base_Element="_QZCdwOzBEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.7.2"/>
+  <OpenModel_Profile:Reference xmi:id="_WJq_oOzBEeiDgrJNY0AUOg" base_Element="_OSzxEOzBEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.5"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_j-O7tuzBEeiDgrJNY0AUOg" base_Class="_j-O7sOzBEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_j-PiwOzBEeiDgrJNY0AUOg" base_Class="_j-O7sOzBEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_j-PiwezBEeiDgrJNY0AUOg" base_StructuralFeature="_j-O7suzBEeiDgrJNY0AUOg" counter="ZERO_COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_j-PiwuzBEeiDgrJNY0AUOg" base_Property="_j-O7suzBEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_j-Piw-zBEeiDgrJNY0AUOg" base_StructuralFeature="_j-O7tOzBEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_j-PixOzBEeiDgrJNY0AUOg" base_Property="_j-O7tOzBEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Reference xmi:id="_j-RX8OzBEeiDgrJNY0AUOg" base_Element="_j-O7suzBEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.1"/>
+  <OpenModel_Profile:Reference xmi:id="_j-RX8ezBEeiDgrJNY0AUOg" base_Element="_j-O7tOzBEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.2"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ua-nY-zBEeiDgrJNY0AUOg" base_StructuralFeature="_ua-nYuzBEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ua_OcOzBEeiDgrJNY0AUOg" base_Property="_ua-nYuzBEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ua_1gezBEeiDgrJNY0AUOg" base_StructuralFeature="_ua_1gOzBEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ua_1guzBEeiDgrJNY0AUOg" base_Property="_ua_1gOzBEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RoI4sOzCEeiDgrJNY0AUOg" base_StructuralFeature="_RoIRoOzCEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_RoI4sezCEeiDgrJNY0AUOg" base_Property="_RoIRoOzCEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_T8jyYOzCEeiDgrJNY0AUOg" base_StructuralFeature="_T8jLUOzCEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_T8jyYezCEeiDgrJNY0AUOg" base_Property="_T8jLUOzCEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WEjZoezCEeiDgrJNY0AUOg" base_StructuralFeature="_WEjZoOzCEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_WEjZouzCEeiDgrJNY0AUOg" base_Property="_WEjZoOzCEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YshhcezCEeiDgrJNY0AUOg" base_StructuralFeature="_YshhcOzCEeiDgrJNY0AUOg" counter="COUNTER"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_YshhcuzCEeiDgrJNY0AUOg" base_Property="_YshhcOzCEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Reference xmi:id="_cJ1V0OzCEeiDgrJNY0AUOg" base_Element="_YshhcOzCEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.6"/>
+  <OpenModel_Profile:Reference xmi:id="_eSkj8OzCEeiDgrJNY0AUOg" base_Element="_WEjZoOzCEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.5"/>
+  <OpenModel_Profile:Reference xmi:id="_gi_ucOzCEeiDgrJNY0AUOg" base_Element="_T8jLUOzCEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.4"/>
+  <OpenModel_Profile:Reference xmi:id="_iy7wwOzCEeiDgrJNY0AUOg" base_Element="_RoIRoOzCEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.3"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_2OmfQezCEeiDgrJNY0AUOg" base_Class="_2OmfQOzCEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_2OmfQuzCEeiDgrJNY0AUOg" base_Class="_2OmfQOzCEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_2itHBuzCEeiDgrJNY0AUOg" base_Class="_2itHAOzCEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_2ituEOzCEeiDgrJNY0AUOg" base_Class="_2itHAOzCEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2ituEezCEeiDgrJNY0AUOg" base_StructuralFeature="_2itHAuzCEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ituEuzCEeiDgrJNY0AUOg" base_Property="_2itHAuzCEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2iuVIOzCEeiDgrJNY0AUOg" base_StructuralFeature="_2itHBOzCEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2iuVIezCEeiDgrJNY0AUOg" base_Property="_2itHBOzCEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_2iwKUOzCEeiDgrJNY0AUOg" base_Element="_2itHAuzCEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.5"/>
+  <OpenModel_Profile:Reference xmi:id="_2iwKUezCEeiDgrJNY0AUOg" base_Element="_2itHBOzCEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.7.2"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_64_Kw-zCEeiDgrJNY0AUOg" base_StructuralFeature="_64_KwuzCEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_64_KxOzCEeiDgrJNY0AUOg" base_Property="_64_KwuzCEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_64_x0-zCEeiDgrJNY0AUOg" base_StructuralFeature="_64_x0uzCEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_65AY4OzCEeiDgrJNY0AUOg" base_Property="_64_x0uzCEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_G0WJgezDEeiDgrJNY0AUOg" base_StructuralFeature="_G0WJgOzDEeiDgrJNY0AUOg" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_G0WJguzDEeiDgrJNY0AUOg" base_Property="_G0WJgOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_I6Xa0ezDEeiDgrJNY0AUOg" base_StructuralFeature="_I6Xa0OzDEeiDgrJNY0AUOg" partOfObjectKey="2" valueRange="1..2147483647" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_I6Xa0uzDEeiDgrJNY0AUOg" base_Property="_I6Xa0OzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_K_8nQezDEeiDgrJNY0AUOg" base_StructuralFeature="_K_8nQOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_K_9OUOzDEeiDgrJNY0AUOg" base_Property="_K_8nQOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NWSMgezDEeiDgrJNY0AUOg" base_StructuralFeature="_NWSMgOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NWSzkOzDEeiDgrJNY0AUOg" base_Property="_NWSMgOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PYi_MezDEeiDgrJNY0AUOg" base_StructuralFeature="_PYi_MOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PYi_MuzDEeiDgrJNY0AUOg" base_Property="_PYi_MOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TX9bEezDEeiDgrJNY0AUOg" base_StructuralFeature="_TX9bEOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TX-CIOzDEeiDgrJNY0AUOg" base_Property="_TX9bEOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VWTXEOzDEeiDgrJNY0AUOg" base_StructuralFeature="_VWSwAOzDEeiDgrJNY0AUOg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_VWTXEezDEeiDgrJNY0AUOg" base_Property="_VWSwAOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XLNqQezDEeiDgrJNY0AUOg" base_StructuralFeature="_XLNqQOzDEeiDgrJNY0AUOg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_XLNqQuzDEeiDgrJNY0AUOg" base_Property="_XLNqQOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZHi0EOzDEeiDgrJNY0AUOg" base_StructuralFeature="_ZHiNAOzDEeiDgrJNY0AUOg" valueRange="0..255"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ZHi0EezDEeiDgrJNY0AUOg" base_Property="_ZHiNAOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bedoIezDEeiDgrJNY0AUOg" base_StructuralFeature="_bedoIOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_beePMOzDEeiDgrJNY0AUOg" base_Property="_bedoIOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gc20wezDEeiDgrJNY0AUOg" base_StructuralFeature="_gc20wOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gc20wuzDEeiDgrJNY0AUOg" base_Property="_gc20wOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_mE2_EezDEeiDgrJNY0AUOg" base_Class="_mE2_EOzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mE3mIOzDEeiDgrJNY0AUOg" base_Class="_mE2_EOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_mYQcNuzDEeiDgrJNY0AUOg" base_Class="_mYQcMOzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mYRDQOzDEeiDgrJNY0AUOg" base_Class="_mYQcMOzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mYRDQezDEeiDgrJNY0AUOg" base_StructuralFeature="_mYQcMuzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_mYRDQuzDEeiDgrJNY0AUOg" base_Property="_mYQcMuzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mYRDQ-zDEeiDgrJNY0AUOg" base_StructuralFeature="_mYQcNOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_mYRDROzDEeiDgrJNY0AUOg" base_Property="_mYQcNOzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:Reference xmi:id="_mYS4cOzDEeiDgrJNY0AUOg" base_Element="_mYQcMuzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.6.5"/>
+  <OpenModel_Profile:Reference xmi:id="_mYS4cezDEeiDgrJNY0AUOg" base_Element="_mYQcNOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.7.2"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oiyaE-zDEeiDgrJNY0AUOg" base_StructuralFeature="_oiyaEuzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_oiyaFOzDEeiDgrJNY0AUOg" base_Property="_oiyaEuzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oizBI-zDEeiDgrJNY0AUOg" base_StructuralFeature="_oizBIuzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_oizBJOzDEeiDgrJNY0AUOg" base_Property="_oizBIuzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zPhpkezDEeiDgrJNY0AUOg" base_StructuralFeature="_zPhpkOzDEeiDgrJNY0AUOg" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zPhpkuzDEeiDgrJNY0AUOg" base_Property="_zPhpkOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1G1wgezDEeiDgrJNY0AUOg" base_StructuralFeature="_1G1wgOzDEeiDgrJNY0AUOg" partOfObjectKey="2"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1G2XkOzDEeiDgrJNY0AUOg" base_Property="_1G1wgOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3eYPoezDEeiDgrJNY0AUOg" base_StructuralFeature="_3eYPoOzDEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3eY2sOzDEeiDgrJNY0AUOg" base_Property="_3eYPoOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_46-wgezDEeiDgrJNY0AUOg" base_StructuralFeature="_46-wgOzDEeiDgrJNY0AUOg" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_46_XkOzDEeiDgrJNY0AUOg" base_Property="_46-wgOzDEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_8LSqsOzDEeiDgrJNY0AUOg" base_Class="_8LSDoOzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_8LSqsezDEeiDgrJNY0AUOg" base_Class="_8LSDoOzDEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_AkeRcuzEEeiDgrJNY0AUOg" base_StructuralFeature="_AkeRcezEEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AkeRc-zEEeiDgrJNY0AUOg" base_Property="_AkeRcezEEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ake4g-zEEeiDgrJNY0AUOg" base_StructuralFeature="_Ake4guzEEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Ake4hOzEEeiDgrJNY0AUOg" base_Property="_Ake4guzEEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HN6qoOzEEeiDgrJNY0AUOg" base_StructuralFeature="_HN6DkOzEEeiDgrJNY0AUOg" partOfObjectKey="1" valueRange="9..126" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HN6qoezEEeiDgrJNY0AUOg" base_Property="_HN6DkOzEEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KCr4UezEEeiDgrJNY0AUOg" base_StructuralFeature="_KCr4UOzEEeiDgrJNY0AUOg" valueRange="0..511"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_KCr4UuzEEeiDgrJNY0AUOg" base_Property="_KCr4UOzEEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_OxoTsezEEeiDgrJNY0AUOg" base_Class="_OxoTsOzEEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_OxoTsuzEEeiDgrJNY0AUOg" base_Class="_OxoTsOzEEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Se-II-zEEeiDgrJNY0AUOg" base_StructuralFeature="_Se-IIuzEEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Se-vMOzEEeiDgrJNY0AUOg" base_Property="_Se-IIuzEEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Se_WQ-zEEeiDgrJNY0AUOg" base_StructuralFeature="_Se_WQuzEEeiDgrJNY0AUOg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Se_WROzEEeiDgrJNY0AUOg" base_Property="_Se_WQuzEEeiDgrJNY0AUOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dpJFEOzFEeiDgrJNY0AUOg" base_StructuralFeature="_dpIeAOzFEeiDgrJNY0AUOg" partOfObjectKey="1" valueRange="3"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_dpJsIOzFEeiDgrJNY0AUOg" base_Property="_dpIeAOzFEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_f1PJMezFEeiDgrJNY0AUOg" base_StructuralFeature="_f1PJMOzFEeiDgrJNY0AUOg" partOfObjectKey="2" valueRange="1..255" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_f1PJMuzFEeiDgrJNY0AUOg" base_Property="_f1PJMOzFEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iy4mEOzFEeiDgrJNY0AUOg" base_StructuralFeature="_iy3_AOzFEeiDgrJNY0AUOg" partOfObjectKey="3" valueRange="1..2147483647" unsigned="true"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_iy4mEezFEeiDgrJNY0AUOg" base_Property="_iy3_AOzFEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lF5KgezFEeiDgrJNY0AUOg" base_StructuralFeature="_lF5KgOzFEeiDgrJNY0AUOg" valueRange="0..507"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_lF5xkOzFEeiDgrJNY0AUOg" base_Property="_lF5KgOzFEeiDgrJNY0AUOg" writeAllowed="WRITE_NOT_ALLOWED"/>
+  <OpenModel_Profile:Reference xmi:id="_wrV58OzhEeig48nFftVy3w" base_Element="_lF5KgOzFEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.6.1.5"/>
+  <OpenModel_Profile:Reference xmi:id="_z5ScoOzhEeig48nFftVy3w" base_Element="_f1PJMOzFEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.6.1.4"/>
+  <OpenModel_Profile:Reference xmi:id="_2XXooOzhEeig48nFftVy3w" base_Element="_dpIeAOzFEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.6.1.3"/>
+  <OpenModel_Profile:Reference xmi:id="_5eP6AOzhEeig48nFftVy3w" base_Element="_KCr4UOzEEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.7.7.1"/>
+  <OpenModel_Profile:Reference xmi:id="_7tL2wOzhEeig48nFftVy3w" base_Element="_HN6DkOzEEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 9.2.7.7.1"/>
+  <OpenModel_Profile:Reference xmi:id="_-rpL8OzhEeig48nFftVy3w" base_Element="_46-wgOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.6"/>
+  <OpenModel_Profile:Reference xmi:id="_A6qoQOziEeig48nFftVy3w" base_Element="_3eYPoOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.5"/>
+  <OpenModel_Profile:Reference xmi:id="_DAiIkOziEeig48nFftVy3w" base_Element="_1G1wgOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.4"/>
+  <OpenModel_Profile:Reference xmi:id="_FDsTIOziEeig48nFftVy3w" base_Element="_zPhpkOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.9.3"/>
+  <OpenModel_Profile:Reference xmi:id="_H4WzIOziEeig48nFftVy3w" base_Element="_gc20wOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.8.2"/>
+  <OpenModel_Profile:Reference xmi:id="_KTKosOziEeig48nFftVy3w" base_Element="_bedoIOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.8.1"/>
+  <OpenModel_Profile:Reference xmi:id="_MgxvwOziEeig48nFftVy3w" base_Element="_ZHiNAOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.7.2"/>
+  <OpenModel_Profile:Reference xmi:id="_PNYf8OziEeig48nFftVy3w" base_Element="_XLNqQOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.6.2"/>
+  <OpenModel_Profile:Reference xmi:id="_RTnMoOziEeig48nFftVy3w" base_Element="_VWSwAOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.5.2"/>
+  <OpenModel_Profile:Reference xmi:id="_TpOZIOziEeig48nFftVy3w" base_Element="_TX9bEOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.3.3"/>
+  <OpenModel_Profile:Reference xmi:id="_WXWzUOziEeig48nFftVy3w" base_Element="_PYi_MOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.3.2"/>
+  <OpenModel_Profile:Reference xmi:id="_YpM6IOziEeig48nFftVy3w" base_Element="_NWSMgOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.2.3"/>
+  <OpenModel_Profile:Reference xmi:id="_a40MUOziEeig48nFftVy3w" base_Element="_K_8nQOzDEeiDgrJNY0AUOg" reference="IEEE Std 802.1AB-2016: 8.5.2.2"/>
+  <OpenModel_Profile:OpenModelNotification xmi:id="_tizMgO1hEeig48nFftVy3w" base_Signal="_tiylcO1hEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_43YfIe1hEeig48nFftVy3w" base_Property="_43YfIO1hEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_43ZGMO1hEeig48nFftVy3w" base_StructuralFeature="_43YfIO1hEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_43fz4e1hEeig48nFftVy3w" base_Property="_43fz4O1hEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_43fz4u1hEeig48nFftVy3w" base_StructuralFeature="_43fz4O1hEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MlJqQ-1iEeig48nFftVy3w" base_Property="_MlJqQu1iEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MlKRUO1iEeig48nFftVy3w" base_StructuralFeature="_MlJqQu1iEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MlK4Ye1iEeig48nFftVy3w" base_Property="_MlK4YO1iEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MlK4Yu1iEeig48nFftVy3w" base_StructuralFeature="_MlK4YO1iEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Z24mE-1iEeig48nFftVy3w" base_Property="_Z24mEu1iEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Z25NIO1iEeig48nFftVy3w" base_StructuralFeature="_Z24mEu1iEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Z25NJO1iEeig48nFftVy3w" base_Property="_Z25NI-1iEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Z25NJe1iEeig48nFftVy3w" base_StructuralFeature="_Z25NI-1iEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_m4pzQO1iEeig48nFftVy3w" base_Property="_m4pMMu1iEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_m4rocO1iEeig48nFftVy3w" base_StructuralFeature="_m4pMMu1iEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_m4rodO1iEeig48nFftVy3w" base_Property="_m4roc-1iEeig48nFftVy3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_m4sPgO1iEeig48nFftVy3w" base_StructuralFeature="_m4roc-1iEeig48nFftVy3w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2NWrozObEemmfYv-bFFYSw" base_Property="_2NWrojObEemmfYv-bFFYSw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2NWrpDObEemmfYv-bFFYSw" base_StructuralFeature="_2NWrojObEemmfYv-bFFYSw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5Ec0kzObEemmfYv-bFFYSw" base_Property="_5Ec0kjObEemmfYv-bFFYSw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5Ec0lDObEemmfYv-bFFYSw" base_StructuralFeature="_5Ec0kjObEemmfYv-bFFYSw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_k0I8oDQVEemgQ-i8ZByeIA" base_StructuralFeature="_k0IVkDQVEemgQ-i8ZByeIA" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_k0KKwDQVEemgQ-i8ZByeIA" base_Property="_k0IVkDQVEemgQ-i8ZByeIA"/>
+</xmi:XMI>

--- a/UML/TapiLldp.uml
+++ b/UML/TapiLldp.uml
@@ -124,6 +124,36 @@ revision 2018-11-11 {&#xD;
         </ownedComment>
         <ownedEnd xmi:type="uml:Property" xmi:id="_43fz4O1hEeig48nFftVy3w" name="_remoteTableChange" type="_tiylcO1hEeig48nFftVy3w" association="_43WC4O1hEeig48nFftVy3w"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_McRzUDT5Eem7cZ08OBDNGQ" name="LldpMepsShareSameLocalSystemData" memberEnd="_McU2oDT5Eem7cZ08OBDNGQ _McWr0DT5Eem7cZ08OBDNGQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_McTogDT5Eem7cZ08OBDNGQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_McUPkDT5Eem7cZ08OBDNGQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_McWr0DT5Eem7cZ08OBDNGQ" name="port(lldpmep/lldpagent)" type="_oeHiAOyuEeiDgrJNY0AUOg" association="_McRzUDT5Eem7cZ08OBDNGQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZJu9YDT5Eem7cZ08OBDNGQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZJ2SIDT5Eem7cZ08OBDNGQ" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_CMgpIDT4Eem7cZ08OBDNGQ" name="config" client="_oeHiAOyuEeiDgrJNY0AUOg">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_YCD1kDT3Eem7cZ08OBDNGQ" client="_5-xO8OymEeiDgrJNY0AUOg">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_EhXnsDT4Eem7cZ08OBDNGQ" name="state" client="_oeHiAOyuEeiDgrJNY0AUOg">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_CFT18DTtEem7cZ08OBDNGQ" client="_7xBNYDTsEem7cZ08OBDNGQ">
+        <supplier xmi:type="uml:Enumeration" href="TapiOam.uml#_tqiDYF3eEeit4-HSxnZlvw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_BHdlQDT7Eem7cZ08OBDNGQ" name="EthernetInterface Has LocalSystemData" memberEnd="_BHezYDT7Eem7cZ08OBDNGQ _BHfacjT7Eem7cZ08OBDNGQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_BHeMUDT7Eem7cZ08OBDNGQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_BHeMUTT7Eem7cZ08OBDNGQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_L9prsDT7Eem7cZ08OBDNGQ" annotatedElement="_BHdlQDT7Eem7cZ08OBDNGQ">
+          <body>Be careful with LAG</body>
+        </ownedComment>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_BHfacjT7Eem7cZ08OBDNGQ" name="ethernet sip (uni/enni/inni)" type="_oetG0DT6Eem7cZ08OBDNGQ" association="_BHdlQDT7Eem7cZ08OBDNGQ"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_q7K-4HkhEeiQ1uqYFXu0Kg" name="ClassDiagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_tE_yIHkhEeiQ1uqYFXu0Kg" name="Interfaces"/>
@@ -308,7 +338,7 @@ revision 2018-11-11 {&#xD;
            An NMS can use this object to reduce polling of the&#xD;
            remote-systems-data objects.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="ImplementationCommonDataTypes.uml#_iP8kI_ZaEeWhRf3FikFX5w"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_6iCS8O-fEeWLlrwIF3w0vA"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nHrlcOysEeiDgrJNY0AUOg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nH0vYOysEeiDgrJNY0AUOg" value="1"/>
         </ownedAttribute>
@@ -390,6 +420,9 @@ revision 2018-11-11 {&#xD;
         <ownedComment xmi:type="uml:Comment" xmi:id="_Vr_8QOytEeiDgrJNY0AUOg" annotatedElement="_DR3jQOytEeiDgrJNY0AUOg">
           <body>LLDP local system operational data.</body>
         </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_1JjhcDT9Eem7cZ08OBDNGQ" annotatedElement="_DR3jQOytEeiDgrJNY0AUOg">
+          <body>LocalSystemData should be writable – as it is what sent by LLDP Job re local LLDP “MEP”. Otherwise it is assumed that the selection of an LLDP “port” implies fixed mapping to related/supporting equipment (and its parameters). TAPI models logical and physical (future equipment model) resources separately.</body>
+        </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ay_EMOytEeiDgrJNY0AUOg" name="chassisIdSubtype" type="_wCaMUDObEemmfYv-bFFYSw" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_11GmsOytEeiDgrJNY0AUOg" annotatedElement="_ay_EMOytEeiDgrJNY0AUOg">
             <body>The type of encoding used to identify the chassis&#xD;
@@ -445,13 +478,19 @@ revision 2018-11-11 {&#xD;
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DDnPYOyuEeiDgrJNY0AUOg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_oeHiAOyuEeiDgrJNY0AUOg" name="Port">
+      <packagedElement xmi:type="uml:Class" xmi:id="_oeHiAOyuEeiDgrJNY0AUOg" name="Port(LldpMep/LldpAgent)">
         <ownedComment xmi:type="uml:Comment" xmi:id="_0FQkQOyuEeiDgrJNY0AUOg" annotatedElement="_oeHiAOyuEeiDgrJNY0AUOg">
           <body>LLDP configuration information for a particular port.&#xD;
   &#xD;
          This configuration parameter controls the transmission and&#xD;
          the reception of LLDP frames on those ports whose rows are&#xD;
          created in this table.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8xBbYDT4Eem7cZ08OBDNGQ" annotatedElement="_oeHiAOyuEeiDgrJNY0AUOg">
+          <body>(a) Split into state/config&#xD;
+Might also be split into source/sink&#xD;
+OR&#xD;
+(b) Define new e.g. ProtocolServicePoint (config) and ProtocolPoint (State), to be augmented with LLDP specific attributes. ProtocolPoint can be an optional package of (Ethernet) CEP. </body>
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_k0IVkDQVEemgQ-i8ZByeIA" name="name?">
           <ownedComment xmi:type="uml:Comment" xmi:id="_HSvQEDQcEemgQ-i8ZByeIA" annotatedElement="_k0IVkDQVEemgQ-i8ZByeIA">
@@ -568,6 +607,10 @@ and Ethernet Port.&quot;;&#xD;
         <ownedAttribute xmi:type="uml:Property" xmi:id="_64_KwuzCEeiDgrJNY0AUOg" name="_remoteSystemsData" type="_2OmfQOzCEeiDgrJNY0AUOg" isReadOnly="true" aggregation="composite" association="_64-jsOzCEeiDgrJNY0AUOg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_64_x0OzCEeiDgrJNY0AUOg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_64_x0ezCEeiDgrJNY0AUOg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_McU2oDT5Eem7cZ08OBDNGQ" name="localsystemdata" type="_DR3jQOytEeiDgrJNY0AUOg" association="_McRzUDT5Eem7cZ08OBDNGQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_McVdsTT5Eem7cZ08OBDNGQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_McWEwDT5Eem7cZ08OBDNGQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_xfvzMOyxEeiDgrJNY0AUOg" name="ManagementAddressTxPort">
@@ -757,6 +800,11 @@ and Ethernet Port.&quot;;&#xD;
           <body>Information about a particular physical network connection.&#xD;
            Entries may be created and deleted in this table by the agent,&#xD;
            if a physical topology discovery process is active.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_DlYjwDT8Eem7cZ08OBDNGQ" annotatedElement="_2OmfQOzCEeiDgrJNY0AUOg">
+          <body>Can be modeled as&#xD;
+a.	a “job result” (Current Data paradigm), or &#xD;
+b.	a “discovered” LLDP-MEP (hence the model could be made more symmetric, e.g. using a single class for both ManagementAddressTxPort and ManagementAddress), building a sort of LLDP topology. This may recall (G)MPLS routing paradigm.</body>
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_G0WJgOzDEeiDgrJNY0AUOg" name="timeMark" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_huJscOziEeig48nFftVy3w" annotatedElement="_G0WJgOzDEeiDgrJNY0AUOg">
@@ -1078,6 +1126,15 @@ and Ethernet Port.&quot;;&#xD;
           <type xmi:type="uml:PrimitiveType" href="TapiCommon.uml#_SR47UC7kEem3g99vIRtESQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ex_yAO1eEeig48nFftVy3w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eyHt0O1eEeig48nFftVy3w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_oetG0DT6Eem7cZ08OBDNGQ" name="Ethernet SIP (UNI/ENNI/INNI)">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_vfHOgDT6Eem7cZ08OBDNGQ" annotatedElement="_oetG0DT6Eem7cZ08OBDNGQ">
+          <body>If agreed, to be replaced by imported class.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BHezYDT7Eem7cZ08OBDNGQ" name="localsystemdata" type="_DR3jQOytEeiDgrJNY0AUOg" association="_BHdlQDT7Eem7cZ08OBDNGQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BHfacDT7Eem7cZ08OBDNGQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BHfacTT7Eem7cZ08OBDNGQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
@@ -1576,6 +1633,12 @@ and Ethernet Port.&quot;;&#xD;
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_7xBNYDTsEem7cZ08OBDNGQ" name="LldpOamJobType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_4bW4IDT3Eem7cZ08OBDNGQ" annotatedElement="_7xBNYDTsEem7cZ08OBDNGQ">
+          <body>This enumeration defines the LLDP specific OAM job types.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_NChKYDTtEem7cZ08OBDNGQ" name="LLDP"/>
+      </packagedElement>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_3-ymMHkhEeiQ1uqYFXu0Kg">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qzOO0DOUEemmfYv-bFFYSw" source="PapyrusVersion">
@@ -1946,4 +2009,18 @@ and Ethernet Port.&quot;;&#xD;
   <OpenModel_Profile:OpenModelAttribute xmi:id="_5Ec0lDObEemmfYv-bFFYSw" base_StructuralFeature="_5Ec0kjObEemmfYv-bFFYSw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_k0I8oDQVEemgQ-i8ZByeIA" base_StructuralFeature="_k0IVkDQVEemgQ-i8ZByeIA" partOfObjectKey="1"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_k0KKwDQVEemgQ-i8ZByeIA" base_Property="_k0IVkDQVEemgQ-i8ZByeIA"/>
+  <OpenModel_Profile:Specify xmi:id="_E05BoDTtEem7cZ08OBDNGQ" base_Abstraction="_CFT18DTtEem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:Specify xmi:id="_cWGdoDT3Eem7cZ08OBDNGQ" base_Abstraction="_YCD1kDT3Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:Specify xmi:id="_KMTxQDT4Eem7cZ08OBDNGQ" base_Abstraction="_CMgpIDT4Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:Specify xmi:id="_LrMKEDT4Eem7cZ08OBDNGQ" base_Abstraction="_EhXnsDT4Eem7cZ08OBDNGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_McU2oTT5Eem7cZ08OBDNGQ" base_Property="_McU2oDT5Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_McVdsDT5Eem7cZ08OBDNGQ" base_StructuralFeature="_McU2oDT5Eem7cZ08OBDNGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_McXS4DT5Eem7cZ08OBDNGQ" base_Property="_McWr0DT5Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_McXS4TT5Eem7cZ08OBDNGQ" base_StructuralFeature="_McWr0DT5Eem7cZ08OBDNGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_oetG0TT6Eem7cZ08OBDNGQ" base_Class="_oetG0DT6Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oett4DT6Eem7cZ08OBDNGQ" base_Class="_oetG0DT6Eem7cZ08OBDNGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BHezYTT7Eem7cZ08OBDNGQ" base_Property="_BHezYDT7Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BHezYjT7Eem7cZ08OBDNGQ" base_StructuralFeature="_BHezYDT7Eem7cZ08OBDNGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BHgBgDT7Eem7cZ08OBDNGQ" base_Property="_BHfacjT7Eem7cZ08OBDNGQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BHgokDT7Eem7cZ08OBDNGQ" base_StructuralFeature="_BHfacjT7Eem7cZ08OBDNGQ"/>
 </xmi:XMI>


### PR DESCRIPTION
LLDP model re-engineered from
https://github.com/YangModels/yang/blob/master/standard/ieee/draft/802.1/ieee802-dot1ab-lldp.yang
revision 2018-11-11

Additional change:
Primitive types MacAddress, Binary and Timeticks added to TapiCommon and then referenced in TapiLldp.

Additional comments:
- TapiOam model not imported yet; so far no augmentation of TAPI classes with LLDP functionality (need discussion)
- Reference stereotype need to be suppressed in the class diagrams (update of style sheet)
- name attribute of Port not modeled (is using localId)
- Type of RemoteStatistics::lastChangeTime not set (depending on TapiOam import)
- ZeroBasedCounter32 and Counter32 modelled as Integer and by using profile properties (bitLength = LENGTH_32_BIT, counter = ZERO_COUNTER/COUNTER)
- Modeling of Binary typed attributes to be discussed
- readOnly attribute property just set to show in diagrams; already defined by property writeAllowed = WRITE_NOT_ALLOWED
- YANG path statements added for information (to be removed finally)
- YANG must statement added for information (to be removed finally)
- Bits-typed data types SystemCapabilitiesMap and TlvsTxEnable have to be updated once TAPI has moved to the latest Profiles.

![greenshot](https://user-images.githubusercontent.com/6310277/52703617-0b648580-2f7f-11e9-91b4-adfafaec4727.png)
