### PR TITLE
Issue #353 - Power management for NMC service provisioning

### DIFF
--- a/YANG/tapi-photonic-media@2018-12-10.tree
+++ b/YANG/tapi-photonic-media@2018-12-10.tree
@@ -79,12 +79,24 @@ module: tapi-photonic-media
           |  +--ro application-code               string
           +--ro supportable-modulation*                modulation-technique
           +--ro total-power-warn-threshold
-             +--ro total-power-upper-warn-threshold-default?   decimal64
-             +--ro total-power-upper-warn-threshold-min?       decimal64
-             +--ro total-power-upper-warn-threshold-max?       decimal64
-             +--ro total-power-lower-warn-threshold-default?   decimal64
-             +--ro total-power-lower-warn-threshold-max?       decimal64
-             +--ro total-power-lower-warn-threshold-min?       decimal64
+          |  +--ro total-power-upper-warn-threshold-default?   decimal64
+          |  +--ro total-power-upper-warn-threshold-min?       decimal64
+          |  +--ro total-power-upper-warn-threshold-max?       decimal64
+          |  +--ro total-power-lower-warn-threshold-default?   decimal64
+          |  +--ro total-power-lower-warn-threshold-max?       decimal64
+          |  +--ro total-power-lower-warn-threshold-min?       decimal64
+          +--ro supportable-maximum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro supportable-minimum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-maximum-input-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-minimum-input-power
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
     +--rw otsi-connectivity-service-end-point-spec
        +--rw otsi-config
@@ -112,45 +124,59 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-common:service-interface-point:
     +--rw media-channel-service-interface-point-spec
        +--ro mc-pool
-          +--ro supportable-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro available-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro occupied-spectrum* [upper-frequency lower-frequency]
-             +--ro upper-frequency         uint64
-             +--ro lower-frequency         uint64
-             +--ro frequency-constraint
-                +--ro adjustment-granularity?   adjustment-granularity
-                +--ro grid-type?                grid-type
+       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro available-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
+       |     +--ro upper-frequency         uint64
+       |     +--ro lower-frequency         uint64
+       |     +--ro frequency-constraint
+       |        +--ro adjustment-granularity?   adjustment-granularity
+       |        +--ro grid-type?                grid-type
+       +--ro mc-capability
+          +--ro supportable-maximum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro supportable-minimum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-maximum-input-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-minimum-input-power
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
-    +--rw media-channel-service-interface-point-spec
-       +--ro mc-pool
-          +--ro supportable-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro available-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro occupied-spectrum* [upper-frequency lower-frequency]
-             +--ro upper-frequency         uint64
-             +--ro lower-frequency         uint64
-             +--ro frequency-constraint
-                +--ro adjustment-granularity?   adjustment-granularity
-                +--ro grid-type?                grid-type
+    +--rw media-channel-connectivity-service-end-point-spec
+       +--rw mc-config
+          +--rw spectrum
+          |  +--rw upper-frequency?        uint64
+          |  +--rw lower-frequency?        uint64
+          |  +--rw frequency-constraint
+          |     +--rw adjustment-granularity?   adjustment-granularity
+          |     +--rw grid-type?                grid-type
+          +--rw power-constrains
+             +--rw intended-maximum-output-power
+             |  +--rw total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +--rw intended-minimum-output-power
+             |  +--rw total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +--rw expected-maximum-input-power
+             |  +--rw total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +--rw expected-minimum-input-power
+                +--rw total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
     +--ro media-channel-connection-end-point-spec
        +--ro media-channel
@@ -201,12 +227,24 @@ module: tapi-photonic-media
           |  +--ro application-code               string
           +--ro supportable-modulation*                modulation-technique
           +--ro total-power-warn-threshold
-             +--ro total-power-upper-warn-threshold-default?   decimal64
-             +--ro total-power-upper-warn-threshold-min?       decimal64
-             +--ro total-power-upper-warn-threshold-max?       decimal64
-             +--ro total-power-lower-warn-threshold-default?   decimal64
-             +--ro total-power-lower-warn-threshold-max?       decimal64
-             +--ro total-power-lower-warn-threshold-min?       decimal64
+          |  +--ro total-power-upper-warn-threshold-default?   decimal64
+          |  +--ro total-power-upper-warn-threshold-min?       decimal64
+          |  +--ro total-power-upper-warn-threshold-max?       decimal64
+          |  +--ro total-power-lower-warn-threshold-default?   decimal64
+          |  +--ro total-power-lower-warn-threshold-max?       decimal64
+          |  +--ro total-power-lower-warn-threshold-min?       decimal64
+          +--ro supportable-maximum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro supportable-minimum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-maximum-input-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-minimum-input-power
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
   augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
     +-- otsi-service-interface-point-spec
        +--ro otsi-capability
@@ -225,12 +263,24 @@ module: tapi-photonic-media
           |  +--ro application-code               string
           +--ro supportable-modulation*                modulation-technique
           +--ro total-power-warn-threshold
-             +--ro total-power-upper-warn-threshold-default?   decimal64
-             +--ro total-power-upper-warn-threshold-min?       decimal64
-             +--ro total-power-upper-warn-threshold-max?       decimal64
-             +--ro total-power-lower-warn-threshold-default?   decimal64
-             +--ro total-power-lower-warn-threshold-max?       decimal64
-             +--ro total-power-lower-warn-threshold-min?       decimal64
+          |  +--ro total-power-upper-warn-threshold-default?   decimal64
+          |  +--ro total-power-upper-warn-threshold-min?       decimal64
+          |  +--ro total-power-upper-warn-threshold-max?       decimal64
+          |  +--ro total-power-lower-warn-threshold-default?   decimal64
+          |  +--ro total-power-lower-warn-threshold-max?       decimal64
+          |  +--ro total-power-lower-warn-threshold-min?       decimal64
+          +--ro supportable-maximum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro supportable-minimum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-maximum-input-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-minimum-input-power
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
   augment /tapi-topology:get-node-edge-point-details/tapi-topology:output/tapi-topology:node-edge-point:
     +-- media-channel-node-edge-point-spec
        +--ro mc-pool
@@ -304,38 +354,90 @@ module: tapi-photonic-media
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
           +-- spectrum
-             +-- upper-frequency?        uint64
-             +-- lower-frequency?        uint64
-             +-- frequency-constraint
-                +-- adjustment-granularity?   adjustment-granularity
-                +-- grid-type?                grid-type
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- power-constrains
+             +-- intended-maximum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- intended-minimum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-maximum-input-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-minimum-input-power
+                +-- total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
           +-- spectrum
-             +-- upper-frequency?        uint64
-             +-- lower-frequency?        uint64
-             +-- frequency-constraint
-                +-- adjustment-granularity?   adjustment-granularity
-                +-- grid-type?                grid-type
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- power-constrains
+             +-- intended-maximum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- intended-minimum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-maximum-input-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-minimum-input-power
+                +-- total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
           +-- spectrum
-             +-- upper-frequency?        uint64
-             +-- lower-frequency?        uint64
-             +-- frequency-constraint
-                +-- adjustment-granularity?   adjustment-granularity
-                +-- grid-type?                grid-type
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- power-constrains
+             +-- intended-maximum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- intended-minimum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-maximum-input-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-minimum-input-power
+                +-- total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
           +-- spectrum
-             +-- upper-frequency?        uint64
-             +-- lower-frequency?        uint64
-             +-- frequency-constraint
-                +-- adjustment-granularity?   adjustment-granularity
-                +-- grid-type?                grid-type
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- power-constrains
+             +-- intended-maximum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- intended-minimum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-maximum-input-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-minimum-input-power
+                +-- total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -388,11 +490,24 @@ module: tapi-photonic-media
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
           +-- spectrum
-             +-- upper-frequency?        uint64
-             +-- lower-frequency?        uint64
-             +-- frequency-constraint
-                +-- adjustment-granularity?   adjustment-granularity
-                +-- grid-type?                grid-type
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- power-constrains
+             +-- intended-maximum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- intended-minimum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-maximum-input-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-minimum-input-power
+                +-- total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -421,11 +536,24 @@ module: tapi-photonic-media
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
           +-- spectrum
-             +-- upper-frequency?        uint64
-             +-- lower-frequency?        uint64
-             +-- frequency-constraint
-                +-- adjustment-granularity?   adjustment-granularity
-                +-- grid-type?                grid-type
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- power-constrains
+             +-- intended-maximum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- intended-minimum-output-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-maximum-input-power
+             |  +-- total-power?              decimal64
+             |  +--ro power-spectral-density?   decimal64
+             +-- expected-minimum-input-power
+                +-- total-power?              decimal64
+                +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -453,45 +581,71 @@ module: tapi-photonic-media
   augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
     +-- media-channel-service-interface-point-spec
        +--ro mc-pool
-          +--ro supportable-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro available-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro occupied-spectrum* [upper-frequency lower-frequency]
-             +--ro upper-frequency         uint64
-             +--ro lower-frequency         uint64
-             +--ro frequency-constraint
-                +--ro adjustment-granularity?   adjustment-granularity
-                +--ro grid-type?                grid-type
+       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro available-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
+       |     +--ro upper-frequency         uint64
+       |     +--ro lower-frequency         uint64
+       |     +--ro frequency-constraint
+       |        +--ro adjustment-granularity?   adjustment-granularity
+       |        +--ro grid-type?                grid-type
+       +--ro mc-capability
+          +--ro supportable-maximum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro supportable-minimum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-maximum-input-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-minimum-input-power
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
   augment /tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip:
     +-- media-channel-service-interface-point-spec
        +--ro mc-pool
-          +--ro supportable-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro available-spectrum* [upper-frequency lower-frequency]
-          |  +--ro upper-frequency         uint64
-          |  +--ro lower-frequency         uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro occupied-spectrum* [upper-frequency lower-frequency]
-             +--ro upper-frequency         uint64
-             +--ro lower-frequency         uint64
-             +--ro frequency-constraint
-                +--ro adjustment-granularity?   adjustment-granularity
-                +--ro grid-type?                grid-type
+       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro available-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
+       |     +--ro upper-frequency         uint64
+       |     +--ro lower-frequency         uint64
+       |     +--ro frequency-constraint
+       |        +--ro adjustment-granularity?   adjustment-granularity
+       |        +--ro grid-type?                grid-type
+       +--ro mc-capability
+          +--ro supportable-maximum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro supportable-minimum-output-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-maximum-input-power
+          |  +--ro total-power?              decimal64
+          |  +--ro power-spectral-density?   decimal64
+          +--ro tolerable-minimum-input-power
+             +--ro total-power?              decimal64
+             +--ro power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connection-end-point-details/tapi-connectivity:output/tapi-connectivity:connection-end-point:
     +-- media-channel-connection-end-point-spec
        +--ro media-channel

--- a/YANG/tapi-photonic-media@2018-12-10.tree
+++ b/YANG/tapi-photonic-media@2018-12-10.tree
@@ -118,7 +118,7 @@ module: tapi-photonic-media
           +--rw laser-control?                      laser-control-type
           +--rw transmit-power
           |  +--rw total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +--rw power-spectral-density?   decimal64
           +--rw total-power-warn-threshold-upper?   decimal64
           +--rw total-power-warn-threshold-lower?   decimal64
   augment /tapi-common:context/tapi-common:service-interface-point:
@@ -167,16 +167,16 @@ module: tapi-photonic-media
           +--rw power-constrains
              +--rw intended-maximum-output-power
              |  +--rw total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +--rw power-spectral-density?   decimal64
              +--rw intended-minimum-output-power
              |  +--rw total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +--rw power-spectral-density?   decimal64
              +--rw expected-maximum-input-power
              |  +--rw total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +--rw power-spectral-density?   decimal64
              +--rw expected-minimum-input-power
                 +--rw total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +--rw power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
     +--ro media-channel-connection-end-point-spec
        +--ro media-channel
@@ -323,7 +323,7 @@ module: tapi-photonic-media
           +-- laser-control?                      laser-control-type
           +-- transmit-power
           |  +-- total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
@@ -347,7 +347,7 @@ module: tapi-photonic-media
           +-- laser-control?                      laser-control-type
           +-- transmit-power
           |  +-- total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
@@ -362,16 +362,16 @@ module: tapi-photonic-media
           +-- power-constrains
              +-- intended-maximum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- intended-minimum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-maximum-input-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-minimum-input-power
                 +-- total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
@@ -384,16 +384,16 @@ module: tapi-photonic-media
           +-- power-constrains
              +-- intended-maximum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- intended-minimum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-maximum-input-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-minimum-input-power
                 +-- total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
@@ -406,16 +406,16 @@ module: tapi-photonic-media
           +-- power-constrains
              +-- intended-maximum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- intended-minimum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-maximum-input-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-minimum-input-power
                 +-- total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config
@@ -428,16 +428,16 @@ module: tapi-photonic-media
           +-- power-constrains
              +-- intended-maximum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- intended-minimum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-maximum-input-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-minimum-input-power
                 +-- total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -459,7 +459,7 @@ module: tapi-photonic-media
           +-- laser-control?                      laser-control-type
           +-- transmit-power
           |  +-- total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
@@ -483,7 +483,7 @@ module: tapi-photonic-media
           +-- laser-control?                      laser-control-type
           +-- transmit-power
           |  +-- total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
@@ -498,16 +498,16 @@ module: tapi-photonic-media
           +-- power-constrains
              +-- intended-maximum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- intended-minimum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-maximum-input-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-minimum-input-power
                 +-- total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -529,7 +529,7 @@ module: tapi-photonic-media
           +-- laser-control?                      laser-control-type
           +-- transmit-power
           |  +-- total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
@@ -544,16 +544,16 @@ module: tapi-photonic-media
           +-- power-constrains
              +-- intended-maximum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- intended-minimum-output-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-maximum-input-power
              |  +-- total-power?              decimal64
-             |  +--ro power-spectral-density?   decimal64
+             |  +-- power-spectral-density?   decimal64
              +-- expected-minimum-input-power
                 +-- total-power?              decimal64
-                +--ro power-spectral-density?   decimal64
+                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -575,7 +575,7 @@ module: tapi-photonic-media
           +-- laser-control?                      laser-control-type
           +-- transmit-power
           |  +-- total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
+          |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
@@ -701,3 +701,6 @@ module: tapi-photonic-media
              +--ro laser-application-type?   laser-type
              +--ro laser-bias-current?       decimal64
              +--ro laser-temperature?        decimal64
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link:
+    +--ro power-loss-characteristic
+       +--ro expected-loss?   decimal64

--- a/YANG/tapi-photonic-media@2018-12-10.yang
+++ b/YANG/tapi-photonic-media@2018-12-10.yang
@@ -109,8 +109,8 @@ module tapi-photonic-media {
         description "none";
     }
     augment "/tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point" {
-        container media-channel-service-interface-point-spec {
-            uses media-channel-service-interface-point-spec;
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
             description "none";
         }
         description "none";
@@ -276,6 +276,13 @@ module tapi-photonic-media {
         }
         description "none";
     }
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link" {
+        container power-loss-characteristic {
+            uses power-loss-pac;
+            description "none";
+        }
+        description "none";
+    }
 
    /**************************
     * package object-classes
@@ -429,7 +436,9 @@ module tapi-photonic-media {
             uses total-power-threshold-pac;
             description "none";
         }
+        uses power-management-capability-pac;
         description "Can read the status of the warning for the upper value that the power can reach.";
+
     }
     grouping otsi-service-interface-point-spec {
         container otsi-capability {
@@ -446,6 +455,57 @@ module tapi-photonic-media {
         }
         description "none";
     }
+    grouping power-management-capability-pac{
+      container supportable-maximum-output-power {
+          uses power-properties-pac;
+          description "This parameter exposes the maximum output power
+            supported at the Logical-Termination-Point (LTP) associated to the SIP.";
+      }
+      container supportable-minimum-output-power {
+          uses power-properties-pac;
+          description "This parameter exposes the minimum output power
+            supported at the Logical-Termination-Point (LTP) associated to the SIP.";
+      }
+      container tolerable-maximum-input-power {
+          uses power-properties-pac;
+          description "This parameter exposes the maximum input power
+            tolerated at the Logical-Termination-Point (LTP) associated to the SIP.";
+      }
+      container tolerable-minimum-input-power {
+          uses power-properties-pac;
+          description "This parameter exposes the minimum input power
+            tolerated at the Logical-Termination-Point (LTP) associated to the SIP.";
+      }
+      description "This pac includes power management capabilities which can
+        be exposed as part of the characterization of the different LTPs at the PHOTONIC_MEDIA layer.";
+    }
+
+    grouping power-management-config-pac{
+      container intended-maximum-output-power {
+          uses power-properties-pac;
+          description "This parameter shall be used to specify the maximum output power
+            desired at the Logical-Termination-Point (LTP) associated to the CSEP.";
+      }
+      container intended-minimum-output-power {
+          uses power-properties-pac;
+          description "This parameter shall be used to specify the minimum output power
+            desired at the Logical-Termination-Point (LTP) associated to the CSEP.";
+      }
+      container expected-maximum-input-power {
+          uses power-properties-pac;
+          description "This parameter shall be used to specify the maximum input power
+            being received at the Logical-Termination-Point (LTP) associated to the CSEP.";
+      }
+      container expected-minimum-input-power {
+          uses power-properties-pac;
+          description "This parameter shall be used to specify the minimum input power
+            being received at the Logical-Termination-Point (LTP) associated to the CSEP.";
+      }
+      description "This pac includes power management constrains which can
+        be included as part of the characterization of the Connectivity-Service-End-Points
+        associated to Logical-Termination-Points (LTPs) at the PHOTONIC_MEDIA layer.";
+    }
+
     grouping otsi-termination-config-pac {
         container central-frequency {
             uses central-frequency;
@@ -524,6 +584,11 @@ module tapi-photonic-media {
             uses media-channel-pool-capability-pac;
             description "none";
         }
+        container mc-capability{
+            config false;
+            uses power-management-capability-pac;
+            description "none";
+        }
         description "none";
     }
     grouping media-channel-connectivity-service-end-point-spec {
@@ -537,6 +602,13 @@ module tapi-photonic-media {
         container spectrum {
             uses spectrum-band;
             description "none";
+        }
+        container power-constrains{
+            uses power-management-config-pac;
+            description "This parameters shall be used to configure the expected
+              and intended (desired) power levels at the endpoints of the media
+              Channel connectivity service. These parameters are dependent of the
+              related OTSi power-management capabilities exposed at the SIPs";
         }
         description "none";
     }
@@ -585,6 +657,14 @@ module tapi-photonic-media {
             description "The temperature of the laser";
         }
         description "none";
+    }
+    grouping power-loss-pac {
+        leaf expected-loss {
+            type decimal64 {
+                fraction-digits 7;
+            }
+            description "The total power loss in a photonic link specified in dB.";
+        }
     }
     grouping power-properties-pac {
         leaf total-power {

--- a/YANG/tapi-photonic-media@2018-12-10.yang
+++ b/YANG/tapi-photonic-media@2018-12-10.yang
@@ -677,7 +677,6 @@ module tapi-photonic-media {
             type decimal64 {
                 fraction-digits 7;
             }
-            config false;
             description "This describes how power of a signal  is distributed over frequency specified in nW/MHz";
         }
         description "Indication with severity warning raised when a total power value measured is above the threshold.";


### PR DESCRIPTION
This commit includes extensions to the tapi-photonic-media information model. Specifically, OTSi and Media Channel Service Interface Points (SIPs) are extended with capability information of the operational power range asociated to the related LTPs.
On the other hand, the MC Connectivity Service End-Points (CSEPs) are extended with a set of power management constrains which can be configured at the connectivity service creation to denote intent-like soft constrains.
Moreover, this commit includes an extension for photonic-media links which includes the expected power loss as a state characteristic to be specified by the TAPI server.