### PR TITLE
Several enhancements:

### DIFF
--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -373,10 +373,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_rNbewr1-EeWdore3Cxez9g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ALOE4UwCEeewALXL7BvPYw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_vzQ2YFtUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_l9HQoFtUEeexvMtO2oNM9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_vzQ2YVtUEeexvMtO2oNM9g"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__NNkgUwBEeewALXL7BvPYw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__NNkgkwBEeewALXL7BvPYw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="__NNkg0wBEeewALXL7BvPYw"/>
@@ -418,84 +414,6 @@
       </children>
       <element xmi:type="uml:DataType" href="TapiCommon.uml#_ReBfoFs7EeexvMtO2oNM9g"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ReDU0Vs7EeexvMtO2oNM9g" x="73" y="550" height="90"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nCdRcFs7EeexvMtO2oNM9g" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_nCdRcls7EeexvMtO2oNM9g" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nCdRc1s7EeexvMtO2oNM9g" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nCdRdFs7EeexvMtO2oNM9g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nCdRdVs7EeexvMtO2oNM9g" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_n9nSIFs7EeexvMtO2oNM9g" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_PYdMgD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_n9nSIVs7EeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_n9nSIls7EeexvMtO2oNM9g" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_R0GvkD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_n9nSI1s7EeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_n9n5MFs7EeexvMtO2oNM9g" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_VNVVMD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_n9n5MVs7EeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_n9ogQFs7EeexvMtO2oNM9g" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_YMrbMD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_n9ogQVs7EeexvMtO2oNM9g"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nCdRdls7EeexvMtO2oNM9g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nCdRd1s7EeexvMtO2oNM9g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nCdReFs7EeexvMtO2oNM9g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCdReVs7EeexvMtO2oNM9g"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_EuZIcD6gEeai_egNtQKqQA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCdRcVs7EeexvMtO2oNM9g" x="424" y="501"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wVr44FtSEeexvMtO2oNM9g" type="DataType_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_wVsf8FtSEeexvMtO2oNM9g" type="DataType_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_wVsf8VtSEeexvMtO2oNM9g" type="DataType_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_wVsf8ltSEeexvMtO2oNM9g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_wVsf81tSEeexvMtO2oNM9g" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_14yDIFtUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_zB_30D6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14yDIVtUEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_14yqMFtUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_FKRr0D6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14yqMVtUEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_14yqMltUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_VJ4jID6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14yqM1tUEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_14yqNFtUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_aMoEQD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14yqNVtUEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_14zRQFtUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_g9oeAD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14zRQVtUEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_14zRQltUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_or7mcD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14zRQ1tUEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_14zRRFtUEeexvMtO2oNM9g" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_u_PXkD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_14zRRVtUEeexvMtO2oNM9g"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_wVsf9FtSEeexvMtO2oNM9g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_wVsf9VtSEeexvMtO2oNM9g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_wVsf9ltSEeexvMtO2oNM9g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wVsf91tSEeexvMtO2oNM9g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_wVsf-FtSEeexvMtO2oNM9g" type="DataType_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_wVsf-VtSEeexvMtO2oNM9g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_wVsf-ltSEeexvMtO2oNM9g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_wVsf-1tSEeexvMtO2oNM9g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wVsf_FtSEeexvMtO2oNM9g"/>
-      </children>
-      <element xmi:type="uml:DataType" href="TapiCommon.uml#_wT5JIFtSEeexvMtO2oNM9g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wVr44VtSEeexvMtO2oNM9g" x="410" y="308" height="167"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_-ilVEFtVEeexvMtO2oNM9g" type="DataType_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_-il8IFtVEeexvMtO2oNM9g" type="DataType_NameLabel"/>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -483,41 +483,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rNbexL1-EeWdore3Cxez9g" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNbexb1-EeWdore3Cxez9g" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_l9HQoFtUEeexvMtO2oNM9g" name="bandwidthProfile" type="_wT5JIFtSEeexvMtO2oNM9g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9_4ZwH4JEeeh4KO3PMo8Rw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-ElTkH4JEeeh4KO3PMo8Rw" value="1"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_wT5JIFtSEeexvMtO2oNM9g" name="BandwidthProfile">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_zB_30D6iEeai_egNtQKqQA" name="bwProfileType" type="_EuZIcD6gEeai_egNtQKqQA"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_FKRr0D6jEeai_egNtQKqQA" name="committedInformationRate" type="_ReBfoFs7EeexvMtO2oNM9g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HJt0AD6jEeai_egNtQKqQA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HJt0Aj6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_VJ4jID6jEeai_egNtQKqQA" name="committedBurstSize" type="_ReBfoFs7EeexvMtO2oNM9g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WDdPcD6jEeai_egNtQKqQA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WDdPcj6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_aMoEQD6jEeai_egNtQKqQA" name="peakInformationRate" type="_ReBfoFs7EeexvMtO2oNM9g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_btxt8D6jEeai_egNtQKqQA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bt634D6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_g9oeAD6jEeai_egNtQKqQA" name="peakBurstSize" type="_ReBfoFs7EeexvMtO2oNM9g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iAAhAD6jEeai_egNtQKqQA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iAAhAj6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_or7mcD6jEeai_egNtQKqQA" name="colorAware">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wk4fsD6jEeai_egNtQKqQA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wlCQsT6jEeai_egNtQKqQA" value="1"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_or7mcT6jEeai_egNtQKqQA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_u_PXkD6jEeai_egNtQKqQA" name="couplingFlag">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xq1bID6jEeai_egNtQKqQA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xq1bIj6jEeai_egNtQKqQA" value="1"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_u_PXkT6jEeai_egNtQKqQA"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_ReBfoFs7EeexvMtO2oNM9g" name="CapacityValue" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_mikQgGHKEee8BtPo-u_r6A">
@@ -571,12 +536,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
         </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_QGV4QJqQEeid4dfn4JFJZg" name="GHz"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_SDsVwJqQEeid4dfn4JFJZg" name="MHz"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EuZIcD6gEeai_egNtQKqQA" name="BandwidthProfileType" isLeaf="true">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PYdMgD6iEeai_egNtQKqQA" name="MEF_10.x"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_R0GvkD6iEeai_egNtQKqQA" name="RFC_2697"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VNVVMD6iEeai_egNtQKqQA" name="RFC_2698"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YMrbMD6iEeai_egNtQKqQA" name="RFC_4115"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_-ijf4FtVEeexvMtO2oNM9g" name="TimeRange" isLeaf="true">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_qDhdIL2OEeWdore3Cxez9g" name="endTime" type="_6iCS8O-fEeWLlrwIF3w0vA">
@@ -773,22 +732,8 @@ The timeticks type represents a non-negative integer that represents the time, m
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhRhrEeewCs0lkpWskw" base_Property="_6efrZtnVEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhhhrEeewCs0lkpWskw" base_Property="_FRi-QtnWEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3RhsEeewCs0lkpWskw" base_Property="_rNbewr1-EeWdore3Cxez9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3hhsEeewCs0lkpWskw" base_Property="_zB_30D6iEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3xhsEeewCs0lkpWskw" base_Property="_FKRr0D6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcBhsEeewCs0lkpWskw" base_Property="_VJ4jID6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcRhsEeewCs0lkpWskw" base_Property="_aMoEQD6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMchhsEeewCs0lkpWskw" base_Property="_g9oeAD6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcxhsEeewCs0lkpWskw" base_Property="_or7mcD6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMdBhsEeewCs0lkpWskw" base_Property="_u_PXkD6jEeai_egNtQKqQA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OxhsEeewCs0lkpWskw" base_Property="_KjZXNdyKEeWXdJnxZxtFYA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_PBhsEeewCs0lkpWskw" base_Property="_KjZXOdyKEeWXdJnxZxtFYA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_zB_30j6iEeai_egNtQKqQA" base_StructuralFeature="_zB_30D6iEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_FKRr0j6jEeai_egNtQKqQA" base_StructuralFeature="_FKRr0D6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_VJ4jIj6jEeai_egNtQKqQA" base_StructuralFeature="_VJ4jID6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_aMoEQj6jEeai_egNtQKqQA" base_StructuralFeature="_aMoEQD6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_g9oeAj6jEeai_egNtQKqQA" base_StructuralFeature="_g9oeAD6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_or7mcz6jEeai_egNtQKqQA" base_StructuralFeature="_or7mcD6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_u_PXkz6jEeai_egNtQKqQA" base_StructuralFeature="_u_PXkD6jEeai_egNtQKqQA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_Kk4ksdyKEeWXdJnxZxtFYA" base_Class="_KjZXM9yKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4kstyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXNdyKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ks9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXOdyKEeWXdJnxZxtFYA"/>
@@ -814,8 +759,6 @@ The timeticks type represents a non-negative integer that represents the time, m
   <OpenModel_Profile:OpenModelAttribute xmi:id="_axM7MVs7EeexvMtO2oNM9g" base_StructuralFeature="_axM7MFs7EeexvMtO2oNM9g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_axM7Mls7EeexvMtO2oNM9g" base_Property="_axM7MFs7EeexvMtO2oNM9g"/>
   <OpenModel_Profile:Reference xmi:id="_DZgKEFs9EeexvMtO2oNM9g" base_Element="_FRi-QNnWEeWIOYiRCk5bbQ" reference="{&quot;source&quot;:&quot;rfc6991&quot;, &quot;yang-import&quot;:&quot;ietf-yang-types/uuid&quot;}"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_l9HQoVtUEeexvMtO2oNM9g" base_StructuralFeature="_l9HQoFtUEeexvMtO2oNM9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_l9HQoltUEeexvMtO2oNM9g" base_Property="_l9HQoFtUEeexvMtO2oNM9g"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_OxAk4GNAEee0bPnI-Gt-mQ" base_Operation="_OsQnwGNAEee0bPnI-Gt-mQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_qbqmsGNDEee0bPnI-Gt-mQ" base_Parameter="_qZ9WgGNDEee0bPnI-Gt-mQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_ee1y4GNEEee0bPnI-Gt-mQ" base_Parameter="_ee1L0GNEEee0bPnI-Gt-mQ"/>

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -94,89 +94,33 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pxOQUjN7Eea40e5DA9KE3w" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_pxOQUzN7Eea40e5DA9KE3w" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_2ll6sDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2Cq60DaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_Styy4C0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2ll6sTN7Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2Crh4DaqEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2lsBUDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2CsI8DaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_Ny8pgC0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2lsBUTN7Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2CsI8TaqEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2lxg4DN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2CsI8jaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_QsAhUC0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2lxg4TN7Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2CsI8zaqEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2l3AcDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_Osz7EOuHEeGZr5p9Vdkojw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2l3AcTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2l8gADN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_dOaR8C0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2l8gATN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mCmoDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_ukk3kDqaEeCu35lketJ8Yg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mCmoTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mHfIDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_-A0TI5MuEeCKK9uc7Khnmg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mHfITN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mR3MDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_hBZhA5MvEeCKK9uc7Khnmg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mR3MTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mXWwDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_bXqLsC0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mXWwTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mc2UDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#__7TK8C01EeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mc2UTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mjkADN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel" fontName="Segoe UI">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_9Gc_oDN7Eea40e5DA9KE3w" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9Gc_oTN7Eea40e5DA9KE3w" key="fontHeight" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9GdmsDN7Eea40e5DA9KE3w" key="bold" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9GdmsTN7Eea40e5DA9KE3w" key="italic" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hl0xwDlFEeaHY8ihI-WgZg" key="fontColor" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiEth.uml#_LpAAEJMvEeCKK9uc7Khnmg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mjkATN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2mq4wDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_0_3YIC01EeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mq4wTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2my0kDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_Xo3rYJMvEeCKK9uc7Khnmg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2my0kTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2m6wYDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2CsI9DaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_Zg5eYC0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2m6wYTN7Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2CsI9TaqEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2nDTQDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2CsI9jaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_VVbjgC0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2nDTQTN7Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2CsI9zaqEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2nPggDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2CswADaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_Xkn-8C0xEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2nPggTN7Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2CswATaqEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2nZRgDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_pU1bwC0yEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2nZRgTN7Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_2njCgDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel" fontName="Segoe UI">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6xiioDO7Eea40e5DA9KE3w" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6xiioTO7Eea40e5DA9KE3w" key="fontHeight" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6xjwwDO7Eea40e5DA9KE3w" key="bold" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6xkX0DO7Eea40e5DA9KE3w" key="italic" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_eoxKwDlFEeaHY8ihI-WgZg" key="fontColor" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiEth.uml#_VAOosziEEeGKKvtWtO2aIg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2njCgTN7Eea40e5DA9KE3w"/>
+        <children xmi:type="notation:Shape" xmi:id="_2CswAjaqEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_bXqLsC0xEeC5VOR5P4wONQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2CswAzaqEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_pxOQVDN7Eea40e5DA9KE3w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_pxOQVTN7Eea40e5DA9KE3w"/>
@@ -196,7 +140,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pxOQYTN7Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_7ySKwOuGEeGZr5p9Vdkojw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pxNpQTN7Eea40e5DA9KE3w" x="660" y="286" height="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pxNpQTN7Eea40e5DA9KE3w" x="662" y="176" height="151"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_M-W3ADN9Eea40e5DA9KE3w" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_M-XeEDN9Eea40e5DA9KE3w" type="Class_NameLabel"/>
@@ -204,29 +148,9 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_M-XeEjN9Eea40e5DA9KE3w" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_M-XeEzN9Eea40e5DA9KE3w" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_UJj5cDN9Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_vOIbgHp1Ed2F76X026nNcA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UJj5cTN9Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UJ4CgDN9Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#__KuU8HnOEd2GobjTM4neEA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UJ4CgTN9Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UKBMcDN9Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_0_GOcHnOEd2GobjTM4neEA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UKBzgDN9Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UKK9cDN9Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_zDHp8HnOEd2GobjTM4neEA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UKK9cTN9Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UKVVgDN9Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_q7yL8nnNEd2GobjTM4neEA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UKVVgTN9Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UKzPkDN9Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_upySMHnOEd2GobjTM4neEA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UKzPkTN9Eea40e5DA9KE3w"/>
+        <children xmi:type="notation:Shape" xmi:id="_aFUCUDp_EemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_rkBnITapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aFUCUTp_EemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_M-XeFDN9Eea40e5DA9KE3w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_M-XeFTN9Eea40e5DA9KE3w"/>
@@ -246,7 +170,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-XeITN9Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_ACUEMOxFEeGzwM2Uvwf5Xw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-W3ATN9Eea40e5DA9KE3w" x="86" y="289" height="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-W3ATN9Eea40e5DA9KE3w" x="371" y="175" width="221" height="77"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_3gR58DN-Eea40e5DA9KE3w" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_3gR58jN-Eea40e5DA9KE3w" type="Class_NameLabel"/>
@@ -254,21 +178,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3gR59DN-Eea40e5DA9KE3w" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_3gR59TN-Eea40e5DA9KE3w" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_82g-0DN-Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_J3_wsHzUEd2S7rQMqMRYLA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_82g-0TN-Eea40e5DA9KE3w"/>
+        <children xmi:type="notation:Shape" xmi:id="_cHQr8Dp_EemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_mN_ogDanEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cHQr8Tp_EemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_82xdgDN-Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_ibtJIC0kEeC5VOR5P4wONQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_82xdgTN-Eea40e5DA9KE3w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_83BVIDN-Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cHRTADp_EemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_PFLnQHzUEd2S7rQMqMRYLA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_83BVITN-Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cHRTATp_EemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_83TB8DN-Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_cHR6EDp_EemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_QoRxsHzUEd2S7rQMqMRYLA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_83TB8TN-Eea40e5DA9KE3w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cHR6ETp_EemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_3gR59jN-Eea40e5DA9KE3w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_3gR59zN-Eea40e5DA9KE3w"/>
@@ -288,7 +208,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3gShBDN-Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_fzLz0OxQEeGzwM2Uvwf5Xw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3gR58TN-Eea40e5DA9KE3w" x="-14" y="174" height="111"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3gR58TN-Eea40e5DA9KE3w" x="117" y="164" width="226" height="83"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F9-GMDO5Eea40e5DA9KE3w" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_F9-GMjO5Eea40e5DA9KE3w" type="Class_NameLabel"/>
@@ -330,7 +250,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F9-tUDO5Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_8QIrYK4wEeGjbtFXtCFKWg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F9-GMTO5Eea40e5DA9KE3w" x="120" y="439" height="107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F9-GMTO5Eea40e5DA9KE3w" x="678" y="699" height="107"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_iCoq0DO5Eea40e5DA9KE3w" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_iCoq0jO5Eea40e5DA9KE3w" type="Class_NameLabel"/>
@@ -368,7 +288,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCpR7jO5Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_8QR1UK4wEeGjbtFXtCFKWg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCoq0TO5Eea40e5DA9KE3w" x="117" y="558" height="88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCoq0TO5Eea40e5DA9KE3w" x="247" y="700" height="88"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F4J7YDlGEeaHY8ihI-WgZg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_F4J7YTlGEeaHY8ihI-WgZg" showTitle="true"/>
@@ -550,6 +470,632 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6W70ovK3EeiTnqcAgKK24Q" x="632" y="-117"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_v0O_cDamEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v0PmgDamEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_v0PmgTamEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_v0PmgjamEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v0PmgzamEem8b5f98b_cVw" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v0PmhDamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v0PmhTamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v0PmhjamEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v0PmhzamEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v0QNkDamEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v0QNkTamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v0QNkjamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v0QNkzamEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v0QNlDamEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_v0QNlTamEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_v0QNljamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_v0QNlzamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_v0QNmDamEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v0QNmTamEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v0O_cTamEem8b5f98b_cVw" x="894" y="-114" height="59"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v0tgkDamEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v0tgkTamEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v0tgkzamEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v0tgkjamEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9DNiMDamEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9DOJQDamEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9DOJQTamEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9DOJQjamEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9DOJQzamEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9DOJRDamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9DOJRTamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9DOJRjamEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9DOJRzamEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9DOJSDamEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9DOJSTamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9DOJSjamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9DOJSzamEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9DOJTDamEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9DOJTTamEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9DOJTjamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9DOJTzamEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9DOJUDamEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9DOJUTamEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_9DICoDamEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9DNiMTamEem8b5f98b_cVw" x="854" y="4" width="243" height="81"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9DX6SzamEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9DX6TDamEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9DX6TjamEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_9DICoDamEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9DX6TTamEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KIO3sDanEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_KIO3sjanEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_KIO3szanEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KIO3tDanEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KIO3tTanEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_VvCiwDanEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Vu71EDanEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_VvCiwTanEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ZG-u8DanEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_ZG6dgDanEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZG-u8TanEem8b5f98b_cVw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KIO3tjanEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KIO3tzanEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KIO3uDanEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KIO3uTanEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KIO3ujanEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KIO3uzanEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KIO3vDanEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KIO3vTanEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KIO3vjanEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KIO3vzanEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KIO3wDanEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KIO3wTanEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KIO3wjanEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KIO3wzanEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_KIJ_MDanEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KIO3sTanEem8b5f98b_cVw" x="111" y="315"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KIU-UzanEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KIU-VDanEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KIU-VjanEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_KIJ_MDanEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KIU-VTanEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__Zb9QzanEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__Zb9RDanEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__ZckUDanEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_mN4TwDanEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Zb9RTanEem8b5f98b_cVw" x="186" y="74"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SmKQ0zaoEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SmKQ1DaoEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SmKQ1jaoEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_CdjOgDaoEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SmKQ1TaoEem8b5f98b_cVw" x="1095" y="-76"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YmeNcDaoEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YmeNcTaoEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YmeNczaoEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_XPJ1MDaoEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YmeNcjaoEem8b5f98b_cVw" x="1095" y="-76"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nsYAIDapEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nsYAIjapEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nsYAIzapEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nsYAJDapEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nsYAJTapEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_0rp6ADapEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0rSGkDapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0rp6ATapEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0rqhEDapEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0rceoDapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0rqhETapEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0rqhEjapEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0rZbUDapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0rqhEzapEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0rrIIDapEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0rPDQDapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0rrIITapEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0rrIIjapEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0rVJ4DapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0rrIIzapEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_0rrIJDapEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0rhXIDapEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0rrIJTapEem8b5f98b_cVw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nsYAJjapEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nsYAJzapEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nsYAKDapEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nsYAKTapEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nsYAKjapEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nsYAKzapEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nsYALDapEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nsYALTapEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nsYALjapEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nsYALzapEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nsYAMDapEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nsYnMDapEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nsYnMTapEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nsYnMjapEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_nsU80DapEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nsYAITapEem8b5f98b_cVw" x="71" y="443" height="134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nseGzjapEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nseGzzapEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nseG0TapEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_nsU80DapEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nseG0DapEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RLQHIDaqEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_RLQuMDaqEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RLQuMTaqEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RLQuMjaqEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RLQuMzaqEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_2l3AcDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Osz7EOuHEeGZr5p9Vdkojw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2l3AcTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2l8gADN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_dOaR8C0xEeC5VOR5P4wONQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2l8gATN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2mCmoDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_ukk3kDqaEeCu35lketJ8Yg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mCmoTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2mHfIDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_-A0TI5MuEeCKK9uc7Khnmg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mHfITN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2mR3MDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_hBZhA5MvEeCKK9uc7Khnmg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mR3MTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2mc2UDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#__7TK8C01EeC5VOR5P4wONQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mc2UTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2mjkADN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel" fontName="Segoe UI">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_9Gc_oDN7Eea40e5DA9KE3w" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9Gc_oTN7Eea40e5DA9KE3w" key="fontHeight" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9GdmsDN7Eea40e5DA9KE3w" key="bold" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9GdmsTN7Eea40e5DA9KE3w" key="italic" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hl0xwDlFEeaHY8ihI-WgZg" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element xmi:type="uml:Property" href="TapiEth.uml#_LpAAEJMvEeCKK9uc7Khnmg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mjkATN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2mq4wDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_0_3YIC01EeC5VOR5P4wONQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2mq4wTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2my0kDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Xo3rYJMvEeCKK9uc7Khnmg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2my0kTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2nZRgDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_pU1bwC0yEeC5VOR5P4wONQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2nZRgTN7Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2njCgDN7Eea40e5DA9KE3w" type="Property_ClassAttributeLabel" fontName="Segoe UI">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6xiioDO7Eea40e5DA9KE3w" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6xiioTO7Eea40e5DA9KE3w" key="fontHeight" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6xjwwDO7Eea40e5DA9KE3w" key="bold" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6xkX0DO7Eea40e5DA9KE3w" key="italic" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_eoxKwDlFEeaHY8ihI-WgZg" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element xmi:type="uml:Property" href="TapiEth.uml#_VAOosziEEeGKKvtWtO2aIg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2njCgTN7Eea40e5DA9KE3w"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RLQuNDaqEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RLQuNTaqEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RLQuNjaqEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RLQuNzaqEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RLQuODaqEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RLQuOTaqEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RLQuOjaqEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RLQuOzaqEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RLQuPDaqEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RLQuPTaqEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RLQuPjaqEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RLQuPzaqEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RLQuQDaqEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RLQuQTaqEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_RLND0DaqEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RLQHITaqEem8b5f98b_cVw" x="688" y="441" width="193" height="210"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RLYC8zaqEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_RLYC9DaqEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RLYC9jaqEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_RLND0DaqEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RLYC9TaqEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dy9cQDavEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dy9cQTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dy9cQzavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_4n7QYDarEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dy9cQjavEem8b5f98b_cVw" x="862" y="76"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gkBOoDavEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gkBOoTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gkBOozavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_rj_x8DapEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gkBOojavEem8b5f98b_cVw" x="571" y="75"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_jX1aEDavEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_jX1aETavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jX1aEzavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_DGw4sDaqEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jX1aEjavEem8b5f98b_cVw" x="1081" y="-94"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_l9f0wDavEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_l9f0wTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l9f0wzavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_PA9dADauEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l9f0wjavEem8b5f98b_cVw" x="1081" y="-94"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9ynWIDa3Eem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9yn9MDa3Eem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9yn9MTa3Eem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9yn9Mja3Eem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9yn9Mza3Eem8b5f98b_cVw" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9yn9NDa3Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9yn9NTa3Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9yn9Nja3Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9yn9Nza3Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9yn9ODa3Eem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9yn9OTa3Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9yn9Oja3Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9yn9Oza3Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9yn9PDa3Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9yn9PTa3Eem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9yn9Pja3Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9yn9Pza3Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9yn9QDa3Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9yn9QTa3Eem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9ynWITa3Eem8b5f98b_cVw" x="-120" y="-105" width="157" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9y7fMza3Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9y7fNDa3Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9y7fNja3Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9y7fNTa3Eem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_h48JcDbLEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_h4_MwDbLEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_h4_MwTbLEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_h4_z0DbLEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_h4_z0TbLEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_jgQSwDp_EemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_PFLnQHzUEd2S7rQMqMRYLA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jgQSwTp_EemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jgRg4Dp_EemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_QoRxsHzUEd2S7rQMqMRYLA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jgRg4Tp_EemSPvPXzEQ11A"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_h4_z0jbLEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_h5Aa4DbLEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_h5Aa4TbLEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h5Aa4jbLEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_h5BB8DbLEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_h5BB8TbLEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_h5BB8jbLEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_h5BB8zbLEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h5BB9DbLEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_h5BpADbLEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_h5BpATbLEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_h5BpAjbLEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_h5BpAzbLEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h5BpBDbLEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_h4caMDbLEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h48wgDbLEem8b5f98b_cVw" x="-159" y="13" width="268" height="70"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_h57A4DbLEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_h57A4TbLEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_h57A4zbLEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_h4caMDbLEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h57A4jbLEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yUdgsDbLEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yUdgsTbLEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yUdgszbLEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wNHZsDbLEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yUdgsjbLEem8b5f98b_cVw" x="1389" y="-83"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_myZWQDbMEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_myZWQjbMEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_myZWQzbMEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_myZWRDbMEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_myZ9UDbMEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_83BVIDN-Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_PFLnQHzUEd2S7rQMqMRYLA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_83BVITN-Eea40e5DA9KE3w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_83TB8DN-Eea40e5DA9KE3w" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_QoRxsHzUEd2S7rQMqMRYLA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_83TB8TN-Eea40e5DA9KE3w"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_myZ9UTbMEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_myZ9UjbMEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_myZ9UzbMEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_myZ9VDbMEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_myZ9VTbMEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_myZ9VjbMEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_myZ9VzbMEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_myZ9WDbMEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_myZ9WTbMEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_myZ9WjbMEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_myZ9WzbMEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_myZ9XDbMEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_myZ9XTbMEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_myZ9XjbMEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_myT2sDbMEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_myZWQTbMEem8b5f98b_cVw" x="-166" y="175" height="74"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_myh5IDbMEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_myh5ITbMEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_myh5IzbMEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_myT2sDbMEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_myh5IjbMEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FRAtgDh9Eem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FRDJwDh9Eem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FRDJwTh9Eem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FRDJwjh9Eem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FRDw0Dh9Eem1lYbrIE6BNw" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FRDw0Th9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FRDw0jh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FRDw0zh9Eem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FRDw1Dh9Eem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FRDw1Th9Eem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FRDw1jh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FRDw1zh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FRDw2Dh9Eem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FRDw2Th9Eem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FRDw2jh9Eem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FRDw2zh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FRDw3Dh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FRDw3Th9Eem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FRDw3jh9Eem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FRAtgTh9Eem1lYbrIE6BNw" x="1194" y="-113" width="231" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FRXS0zh9Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FRXS1Dh9Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FRXS1jh9Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FRXS1Th9Eem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_M-sx8Dh9Eem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_M-uAEDh9Eem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_M-uAETh9Eem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_M-uAEjh9Eem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_M-uAEzh9Eem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_M-uAFDh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_M-uAFTh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_M-uAFjh9Eem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-uAFzh9Eem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_M-uAGDh9Eem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_M-uAGTh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_M-uAGjh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_M-uAGzh9Eem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-uAHDh9Eem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_M-uAHTh9Eem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_M-uAHjh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_M-uAHzh9Eem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_M-uAIDh9Eem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-uAITh9Eem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_M-QGADh9Eem1lYbrIE6BNw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-tZADh9Eem1lYbrIE6BNw" x="1199" y="14" width="230" height="64"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_M-3xFTh9Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_M-3xFjh9Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_M-4YIDh9Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_M-QGADh9Eem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M-3xFzh9Eem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dMf2QDh9Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dMf2QTh9Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dMgdUDh9Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_UpR4ADh9Eem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dMf2Qjh9Eem1lYbrIE6BNw" x="1361" y="168"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_peUnEDjnEem1lYbrIE6BNw" type="Enumeration_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_peUnEjjnEem1lYbrIE6BNw" type="Enumeration_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_peUnEzjnEem1lYbrIE6BNw" type="Enumeration_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_peUnFDjnEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_peUnFTjnEem1lYbrIE6BNw" type="Enumeration_LiteralCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_2YJZMDjnEem1lYbrIE6BNw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_twb8gDjnEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2YJZMTjnEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2YKAQDjnEem1lYbrIE6BNw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_vqnxQDjnEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2YKAQTjnEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2YKnUDjnEem1lYbrIE6BNw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_xhdXEDjnEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2YKnUTjnEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2YKnUjjnEem1lYbrIE6BNw" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiEth.uml#_y9KgEDjnEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2YKnUzjnEem1lYbrIE6BNw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_peUnFjjnEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_peUnFzjnEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_peUnGDjnEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_peUnGTjnEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiEth.uml#_peSK0DjnEem1lYbrIE6BNw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_peUnETjnEem1lYbrIE6BNw" x="1178" y="578"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O4LZcDjoEem1lYbrIE6BNw" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_O4MAgDjoEem1lYbrIE6BNw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_O4MAgTjoEem1lYbrIE6BNw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O4MAgjjoEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_O4MAgzjoEem1lYbrIE6BNw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_RfeL0DjoEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_rNbewr1-EeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RfeL0TjoEem1lYbrIE6BNw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_O4MAhDjoEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_O4MAhTjoEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_O4MAhjjoEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O4MAhzjoEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_O4MAiDjoEem1lYbrIE6BNw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_O4MAiTjoEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_O4MAijjoEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_O4MAizjoEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O4MAjDjoEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O4LZcTjoEem1lYbrIE6BNw" x="1186" y="128" width="263" height="77"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_t79lIDjpEem1lYbrIE6BNw" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_t79lIjjpEem1lYbrIE6BNw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_t79lIzjpEem1lYbrIE6BNw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_t79lJDjpEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_t79lJTjpEem1lYbrIE6BNw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_E0bxsDjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_EmpNUDjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_E0bxsTjqEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_F3DsUDjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Fpjb0DjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_F3DsUTjqEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_G2nr4DjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_GoS8ADjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_G2nr4TjqEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_IyuMMDjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_Il4DADjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_IyuMMTjqEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_KHveYDjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_J7EUUDjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_KHveYTjqEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LT_2IDjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_LHK7EDjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LT_2ITjqEem1lYbrIE6BNw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MeBZQDjqEem1lYbrIE6BNw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_MQ144DjqEem1lYbrIE6BNw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MeBZQTjqEem1lYbrIE6BNw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_t79lJjjpEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_t79lJzjpEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_t79lKDjpEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t79lKTjpEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_t79lKjjpEem1lYbrIE6BNw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_t79lKzjpEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_t79lLDjpEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_t79lLTjpEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t79lLjjpEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiEth.uml#_t77v8DjpEem1lYbrIE6BNw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t79lITjpEem1lYbrIE6BNw" x="1166" y="358" height="160"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0dUQ0Dp_EemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_0dUQ0Tp_EemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0dUQ0zp_EemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_tmC3ADp_EemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0dUQ0jp_EemSPvPXzEQ11A" x="1366" y="258"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Oq90sTN7Eea40e5DA9KE3w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Oq90sjN7Eea40e5DA9KE3w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_b3Nj8IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -571,10 +1117,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_isFe0MivEees0-2jg5eWTg" type="Abstraction_Edge" source="_T7eFADN7Eea40e5DA9KE3w" target="_TLA3wEWrEeaB8vMnkFQLXQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_isFe08ivEees0-2jg5eWTg" type="Abstraction_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_isFe1MivEees0-2jg5eWTg" x="15" y="4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_isFe1MivEees0-2jg5eWTg" x="7" y="65"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_isFe1civEees0-2jg5eWTg" type="Abstraction_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_isGF4MivEees0-2jg5eWTg" x="-5" y="-2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_isGF4MivEees0-2jg5eWTg" x="-11" y="72"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_isFe0civEees0-2jg5eWTg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_isDCkMivEees0-2jg5eWTg"/>
@@ -585,11 +1131,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_cFOiAItvEei-xbb4-xH0fg" type="Association_Edge" source="_T7eFADN7Eea40e5DA9KE3w" target="_3gR58DN-Eea40e5DA9KE3w" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_cFQ-QItvEei-xbb4-xH0fg" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eG1NYItvEei-xbb4-xH0fg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-QYtvEei-xbb4-xH0fg" x="-43" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-QYtvEei-xbb4-xH0fg" x="-63" y="-15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_cFQ-QotvEei-xbb4-xH0fg" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eJrtEItvEei-xbb4-xH0fg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-Q4tvEei-xbb4-xH0fg" x="-27" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-Q4tvEei-xbb4-xH0fg" x="-47" y="15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_cFQ-RItvEei-xbb4-xH0fg" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eL9lAItvEei-xbb4-xH0fg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -601,26 +1147,26 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_cFQ-SItvEei-xbb4-xH0fg" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eQjKEItvEei-xbb4-xH0fg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-SYtvEei-xbb4-xH0fg" x="54" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-SYtvEei-xbb4-xH0fg" x="14" y="-16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_cFQ-SotvEei-xbb4-xH0fg" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eTXNgItvEei-xbb4-xH0fg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-S4tvEei-xbb4-xH0fg" x="-54" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cFQ-S4tvEei-xbb4-xH0fg" x="-18" y="-25"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_cFOiAYtvEei-xbb4-xH0fg"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_IyE4kEWsEeaB8vMnkFQLXQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cFOiAotvEei-xbb4-xH0fg" points="[327, 40, -643984, -643984]$[100, 40, -643984, -643984]$[100, 174, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eEMwIItvEei-xbb4-xH0fg" id="(0.0,0.4020618556701031)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eEMwIYtvEei-xbb4-xH0fg" id="(0.47107438016528924,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eEMwIYtvEei-xbb4-xH0fg" id="(0.26991150442477874,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_S2mkYItxEeik7I8D544C6Q" type="Association_Edge" source="_T7eFADN7Eea40e5DA9KE3w" target="_M-W3ADN9Eea40e5DA9KE3w" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_S2nLcItxEeik7I8D544C6Q" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_be4BwItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLcYtxEeik7I8D544C6Q" x="-7" y="11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLcYtxEeik7I8D544C6Q" x="13" y="61"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_S2nLcotxEeik7I8D544C6Q" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bhM9AItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLc4txEeik7I8D544C6Q" x="-27" y="15"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLc4txEeik7I8D544C6Q" x="-4" y="74"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_S2nLdItxEeik7I8D544C6Q" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bjtecItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -632,26 +1178,26 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_S2nLeItxEeik7I8D544C6Q" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_boX8AItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLeYtxEeik7I8D544C6Q" x="29" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLeYtxEeik7I8D544C6Q" x="15" y="-17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_S2nLeotxEeik7I8D544C6Q" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bqrCEItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLe4txEeik7I8D544C6Q" x="-29" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S2nLe4txEeik7I8D544C6Q" x="-9" y="-21"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_S2mkYYtxEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#__17LsDN9Eea40e5DA9KE3w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_S2mkYotxEeik7I8D544C6Q" points="[500, 98, -643984, -643984]$[500, 289, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bbeIcItxEeik7I8D544C6Q" id="(0.4942857142857143,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bbevgItxEeik7I8D544C6Q" id="(0.7582417582417582,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_S2mkYotxEeik7I8D544C6Q" points="[520, 98, -643984, -643984]$[520, 175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bbeIcItxEeik7I8D544C6Q" id="(0.5542857142857143,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bbevgItxEeik7I8D544C6Q" id="(0.6787330316742082,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_U5j6oItxEeik7I8D544C6Q" type="Association_Edge" source="_T7eFADN7Eea40e5DA9KE3w" target="_pxNpQDN7Eea40e5DA9KE3w" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_U5khsItxEeik7I8D544C6Q" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ye6QsItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5khsYtxEeik7I8D544C6Q" x="86" y="11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5khsYtxEeik7I8D544C6Q" x="-51" y="8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U5lIwItxEeik7I8D544C6Q" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Yh5TQItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5lIwYtxEeik7I8D544C6Q" x="64" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5lIwYtxEeik7I8D544C6Q" x="-51" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U5lIwotxEeik7I8D544C6Q" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YkYmkItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -663,50 +1209,57 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U5lIxotxEeik7I8D544C6Q" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YpnE0ItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5lIx4txEeik7I8D544C6Q" x="57" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5lIx4txEeik7I8D544C6Q" x="14" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_U5lIyItxEeik7I8D544C6Q" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Yr48wItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5lIyYtxEeik7I8D544C6Q" x="-46" y="-9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_U5lIyYtxEeik7I8D544C6Q" x="-12" y="22"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_U5j6oYtxEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_ITi4QDN-Eea40e5DA9KE3w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U5j6ootxEeik7I8D544C6Q" points="[677, 40, -643984, -643984]$[800, 40, -643984, -643984]$[800, 286, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YcRMYItxEeik7I8D544C6Q" id="(1.0,0.4020618556701031)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YcRzcItxEeik7I8D544C6Q" id="(0.46357615894039733,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U5j6ootxEeik7I8D544C6Q" points="[676, 50, -643984, -643984]$[805, 50, -643984, -643984]$[805, 176, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YcRMYItxEeik7I8D544C6Q" id="(0.9971428571428571,0.4948453608247423)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YcRzcItxEeik7I8D544C6Q" id="(0.5958333333333333,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dV9fMItxEeik7I8D544C6Q" type="Association_Edge" source="_pxNpQDN7Eea40e5DA9KE3w" target="_F9-GMDO5Eea40e5DA9KE3w">
+    <edges xmi:type="notation:Connector" xmi:id="_dV9fMItxEeik7I8D544C6Q" type="Association_Edge" source="_RLQHIDaqEem8b5f98b_cVw" target="_F9-GMDO5Eea40e5DA9KE3w" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_dV-GQItxEeik7I8D544C6Q" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GQYtxEeik7I8D544C6Q" x="5" y="-7"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PC9TADasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GQYtxEeik7I8D544C6Q" x="12" y="-64"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_dV-GQotxEeik7I8D544C6Q" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GQ4txEeik7I8D544C6Q" x="3" y="13"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PMtr8DasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GQ4txEeik7I8D544C6Q" x="-3" y="-127"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_dV-GRItxEeik7I8D544C6Q" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GRYtxEeik7I8D544C6Q" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PWWwIDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GRYtxEeik7I8D544C6Q" x="147" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_dV-GRotxEeik7I8D544C6Q" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GR4txEeik7I8D544C6Q" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PfqdIDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GR4txEeik7I8D544C6Q" x="-148" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_dV-GSItxEeik7I8D544C6Q" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GSYtxEeik7I8D544C6Q" x="-23" y="-7"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PpUIYDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GSYtxEeik7I8D544C6Q" x="12" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_dV-GSotxEeik7I8D544C6Q" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GS4txEeik7I8D544C6Q" x="16" y="-7"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P1MoQDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dV-GS4txEeik7I8D544C6Q" x="-9" y="30"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_dV9fMYtxEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_AbxMcDO6Eea40e5DA9KE3w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dV9fMotxEeik7I8D544C6Q" points="[660, 464, -643984, -643984]$[409, 482, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exclwItxEeik7I8D544C6Q" id="(0.0,0.6369047619047619)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dV9fMotxEeik7I8D544C6Q" points="[785, 649, -643984, -643984]$[785, 698, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exclwItxEeik7I8D544C6Q" id="(0.5181347150259067,0.9857142857142858)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QCO-sDasEem8b5f98b_cVw" id="(0.3806228373702422,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iB-iYItxEeik7I8D544C6Q" type="Association_Edge" source="_pxNpQDN7Eea40e5DA9KE3w" target="_iCoq0DO5Eea40e5DA9KE3w">
+    <edges xmi:type="notation:Connector" xmi:id="_iB-iYItxEeik7I8D544C6Q" type="Association_Edge" source="_RLQHIDaqEem8b5f98b_cVw" target="_iCoq0DO5Eea40e5DA9KE3w" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_iB-iY4txEeik7I8D544C6Q" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_j_CsAItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB-iZItxEeik7I8D544C6Q" x="-7" y="-6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB-iZItxEeik7I8D544C6Q" x="-28" y="-12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_iB-iZYtxEeik7I8D544C6Q" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_kBT84ItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB-iZotxEeik7I8D544C6Q" x="-1" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB-iZotxEeik7I8D544C6Q" x="-25" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_iB-iZ4txEeik7I8D544C6Q" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_kEi3EItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -718,17 +1271,17 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_iB_JcYtxEeik7I8D544C6Q" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_kJdMQItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB_JcotxEeik7I8D544C6Q" x="15" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB_JcotxEeik7I8D544C6Q" x="9" y="-16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_iB_Jc4txEeik7I8D544C6Q" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_kLz8sItxEeik7I8D544C6Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB_JdItxEeik7I8D544C6Q" x="-27" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iB_JdItxEeik7I8D544C6Q" x="-13" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_iB-iYYtxEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_3Dz-kDO5Eea40e5DA9KE3w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iB-iYotxEeik7I8D544C6Q" points="[660, 600, -643984, -643984]$[464, 600, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j8uX0ItxEeik7I8D544C6Q" id="(0.0,0.9345238095238095)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j8uX0YtxEeik7I8D544C6Q" id="(1.0,0.4772727272727273)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iB-iYotxEeik7I8D544C6Q" points="[688, 624, -643984, -643984]$[440, 624, -643984, -643984]$[440, 700, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j8uX0ItxEeik7I8D544C6Q" id="(0.0,0.8714285714285714)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j8uX0YtxEeik7I8D544C6Q" id="(0.5561959654178674,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_6N2xJPK3EeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_T7eFADN7Eea40e5DA9KE3w" target="_6N2xIPK3EeiTnqcAgKK24Q">
       <styles xmi:type="notation:FontStyle" xmi:id="_6N2xJfK3EeiTnqcAgKK24Q"/>
@@ -860,6 +1413,474 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6W70p_K3EeiTnqcAgKK24Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6W70qPK3EeiTnqcAgKK24Q"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v0uHoDamEem8b5f98b_cVw" type="StereotypeCommentLink" source="_v0O_cDamEem8b5f98b_cVw" target="_v0tgkDamEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v0uHoTamEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v0uHpTamEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v0uHojamEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v0uHozamEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v0uHpDamEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9DYhUDamEem8b5f98b_cVw" type="StereotypeCommentLink" source="_9DNiMDamEem8b5f98b_cVw" target="_9DX6SzamEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9DYhUTamEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9DYhVTamEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_9DICoDamEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9DYhUjamEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9DYhUzamEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9DYhVDamEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KIU-VzanEem8b5f98b_cVw" type="StereotypeCommentLink" source="_KIO3sDanEem8b5f98b_cVw" target="_KIU-UzanEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KIU-WDanEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KIU-XDanEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_KIJ_MDanEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KIU-WTanEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KIU-WjanEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KIU-WzanEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mWePEDanEem8b5f98b_cVw" type="Association_Edge" source="_3gR58DN-Eea40e5DA9KE3w" target="_KIO3sDanEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mWePEzanEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_L_jzcDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mWePFDanEem8b5f98b_cVw" x="14" y="70"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mWePFTanEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MJOs0DasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mWePFjanEem8b5f98b_cVw" x="-2" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mWePFzanEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MSNpsDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mWePGDanEem8b5f98b_cVw" x="158" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mWePGTanEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MbruwDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mWePGjanEem8b5f98b_cVw" x="-159" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mWePGzanEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Mk3f8DasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mWePHDanEem8b5f98b_cVw" x="11" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mWe2IDanEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Mvn-cDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mWe2ITanEem8b5f98b_cVw" x="-12" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mWePETanEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_mN4TwDanEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mWePEjanEem8b5f98b_cVw" points="[233, 247, -643984, -643984]$[233, 315, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mn5WQDanEem8b5f98b_cVw" id="(0.5176991150442478,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mn5WQTanEem8b5f98b_cVw" id="(0.5278969957081545,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__ZckUTanEem8b5f98b_cVw" type="StereotypeCommentLink" source="_mWePEDanEem8b5f98b_cVw" target="__Zb9QzanEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="__ZckUjanEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__ZckVjanEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_mN4TwDanEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__ZckUzanEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ZckVDanEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ZckVTanEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CmK_ADaoEem8b5f98b_cVw" type="Association_Edge" source="_9DNiMDamEem8b5f98b_cVw" target="_KIO3sDanEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_CmLmEDaoEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PCFtIDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CmLmETaoEem8b5f98b_cVw" x="-160" y="25"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CmLmEjaoEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PKRYwDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CmLmEzaoEem8b5f98b_cVw" x="-113" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CmLmFDaoEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PS37IDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CmLmFTaoEem8b5f98b_cVw" x="147" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CmLmFjaoEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PbDmwDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CmLmFzaoEem8b5f98b_cVw" x="-147" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CmLmGDaoEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Pk8ikDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CmLmGTaoEem8b5f98b_cVw" x="12" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_CmLmGjaoEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Puv-0DaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CmLmGzaoEem8b5f98b_cVw" x="-24" y="15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_CmK_ATaoEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_CdjOgDaoEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CmK_AjaoEem8b5f98b_cVw" points="[1012, 85, -643984, -643984]$[1012, 369, -643984, -643984]$[1010, 369, -643984, -643984]$[1010, 368, -643984, -643984]$[302, 368, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C4DZMDaoEem8b5f98b_cVw" id="(0.6502057613168725,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C4EAQDaoEem8b5f98b_cVw" id="(1.0,0.5)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SmKQ1zaoEem8b5f98b_cVw" type="StereotypeCommentLink" source="_CmK_ADaoEem8b5f98b_cVw" target="_SmKQ0zaoEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SmKQ2DaoEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SmK34jaoEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_CdjOgDaoEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SmKQ2TaoEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SmK34DaoEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SmK34TaoEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XPLqYDaoEem8b5f98b_cVw" type="Abstraction_Edge" source="_9DNiMDamEem8b5f98b_cVw" target="_v0O_cDamEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_XPLqYzaoEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-re1oDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XPLqZDaoEem8b5f98b_cVw" x="12" y="-82"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XPLqZTaoEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-1shkDaoEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XPLqZjaoEem8b5f98b_cVw" x="-9" y="-63"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_XPLqYTaoEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_XPJ1MDaoEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XPLqYjaoEem8b5f98b_cVw" points="[998, 4, -643984, -643984]$[998, -56, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xgp04DaoEem8b5f98b_cVw" id="(0.5843621399176955,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xgp04TaoEem8b5f98b_cVw" id="(0.5543478260869565,0.9830508474576272)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YmeNdDaoEem8b5f98b_cVw" type="StereotypeCommentLink" source="_XPLqYDaoEem8b5f98b_cVw" target="_YmeNcDaoEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YmeNdTaoEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yme0gDaoEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_XPJ1MDaoEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YmeNdjaoEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YmeNdzaoEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YmeNeDaoEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nset0DapEem8b5f98b_cVw" type="StereotypeCommentLink" source="_nsYAIDapEem8b5f98b_cVw" target="_nseGzjapEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nset0TapEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nset1TapEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_nsU80DapEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nset0japEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nset0zapEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nset1DapEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rtj9oDapEem8b5f98b_cVw" type="Association_Edge" source="_M-W3ADN9Eea40e5DA9KE3w" target="_nsYAIDapEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rtj9ozapEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_20VdwDapEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rtj9pDapEem8b5f98b_cVw" x="-45" y="48"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rtj9pTapEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2-xzMDapEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rtj9pjapEem8b5f98b_cVw" x="-57" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rtj9pzapEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3IRtcDapEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rtj9qDapEem8b5f98b_cVw" x="18" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rtkksDapEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3RJ8oDapEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rtkksTapEem8b5f98b_cVw" x="-18" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rtkksjapEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3adpoDapEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rtkkszapEem8b5f98b_cVw" x="16" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rtkktDapEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3jnloDapEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rtkktTapEem8b5f98b_cVw" x="-12" y="17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_rtj9oTapEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_rj_x8DapEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rtj9ojapEem8b5f98b_cVw" points="[481, 250, -643984, -643984]$[481, 442, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r_sPcDapEem8b5f98b_cVw" id="(0.49321266968325794,0.961038961038961)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r_sPcTapEem8b5f98b_cVw" id="(0.7490842490842491,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DPy44DaqEem8b5f98b_cVw" type="Association_Edge" source="_9DNiMDamEem8b5f98b_cVw" target="_nsYAIDapEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DPy44zaqEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LauS8DaqEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DPy45DaqEem8b5f98b_cVw" x="-45" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DPzf8DaqEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LlgmoDaqEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DPzf8TaqEem8b5f98b_cVw" x="-7" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DPzf8jaqEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LwtKADaqEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DPzf8zaqEem8b5f98b_cVw" x="122" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DPzf9DaqEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_L7TQcDaqEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DPzf9TaqEem8b5f98b_cVw" x="-60" y="-42"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DPzf9jaqEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MEkhMDaqEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DPzf9zaqEem8b5f98b_cVw" x="13" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DPzf-DaqEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MN7RgDaqEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DPzf-TaqEem8b5f98b_cVw" x="-60" y="-82"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_DPy44TaqEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_DGw4sDaqEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DPy44jaqEem8b5f98b_cVw" points="[1052, 84, -643984, -643984]$[1052, 400, -643984, -643984]$[552, 400, -643984, -643984]$[552, 442, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Dk0GoDaqEem8b5f98b_cVw" id="(0.8189300411522634,0.9876543209876543)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Dk0tsDaqEem8b5f98b_cVw" id="(0.8809523809523809,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RLYC9zaqEem8b5f98b_cVw" type="StereotypeCommentLink" source="_RLQHIDaqEem8b5f98b_cVw" target="_RLYC8zaqEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RLYC-DaqEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RLYC_DaqEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_RLND0DaqEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RLYC-TaqEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RLYC-jaqEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RLYC-zaqEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4xusoDarEem8b5f98b_cVw" type="Association_Edge" source="_pxNpQDN7Eea40e5DA9KE3w" target="_RLQHIDaqEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4xusozarEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JkyaIDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4xuspDarEem8b5f98b_cVw" x="-27" y="71"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4xuspTarEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JubeUDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4xuspjarEem8b5f98b_cVw" x="-44" y="91"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4xuspzarEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_J3cQYDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4xusqDarEem8b5f98b_cVw" x="53" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4xusqTarEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KAxykDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4xusqjarEem8b5f98b_cVw" x="-55" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4xusqzarEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KKbd0DasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4xusrDarEem8b5f98b_cVw" x="11" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4xusrTarEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KVUfMDasEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4xusrjarEem8b5f98b_cVw" x="-11" y="15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_4xusoTarEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_4n7QYDarEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4xusojarEem8b5f98b_cVw" points="[765, 326, -643984, -643984]$[765, 440, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5EU4gDarEem8b5f98b_cVw" id="(0.425,0.9867549668874173)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5EU4gTarEem8b5f98b_cVw" id="(0.39378238341968913,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PKyucDauEem8b5f98b_cVw" type="Association_Edge" source="_9DNiMDamEem8b5f98b_cVw" target="_RLQHIDaqEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PKzVgDauEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_s2-OADavEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PKzVgTauEem8b5f98b_cVw" x="122" y="55"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PKzVgjauEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tBATwDavEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PKzVgzauEem8b5f98b_cVw" x="97" y="87"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PKzVhDauEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tKwssDavEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PKzVhTauEem8b5f98b_cVw" x="129" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PKzVhjauEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tUOKsDavEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PKzVhzauEem8b5f98b_cVw" x="-129" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PKzViDauEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tehWMDavEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PKzViTauEem8b5f98b_cVw" x="12" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PKzVijauEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tqIJQDavEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PKzVizauEem8b5f98b_cVw" x="-49" y="-18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_PKyucTauEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiEth.uml#_PA9dADauEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKyucjauEem8b5f98b_cVw" points="[1086, 84, -643984, -643984]$[1086, 518, -643984, -643984]$[880, 518, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pe1r0DauEem8b5f98b_cVw" id="(0.9629629629629629,0.9876543209876543)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pe1r0TauEem8b5f98b_cVw" id="(0.9948186528497409,0.3619047619047619)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dy9cRDavEem8b5f98b_cVw" type="StereotypeCommentLink" source="_4xusoDarEem8b5f98b_cVw" target="_dy9cQDavEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dy9cRTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dy-DUDavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_4n7QYDarEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dy9cRjavEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dy9cRzavEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dy9cSDavEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gkBOpDavEem8b5f98b_cVw" type="StereotypeCommentLink" source="_rtj9oDapEem8b5f98b_cVw" target="_gkBOoDavEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gkBOpTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gkB1sDavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_rj_x8DapEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gkBOpjavEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gkBOpzavEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gkBOqDavEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jX1aFDavEem8b5f98b_cVw" type="StereotypeCommentLink" source="_DPy44DaqEem8b5f98b_cVw" target="_jX1aEDavEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_jX1aFTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jX1aGTavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_DGw4sDaqEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jX1aFjavEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jX1aFzavEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jX1aGDavEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_l9f0xDavEem8b5f98b_cVw" type="StereotypeCommentLink" source="_PKyucDauEem8b5f98b_cVw" target="_l9f0wDavEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_l9f0xTavEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l9f0yTavEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_PA9dADauEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l9f0xjavEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l9f0xzavEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l9f0yDavEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9y7fNza3Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_9ynWIDa3Eem8b5f98b_cVw" target="_9y7fMza3Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9y7fODa3Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9y8GQja3Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9y7fOTa3Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9y8GQDa3Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9y8GQTa3Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_h582EDbLEem8b5f98b_cVw" type="StereotypeCommentLink" source="_h48JcDbLEem8b5f98b_cVw" target="_h57A4DbLEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_h582ETbLEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_h6Oi4TbLEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_h4caMDbLEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_h582EjbLEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h6IcQDbLEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h6Oi4DbLEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_wNLEEDbLEem8b5f98b_cVw" type="Abstraction_Edge" source="_h48JcDbLEem8b5f98b_cVw" target="_9ynWIDa3Eem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_wNLrIDbLEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_b10J8DmrEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wNLrITbLEem8b5f98b_cVw" x="13" y="62"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_wNLrIjbLEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cBiRwDmrEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wNLrIzbLEem8b5f98b_cVw" x="-8" y="70"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_wNLEETbLEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_wNHZsDbLEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wNLEEjbLEem8b5f98b_cVw" points="[-53, 13, -643984, -643984]$[-53, -44, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wjy0UDbLEem8b5f98b_cVw" id="(0.39925373134328357,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wjy0UTbLEem8b5f98b_cVw" id="(0.43312101910828027,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yUdgtDbLEem8b5f98b_cVw" type="StereotypeCommentLink" source="_wNLEEDbLEem8b5f98b_cVw" target="_yUdgsDbLEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yUdgtTbLEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yUeHwDbLEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wNHZsDbLEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yUdgtjbLEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yUdgtzbLEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yUdguDbLEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_myh5JDbMEem8b5f98b_cVw" type="StereotypeCommentLink" source="_myZWQDbMEem8b5f98b_cVw" target="_myh5IDbMEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_myh5JTbMEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_myh5KTbMEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_myT2sDbMEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_myh5JjbMEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_myh5JzbMEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_myh5KDbMEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0GUqcDbMEem8b5f98b_cVw" type="Generalization_Edge" source="_3gR58DN-Eea40e5DA9KE3w" target="_myZWQDbMEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_0GUqczbMEem8b5f98b_cVw" type="Generalization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8JX64DbMEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0GUqdDbMEem8b5f98b_cVw" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_0GUqcTbMEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Generalization" href="TapiEth.uml#_z61MIDbMEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0GUqcjbMEem8b5f98b_cVw" points="[117, 200, -643984, -643984]$[76, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0fqXgDbMEem8b5f98b_cVw" id="(0.0,0.4457831325301205)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0frloDbMEem8b5f98b_cVw" id="(1.0,0.35135135135135137)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1x-7ADbMEem8b5f98b_cVw" type="Generalization_Edge" source="_h48JcDbLEem8b5f98b_cVw" target="_myZWQDbMEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1x_iEDbMEem8b5f98b_cVw" type="Generalization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6-DXQDbMEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1x_iETbMEem8b5f98b_cVw" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_1x-7ATbMEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Generalization" href="TapiEth.uml#_1mUdkDbMEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1x-7AjbMEem8b5f98b_cVw" points="[-38, 83, -643984, -643984]$[-38, 175, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2JQLgDbMEem8b5f98b_cVw" id="(0.4552238805970149,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2JQLgTbMEem8b5f98b_cVw" id="(0.5330578512396694,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FRX54Dh9Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_FRAtgDh9Eem1lYbrIE6BNw" target="_FRXS0zh9Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FRX54Th9Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FRX55Th9Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FRX54jh9Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FRX54zh9Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FRX55Dh9Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_M-4YITh9Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_M-sx8Dh9Eem1lYbrIE6BNw" target="_M-3xFTh9Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_M-4YIjh9Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_M-4YJjh9Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_M-QGADh9Eem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M-4YIzh9Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M-4YJDh9Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M-4YJTh9Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UpbB8Dh9Eem1lYbrIE6BNw" type="Abstraction_Edge" source="_M-sx8Dh9Eem1lYbrIE6BNw" target="_FRAtgDh9Eem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UpbB8zh9Eem1lYbrIE6BNw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_W6fFoDh9Eem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UpbB9Dh9Eem1lYbrIE6BNw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UpbpADh9Eem1lYbrIE6BNw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XEyRIDh9Eem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UpbpATh9Eem1lYbrIE6BNw" x="14" y="-72"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UpbB8Th9Eem1lYbrIE6BNw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_UpR4ADh9Eem1lYbrIE6BNw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UpbB8jh9Eem1lYbrIE6BNw" points="[1336, 14, -643984, -643984]$[1336, -52, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U-O0UDh9Eem1lYbrIE6BNw" id="(0.5956521739130435,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U-O0UTh9Eem1lYbrIE6BNw" id="(0.6147186147186147,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dMgdUTh9Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_UpbB8Dh9Eem1lYbrIE6BNw" target="_dMf2QDh9Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dMgdUjh9Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dMgdVjh9Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_UpR4ADh9Eem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dMgdUzh9Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dMgdVDh9Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dMgdVTh9Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tmF6UDp_EemSPvPXzEQ11A" type="Abstraction_Edge" source="_t79lIDjpEem1lYbrIE6BNw" target="_O4LZcDjoEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_tmF6Uzp_EemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2yTyQDp_EemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tmF6VDp_EemSPvPXzEQ11A" x="20" y="-63"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_tmGhYDp_EemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3AeKEDp_EemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tmGhYTp_EemSPvPXzEQ11A" y="-58"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_tmF6UTp_EemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_tmC3ADp_EemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tmF6Ujp_EemSPvPXzEQ11A" points="[1315, 358, -643984, -643984]$[1315, 205, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uHunwDp_EemSPvPXzEQ11A" id="(0.5287769784172662,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uHunwTp_EemSPvPXzEQ11A" id="(0.4828897338403042,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0dUQ1Dp_EemSPvPXzEQ11A" type="StereotypeCommentLink" source="_tmF6UDp_EemSPvPXzEQ11A" target="_0dUQ0Dp_EemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0dUQ1Tp_EemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0dU34jp_EemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_tmC3ADp_EemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0dUQ1jp_EemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0dU34Dp_EemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0dU34Tp_EemSPvPXzEQ11A"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_--vAkE-wEeitY7qZgkO_XQ" type="PapyrusUMLClassDiagram" name="EthOamResourceSpec" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_SaiR8E-xEeitY7qZgkO_XQ" type="Class_Shape">
@@ -882,10 +1903,6 @@
         <children xmi:type="notation:Shape" xmi:id="_JAGQUm6IEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_B9eEoIHDEeeh4KO3PMo8Rw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_JAGQU26IEeivMcJ3aRh7eg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_JAGQVG6IEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_A0XLAJPsEeePQIrrJoWPZA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_JAGQVW6IEeivMcJ3aRh7eg"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_JAG3ZG6IEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
@@ -913,7 +1930,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SaoYnk-xEeitY7qZgkO_XQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SaiR8U-xEeitY7qZgkO_XQ" x="24" y="-274" width="307" height="189"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SaiR8U-xEeitY7qZgkO_XQ" x="-26" y="-419" width="307" height="132"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_S_jqkE-xEeitY7qZgkO_XQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_S_jqkk-xEeitY7qZgkO_XQ" type="Class_NameLabel"/>
@@ -958,7 +1975,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_S_jqo0-xEeitY7qZgkO_XQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_S_jqkU-xEeitY7qZgkO_XQ" x="341" y="-196" width="304" height="109"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_S_jqkU-xEeitY7qZgkO_XQ" x="291" y="-419" width="304" height="109"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_V9OVkE-xEeitY7qZgkO_XQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_V9OVkk-xEeitY7qZgkO_XQ" type="Class_NameLabel"/>
@@ -984,10 +2001,6 @@
         <children xmi:type="notation:Shape" xmi:id="_4Ljf5AVHEemxeNG9TDCtFQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_EBqfUE46EeiMYveOdt1-rQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_4Ljf5QVHEemxeNG9TDCtFQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_4LkG8AVHEemxeNG9TDCtFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_IJQGIE5CEeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_4LkG8QVHEemxeNG9TDCtFQ"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_4LkG8gVHEemxeNG9TDCtFQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
@@ -1015,7 +2028,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V9OVo0-xEeitY7qZgkO_XQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V9OVkU-xEeitY7qZgkO_XQ" x="-263" y="-275" width="274" height="189"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V9OVkU-xEeitY7qZgkO_XQ" x="-330" y="-432" width="274" height="145"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_iN-8kE-xEeitY7qZgkO_XQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_iN-8kk-xEeitY7qZgkO_XQ" type="Class_NameLabel"/>
@@ -1056,7 +2069,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iN-8o0-xEeitY7qZgkO_XQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_iN418E-xEeitY7qZgkO_XQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iN-8kU-xEeitY7qZgkO_XQ" x="-423" y="-21" width="431" height="76"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iN-8kU-xEeitY7qZgkO_XQ" x="-473" y="-244" width="431" height="76"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_jrxwQ0-xEeitY7qZgkO_XQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_jrxwRU-xEeitY7qZgkO_XQ" type="Class_NameLabel"/>
@@ -1101,7 +2114,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jrxwVk-xEeitY7qZgkO_XQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_jrxwQE-xEeitY7qZgkO_XQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jrxwRE-xEeitY7qZgkO_XQ" x="27" y="-2" width="300" height="94"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jrxwRE-xEeitY7qZgkO_XQ" x="-23" y="-225" width="300" height="94"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_lJLiYE-xEeitY7qZgkO_XQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_lJLiYk-xEeitY7qZgkO_XQ" type="Class_NameLabel"/>
@@ -1140,7 +2153,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lJLic0-xEeitY7qZgkO_XQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_lJFbwE-xEeitY7qZgkO_XQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lJLiYU-xEeitY7qZgkO_XQ" x="354" y="2" width="288"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lJLiYU-xEeitY7qZgkO_XQ" x="304" y="-221" width="288"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_nT0GYFRxEeitkMFXBYQFcg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_nT1UgFRxEeitkMFXBYQFcg" type="Class_NameLabel"/>
@@ -1171,14 +2184,19 @@
           <element xmi:type="uml:Property" href="TapiEth.uml#_Cw5uva5TEeKbRfTRicRZzQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_8B8DOV6hEeitO-Stqhyn1g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_0h_t8P2hEei1gqEzWZRG1Q" type="Property_ClassAttributeLabel" fontColor="255" fontName="Segoe UI">
+        <children xmi:type="notation:Shape" xmi:id="_0h_t8P2hEei1gqEzWZRG1Q" type="Property_ClassAttributeLabel" fontName="Segoe UI">
           <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4J-hQP2hEei1gqEzWZRG1Q" source="PapyrusCSSForceValue">
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4J-hQf2hEei1gqEzWZRG1Q" key="fontHeight" value="true"/>
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4J_IUP2hEei1gqEzWZRG1Q" key="bold" value="true"/>
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4J_vYP2hEei1gqEzWZRG1Q" key="italic" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gOB3kDqAEemSPvPXzEQ11A" key="fontColor" value="true"/>
           </eAnnotations>
           <element xmi:type="uml:Property" href="TapiEth.uml#_prGFsNdpEeidLb5WEUMFmw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_0h_t8f2hEei1gqEzWZRG1Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_poas0DocEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_zZMf0DobEemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poas0TocEemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_nT17kVRxEeitkMFXBYQFcg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_nT17klRxEeitkMFXBYQFcg"/>
@@ -1298,7 +2316,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arsiJ16fEeitO-Stqhyn1g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_nTcS8FRxEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nT0GYVRxEeitkMFXBYQFcg" x="153" y="195" width="219" height="157"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nT0GYVRxEeitkMFXBYQFcg" x="103" y="-28" width="219" height="157"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F-r4QFRyEeitkMFXBYQFcg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_F-r4QlRyEeitkMFXBYQFcg" type="Class_NameLabel"/>
@@ -1343,7 +2361,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-sfXlRyEeitkMFXBYQFcg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_F-hgMFRyEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-r4QVRyEeitkMFXBYQFcg" x="54" y="405" width="232" height="117"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-r4QVRyEeitkMFXBYQFcg" x="4" y="182" width="232" height="117"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_VUtAAFRyEeitkMFXBYQFcg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_VUtAAlRyEeitkMFXBYQFcg" type="Class_NameLabel"/>
@@ -1394,11 +2412,12 @@
           <element xmi:type="uml:Property" href="TapiEth.uml#_2fZvcF7qEeGyKcjKnV9Bqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_O0DPo16oEeitO-Stqhyn1g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_XJajYP3uEei1gqEzWZRG1Q" type="Property_ClassAttributeLabel" fontColor="255" fontName="Segoe UI">
+        <children xmi:type="notation:Shape" xmi:id="_XJajYP3uEei1gqEzWZRG1Q" type="Property_ClassAttributeLabel" fontName="Segoe UI">
           <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Z8Uv4P3uEei1gqEzWZRG1Q" source="PapyrusCSSForceValue">
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Z8VW8P3uEei1gqEzWZRG1Q" key="fontHeight" value="true"/>
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Z8VW8f3uEei1gqEzWZRG1Q" key="bold" value="true"/>
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Z8VW8v3uEei1gqEzWZRG1Q" key="italic" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_k0oPQDqAEemSPvPXzEQ11A" key="fontColor" value="true"/>
           </eAnnotations>
           <element xmi:type="uml:Property" href="TapiEth.uml#_47LV0NdvEeidLb5WEUMFmw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_XJajYf3uEei1gqEzWZRG1Q"/>
@@ -1430,7 +2449,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUtAE1RyEeitkMFXBYQFcg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_VUpVoFRyEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUtAAVRyEeitkMFXBYQFcg" x="386" y="295" width="252" height="235"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VUtAAVRyEeitkMFXBYQFcg" x="336" y="72" width="252" height="235"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_3JXW21VCEeitkMFXBYQFcg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_3JXW3FVCEeitkMFXBYQFcg" showTitle="true"/>
@@ -2613,7 +3632,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKr8_v-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_nkE94NYAEeidMu8ST4Ma3w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKizAf-vEeiABdf1yJ9dlA" x="-445" y="212" height="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKizAf-vEeiABdf1yJ9dlA" x="-495" y="-11" height="80"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_FLTA8P-vEeiABdf1yJ9dlA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_FLTA8f-vEeiABdf1yJ9dlA"/>
@@ -2660,7 +3679,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_SCpP-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_-vckINa3EeidLb5WEUMFmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_PmYf-vEeiABdf1yJ9dlA" x="-363" y="357" height="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F_PmYf-vEeiABdf1yJ9dlA" x="-413" y="134" height="66"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F_pPA_-vEeiABdf1yJ9dlA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_F_p2EP-vEeiABdf1yJ9dlA"/>
@@ -2703,7 +3722,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SawE1_-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiEth.uml#_15PQINYBEeidMu8ST4Ma3w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Savdwf-vEeiABdf1yJ9dlA" x="-291" y="545"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Savdwf-vEeiABdf1yJ9dlA" x="-341" y="322"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TEUmQP-vEeiABdf1yJ9dlA" type="Enumeration_Shape" fontColor="255" fontName="Segoe UI">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1PAVASwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
@@ -2738,7 +3757,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TEVNV_-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiEth.uml#_UStqANZEEeidLb5WEUMFmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TEUmQf-vEeiABdf1yJ9dlA" x="-58" y="548"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TEUmQf-vEeiABdf1yJ9dlA" x="-108" y="325"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TtthgP-vEeiABdf1yJ9dlA" type="Enumeration_Shape" fontColor="255" fontName="Segoe UI">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1OZQQSwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
@@ -2777,7 +3796,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TtuIkv-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiEth.uml#_NAYSUNboEeidLb5WEUMFmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ttthgf-vEeiABdf1yJ9dlA" x="477" y="546"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ttthgf-vEeiABdf1yJ9dlA" x="427" y="323"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_VDGnIP-vEeiABdf1yJ9dlA" type="DataType_Shape" fontColor="255" fontName="Segoe UI">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1PAUgSwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
@@ -2826,7 +3845,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDHOPP-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiEth.uml#_V7D14NcKEeidLb5WEUMFmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDGnIf-vEeiABdf1yJ9dlA" x="257" y="547"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDGnIf-vEeiABdf1yJ9dlA" x="207" y="324"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Hp6nYASwEemABdf1yJ9dlA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Hp6nYQSwEemABdf1yJ9dlA"/>
@@ -3022,7 +4041,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__VoXsRgkEem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#__VkGMBgkEem7b6CPWW1OrA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__VnwkRgkEem7b6CPWW1OrA" x="455" y="156" width="190" height="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__VnwkRgkEem7b6CPWW1OrA" x="405" y="-67" width="190" height="66"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__V0k4BgkEem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__V0k4RgkEem7b6CPWW1OrA"/>
@@ -3054,13 +4073,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_oZdhZBglEem7b6CPWW1OrA" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_oZdhZRglEem7b6CPWW1OrA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_wktQIGA8Eei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_vZQJoGA8Eei7_-Uhq6CryQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_wktQIWA8Eei7_-Uhq6CryQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_j3djMDoOEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_ap5AYDoOEemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j3djMToOEemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_zyo0UAVGEemxeNG9TDCtFQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_j3exUDoOEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_vZQJoGA8Eei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j3exUToOEemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_j3exUjoOEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_zrY80AVGEemxeNG9TDCtFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_zyo0UQVGEemxeNG9TDCtFQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j3exUzoOEemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_oZdhZhglEem7b6CPWW1OrA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_oZdhZxglEem7b6CPWW1OrA"/>
@@ -3080,7 +4103,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oZeIeRglEem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_oZZ3ABglEem7b6CPWW1OrA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oZdhYRglEem7b6CPWW1OrA" x="-267" y="108" width="234" height="63"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oZdhYRglEem7b6CPWW1OrA" x="-317" y="-115" width="234" height="73"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_oZpHlRglEem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_oZpHlhglEem7b6CPWW1OrA"/>
@@ -3202,6 +4225,182 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sdCg4SD_EemsM5ohGqY7Gw" x="554" y="-98"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_c6wUUDVvEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c6wUUTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c6wUUzVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c6wUUjVvEem8b5f98b_cVw" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dFAcgDVvEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dFAcgTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dFAcgzVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dFAcgjVvEem8b5f98b_cVw" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gJg54DVwEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gJg54TVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gJg54zVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gJg54jVwEem8b5f98b_cVw" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gWwrsDVwEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gWwrsTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gWwrszVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gWwrsjVwEem8b5f98b_cVw" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TjiCoDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_TjiCoTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TjiCozXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TjiCojXlEem8b5f98b_cVw" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Twb2MDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Twb2MTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Twb2MzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Twb2MjXlEem8b5f98b_cVw" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JmRVADX1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JmRVATX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JmRVAzX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JmRVAjX1Eem8b5f98b_cVw" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_J0aesDX1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_J0aesTX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0bFwDX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J0aesjX1Eem8b5f98b_cVw" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gBVYwDY1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gBVYwTY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gBV_0DY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gBVYwjY1Eem8b5f98b_cVw" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gMzo8DY1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gMzo8TY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gMzo8zY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gMzo8jY1Eem8b5f98b_cVw" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rMTOcDh8Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rMTOcTh8Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rMTOczh8Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rMTOcjh8Eem1lYbrIE6BNw" x="541" y="-196"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rX2XIDh8Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rX2XITh8Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rX2XIzh8Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rX2XIjh8Eem1lYbrIE6BNw" x="554" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MOZ4QDiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MOZ4QTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MOZ4QziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MOZ4QjiPEem1lYbrIE6BNw" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MYCVYDiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MYCVYTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MYCVYziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MYCVYjiPEem1lYbrIE6BNw" x="504" y="-321"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BfiIgDiUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BfiIgTiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BfivkDiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BfiIgjiUEem1lYbrIE6BNw" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BpU9sDiUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BpU9sTiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpVkwDiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BpU9sjiUEem1lYbrIE6BNw" x="504" y="-321"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Xds2QDkTEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Xds2QTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Xds2QzkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Xds2QjkTEemjx6Nna_xyog" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XnpccDkTEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XnpccTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XnpcczkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XnpccjkTEemjx6Nna_xyog" x="504" y="-321"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_jhN58DmsEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_jhN58TmsEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jhN58zmsEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jhN58jmsEemSPvPXzEQ11A" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_jrfQQDmsEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_jrfQQTmsEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jrfQQzmsEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jrfQQjmsEemSPvPXzEQ11A" x="504" y="-321"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KX5NADoYEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KX5NAToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KX5NAzoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KX5NAjoYEemSPvPXzEQ11A" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KjIMoDoYEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KjIMoToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KjIMozoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KjIMojoYEemSPvPXzEQ11A" x="504" y="-321"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_--vAkU-wEeitY7qZgkO_XQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_--vAkk-wEeitY7qZgkO_XQ"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_bxG78IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -3220,48 +4419,48 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S_1-ek-xEeitY7qZgkO_XQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S_1-e0-xEeitY7qZgkO_XQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_slcfoE-xEeitY7qZgkO_XQ" type="Abstraction_Edge" source="_iN-8kE-xEeitY7qZgkO_XQ" target="_V9OVkE-xEeitY7qZgkO_XQ">
+    <edges xmi:type="notation:Connector" xmi:id="_slcfoE-xEeitY7qZgkO_XQ" type="Abstraction_Edge" source="_iN-8kE-xEeitY7qZgkO_XQ" target="_V9OVkE-xEeitY7qZgkO_XQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_slcfo0-xEeitY7qZgkO_XQ" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pfTYIJyfEeihoemEj9HqGA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_slcfpE-xEeitY7qZgkO_XQ" x="9" y="-2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_slcfpE-xEeitY7qZgkO_XQ" x="11" y="-72"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_slcfpU-xEeitY7qZgkO_XQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pkc94JyfEeihoemEj9HqGA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_slcfpk-xEeitY7qZgkO_XQ" x="-8" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_slcfpk-xEeitY7qZgkO_XQ" x="-9" y="-65"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_slcfoU-xEeitY7qZgkO_XQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_slWZAE-xEeitY7qZgkO_XQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_slcfok-xEeitY7qZgkO_XQ" points="[-125, -2, -643984, -643984]$[-126, -86, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_smNUoE-xEeitY7qZgkO_XQ" id="(0.691415313225058,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_slcfok-xEeitY7qZgkO_XQ" points="[-193, -244, -643984, -643984]$[-193, -287, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_smNUoE-xEeitY7qZgkO_XQ" id="(0.6496519721577726,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_smNUoU-xEeitY7qZgkO_XQ" id="(0.5,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_szDBUU-yEeitY7qZgkO_XQ" type="Abstraction_Edge" source="_jrxwQ0-xEeitY7qZgkO_XQ" target="_SaiR8E-xEeitY7qZgkO_XQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_szDBVE-yEeitY7qZgkO_XQ" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pxO1oJyfEeihoemEj9HqGA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_szDBVU-yEeitY7qZgkO_XQ" x="3" y="7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_szDBVU-yEeitY7qZgkO_XQ" x="13" y="-71"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_szDBVk-yEeitY7qZgkO_XQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_p2HVoJyfEeihoemEj9HqGA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_szDBV0-yEeitY7qZgkO_XQ" x="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_szDBV0-yEeitY7qZgkO_XQ" x="-6" y="-62"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_szDBUk-yEeitY7qZgkO_XQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_szDBUE-yEeitY7qZgkO_XQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_szDBU0-yEeitY7qZgkO_XQ" points="[170, -2, -643984, -643984]$[166, -67, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_szDBU0-yEeitY7qZgkO_XQ" points="[120, -225, -643984, -643984]$[116, -290, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_szz2UE-yEeitY7qZgkO_XQ" id="(0.4766666666666667,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_szz2UU-yEeitY7qZgkO_XQ" id="(0.4755700325732899,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_z8BPIU-yEeitY7qZgkO_XQ" type="Abstraction_Edge" source="_lJLiYE-xEeitY7qZgkO_XQ" target="_S_jqkE-xEeitY7qZgkO_XQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_z8HVwE-yEeitY7qZgkO_XQ" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_pojawJyfEeihoemEj9HqGA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_z8HVwU-yEeitY7qZgkO_XQ" x="11" y="1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z8HVwU-yEeitY7qZgkO_XQ" x="9" y="-63"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_z8HVwk-yEeitY7qZgkO_XQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_psp3oJyfEeihoemEj9HqGA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_z8HVw0-yEeitY7qZgkO_XQ" x="-10" y="5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z8HVw0-yEeitY7qZgkO_XQ" x="-9" y="-65"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_z8BPIk-yEeitY7qZgkO_XQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z8BPI0-yEeitY7qZgkO_XQ" points="[488, -22, -643984, -643984]$[691, 13, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z8BPI0-yEeitY7qZgkO_XQ" points="[438, -245, -643984, -643984]$[641, -210, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z84KwE-yEeitY7qZgkO_XQ" id="(0.46875,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z84KwU-yEeitY7qZgkO_XQ" id="(0.4868421052631579,1.0)"/>
     </edges>
@@ -4402,7 +5601,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_m_RGUYtyEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_I55FIFRyEeitkMFXBYQFcg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_m_RGUotyEeik7I8D544C6Q" points="[91, 92, -643984, -643984]$[91, 405, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_m_RGUotyEeik7I8D544C6Q" points="[41, -131, -643984, -643984]$[41, 182, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pZftEItyEeik7I8D544C6Q" id="(0.21,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pZgUIItyEeik7I8D544C6Q" id="(0.15517241379310345,0.0)"/>
     </edges>
@@ -4433,7 +5632,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_06Y9YYtyEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_zNY8cFRxEeitkMFXBYQFcg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_06Y9YotyEeik7I8D544C6Q" points="[183, 92, -643984, -643984]$[183, 145, -643984, -643984]$[179, 145, -643984, -643984]$[179, 195, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_06Y9YotyEeik7I8D544C6Q" points="[133, -131, -643984, -643984]$[133, -78, -643984, -643984]$[129, -78, -643984, -643984]$[129, -28, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3v2HkItyEeik7I8D544C6Q" id="(0.5066666666666667,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3v2HkYtyEeik7I8D544C6Q" id="(0.1187214611872146,0.0)"/>
     </edges>
@@ -4464,7 +5663,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_6f074YtyEeik7I8D544C6Q"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_YkLMsFRyEeitkMFXBYQFcg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6f074otyEeik7I8D544C6Q" points="[309, 92, -643984, -643984]$[309, 138, -643984, -643984]$[478, 138, -643984, -643984]$[478, 263, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6f074otyEeik7I8D544C6Q" points="[259, -131, -643984, -643984]$[259, -85, -643984, -643984]$[428, -85, -643984, -643984]$[428, 40, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9scB0ItyEeik7I8D544C6Q" id="(0.94,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9scB0YtyEeik7I8D544C6Q" id="(0.06746031746031746,0.0)"/>
     </edges>
@@ -4865,7 +6064,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_-xFwEQSwEemABdf1yJ9dlA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_RLGcANZIEeidLb5WEUMFmw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-xFwEgSwEemABdf1yJ9dlA" points="[-406, 55, -643984, -643984]$[-406, 212, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-xFwEgSwEemABdf1yJ9dlA" points="[-456, -168, -643984, -643984]$[-456, -11, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIASxEemABdf1yJ9dlA" id="(0.03944315545243619,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIQSxEemABdf1yJ9dlA" id="(0.09848484848484848,0.0)"/>
     </edges>
@@ -4906,7 +6105,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__b3ycQSwEemABdf1yJ9dlA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_2_a7wNcXEeidLb5WEUMFmw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__b3ycgSwEemABdf1yJ9dlA" points="[-14, 98, -643984, -643984]$[-14, 357, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__b3ycgSwEemABdf1yJ9dlA" points="[-64, -125, -643984, -643984]$[-64, 134, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E1CPgASxEemABdf1yJ9dlA" id="(0.9489559164733179,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E1C2kASxEemABdf1yJ9dlA" id="(0.9136125654450262,0.0)"/>
     </edges>
@@ -5117,7 +6316,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_GoXlcRglEem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_GZifQBglEem7b6CPWW1OrA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GoXlchglEem7b6CPWW1OrA" points="[486, 102, -643984, -643984]$[486, 156, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GoXlchglEem7b6CPWW1OrA" points="[436, -121, -643984, -643984]$[436, -67, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HCHiMBglEem7b6CPWW1OrA" id="(0.4583333333333333,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HCHiMRglEem7b6CPWW1OrA" id="(0.1631578947368421,0.0)"/>
     </edges>
@@ -5178,7 +6377,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_0NaQkRglEem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_0CG_gBglEem7b6CPWW1OrA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0NaQkhglEem7b6CPWW1OrA" points="[-114, 55, -643984, -643984]$[-114, 82, -643984, -643984]$[-110, 82, -643984, -643984]$[-110, 110, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0NaQkhglEem7b6CPWW1OrA" points="[-164, -168, -643984, -643984]$[-164, -141, -643984, -643984]$[-160, -141, -643984, -643984]$[-160, -113, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0nEGsBglEem7b6CPWW1OrA" id="(0.7169373549883991,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0nEGsRglEem7b6CPWW1OrA" id="(0.6538461538461539,0.0)"/>
     </edges>
@@ -5321,6 +6520,226 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sdCg5SD_EemsM5ohGqY7Gw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sdCg5iD_EemsM5ohGqY7Gw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sdCg5yD_EemsM5ohGqY7Gw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_c6wUVDVvEem8b5f98b_cVw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_c6wUUDVvEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c6wUVTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c6w7YDVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c6wUVjVvEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c6wUVzVvEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c6wUWDVvEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dFAchDVvEem8b5f98b_cVw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_dFAcgDVvEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dFAchTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dFAciTVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dFAchjVvEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dFAchzVvEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dFAciDVvEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gJg55DVwEem8b5f98b_cVw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_gJg54DVwEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gJg55TVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gJg56TVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gJg55jVwEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gJg55zVwEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gJg56DVwEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gWwrtDVwEem8b5f98b_cVw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_gWwrsDVwEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gWwrtTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gWwruTVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gWwrtjVwEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gWwrtzVwEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gWwruDVwEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_TjiCpDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_TjiCoDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_TjiCpTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TjiCqTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TjiCpjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TjiCpzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TjiCqDXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Twb2NDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_Twb2MDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Twb2NTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TwcdQDXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Twb2NjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Twb2NzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Twb2ODXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JmRVBDX1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_JmRVADX1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JmRVBTX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JmRVCTX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JmRVBjX1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JmRVBzX1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JmRVCDX1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_J0bFwTX1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_J0aesDX1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_J0bFwjX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0bFxjX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J0bFwzX1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0bFxDX1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0bFxTX1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gBV_0TY1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_gBVYwDY1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gBV_0jY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gBV_1jY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gBV_0zY1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gBV_1DY1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gBV_1TY1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gM0QADY1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_gMzo8DY1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gM0QATY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gM0QBTY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gM0QAjY1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gM0QAzY1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gM0QBDY1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rMTOdDh8Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_rMTOcDh8Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rMTOdTh8Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rMT1gTh8Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rMTOdjh8Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rMTOdzh8Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rMT1gDh8Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rX2XJDh8Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_rX2XIDh8Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rX2XJTh8Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rX2XKTh8Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rX2XJjh8Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rX2XJzh8Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rX2XKDh8Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MOZ4RDiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_MOZ4QDiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MOZ4RTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MOafUDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MOZ4RjiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOZ4RziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MOZ4SDiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MYCVZDiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_MYCVYDiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MYCVZTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MYCVaTiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MYCVZjiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MYCVZziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MYCVaDiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BfivkTiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_BfiIgDiUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BfivkjiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BfivljiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BfivkziUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BfivlDiUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BfivlTiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BpVkwTiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_BpU9sDiUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BpVkwjiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpVkxjiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BpVkwziUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BpVkxDiUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BpVkxTiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Xds2RDkTEemjx6Nna_xyog" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_Xds2QDkTEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Xds2RTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Xds2STkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xds2RjkTEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xds2RzkTEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xds2SDkTEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XnpcdDkTEemjx6Nna_xyog" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_XnpccDkTEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XnpcdTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XnpceTkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XnpcdjkTEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XnpcdzkTEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XnpceDkTEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jhN59DmsEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_jhN58DmsEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_jhN59TmsEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jhOhAjmsEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jhN59jmsEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jhOhADmsEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jhOhATmsEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jrfQRDmsEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_jrfQQDmsEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_jrfQRTmsEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jrfQSTmsEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jrfQRjmsEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jrfQRzmsEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jrfQSDmsEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KX5NBDoYEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_KX5NADoYEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KX5NBToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KX5NCToYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KX5NBjoYEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KX5NBzoYEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KX5NCDoYEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KjIMpDoYEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_KjIMoDoYEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KjIMpToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KjIMqToYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KjIMpjoYEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KjIMpzoYEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KjIMqDoYEemSPvPXzEQ11A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_ODB7UFhmEeiYiLRYKaTpTw" type="PapyrusUMLClassDiagram" name="EthProActivePmJobs" measurementUnit="Pixel">
@@ -5744,33 +7163,29 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__ZXupF0YEeipas1p-rFJBA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__ZXupV0YEeipas1p-rFJBA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_CMnSUF0ZEeipas1p-rFJBA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CMnSUV0ZEeipas1p-rFJBA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bg-wsF6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_HLiWIH2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bg-wsV6gEeitO-Stqhyn1g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bg-wsl6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_mdw7oDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WztYsLFXEd2MOdzuQUV2bQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bg-ws16gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mdw7oTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bg_XwF6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_mdxisDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_uGZgsH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bg_XwV6gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mdxisTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bg_Xwl6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_n-WkYH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bg_Xw16gEeitO-Stqhyn1g"/>
+        <children xmi:type="notation:Shape" xmi:id="_mdyJwDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_b23MADU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mdyJwTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bg_XxF6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_mdyw0DVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mdyw0TVvEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_mdyw0jVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bg_XxV6gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mdyw0zVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bg_Xxl6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_mdyw1DVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bg_Xx16gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_mdyw1TVvEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__ZXupl0YEeipas1p-rFJBA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__ZXup10YEeipas1p-rFJBA"/>
@@ -5806,25 +7221,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__wf1NF0YEeipas1p-rFJBA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__wf1NV0YEeipas1p-rFJBA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_DAOV4F6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_AJG_wH20Ed2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAOV4V6gEeitO-Stqhyn1g"/>
+        <children xmi:type="notation:Shape" xmi:id="_rSMT8DVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_oesicNl2EeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_rSMT8TVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_DAOV4l6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_rSM7ADVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_9dJv0H2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAOV416gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_rSM7ATVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_DAO88F6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_3ZT3I0RhEeKsbYfVW3kmQQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAO88V6gEeitO-Stqhyn1g"/>
+        <children xmi:type="notation:Shape" xmi:id="_rSM7AjVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_ugy7kTU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_rSM7AzVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_DAO88l6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_rSNiEDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAO8816gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_rSNiETVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_DAO89F6gEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_rSNiEjVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAO89V6gEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_rSNiEzVvEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__wf1Nl0YEeipas1p-rFJBA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__wf1N10YEeipas1p-rFJBA"/>
@@ -7522,6 +8937,356 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xJ5EwiGzEemyX4Zl-fbCkw" x="517" y="-141"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_iCb1QDVuEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iCb1QTVuEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCb1QzVuEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCb1QjVuEem8b5f98b_cVw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iHpscDVuEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iHpscTVuEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iHpsczVuEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iHpscjVuEem8b5f98b_cVw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_f09boDVvEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_f09boTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f09bozVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f09bojVvEem8b5f98b_cVw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_f50GcDVvEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_f50GcTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f50tgDVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f50GcjVvEem8b5f98b_cVw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zSAqMDVvEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_zSAqMjVvEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zSBRQDVvEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zSBRQTVvEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zSBRQjVvEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_8-evgDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_3ZL4kDU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8-evgTVvEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8-fWkDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_6WMcQDU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8-fWkTVvEem8b5f98b_cVw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zSBRQzVvEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zSBRRDVvEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zSBRRTVvEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zSBRRjVvEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zSBRRzVvEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zSBRSDVvEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zSBRSTVvEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zSBRSjVvEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zSBRSzVvEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_zSB4UDVvEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_zSB4UTVvEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_zSB4UjVvEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_zSB4UzVvEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zSB4VDVvEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zSAqMTVvEem8b5f98b_cVw" x="-123" y="664" height="73"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zSbg8DVvEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zSbg8TVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zSbg8zVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zSbg8jVvEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iwMBMDVwEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iwMBMTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iwMBMzVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iwMBMjVwEem8b5f98b_cVw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_i0LJUDVwEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_i0LJUTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i0LJUzVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i0LJUjVwEem8b5f98b_cVw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q6bxEDW4Eem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_q6cYIDW4Eem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_q6cYITW4Eem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_q6cYIjW4Eem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q6c_MDW4Eem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q6c_MTW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q6c_MjW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q6c_MzW4Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q6c_NDW4Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q6c_NTW4Eem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q6c_NjW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q6c_NzW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q6c_ODW4Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q6c_OTW4Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q6c_OjW4Eem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q6c_OzW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q6c_PDW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q6c_PTW4Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q6c_PjW4Eem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_q5_sMDW4Eem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q6bxETW4Eem8b5f98b_cVw" x="440" y="419" width="339" height="44"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q6rosDW4Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_q6rosTW4Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q6roszW4Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_q5_sMDW4Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q6rosjW4Eem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3CrVQDW4Eem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3Cr8UDW4Eem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3Cr8UTW4Eem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Cr8UjW4Eem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3Cr8UzW4Eem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3Cr8VDW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3Cr8VTW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3Cr8VjW4Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Cr8VzW4Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3Cr8WDW4Eem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3Cr8WTW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3Cr8WjW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3Cr8WzW4Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Cr8XDW4Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3Cr8XTW4Eem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3Cr8XjW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3Cr8XzW4Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3Cr8YDW4Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Cr8YTW4Eem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_3CgWIDW4Eem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3CrVQTW4Eem8b5f98b_cVw" x="454" y="637" width="329" height="53"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3C5XszW4Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3C5XtDW4Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3C5-wDW4Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_3CgWIDW4Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3C5XtTW4Eem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_b9c-8DW5Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_b9c-8TW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_b9c-8zW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_ZrMocDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b9c-8jW5Eem8b5f98b_cVw" x="640" y="319"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mKZUEDW5Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mKZUETW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mKZUEzW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_fxhGcDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mKZUEjW5Eem8b5f98b_cVw" x="640" y="319"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uDkPwDW5Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uDkPwTW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uDkPwzW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sAu1UDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uDkPwjW5Eem8b5f98b_cVw" x="654" y="537"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0ROE0DW5Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_0ROE0TW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0ROE0zW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_x_PbIDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0ROE0jW5Eem8b5f98b_cVw" x="654" y="537"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WuFTEDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WuFTETXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WuFTEzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WuFTEjXlEem8b5f98b_cVw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WycOoDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WycOoTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WycOozXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WycOojXlEem8b5f98b_cVw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_W8SHIDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_W8SHITXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W8SHIzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W8SHIjXlEem8b5f98b_cVw" x="89" y="140"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_W-yBgDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_W-yBgTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W-yBgzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W-yBgjXlEem8b5f98b_cVw" x="88" y="384"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KrkJIDX1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KrkJITX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KrkwMDX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KrkJIjX1Eem8b5f98b_cVw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KwjW0DX1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Kwj94DX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Kwj94jX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Kwj94TX1Eem8b5f98b_cVw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_hL7joDY1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hL7joTY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hL7jozY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hL7jojY1Eem8b5f98b_cVw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_hQPb4DY1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hQPb4TY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hQPb4zY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hQPb4jY1Eem8b5f98b_cVw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rjErMDd1Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rjErMTd1Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rjFSQDd1Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rjErMjd1Eem1lYbrIE6BNw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rp1agDd1Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rp1agTd1Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rp1agzd1Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rp1agjd1Eem1lYbrIE6BNw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NOT2EDiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NOT2ETiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NOT2EziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NOT2EjiPEem1lYbrIE6BNw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NSfygDiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NSfygTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NSfygziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NSfygjiPEem1lYbrIE6BNw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CaGTUDiUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CaGTUTiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CaGTUziUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CaGTUjiUEem1lYbrIE6BNw" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Cd-GsDiUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Cd-GsTiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Cd-GsziUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Cd-GsjiUEem1lYbrIE6BNw" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Yb-cYDkTEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Yb-cYTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yb-cYzkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yb-cYjkTEemjx6Nna_xyog" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YgGHYDkTEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YgGHYTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YgGucDkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YgGHYjkTEemjx6Nna_xyog" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_GQ8BUDmtEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_GQ8BUTmtEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GQ8BUzmtEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GQ8BUjmtEemSPvPXzEQ11A" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_GUymkDmtEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_GUymkTmtEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GUymkzmtEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GUymkjmtEemSPvPXzEQ11A" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_K6lDUDoYEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K6lDUToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K6lDUzoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K6lDUjoYEemSPvPXzEQ11A" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_K_buIDoYEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K_cVMDoYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K_cVMjoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K_cVMToYEemSPvPXzEQ11A" x="517" y="-141"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_ODB7UVhmEeiYiLRYKaTpTw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_ODB7UlhmEeiYiLRYKaTpTw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_brdm8IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -7696,7 +9461,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wpmOV0YEeipas1p-rFJBA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wpmOl0YEeipas1p-rFJBA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_EK15kF0ZEeipas1p-rFJBA" type="Abstraction_Edge" source="_yhygIFiiEei2nODetmeP6A" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_EK15kF0ZEeipas1p-rFJBA" type="Abstraction_Edge" source="_yhygIFiiEei2nODetmeP6A" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_EK15k10ZEeipas1p-rFJBA" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_knyKMIt1Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_EK15lF0ZEeipas1p-rFJBA" y="40"/>
@@ -7711,7 +9476,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EOfqgF0ZEeipas1p-rFJBA" id="(0.0,0.24691358024691357)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EOfqgV0ZEeipas1p-rFJBA" id="(1.0,0.12121212121212122)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MwGfMF0ZEeipas1p-rFJBA" type="Abstraction_Edge" source="_yhygIFiiEei2nODetmeP6A" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_MwGfMF0ZEeipas1p-rFJBA" type="Abstraction_Edge" source="_yhygIFiiEei2nODetmeP6A" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_MwHGQF0ZEeipas1p-rFJBA" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yQvvsIt0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_MwHGQV0ZEeipas1p-rFJBA" y="40"/>
@@ -7871,7 +9636,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aw-qx16fEeitO-Stqhyn1g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aw-qyF6fEeitO-Stqhyn1g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6CCS4F6fEeitO-Stqhyn1g" type="Abstraction_Edge" source="_HprpcFivEei2nODetmeP6A" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_6CCS4F6fEeitO-Stqhyn1g" type="Abstraction_Edge" source="_HprpcFivEei2nODetmeP6A" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_6CCS416fEeitO-Stqhyn1g" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_98CSIIt0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_6CCS5F6fEeitO-Stqhyn1g" y="40"/>
@@ -7882,9 +9647,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_6CCS4V6fEeitO-Stqhyn1g"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_6CBEwF6fEeitO-Stqhyn1g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6CCS4l6fEeitO-Stqhyn1g" points="[427, 480, -643984, -643984]$[180, 480, -643984, -643984]$[180, 380, -643984, -643984]$[130, 380, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6CCS4l6fEeitO-Stqhyn1g" points="[364, 480, -643984, -643984]$[178, 480, -643984, -643984]$[178, 373, -643984, -643984]$[104, 373, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6GFFYF6fEeitO-Stqhyn1g" id="(0.0,0.10126582278481013)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6GFFYV6fEeitO-Stqhyn1g" id="(1.0,0.8484848484848485)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6GFFYV6fEeitO-Stqhyn1g" id="(0.9953703703703703,0.8)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7I4mN16fEeitO-Stqhyn1g" type="StereotypeCommentLink" source="_6CCS4F6fEeitO-Stqhyn1g" target="_7I4mM16fEeitO-Stqhyn1g">
       <styles xmi:type="notation:FontStyle" xmi:id="_7I4mOF6fEeitO-Stqhyn1g"/>
@@ -7896,20 +9661,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7I4mOl6fEeitO-Stqhyn1g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7I4mO16fEeitO-Stqhyn1g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9yDn4F6fEeitO-Stqhyn1g" type="Abstraction_Edge" source="_HprpcFivEei2nODetmeP6A" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_9yDn4F6fEeitO-Stqhyn1g" type="Abstraction_Edge" source="_HprpcFivEei2nODetmeP6A" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_9yDn416fEeitO-Stqhyn1g" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2OTxcIt0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_9yDn5F6fEeitO-Stqhyn1g" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_9yDn5V6fEeitO-Stqhyn1g" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2ULv8It0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9yDn5l6fEeitO-Stqhyn1g" x="-66" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9yDn5l6fEeitO-Stqhyn1g" x="-69" y="8"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_9yDn4V6fEeitO-Stqhyn1g"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_9yCZwF6fEeitO-Stqhyn1g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9yDn4l6fEeitO-Stqhyn1g" points="[427, 540, -643984, -643984]$[100, 540, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cF6fEeitO-Stqhyn1g" id="(0.0,0.8607594936708861)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cV6fEeitO-Stqhyn1g" id="(1.0,0.4307692307692308)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9yDn4l6fEeitO-Stqhyn1g" points="[364, 547, -643984, -643984]$[104, 547, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cF6fEeitO-Stqhyn1g" id="(0.0,0.9620253164556962)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cV6fEeitO-Stqhyn1g" id="(1.0,0.49230769230769234)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_-ybfx16fEeitO-Stqhyn1g" type="StereotypeCommentLink" source="_9yDn4F6fEeitO-Stqhyn1g" target="_-ybfw16fEeitO-Stqhyn1g">
       <styles xmi:type="notation:FontStyle" xmi:id="_-ybfyF6fEeitO-Stqhyn1g"/>
@@ -8174,7 +9939,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JqjQAGA5Eei7_-Uhq6CryQ" id="(1.0,0.3050847457627119)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JqjQAWA5Eei7_-Uhq6CryQ" id="(0.0,0.8285714285714286)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MLunwGBDEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_aUTr0GAeEeiHT-m6nqduOA" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_MLunwGBDEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_aUTr0GAeEeiHT-m6nqduOA" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_MLvO0GBDEei7_-Uhq6CryQ" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oPvIUIt1Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_MLvO0WBDEei7_-Uhq6CryQ" y="40"/>
@@ -8185,9 +9950,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_MLunwWBDEei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_MLrkcGBDEei7_-Uhq6CryQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MLunwmBDEei7_-Uhq6CryQ" points="[360, 359, -643984, -643984]$[130, 359, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MO4CYGBDEei7_-Uhq6CryQ" id="(0.0,0.3088235294117647)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MO4CYWBDEei7_-Uhq6CryQ" id="(1.0,0.7333333333333333)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MLunwmBDEei7_-Uhq6CryQ" points="[360, 352, -643984, -643984]$[104, 352, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MO4CYGBDEei7_-Uhq6CryQ" id="(0.0,0.11764705882352941)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MO4CYWBDEei7_-Uhq6CryQ" id="(0.9953703703703703,0.6545454545454545)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_RE_cx2BDEei7_-Uhq6CryQ" type="StereotypeCommentLink" source="_MLunwGBDEei7_-Uhq6CryQ" target="_RE_cw2BDEei7_-Uhq6CryQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_RE_cyGBDEei7_-Uhq6CryQ"/>
@@ -8199,7 +9964,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RFAD0GBDEei7_-Uhq6CryQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RFAD0WBDEei7_-Uhq6CryQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wt9jsGBFEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_aUTr0GAeEeiHT-m6nqduOA" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_wt9jsGBFEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_aUTr0GAeEeiHT-m6nqduOA" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_wt9js2BFEei7_-Uhq6CryQ" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0d1SUIt0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_wt9jtGBFEei7_-Uhq6CryQ" y="40"/>
@@ -8224,35 +9989,35 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4ee5sGBFEei7_-Uhq6CryQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4ee5sWBFEei7_-Uhq6CryQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7v1q0GBHEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_baAIkGAeEeiHT-m6nqduOA" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_7v1q0GBHEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_baAIkGAeEeiHT-m6nqduOA" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_7v2R4GBHEei7_-Uhq6CryQ" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GjfQIIt1Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7v2R4WBHEei7_-Uhq6CryQ" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7v2R4mBHEei7_-Uhq6CryQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Gn8SUIt1Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7v2R42BHEei7_-Uhq6CryQ" x="-66" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7v2R42BHEei7_-Uhq6CryQ" x="-65" y="-15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7v1q0WBHEei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_7v1DwGBHEei7_-Uhq6CryQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7v1q0mBHEei7_-Uhq6CryQ" points="[364, 600, -643984, -643984]$[100, 600, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7yhycGBHEei7_-Uhq6CryQ" id="(0.0,0.6101694915254238)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7yhycWBHEei7_-Uhq6CryQ" id="(1.0,0.8923076923076924)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7v1q0mBHEei7_-Uhq6CryQ" points="[364, 591, -643984, -643984]$[104, 591, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7yhycGBHEei7_-Uhq6CryQ" id="(0.0,0.4406779661016949)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7yhycWBHEei7_-Uhq6CryQ" id="(1.0,0.8153846153846154)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_8hyFIGBHEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_baAIkGAeEeiHT-m6nqduOA" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_8hyFIGBHEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_baAIkGAeEeiHT-m6nqduOA" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_8hysMGBHEei7_-Uhq6CryQ" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-5gnAIt0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_8hysMWBHEei7_-Uhq6CryQ" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8hysMmBHEei7_-Uhq6CryQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__AD68It0Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8hysM2BHEei7_-Uhq6CryQ" x="10" y="138"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8hysM2BHEei7_-Uhq6CryQ" x="-14" y="139"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_8hyFIWBHEei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_8hwP8GBHEei7_-Uhq6CryQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8hyFImBHEei7_-Uhq6CryQ" points="[426, 580, -643984, -643984]$[160, 580, -643984, -643984]$[160, 400, -643984, -643984]$[130, 400, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8hyFImBHEei7_-Uhq6CryQ" points="[364, 580, -643984, -643984]$[160, 580, -643984, -643984]$[160, 388, -643984, -643984]$[104, 388, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8kwgoGBHEei7_-Uhq6CryQ" id="(0.0,0.2711864406779661)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8kxHsGBHEei7_-Uhq6CryQ" id="(1.0,0.9696969696969697)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8kxHsGBHEei7_-Uhq6CryQ" id="(0.9953703703703703,0.8848484848484849)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_A5u81GBIEei7_-Uhq6CryQ" type="StereotypeCommentLink" source="_8hyFIGBHEei7_-Uhq6CryQ" target="_A5u80GBIEei7_-Uhq6CryQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_A5u81WBIEei7_-Uhq6CryQ"/>
@@ -8684,29 +10449,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C_QJ1It0Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C_QJ1Yt0Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_YeeEcIt0Eeiu6boZkiJHCA" type="Association_Edge" source="_4UpIAFiAEei2nODetmeP6A" target="__ZXuoF0YEeipas1p-rFJBA">
+    <edges xmi:type="notation:Connector" xmi:id="_YeeEcIt0Eeiu6boZkiJHCA" type="Association_Edge" source="_4UpIAFiAEei2nODetmeP6A" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_YeeEc4t0Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_R_zNMDVwEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YeeEdIt0Eeiu6boZkiJHCA" x="9" y="-57"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YeeEdYt0Eeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SQX_0DVwEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YeeEdot0Eeiu6boZkiJHCA" x="-11" y="-70"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YeergIt0Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YeergYt0Eeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SeO1oDVwEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YeergYt0Eeiu6boZkiJHCA" x="15" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Yeergot0Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Yeerg4t0Eeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SsHgoDVwEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Yeerg4t0Eeiu6boZkiJHCA" x="-15" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YeerhIt0Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YeerhYt0Eeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_S8QOYDVwEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YeerhYt0Eeiu6boZkiJHCA" x="15" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Yeerhot0Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Yeerh4t0Eeiu6boZkiJHCA" x="2" y="18"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TJ96QDVwEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Yeerh4t0Eeiu6boZkiJHCA" x="-13" y="18"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_YeeEcYt0Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YeeEcot0Eeiu6boZkiJHCA" points="[19, 103, -643984, -643984]$[13, 240, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hwqRcJyfEeihoemEj9HqGA" id="(0.42671009771986973,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YeeEcot0Eeiu6boZkiJHCA" points="[6, 139, -643984, -643984]$[6, 240, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hwqRcJyfEeihoemEj9HqGA" id="(0.38436482084690554,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RxWhgDVwEem8b5f98b_cVw" id="(0.5416666666666666,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Yest9It0Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_YeeEcIt0Eeiu6boZkiJHCA" target="_Yest8It0Eeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Yest9Yt0Eeiu6boZkiJHCA"/>
@@ -8730,10 +10502,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_pLh3oIt0Eeiu6boZkiJHCA" type="Association_Edge" source="__ZXuoF0YEeipas1p-rFJBA" target="__wf1MF0YEeipas1p-rFJBA">
       <children xmi:type="notation:DecorationNode" xmi:id="_pLiesIt0Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLiesYt0Eeiu6boZkiJHCA" x="2" y="14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLiesYt0Eeiu6boZkiJHCA" x="-1" y="61"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_pLiesot0Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLies4t0Eeiu6boZkiJHCA" x="-18" y="10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLies4t0Eeiu6boZkiJHCA" x="-17" y="79"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_pLietIt0Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pLietYt0Eeiu6boZkiJHCA" y="-20"/>
@@ -8742,10 +10514,10 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pLiet4t0Eeiu6boZkiJHCA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_pLieuIt0Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLieuYt0Eeiu6boZkiJHCA" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLieuYt0Eeiu6boZkiJHCA" x="-2" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_pLieuot0Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLieu4t0Eeiu6boZkiJHCA" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pLieu4t0Eeiu6boZkiJHCA" x="5" y="-16"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_pLh3oYt0Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
@@ -9436,6 +11208,458 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xJ5ExyGzEemyX4Zl-fbCkw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xJ5EyCGzEemyX4Zl-fbCkw"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iCb1RDVuEem8b5f98b_cVw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_iCb1QDVuEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iCb1RTVuEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCccUjVuEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iCb1RjVuEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCccUDVuEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCccUTVuEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iHpsdDVuEem8b5f98b_cVw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_iHpscDVuEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iHpsdTVuEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iHqTgDVuEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iHpsdjVuEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iHpsdzVuEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iHpseDVuEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_f09bpDVvEem8b5f98b_cVw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_f09boDVvEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_f09bpTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f09bqTVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f09bpjVvEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f09bpzVvEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f09bqDVvEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_f50tgTVvEem8b5f98b_cVw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_f50GcDVvEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_f50tgjVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f50thjVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f50tgzVvEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f50thDVvEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f50thTVvEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zSbg9DVvEem8b5f98b_cVw" type="StereotypeCommentLink" source="_zSAqMDVvEem8b5f98b_cVw" target="_zSbg8DVvEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zSbg9TVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zSbg-TVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zSbg9jVvEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zSbg9zVvEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zSbg-DVvEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_11q5wDVvEem8b5f98b_cVw" type="Association_Edge" source="__ZXuoF0YEeipas1p-rFJBA" target="_zSAqMDVvEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_11q5wzVvEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5cR0EDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_11rg0DVvEem8b5f98b_cVw" x="-169" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_11rg0TVvEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5puaMDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_11rg0jVvEem8b5f98b_cVw" x="-203" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_11rg0zVvEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_53Gu4DVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_11rg1DVvEem8b5f98b_cVw" x="22" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_11rg1TVvEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6HYmkDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_11rg1jVvEem8b5f98b_cVw" x="-22" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_11rg1zVvEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6VCoEDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_11rg2DVvEem8b5f98b_cVw" x="12" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_11rg2TVvEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6ienIDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_11rg2jVvEem8b5f98b_cVw" x="-22" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_11q5wTVvEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_11q5wjVvEem8b5f98b_cVw" points="[-111, 322, -643984, -643984]$[-196, 322, -643984, -643984]$[-196, 685, -643984, -643984]$[-124, 685, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OpAsDVvEem8b5f98b_cVw" id="(0.0,0.49696969696969695)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OpAsTVvEem8b5f98b_cVw" id="(0.0,0.6164383561643836)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_2b3XEDVvEem8b5f98b_cVw" type="Association_Edge" source="__wf1MF0YEeipas1p-rFJBA" target="_zSAqMDVvEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_2b3XEzVvEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-HDhIDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2b3XFDVvEem8b5f98b_cVw" x="5" y="64"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2b3XFTVvEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-VEH8DVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2b3XFjVvEem8b5f98b_cVw" x="-10" y="78"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2b3XFzVvEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-jciMDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2b3XGDVvEem8b5f98b_cVw" x="59" y="24"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2b3XGTVvEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-zhlkDVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2b3XGjVvEem8b5f98b_cVw" x="-59" y="64"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2b3XGzVvEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__CZIADVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2b3-IDVvEem8b5f98b_cVw" x="12" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2b3-ITVvEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__QRL8DVvEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2b3-IjVvEem8b5f98b_cVw" x="-14" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_2b3XETVvEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2b3XEjVvEem8b5f98b_cVw" points="[-3, 614, -643984, -643984]$[-3, 664, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__g6QADVvEem8b5f98b_cVw" id="(0.5092592592592593,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__g6QATVvEem8b5f98b_cVw" id="(0.5020746887966805,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iwMBNDVwEem8b5f98b_cVw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_iwMBMDVwEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iwMBNTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iwMBOTVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iwMBNjVwEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iwMBNzVwEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iwMBODVwEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_i0LJVDVwEem8b5f98b_cVw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_i0LJUDVwEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_i0LJVTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i0LJWTVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i0LJVjVwEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i0LJVzVwEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i0LJWDVwEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_q6rotDW4Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_q6bxEDW4Eem8b5f98b_cVw" target="_q6rosDW4Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_q6rotTW4Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q6rouTW4Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_q5_sMDW4Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_q6rotjW4Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q6rotzW4Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q6rouDW4Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3C5-wTW4Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_3CrVQDW4Eem8b5f98b_cVw" target="_3C5XszW4Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3C5-wjW4Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3C5-xjW4Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_3CgWIDW4Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3C5-wzW4Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3C5-xDW4Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3C5-xTW4Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZrjNwDW5Eem8b5f98b_cVw" type="Abstraction_Edge" source="_q6bxEDW4Eem8b5f98b_cVw" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Zrj00DW5Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_L22SUDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Zrj00TW5Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Zrj00jW5Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MG5ggDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Zrj00zW5Eem8b5f98b_cVw" x="-63" y="10"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZrjNwTW5Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_ZrMocDW5Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZrjNwjW5Eem8b5f98b_cVw" points="[440, 432, -643984, -643984]$[232, 432, -643984, -643984]$[232, 364, -643984, -643984]$[104, 364, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aMkQIDW5Eem8b5f98b_cVw" id="(0.0,0.29545454545454547)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aMk3MDW5Eem8b5f98b_cVw" id="(0.9953703703703703,0.7272727272727273)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_b9c-9DW5Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_ZrjNwDW5Eem8b5f98b_cVw" target="_b9c-8DW5Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_b9c-9TW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_b9c--TW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_ZrMocDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b9c-9jW5Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b9c-9zW5Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b9c--DW5Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fxkJwDW5Eem8b5f98b_cVw" type="Abstraction_Edge" source="_q6bxEDW4Eem8b5f98b_cVw" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fxkw0DW5Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Z3lCIDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fxkw0TW5Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fxkw0jW5Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_aFydQDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fxkw0zW5Eem8b5f98b_cVw" x="-52" y="-95"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fxkJwTW5Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_fxhGcDW5Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fxkJwjW5Eem8b5f98b_cVw" points="[440, 456, -643984, -643984]$[277, 456, -643984, -643984]$[277, 531, -643984, -643984]$[104, 531, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gOeIMDW5Eem8b5f98b_cVw" id="(0.0,0.8409090909090909)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gOeIMTW5Eem8b5f98b_cVw" id="(1.0,0.36923076923076925)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mKZUFDW5Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_fxkJwDW5Eem8b5f98b_cVw" target="_mKZUEDW5Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mKZUFTW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mKZ7IjW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_fxhGcDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mKZUFjW5Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mKZ7IDW5Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mKZ7ITW5Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sAwqgDW5Eem8b5f98b_cVw" type="Abstraction_Edge" source="_3CrVQDW4Eem8b5f98b_cVw" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_sAwqgzW5Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_RRIwwDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sAwqhDW5Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sAwqhTW5Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Rf7asDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sAwqhjW5Eem8b5f98b_cVw" x="-215" y="8"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_sAwqgTW5Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_sAu1UDW5Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sAwqgjW5Eem8b5f98b_cVw" points="[453, 640, -643984, -643984]$[140, 640, -643984, -643984]$[140, 399, -643984, -643984]$[104, 399, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_se1GkDW5Eem8b5f98b_cVw" id="(0.0,0.05660377358490566)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_se1GkTW5Eem8b5f98b_cVw" id="(0.9953703703703703,0.9575757575757575)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uDkPxDW5Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_sAwqgDW5Eem8b5f98b_cVw" target="_uDkPwDW5Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uDkPxTW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uDmE8DW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sAu1UDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uDkPxjW5Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uDkPxzW5Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uDkPyDW5Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_x_RQUDW5Eem8b5f98b_cVw" type="Abstraction_Edge" source="_3CrVQDW4Eem8b5f98b_cVw" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_x_R3YDW5Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fE7QwDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_x_R3YTW5Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_x_R3YjW5Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fWndsDW6Eem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_x_R3YzW5Eem8b5f98b_cVw" x="-109" y="9"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_x_RQUTW5Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_x_PbIDW5Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_x_RQUjW5Eem8b5f98b_cVw" points="[453, 664, -643984, -643984]$[196, 664, -643984, -643984]$[196, 601, -643984, -643984]$[104, 601, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybjjsDW5Eem8b5f98b_cVw" id="(0.0,0.5094339622641509)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybjjsTW5Eem8b5f98b_cVw" id="(1.0,0.9)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0ROE1DW5Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_x_RQUDW5Eem8b5f98b_cVw" target="_0ROE0DW5Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0ROE1TW5Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0ROr4DW5Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_x_PbIDW5Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0ROE1jW5Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0ROE1zW5Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0ROE2DW5Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WuFTFDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_WuFTEDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WuFTFTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WuF6IjXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WuFTFjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WuF6IDXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WuF6ITXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WycOpDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_WycOoDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WycOpTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wyc1sDXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WycOpjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WycOpzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WycOqDXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_W8SHJDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_11q5wDVvEem8b5f98b_cVw" target="_W8SHIDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_W8SHJTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W8SHKTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W8SHJjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W8SHJzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W8SHKDXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_W-yBhDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_2b3XEDVvEem8b5f98b_cVw" target="_W-yBgDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_W-yBhTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W-yBiTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W-yBhjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W-yBhzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W-yBiDXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KrkwMTX1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_KrkJIDX1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KrkwMjX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KrkwNjX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KrkwMzX1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KrkwNDX1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KrkwNTX1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Kwj94zX1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_KwjW0DX1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Kwj95DX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Kwj96DX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Kwj95TX1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Kwj95jX1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Kwj95zX1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hL7jpDY1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_hL7joDY1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hL7jpTY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hL7jqTY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hL7jpjY1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hL7jpzY1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hL7jqDY1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hQQC8DY1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_hQPb4DY1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hQQC8TY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hQQC9TY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hQQC8jY1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hQQC8zY1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hQQC9DY1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rjFSQTd1Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_rjErMDd1Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rjFSQjd1Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rjFSRjd1Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rjFSQzd1Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rjFSRDd1Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rjFSRTd1Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rp1ahDd1Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_rp1agDd1Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rp1ahTd1Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rp2Bkjd1Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rp1ahjd1Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rp2BkDd1Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rp2BkTd1Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NOT2FDiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_NOT2EDiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NOT2FTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NOUdIjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NOT2FjiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NOUdIDiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NOUdITiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NSgZkDiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_NSfygDiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NSgZkTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NSgZlTiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NSgZkjiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NSgZkziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NSgZlDiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CaGTVDiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_CaGTUDiUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CaGTVTiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CaG6YDiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CaGTVjiUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CaGTVziUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CaGTWDiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Cd-GtDiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_Cd-GsDiUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Cd-GtTiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Cd-GuTiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Cd-GtjiUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cd-GtziUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cd-GuDiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Yb-cZDkTEemjx6Nna_xyog" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_Yb-cYDkTEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Yb-cZTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yb-caTkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Yb-cZjkTEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yb-cZzkTEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yb-caDkTEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YgGucTkTEemjx6Nna_xyog" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_YgGHYDkTEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YgGucjkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YgGudjkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YgGuczkTEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YgGudDkTEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YgGudTkTEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GQ8BVDmtEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_GQ8BUDmtEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_GQ8BVTmtEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GQ8BWTmtEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GQ8BVjmtEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GQ8BVzmtEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GQ8BWDmtEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GUymlDmtEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_GUymkDmtEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_GUymlTmtEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GUymmTmtEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GUymljmtEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GUymlzmtEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GUymmDmtEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_K6lDVDoYEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_K6lDUDoYEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K6lDVToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K6lDWToYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K6lDVjoYEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K6lDVzoYEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K6lDWDoYEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_K_cVMzoYEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_K_buIDoYEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K_cVNDoYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K_cVODoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K_cVNToYEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K_cVNjoYEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K_cVNzoYEemSPvPXzEQ11A"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_tC4KUGBLEei7_-Uhq6CryQ" type="PapyrusUMLClassDiagram" name="EthOnDemandPmJobs" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_vI3mcGBLEei7_-Uhq6CryQ" type="Enumeration_Shape">
@@ -9646,9 +11870,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ITI2hGBMEei7_-Uhq6CryQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_ITJdkGBMEei7_-Uhq6CryQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_KtJlYGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_QRSk2DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_BFQU8DafEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRSk2TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTL4DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_VIVkcosyEeK2NvDLt60gDw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KtJlYWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL4TagEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_ITJdkWBMEei7_-Uhq6CryQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_ITJdkmBMEei7_-Uhq6CryQ"/>
@@ -9676,9 +11904,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_IpzqFGBMEei7_-Uhq6CryQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_IpzqFWBMEei7_-Uhq6CryQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_LzEEkGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_QRTL7DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_ZDAHgDafEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL7TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTy8DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_ABzeMEN2EeKtRKTHZgJhIg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_LzEEkWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTy8TagEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_IpzqFmBMEei7_-Uhq6CryQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_IpzqF2BMEei7_-Uhq6CryQ"/>
@@ -9698,7 +11930,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpzqI2BMEei7_-Uhq6CryQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_w8GAcFesEeiqWMdX2ZZi3w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpzqEWBMEei7_-Uhq6CryQ" x="443" y="640" height="69"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpzqEWBMEei7_-Uhq6CryQ" x="444" y="646" height="69"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_JIkpsGBMEei7_-Uhq6CryQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_JIkpsmBMEei7_-Uhq6CryQ" type="Class_NameLabel"/>
@@ -9706,13 +11938,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_JIkptGBMEei7_-Uhq6CryQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_JIkptWBMEei7_-Uhq6CryQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_NhJ-EGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_pjlxIIu1EeK2NvDLt60gDw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NhJ-EWBNEei7_-Uhq6CryQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_QRR9wDagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_rCx8QDaeEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRR9wTagEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_NhKlIGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_QRSk0DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_rCnkMDaeEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRSk0TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRSk0jagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_rCtq0DaeEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRSk0zagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRSk1DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_c0CVUou1EeK2NvDLt60gDw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NhKlIWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRSk1TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRSk1jagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_pjlxIIu1EeK2NvDLt60gDw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRSk1zagEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_JIkptmBMEei7_-Uhq6CryQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_JIkpt2BMEei7_-Uhq6CryQ"/>
@@ -9732,7 +11976,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JIlQyWBMEei7_-Uhq6CryQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_tDn6EFesEeiqWMdX2ZZi3w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JIkpsWBMEei7_-Uhq6CryQ" x="442" y="321" height="81"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JIkpsWBMEei7_-Uhq6CryQ" x="442" y="291" height="111"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_KGse0GBMEei7_-Uhq6CryQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_KGse0mBMEei7_-Uhq6CryQ" type="Class_NameLabel"/>
@@ -9740,13 +11984,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_KGse1GBMEei7_-Uhq6CryQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_KGse1WBMEei7_-Uhq6CryQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_Pv_NIGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_in3Is0N1EeKtRKTHZgJhIg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Pv_NIWBNEei7_-Uhq6CryQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_QRTL4jagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_HziK0DafEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL4zagEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Pv_0MGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_QRTL5DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_HzmcQDafEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL5TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTL5jagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_HzegcDafEem8b5f98b_cVw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL5zagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTL6DagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_in3IsEN1EeKtRKTHZgJhIg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Pv_0MWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL6TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTL6jagEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_in3Is0N1EeKtRKTHZgJhIg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTL6zagEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_KGse1mBMEei7_-Uhq6CryQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_KGse12BMEei7_-Uhq6CryQ"/>
@@ -9766,7 +12022,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KGtF6WBMEei7_-Uhq6CryQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_u10QcFesEeiqWMdX2ZZi3w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KGse0WBMEei7_-Uhq6CryQ" x="440" y="539" height="81"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KGse0WBMEei7_-Uhq6CryQ" x="440" y="539" height="103"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SRoDcGBNEei7_-Uhq6CryQ" type="DataType_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_SRoqgGBNEei7_-Uhq6CryQ" type="DataType_NameLabel"/>
@@ -9798,7 +12054,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SRoqjGBNEei7_-Uhq6CryQ"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiEth.uml#_zeuZsFEbEd6VSrclB-Ybig"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SRoDcWBNEei7_-Uhq6CryQ" x="1071" y="412" height="104"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SRoDcWBNEei7_-Uhq6CryQ" x="1073" y="427" height="104"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Vq0z4GBNEei7_-Uhq6CryQ" type="DataType_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_Vq1a8GBNEei7_-Uhq6CryQ" type="DataType_NameLabel"/>
@@ -9830,7 +12086,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vq1a_GBNEei7_-Uhq6CryQ"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiEth.uml#_uyMrEFEZEd6VSrclB-Ybig"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vq0z4WBNEei7_-Uhq6CryQ" x="1056" y="573" height="107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vq0z4WBNEei7_-Uhq6CryQ" x="1071" y="546" height="107"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_cQAYIGBNEei7_-Uhq6CryQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_cQAYImBNEei7_-Uhq6CryQ" type="Class_NameLabel"/>
@@ -9838,33 +12094,29 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_cQA_MGBNEei7_-Uhq6CryQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_cQA_MWBNEei7_-Uhq6CryQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_i5J2YGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5J2YWBNEei7_-Uhq6CryQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_i5KdcGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_HLiWIH2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5KdcWBNEei7_-Uhq6CryQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_i5KdcmBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_wosCEDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WztYsLFXEd2MOdzuQUV2bQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5Kdc2BNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wosCETVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_i5KddGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_wospIDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_uGZgsH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5KddWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wospITVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_i5KddmBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_n-WkYH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5Kdd2BNEei7_-Uhq6CryQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_wotQMDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_b23MADU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wotQMTVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_i5LEgGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_wotQMjVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wotQMzVwEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wotQNDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5LEgWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wotQNTVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_i5LEgmBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_wotQNjVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_i5LEg2BNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wotQNzVwEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_cQA_MmBNEei7_-Uhq6CryQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_cQA_M2BNEei7_-Uhq6CryQ"/>
@@ -9892,25 +12144,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ns4rI2BNEei7_-Uhq6CryQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_ns4rJGBNEei7_-Uhq6CryQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_rHyrwGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_AJG_wH20Ed2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rHyrwWBNEei7_-Uhq6CryQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_2NH7ADVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_oesicNl2EeidLb5WEUMFmw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2NH7ATVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rHyrwmBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2NIiEDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_9dJv0H2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rHyrw2BNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2NIiETVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rHyrxGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_3ZT3I0RhEeKsbYfVW3kmQQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rHyrxWBNEei7_-Uhq6CryQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_2NIiEjVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_ugy7kTU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2NIiEzVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rHyrxmBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2NIiFDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rHyrx2BNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2NIiFTVwEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rHyryGBNEei7_-Uhq6CryQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_2NJJIDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rHyryWBNEei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2NJJITVwEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_ns4rJWBNEei7_-Uhq6CryQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_ns4rJmBNEei7_-Uhq6CryQ"/>
@@ -10274,6 +12526,248 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9l-X2R3KEemKheKmU0GLKg" x="200"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_4PRY8DVwEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4PSAADVwEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4PSAATVwEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4PSAAjVwEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4PSnEDVwEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_65otcDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_3ZL4kDU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_65otcTVwEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_65pUgDVwEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_6WMcQDU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_65pUgTVwEem8b5f98b_cVw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4PSnETVwEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4PSnEjVwEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4PSnEzVwEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4PSnFDVwEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4PSnFTVwEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4PSnFjVwEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4PSnFzVwEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4PSnGDVwEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4PSnGTVwEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4PSnGjVwEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4PSnGzVwEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4PSnHDVwEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4PSnHTVwEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4PSnHjVwEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4PRY8TVwEem8b5f98b_cVw" x="-9" y="758" height="70"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4PzkcTVwEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4PzkcjVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4PzkdDVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4PzkczVwEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VAXNADXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_VAXNATXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VAXNAzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VAXNAjXlEem8b5f98b_cVw" x="188" y="222"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VDgAkDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_VDgAkTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VDgAkzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VDgAkjXlEem8b5f98b_cVw" x="190" y="472"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SkEF4DY2Eem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SkFUADY2Eem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SkFUATY2Eem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SkFUAjY2Eem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SkFUAzY2Eem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SkFUBDY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SkFUBTY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SkFUBjY2Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SkFUBzY2Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SkFUCDY2Eem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SkFUCTY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SkFUCjY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SkFUCzY2Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SkFUDDY2Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SkFUDTY2Eem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SkFUDjY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SkFUDzY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SkFUEDY2Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SkFUETY2Eem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_Sj9_QDY2Eem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SkEF4TY2Eem8b5f98b_cVw" x="535" y="722" width="388" height="49"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SkNP0zY2Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SkNP1DY2Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SkNP1jY2Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_Sj9_QDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SkNP1TY2Eem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d18CwDY2Eem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_d18CwjY2Eem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_d18p0DY2Eem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_d18p0TY2Eem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_d18p0jY2Eem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_d18p0zY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_d18p1DY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_d18p1TY2Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d18p1jY2Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_d18p1zY2Eem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_d18p2DY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_d18p2TY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_d18p2jY2Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d18p2zY2Eem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_d18p3DY2Eem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_d18p3TY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_d18p3jY2Eem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_d18p3zY2Eem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d18p4DY2Eem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_d1y40DY2Eem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d18CwTY2Eem8b5f98b_cVw" x="538" y="496" width="330" height="37"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d2FMszY2Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d2FMtDY2Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d2FMtjY2Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_d1y40DY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d2FMtTY2Eem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LqxCcDacEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LqxCcTacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LqxpgDacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_kqPBEDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LqxCcjacEem8b5f98b_cVw" x="738" y="396"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ROH9UDacEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ROH9UTacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ROH9UzacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_ox5aADY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ROH9UjacEem8b5f98b_cVw" x="735" y="622"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XAgysDacEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XAgysTacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XAgyszacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_mJJPEDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XAgysjacEem8b5f98b_cVw" x="738" y="396"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aTveADacEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_aTveATacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aTveAzacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qNaVwDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aTveAjacEem8b5f98b_cVw" x="735" y="622"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4bGLwDafEem8b5f98b_cVw" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4bGLwjafEem8b5f98b_cVw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4bGLwzafEem8b5f98b_cVw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4bGLxDafEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4bGLxTafEem8b5f98b_cVw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_QRTy8jagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_3FTVAURsEeKsbYfVW3kmQQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTy8zagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTy9DagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_3FTVA0RsEeKsbYfVW3kmQQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTy9TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTy9jagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_3FTVBURsEeKsbYfVW3kmQQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTy9zagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRTy-DagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_3FTVE0RsEeKsbYfVW3kmQQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRTy-TagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRUaADagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_3FTVFURsEeKsbYfVW3kmQQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRUaATagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRUaAjagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_3FTVF0RsEeKsbYfVW3kmQQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRUaAzagEem8b5f98b_cVw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4bGLxjafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4bGLxzafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4bGLyDafEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4bGLyTafEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4bGLyjafEem8b5f98b_cVw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4bGLyzafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4bGLzDafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4bGLzTafEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4bGLzjafEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiEth.uml#_3FTVAERsEeKsbYfVW3kmQQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4bGLwTafEem8b5f98b_cVw" x="1071" y="272" height="140"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4qvxUDafEem8b5f98b_cVw" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4qvxUjafEem8b5f98b_cVw" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4qvxUzafEem8b5f98b_cVw" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4qvxVDafEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4qwYYDafEem8b5f98b_cVw" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_QRUaBDagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_oF4ZgVEYEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRUaBTagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRUaBjagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_oF4Zg1EYEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRUaBzagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRUaCDagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_oGBjcVEYEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRUaCTagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRUaCjagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_GFPJMVEZEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRUaCzagEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_QRVBEDagEem8b5f98b_cVw" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_GFPJNFEZEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_QRVBETagEem8b5f98b_cVw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4qwYYTafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4qwYYjafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4qwYYzafEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4qwYZDafEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4qwYZTafEem8b5f98b_cVw" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4qwYZjafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4qwYZzafEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4qwYaDafEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4qwYaTafEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiEth.uml#_oF4ZgFEYEd6VSrclB-Ybig"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4qvxUTafEem8b5f98b_cVw" x="1073" y="672" height="127"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_tC4KUWBLEei7_-Uhq6CryQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_tC4KUmBLEei7_-Uhq6CryQ"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_pn3PkIrKEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -10295,29 +12789,29 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w9saF2BLEei7_-Uhq6CryQ" id="(0.43119266055045874,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w9tBIGBLEei7_-Uhq6CryQ" id="(0.46,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ddNVoGBOEei7_-Uhq6CryQ" type="Dependency_Edge" source="_JIkpsGBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_ddNVoGBOEei7_-Uhq6CryQ" type="Dependency_Edge" source="_JIkpsGBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_ddNVo2BOEei7_-Uhq6CryQ" visible="false" type="Dependency_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__dJ_QIt3Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ddNVpGBOEei7_-Uhq6CryQ" y="16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ddNVpWBOEei7_-Uhq6CryQ" type="Dependency_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__geZAIt3Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddNVpmBOEei7_-Uhq6CryQ" x="-58" y="12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ddNVpmBOEei7_-Uhq6CryQ" x="-19" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ddNVoWBOEei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_9xBW4GAwEei7_-Uhq6CryQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ddNVomBOEei7_-Uhq6CryQ" points="[442, 348, -643984, -643984]$[229, 348, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ddNVp2BOEei7_-Uhq6CryQ" id="(0.0,0.30864197530864196)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ddNVp2BOEei7_-Uhq6CryQ" id="(0.0,0.4954954954954955)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ddNVqGBOEei7_-Uhq6CryQ" id="(1.0,0.14634146341463414)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_d9XcYGBOEei7_-Uhq6CryQ" type="Dependency_Edge" source="_IpzqEGBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_d9XcYGBOEei7_-Uhq6CryQ" type="Dependency_Edge" source="_IpzqEGBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_d9XcY2BOEei7_-Uhq6CryQ" visible="false" type="Dependency_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LKRGoIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_d9XcZGBOEei7_-Uhq6CryQ" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_d9XcZWBOEei7_-Uhq6CryQ" type="Dependency_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_LN30QIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_d9XcZmBOEei7_-Uhq6CryQ" x="-42" y="129"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_d9XcZmBOEei7_-Uhq6CryQ" x="-52" y="127"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_d9XcYWBOEei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_-6oDQGAwEei7_-Uhq6CryQ"/>
@@ -10325,14 +12819,14 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d9XcZ2BOEei7_-Uhq6CryQ" id="(0.0,0.463768115942029)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d9XcaGBOEei7_-Uhq6CryQ" id="(1.0,0.8902439024390244)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_eav78GBOEei7_-Uhq6CryQ" type="Dependency_Edge" source="_ITI2gGBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_eav78GBOEei7_-Uhq6CryQ" type="Dependency_Edge" source="_ITI2gGBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_eav782BOEei7_-Uhq6CryQ" visible="false" type="Dependency_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AZOl8It4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_eav79GBOEei7_-Uhq6CryQ" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_eav79WBOEei7_-Uhq6CryQ" type="Dependency_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AdMf8It4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eav79mBOEei7_-Uhq6CryQ" x="-65" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eav79mBOEei7_-Uhq6CryQ" x="-83" y="8"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_eav78WBOEei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#__v0l4GAwEei7_-Uhq6CryQ"/>
@@ -10377,13 +12871,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_d6tNJWBSEeiBxvDM8HEDKw" type="Usage_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_j7ougIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_d6tNJmBSEeiBxvDM8HEDKw" x="-13" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_d6tNJmBSEeiBxvDM8HEDKw" x="-46" y="-78"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_d6tNIWBSEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Usage" href="TapiEth.uml#_d6g_4GBSEeiBxvDM8HEDKw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d6tNImBSEeiBxvDM8HEDKw" points="[889, 372, -643984, -643984]$[976, 372, -643984, -643984]$[976, 406, -643984, -643984]$[1064, 406, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d-EDIGBSEeiBxvDM8HEDKw" id="(1.0,0.6296296296296297)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d-EDIWBSEeiBxvDM8HEDKw" id="(0.0,0.125)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d6tNImBSEeiBxvDM8HEDKw" points="[868, 382, -643984, -643984]$[936, 382, -643984, -643984]$[936, 449, -643984, -643984]$[1073, 449, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d-EDIGBSEeiBxvDM8HEDKw" id="(1.0,0.8198198198198198)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d-EDIWBSEeiBxvDM8HEDKw" id="(0.0,0.22115384615384615)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_e7UVkWBSEeiBxvDM8HEDKw" type="Usage_Edge" source="_ITI2gGBMEei7_-Uhq6CryQ" target="_SRoDcGBNEei7_-Uhq6CryQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_e7UVlGBSEeiBxvDM8HEDKw" visible="false" type="Usage_NameLabel">
@@ -10392,13 +12886,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_e7UVlmBSEeiBxvDM8HEDKw" type="Usage_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_i3fw8It4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_e7UVl2BSEeiBxvDM8HEDKw" x="-5" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e7UVl2BSEeiBxvDM8HEDKw" x="-79" y="-9"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_e7UVkmBSEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Usage" href="TapiEth.uml#_e7UVkGBSEeiBxvDM8HEDKw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e7UVk2BSEeiBxvDM8HEDKw" points="[893, 469, -643984, -643984]$[1071, 469, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-Ri8GBSEeiBxvDM8HEDKw" id="(1.0,0.71875)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-Ri8WBSEeiBxvDM8HEDKw" id="(0.0,0.5480769230769231)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e7UVk2BSEeiBxvDM8HEDKw" points="[872, 472, -643984, -643984]$[1073, 472, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-Ri8GBSEeiBxvDM8HEDKw" id="(1.0,0.75)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-Ri8WBSEeiBxvDM8HEDKw" id="(0.0,0.4230769230769231)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_f0FwoWBSEeiBxvDM8HEDKw" type="Usage_Edge" source="_IpzqEGBMEei7_-Uhq6CryQ" target="_Vq0z4GBNEei7_-Uhq6CryQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_f0FwpGBSEeiBxvDM8HEDKw" visible="false" type="Usage_NameLabel">
@@ -10407,11 +12901,11 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_f0FwpmBSEeiBxvDM8HEDKw" type="Usage_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_aDasgLElEeiB1L1dQuD1kw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_f0Fwp2BSEeiBxvDM8HEDKw" x="6" y="-11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_f0Fwp2BSEeiBxvDM8HEDKw" x="-32" y="22"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_f0FwomBSEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Usage" href="TapiEth.uml#_f0FwoGBSEeiBxvDM8HEDKw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f0Fwo2BSEeiBxvDM8HEDKw" points="[831, 669, -643984, -643984]$[958, 669, -643984, -643984]$[958, 660, -643984, -643984]$[1056, 660, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f0Fwo2BSEeiBxvDM8HEDKw" points="[932, 666, -643984, -643984]$[977, 666, -643984, -643984]$[977, 633, -643984, -643984]$[1071, 633, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f22wwGBSEeiBxvDM8HEDKw" id="(1.0,0.2898550724637681)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f22wwWBSEeiBxvDM8HEDKw" id="(0.0,0.8130841121495327)"/>
     </edges>
@@ -10422,37 +12916,37 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_go_YVWBSEeiBxvDM8HEDKw" type="Usage_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jcO1sIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_go_YVmBSEeiBxvDM8HEDKw" x="-6" y="-11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_go_YVmBSEeiBxvDM8HEDKw" x="-43" y="-10"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_go_YUWBSEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Usage" href="TapiEth.uml#_gotEcGBSEeiBxvDM8HEDKw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_go_YUmBSEeiBxvDM8HEDKw" points="[822, 590, -643984, -643984]$[1056, 590, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_grwYcGBSEeiBxvDM8HEDKw" id="(1.0,0.6296296296296297)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_go_YUmBSEeiBxvDM8HEDKw" points="[922, 567, -643984, -643984]$[1003, 567, -643984, -643984]$[1003, 563, -643984, -643984]$[1071, 563, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_grwYcGBSEeiBxvDM8HEDKw" id="(1.0,0.23300970873786409)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_grwYcWBSEeiBxvDM8HEDKw" id="(0.0,0.1588785046728972)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Xic1IWBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_JIkpsGBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_Xic1IWBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_JIkpsGBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_Xic1JGBTEeiBxvDM8HEDKw" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__DwAwIt3Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Xic1JWBTEeiBxvDM8HEDKw" x="-23" y="-40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Xic1JmBTEeiBxvDM8HEDKw" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__H1PgIt3Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xic1J2BTEeiBxvDM8HEDKw" x="-20" y="-125"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xic1J2BTEeiBxvDM8HEDKw" x="-38" y="-90"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Xic1ImBTEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Xic1IGBTEeiBxvDM8HEDKw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xic1I2BTEeiBxvDM8HEDKw" points="[442, 383, -643984, -643984]$[253, 383, -643984, -643984]$[253, 582, -643984, -643984]$[202, 582, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XlmPwGBTEeiBxvDM8HEDKw" id="(0.0,0.7777777777777778)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XlmPwGBTEeiBxvDM8HEDKw" id="(0.0,0.8378378378378378)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XlmPwWBTEeiBxvDM8HEDKw" id="(1.0,0.07518796992481203)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_YaKgQWBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_ITI2gGBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_YaKgQWBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_ITI2gGBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_YaKgRGBTEeiBxvDM8HEDKw" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Fm0FIIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YaKgRWBTEeiBxvDM8HEDKw" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YaKgRmBTEeiBxvDM8HEDKw" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Fqr4gIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YaKgR2BTEeiBxvDM8HEDKw" x="3" y="-110"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YaKgR2BTEeiBxvDM8HEDKw" x="-16" y="-113"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_YaKgQmBTEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_YaKgQGBTEeiBxvDM8HEDKw"/>
@@ -10460,49 +12954,49 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YdHtoGBTEeiBxvDM8HEDKw" id="(0.0,0.828125)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YdHtoWBTEeiBxvDM8HEDKw" id="(1.0,0.17293233082706766)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZRyEwGBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_KGse0GBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_ZRyEwGBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_KGse0GBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_ZRyEw2BTEeiBxvDM8HEDKw" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EXLCMIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ZRyExGBTEeiBxvDM8HEDKw" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ZRyExWBTEeiBxvDM8HEDKw" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EbapAIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZRyExmBTEeiBxvDM8HEDKw" x="-61" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZRyExmBTEeiBxvDM8HEDKw" x="-56" y="-15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ZRyEwWBTEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_ZRr-IGBTEeiBxvDM8HEDKw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZRyEwmBTEeiBxvDM8HEDKw" points="[440, 611, -643984, -643984]$[202, 611, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUpLgGBTEeiBxvDM8HEDKw" id="(0.0,0.9012345679012346)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUpLgGBTEeiBxvDM8HEDKw" id="(0.0,0.7087378640776699)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUpLgWBTEeiBxvDM8HEDKw" id="(1.0,0.3007518796992481)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_aN_1YGBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_IpzqEGBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_aN_1YGBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_IpzqEGBMEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_aN_1Y2BTEeiBxvDM8HEDKw" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DE_ooIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_aN_1ZGBTEeiBxvDM8HEDKw" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_aN_1ZWBTEeiBxvDM8HEDKw" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DIfBgIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_aN_1ZmBTEeiBxvDM8HEDKw" x="-67" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_aN_1ZmBTEeiBxvDM8HEDKw" x="-59" y="6"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_aN_1YWBTEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_aN5uwGBTEeiBxvDM8HEDKw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aN_1YmBTEeiBxvDM8HEDKw" points="[443, 690, -643984, -643984]$[167, 690, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aQ9CwGBTEeiBxvDM8HEDKw" id="(0.0,0.7246376811594203)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aN_1YmBTEeiBxvDM8HEDKw" points="[444, 690, -643984, -643984]$[206, 690, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aQ9CwGBTEeiBxvDM8HEDKw" id="(0.0,0.6376811594202898)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aQ9CwWBTEeiBxvDM8HEDKw" id="(1.0,0.8872180451127819)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bHJq8GBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_KGse0GBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_bHJq8GBTEeiBxvDM8HEDKw" type="Abstraction_Edge" source="_KGse0GBMEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_bHJq82BTEeiBxvDM8HEDKw" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KdFQgIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_bHJq9GBTEeiBxvDM8HEDKw" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_bHJq9WBTEeiBxvDM8HEDKw" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KgvogIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_bHJq9mBTEeiBxvDM8HEDKw" x="-11" y="80"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bHJq9mBTEeiBxvDM8HEDKw" x="-50" y="83"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_bHJq8WBTEeiBxvDM8HEDKw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_bHDkUGBTEeiBxvDM8HEDKw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bHJq8mBTEeiBxvDM8HEDKw" points="[440, 570, -643984, -643984]$[301, 570, -643984, -643984]$[301, 453, -643984, -643984]$[229, 453, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ0kcGBTEeiBxvDM8HEDKw" id="(0.0,0.38271604938271603)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ0kcGBTEeiBxvDM8HEDKw" id="(0.0,0.30097087378640774)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bJ0kcWBTEeiBxvDM8HEDKw" id="(1.0,0.7987804878048781)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_4SHU4It3Eeiu6boZkiJHCA" type="Association_Edge" source="_3d5-wGBLEei7_-Uhq6CryQ" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear">
@@ -10532,18 +13026,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_4SHU4Yt3Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4SHU4ot3Eeiu6boZkiJHCA" points="[87, 214, -643984, -643984]$[87, 322, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5sWeQIt3Eeiu6boZkiJHCA" id="(0.41605839416058393,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S2WokIt4Eeiu6boZkiJHCA" id="(0.4066390041493776,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4SHU4ot3Eeiu6boZkiJHCA" points="[86, 214, -643984, -643984]$[86, 322, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5sWeQIt3Eeiu6boZkiJHCA" id="(0.4197080291970803,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S2WokIt4Eeiu6boZkiJHCA" id="(0.4583333333333333,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7AaHIIt3Eeiu6boZkiJHCA" type="Association_Edge" source="_cQAYIGBNEei7_-Uhq6CryQ" target="_nsykgGBNEei7_-Uhq6CryQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_7AauMIt3Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SEMy4It4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauMYt3Eeiu6boZkiJHCA" x="7" y="5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauMYt3Eeiu6boZkiJHCA" x="5" y="72"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AauMot3Eeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SJydgIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauM4t3Eeiu6boZkiJHCA" x="-11" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauM4t3Eeiu6boZkiJHCA" x="-11" y="77"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AauNIt3Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SPFNMIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -10555,11 +13049,11 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AauOIt3Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SWCJwIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauOYt3Eeiu6boZkiJHCA" x="13" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauOYt3Eeiu6boZkiJHCA" x="15" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AauOot3Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SZiJsIt4Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauO4t3Eeiu6boZkiJHCA" x="-13" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AauO4t3Eeiu6boZkiJHCA" x="-11" y="-15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7AaHIYt3Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
@@ -10960,6 +13454,278 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l1oLQB3OEemKheKmU0GLKg" id="(1.0,0.1951219512195122)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l1oLQR3OEemKheKmU0GLKg" id="(0.0,0.8707482993197279)"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4PzkdTVwEem8b5f98b_cVw" type="StereotypeCommentLink" source="_4PRY8DVwEem8b5f98b_cVw" target="_4PzkcTVwEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4PzkdjVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4PzkejVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4PzkdzVwEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4PzkeDVwEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4PzkeTVwEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8zDtMDVwEem8b5f98b_cVw" type="Association_Edge" source="_cQAYIGBNEei7_-Uhq6CryQ" target="_4PRY8DVwEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8zDtMzVwEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A1_XIDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8zDtNDVwEem8b5f98b_cVw" x="-161" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8zDtNTVwEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BCEEQDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8zDtNjVwEem8b5f98b_cVw" x="-193" y="4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8zDtNzVwEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BO6NcDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8zDtODVwEem8b5f98b_cVw" x="79" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8zDtOTVwEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BdDXIDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8zDtOjVwEem8b5f98b_cVw" x="-22" y="77"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8zDtOzVwEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BpXU0DVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8zDtPDVwEem8b5f98b_cVw" x="10" y="-16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8zDtPTVwEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_B2pi4DVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8zEUQDVwEem8b5f98b_cVw" x="-18" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_8zDtMTVwEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8zDtMjVwEem8b5f98b_cVw" points="[-12, 447, -643984, -643984]$[-88, 447, -643984, -643984]$[-88, 793, -643984, -643984]$[-9, 793, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ap-7cDVxEem8b5f98b_cVw" id="(0.0,0.7560975609756098)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ap_igDVxEem8b5f98b_cVw" id="(0.0,0.5)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9VgS8DVwEem8b5f98b_cVw" type="Association_Edge" source="_nsykgGBNEei7_-Uhq6CryQ" target="_4PRY8DVwEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9VgS8zVwEem8b5f98b_cVw" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_E0JOwDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9VgS9DVwEem8b5f98b_cVw" x="8" y="94"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9VgS9TVwEem8b5f98b_cVw" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FAXs4DVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9Vg6ADVwEem8b5f98b_cVw" x="-8" y="76"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9Vg6ATVwEem8b5f98b_cVw" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FNZcQDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9Vg6AjVwEem8b5f98b_cVw" x="8" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9Vg6AzVwEem8b5f98b_cVw" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Fb_48DVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9Vg6BDVwEem8b5f98b_cVw" x="-8" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9Vg6BTVwEem8b5f98b_cVw" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FoGbQDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9Vg6BjVwEem8b5f98b_cVw" x="8" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9Vg6BzVwEem8b5f98b_cVw" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F079YDVxEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9Vg6CDVwEem8b5f98b_cVw" x="-10" y="-25"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_9VgS8TVwEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9VgS8jVwEem8b5f98b_cVw" points="[97, 705, -643984, -643984]$[97, 758, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_En1REDVxEem8b5f98b_cVw" id="(0.49074074074074076,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_En1RETVxEem8b5f98b_cVw" id="(0.43568464730290457,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VAXNBDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_8zDtMDVwEem8b5f98b_cVw" target="_VAXNADXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VAXNBTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VAXNCTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VAXNBjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VAXNBzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VAXNCDXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VDgAlDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_9VgS8DVwEem8b5f98b_cVw" target="_VDgAkDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VDgAlTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VDgAmTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VDgAljXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VDgAlzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VDgAmDXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SkNP1zY2Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_SkEF4DY2Eem8b5f98b_cVw" target="_SkNP0zY2Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SkNP2DY2Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SkNP3DY2Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_Sj9_QDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SkNP2TY2Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SkNP2jY2Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SkNP2zY2Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d2FMtzY2Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_d18CwDY2Eem8b5f98b_cVw" target="_d2FMszY2Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d2FMuDY2Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d2FzwDY2Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_d1y40DY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d2FMuTY2Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d2FMujY2Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d2FMuzY2Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_kqSrcDY2Eem8b5f98b_cVw" type="Abstraction_Edge" source="_d18CwDY2Eem8b5f98b_cVw" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_kqSrczY2Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GvfbQDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kqSrdDY2Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_kqSrdTY2Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_G8f8gDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kqSrdjY2Eem8b5f98b_cVw" x="-141" y="11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_kqSrcTY2Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_kqPBEDY2Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kqSrcjY2Eem8b5f98b_cVw" points="[538, 509, -643984, -643984]$[321, 509, -643984, -643984]$[321, 422, -643984, -643984]$[204, 422, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lJQfYDY2Eem8b5f98b_cVw" id="(0.0,0.35135135135135137)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lJQfYTY2Eem8b5f98b_cVw" id="(1.0,0.6097560975609756)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mJLEQDY2Eem8b5f98b_cVw" type="Abstraction_Edge" source="_d18CwDY2Eem8b5f98b_cVw" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mJLEQzY2Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FSOMADacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mJLrUDY2Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mJLrUTY2Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FgJ6UDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mJLrUjY2Eem8b5f98b_cVw" x="-17" y="-142"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mJLEQTY2Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_mJJPEDY2Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mJLEQjY2Eem8b5f98b_cVw" points="[538, 527, -643984, -643984]$[322, 527, -643984, -643984]$[322, 643, -643984, -643984]$[206, 643, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mnYDMDY2Eem8b5f98b_cVw" id="(0.0,0.8378378378378378)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mnYDMTY2Eem8b5f98b_cVw" id="(1.0,0.5338345864661654)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ox7PMDY2Eem8b5f98b_cVw" type="Abstraction_Edge" source="_SkEF4DY2Eem8b5f98b_cVw" target="_cQAYIGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ox7PMzY2Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BxkvwDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ox7PNDY2Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ox7PNTY2Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_B_hFIDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ox7PNjY2Eem8b5f98b_cVw" x="7" y="67"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ox7PMTY2Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_ox5aADY2Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ox7PMjY2Eem8b5f98b_cVw" points="[535, 748, -643984, -643984]$[241, 748, -643984, -643984]$[241, 480, -643984, -643984]$[204, 480, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pOOJoDY2Eem8b5f98b_cVw" id="(0.0,0.5306122448979592)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pOOJoTY2Eem8b5f98b_cVw" id="(1.0,0.9695121951219512)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qNcK8DY2Eem8b5f98b_cVw" type="Abstraction_Edge" source="_SkEF4DY2Eem8b5f98b_cVw" target="_nsykgGBNEei7_-Uhq6CryQ" routing="Rectilinear" lineColor="16711680">
+      <children xmi:type="notation:DecorationNode" xmi:id="_qNeAIDY2Eem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DQvccDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qNeAITY2Eem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qNeAIjY2Eem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DelrMDacEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qNeAIzY2Eem8b5f98b_cVw" x="-4" y="67"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_qNcK8TY2Eem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_qNaVwDY2Eem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qNcK8jY2Eem8b5f98b_cVw" points="[535, 730, -643984, -643984]$[371, 730, -643984, -643984]$[371, 693, -643984, -643984]$[206, 693, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qs_NsDY2Eem8b5f98b_cVw" id="(0.0,0.16326530612244897)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qs_NsTY2Eem8b5f98b_cVw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LqxpgTacEem8b5f98b_cVw" type="StereotypeCommentLink" source="_kqSrcDY2Eem8b5f98b_cVw" target="_LqxCcDacEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LqxpgjacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LqxphjacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_kqPBEDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LqxpgzacEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LqxphDacEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LqxphTacEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ROH9VDacEem8b5f98b_cVw" type="StereotypeCommentLink" source="_ox7PMDY2Eem8b5f98b_cVw" target="_ROH9UDacEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ROH9VTacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ROH9WTacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_ox5aADY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ROH9VjacEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ROH9VzacEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ROH9WDacEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XAgytDacEem8b5f98b_cVw" type="StereotypeCommentLink" source="_mJLEQDY2Eem8b5f98b_cVw" target="_XAgysDacEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XAgytTacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XAhZwjacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_mJJPEDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XAgytjacEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XAhZwDacEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XAhZwTacEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_aTveBDacEem8b5f98b_cVw" type="StereotypeCommentLink" source="_qNcK8DY2Eem8b5f98b_cVw" target="_aTveADacEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_aTveBTacEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aTveCTacEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qNaVwDY2Eem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aTveBjacEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aTveBzacEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aTveCDacEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Xt3EEDagEem8b5f98b_cVw" type="Usage_Edge" source="_JIkpsGBMEei7_-Uhq6CryQ" target="_4bGLwDafEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Xt3rIDagEem8b5f98b_cVw" type="Usage_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qwUoYDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xt3rITagEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Xt3rIjagEem8b5f98b_cVw" type="Usage_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rDQygDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xt3rIzagEem8b5f98b_cVw" x="-74" y="-9"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Xt3EETagEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Usage" href="TapiEth.uml#_Xt0n0DagEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xt3EEjagEem8b5f98b_cVw" points="[868, 323, -643984, -643984]$[1071, 323, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YSFygDagEem8b5f98b_cVw" id="(1.0,0.2882882882882883)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YSFygTagEem8b5f98b_cVw" id="(0.0,0.36428571428571427)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZevL0DagEem8b5f98b_cVw" type="Usage_Edge" source="_ITI2gGBMEei7_-Uhq6CryQ" target="_4bGLwDafEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZevL0zagEem8b5f98b_cVw" type="Usage_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_upDNcDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZevL1DagEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZevL1TagEem8b5f98b_cVw" type="Usage_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u5rDYDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZevL1jagEem8b5f98b_cVw" x="5" y="-103"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZevL0TagEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Usage" href="TapiEth.uml#_ZetWoDagEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZevL0jagEem8b5f98b_cVw" points="[872, 435, -643984, -643984]$[995, 435, -643984, -643984]$[995, 375, -643984, -643984]$[1071, 375, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aAJ20DagEem8b5f98b_cVw" id="(1.0,0.171875)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aAKd4DagEem8b5f98b_cVw" id="(0.0,0.7357142857142858)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ctlGYDagEem8b5f98b_cVw" type="Usage_Edge" source="_KGse0GBMEei7_-Uhq6CryQ" target="_4qvxUDafEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ctlGYzagEem8b5f98b_cVw" type="Usage_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0kkwsDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ctlGZDagEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ctlGZTagEem8b5f98b_cVw" type="Usage_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_003PcDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ctlGZjagEem8b5f98b_cVw" x="-52" y="49"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ctlGYTagEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Usage" href="TapiEth.uml#_ctjRMDagEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ctlGYjagEem8b5f98b_cVw" points="[922, 597, -643984, -643984]$[1000, 597, -643984, -643984]$[1000, 683, -643984, -643984]$[1073, 683, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dOfbEDagEem8b5f98b_cVw" id="(1.0,0.5631067961165048)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dOfbETagEem8b5f98b_cVw" id="(0.0,0.08661417322834646)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eXcnMDagEem8b5f98b_cVw" type="Usage_Edge" source="_IpzqEGBMEei7_-Uhq6CryQ" target="_4qvxUDafEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_eXcnMzagEem8b5f98b_cVw" type="Usage_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1s2AUDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eXcnNDagEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eXcnNTagEem8b5f98b_cVw" type="Usage_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_19TeMDagEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eXcnNjagEem8b5f98b_cVw" x="-50" y="-8"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_eXcnMTagEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Usage" href="TapiEth.uml#_eXbZEDagEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eXcnMjagEem8b5f98b_cVw" points="[932, 697, -643984, -643984]$[1001, 697, -643984, -643984]$[1001, 701, -643984, -643984]$[1073, 701, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2kzMDagEem8b5f98b_cVw" id="(1.0,0.782608695652174)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2kzMTagEem8b5f98b_cVw" id="(0.0,0.2204724409448819)"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_uH_zwGBVEeiBxvDM8HEDKw" type="PapyrusUMLClassDiagram" name="EthFmJobs" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_wPz00GBVEeiBxvDM8HEDKw" type="Enumeration_Shape">
@@ -11225,10 +13991,6 @@
           <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_9gli8YrJEeiT7s5en7ligw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_9gmKAIrJEeiT7s5en7ligw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_HLiWIH2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9gmKAYrJEeiT7s5en7ligw"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_9gmKAorJEeiT7s5en7ligw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WztYsLFXEd2MOdzuQUV2bQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_9gmKA4rJEeiT7s5en7ligw"/>
@@ -11236,10 +13998,6 @@
         <children xmi:type="notation:Shape" xmi:id="_9gmKBIrJEeiT7s5en7ligw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_uGZgsH2REd23zLSjbYwcFw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_9gmKBYrJEeiT7s5en7ligw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9gmxEIrJEeiT7s5en7ligw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_n-WkYH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9gmxEYrJEeiT7s5en7ligw"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_9gmxEorJEeiT7s5en7ligw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
@@ -11267,7 +14025,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bIEzzoqfEeiT7s5en7ligw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bIDloYqfEeiT7s5en7ligw" x="160" y="440" width="261"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bIDloYqfEeiT7s5en7ligw" x="160" y="440" width="261" height="163"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dAGsYIqfEeiT7s5en7ligw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_dAHTcIqfEeiT7s5en7ligw" type="Class_NameLabel"/>
@@ -11915,9 +14673,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_-m5-sYqxEeiT7s5en7ligw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_-m3icIqxEeiT7s5en7ligw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-m5-soqxEeiT7s5en7ligw" points="[560, 595, -643984, -643984]$[421, 595, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-uqMgIqxEeiT7s5en7ligw" id="(0.0,0.2413793103448276)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-uqMgYqxEeiT7s5en7ligw" id="(1.0,0.8651685393258427)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-m5-soqxEeiT7s5en7ligw" points="[560, 594, -643984, -643984]$[492, 594, -643984, -643984]$[492, 590, -643984, -643984]$[421, 590, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-uqMgIqxEeiT7s5en7ligw" id="(0.0,0.1896551724137931)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-uqMgYqxEeiT7s5en7ligw" id="(1.0,0.9263803680981595)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LD1skIrKEeiT7s5en7ligw" type="Abstraction_Edge" source="_4uRXYIqxEeiT7s5en7ligw" target="_bIDloIqfEeiT7s5en7ligw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_LD1sk4rKEeiT7s5en7ligw" visible="false" type="Abstraction_NameLabel">
@@ -11930,11 +14688,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_LD1skYrKEeiT7s5en7ligw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_LDyCMIrKEeiT7s5en7ligw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LD1skorKEeiT7s5en7ligw" points="[563, 544, -643984, -643984]$[421, 544, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LSKccIrKEeiT7s5en7ligw" id="(0.0,0.6666666666666666)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LSKccYrKEeiT7s5en7ligw" id="(1.0,0.5730337078651685)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LD1skorKEeiT7s5en7ligw" points="[563, 523, -643984, -643984]$[421, 523, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LSKccIrKEeiT7s5en7ligw" id="(0.0,0.3333333333333333)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LSKccYrKEeiT7s5en7ligw" id="(1.0,0.50920245398773)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iUThYIrVEeiT7s5en7ligw" type="Abstraction_Edge" source="_dAGsYIqfEeiT7s5en7ligw" target="_bIDloIqfEeiT7s5en7ligw">
+    <edges xmi:type="notation:Connector" xmi:id="_iUThYIrVEeiT7s5en7ligw" type="Abstraction_Edge" source="_dAGsYIqfEeiT7s5en7ligw" target="_bIDloIqfEeiT7s5en7ligw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_iUUIcIrVEeiT7s5en7ligw" visible="false" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KflSkLEiEeiB1L1dQuD1kw" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_iUUIcYrVEeiT7s5en7ligw" x="-1" y="38"/>
@@ -11945,18 +14703,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_iUThYYrVEeiT7s5en7ligw"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_iURsMIrVEeiT7s5en7ligw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iUThYorVEeiT7s5en7ligw" points="[560, 520, -643984, -643984]$[421, 520, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iguMwIrVEeiT7s5en7ligw" id="(0.0,0.8582089552238806)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iguMwYrVEeiT7s5en7ligw" id="(1.0,0.1797752808988764)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iUThYorVEeiT7s5en7ligw" points="[564, 466, -643984, -643984]$[421, 466, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iguMwIrVEeiT7s5en7ligw" id="(0.0,0.8059701492537313)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iguMwYrVEeiT7s5en7ligw" id="(1.0,0.15950920245398773)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BZkzMIt5Eeiu6boZkiJHCA" type="Association_Edge" source="_-EwycGBVEeiBxvDM8HEDKw" target="_bIDloIqfEeiT7s5en7ligw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_BZlaQot5Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8XD_oBgiEem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZlaQ4t5Eeiu6boZkiJHCA" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZlaQ4t5Eeiu6boZkiJHCA" x="-13" y="-56"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BZmBUIt5Eeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8isn4BgiEem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZmBUYt5Eeiu6boZkiJHCA" x="-33" y="5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZmBUYt5Eeiu6boZkiJHCA" x="-34" y="-56"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BZmBUot5Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8vgU0BgiEem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -11968,11 +14726,11 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BZmBVot5Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9BO-ABgiEem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZmBV4t5Eeiu6boZkiJHCA" x="23" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZmBV4t5Eeiu6boZkiJHCA" x="16" y="16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BZmoYIt5Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9Lj-sBgiEem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZmoYYt5Eeiu6boZkiJHCA" x="-23" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BZmoYYt5Eeiu6boZkiJHCA" x="-13" y="16"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BZlaQIt5Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
@@ -12471,7 +15229,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lSybM4b4Eeil5oKL3Vgl-g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_lSsUgIb4Eeil5oKL3Vgl-g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lSybIYb4Eeil5oKL3Vgl-g" x="359" y="326" width="399" height="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lSybIYb4Eeil5oKL3Vgl-g" x="359" y="326" width="422" height="135"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_lS4hw4b4Eeil5oKL3Vgl-g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_lS4hxIb4Eeil5oKL3Vgl-g" showTitle="true"/>
@@ -12529,7 +15287,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BLOhtIb5Eeil5oKL3Vgl-g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_BLIbAIb5Eeil5oKL3Vgl-g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BLOhoob5Eeil5oKL3Vgl-g" x="357" y="113" height="127"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BLOhoob5Eeil5oKL3Vgl-g" x="357" y="113" width="424" height="127"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BLUoWYb5Eeil5oKL3Vgl-g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BLUoWob5Eeil5oKL3Vgl-g" showTitle="true"/>
@@ -12571,7 +15329,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6_YBob5Eeil5oKL3Vgl-g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_E6_X8Ib5Eeil5oKL3Vgl-g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6_X9Ib5Eeil5oKL3Vgl-g" x="357" y="248" width="402" height="64"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6_X9Ib5Eeil5oKL3Vgl-g" x="357" y="248" width="424" height="64"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_E7FeqYb5Eeil5oKL3Vgl-g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_E7Feqob5Eeil5oKL3Vgl-g" showTitle="true"/>
@@ -12613,7 +15371,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LCGgM4b5Eeil5oKL3Vgl-g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_LCAZgIb5Eeil5oKL3Vgl-g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LCGgIYb5Eeil5oKL3Vgl-g" x="360" y="43" width="400" height="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LCGgIYb5Eeil5oKL3Vgl-g" x="360" y="43" width="421" height="66"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LCGgTYb5Eeil5oKL3Vgl-g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_LCGgTob5Eeil5oKL3Vgl-g" showTitle="true"/>
@@ -12954,6 +15712,110 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NoPfEiGQEemyX4Zl-fbCkw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_hrZ1UDVuEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hrZ1UTVuEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hrZ1UzVuEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hrZ1UjVuEem8b5f98b_cVw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_cIjbUDVvEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_cIjbUTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cIjbUzVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cIjbUjVvEem8b5f98b_cVw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_faepoDVwEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_faepoTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_faepozVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_faepojVwEem8b5f98b_cVw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SxHHMDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SxHHMTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SxHHMzXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SxHHMjXlEem8b5f98b_cVw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_I3PEwDX1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_I3PEwTX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_I3Pr0DX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_I3PEwjX1Eem8b5f98b_cVw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fN4ikDY1Eem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fN4ikTY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fN5JoDY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fN4ikjY1Eem8b5f98b_cVw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rHFSwDd1Eem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rHFSwTd1Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rHI9IDd1Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rHFSwjd1Eem1lYbrIE6BNw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LKmR4DiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LKmR4TiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LKmR4ziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LKmR4jiPEem1lYbrIE6BNw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AdO-ADiUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_AdO-ATiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AdPlEDiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AdO-AjiUEem1lYbrIE6BNw" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CUdS0DjrEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CUdS0TjrEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CUiLUDjrEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUdS0jjrEemjx6Nna_xyog" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WcQAUDkTEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WcQAUTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WcQAUzkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WcQAUjkTEemjx6Nna_xyog" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zB8SwDkxEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zB8SwTkxEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zB_WEDkxEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zB8SwjkxEemSPvPXzEQ11A" x="557" y="13"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JWD8kDoYEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JWD8kToYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JWEjoDoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JWD8kjoYEemSPvPXzEQ11A" x="557" y="13"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_e0rQkYbqEeil5oKL3Vgl-g" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_e0rQkobqEeil5oKL3Vgl-g"/>
@@ -13454,12 +16316,142 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NoZQFCGQEemyX4Zl-fbCkw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NoZQFSGQEemyX4Zl-fbCkw"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hrZ1VDVuEem8b5f98b_cVw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_hrZ1UDVuEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hrZ1VTVuEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hracYjVuEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hrZ1VjVuEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hracYDVuEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hracYTVuEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_cIjbVDVvEem8b5f98b_cVw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_cIjbUDVvEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_cIjbVTVvEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cIkCYjVvEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cIjbVjVvEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cIkCYDVvEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cIkCYTVvEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_faeppDVwEem8b5f98b_cVw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_faepoDVwEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_faeppTVwEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fafQsTVwEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_faeppjVwEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_faeppzVwEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fafQsDVwEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SxHHNDXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_SxHHMDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SxHHNTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SxHHOTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SxHHNjXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SxHHNzXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SxHHODXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_I3Pr0TX1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_I3PEwDX1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_I3Pr0jX1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_I3Pr1jX1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_I3Pr0zX1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I3Pr1DX1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I3Pr1TX1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fN5JoTY1Eem8b5f98b_cVw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_fN4ikDY1Eem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fN5JojY1Eem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fN5JpjY1Eem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fN5JozY1Eem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fN5JpDY1Eem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fN5JpTY1Eem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rHJkMDd1Eem1lYbrIE6BNw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_rHFSwDd1Eem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rHJkMTd1Eem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rHKyUTd1Eem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rHJkMjd1Eem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rHKLQDd1Eem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rHKyUDd1Eem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LKm48DiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_LKmR4DiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LKm48TiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LKm49TiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LKm48jiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LKm48ziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LKm49DiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_AdPlETiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_AdO-ADiUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_AdPlEjiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AdPlFjiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AdPlEziUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AdPlFDiUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AdPlFTiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CUjZcDjrEemjx6Nna_xyog" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_CUdS0DjrEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CUjZcTjrEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CUkAgTjrEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CUjZcjjrEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUjZczjrEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUkAgDjrEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WcQnYDkTEemjx6Nna_xyog" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_WcQAUDkTEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WcQnYTkTEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WcQnZTkTEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WcQnYjkTEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WcQnYzkTEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WcQnZDkTEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zB_9IDkxEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_zB8SwDkxEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zB_9ITkxEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zCAkMjkxEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zB_9IjkxEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zCAkMDkxEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zCAkMTkxEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JWEjoToYEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_RzxoQIb5Eeil5oKL3Vgl-g" target="_JWD8kDoYEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JWEjojoYEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JWEjpjoYEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RzrhoIb5Eeil5oKL3Vgl-g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JWEjozoYEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWEjpDoYEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWEjpToYEemSPvPXzEQ11A"/>
+    </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="_pmPTQBKjEemxeNG9TDCtFQ" type="PapyrusUMLClassDiagram" name="EthInterfaceJobs" measurementUnit="Pixel">
+  <notation:Diagram xmi:id="_pmPTQBKjEemxeNG9TDCtFQ" type="PapyrusUMLClassDiagram" name="EthInterfaceFmJobs" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_XkUJcBKkEemxeNG9TDCtFQ" type="NamedElement_DefaultShape">
       <children xmi:type="notation:DecorationNode" xmi:id="_XkUwgBKkEemxeNG9TDCtFQ" type="NamedElement_NameLabel"/>
       <element xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XkUJcRKkEemxeNG9TDCtFQ" x="360" y="20" width="161" height="61"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XkUJcRKkEemxeNG9TDCtFQ" x="500" y="20" width="161" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_XkvAMxKkEemxeNG9TDCtFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_XkvANBKkEemxeNG9TDCtFQ"/>
@@ -13468,142 +16460,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XkvANRKkEemxeNG9TDCtFQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nEBYsBKkEemxeNG9TDCtFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_nEB_wBKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nEB_wRKkEemxeNG9TDCtFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nEB_whKkEemxeNG9TDCtFQ" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nEB_wxKkEemxeNG9TDCtFQ" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nEB_xBKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nEB_xRKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nEB_xhKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nEB_xxKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nEB_yBKkEemxeNG9TDCtFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nEB_yRKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nEB_yhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nEB_yxKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nEB_zBKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nECm0BKkEemxeNG9TDCtFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nECm0RKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nECm0hKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nECm0xKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nECm1BKkEemxeNG9TDCtFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiEth.uml#_J1lZwFiCEei2nODetmeP6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nEBYsRKkEemxeNG9TDCtFQ" x="660" y="60" width="261" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nETFgxKkEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_nETFhBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nETFhhKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_J1lZwFiCEei2nODetmeP6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nETFhRKkEemxeNG9TDCtFQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nErgABKkEemxeNG9TDCtFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_nErgAhKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nErgAxKkEemxeNG9TDCtFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nErgBBKkEemxeNG9TDCtFQ" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nErgBRKkEemxeNG9TDCtFQ" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nErgBhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nErgBxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nErgCBKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nErgCRKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nEsHEBKkEemxeNG9TDCtFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nEsHERKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nEsHEhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nEsHExKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nEsHFBKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nEsHFRKkEemxeNG9TDCtFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nEsHFhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nEsHFxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nEsHGBKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nEsHGRKkEemxeNG9TDCtFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiEth.uml#_c43ZEFhkEeiYiLRYKaTpTw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nErgARKkEemxeNG9TDCtFQ" x="660" y="200" width="261" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nE6wkxKkEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_nE6wlBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nE6wlhKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c43ZEFhkEeiYiLRYKaTpTw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nE6wlRKkEemxeNG9TDCtFQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nFbt8BKkEemxeNG9TDCtFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_nFbt8hKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nFbt8xKkEemxeNG9TDCtFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nFbt9BKkEemxeNG9TDCtFQ" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nFbt9RKkEemxeNG9TDCtFQ" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nFbt9hKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nFbt9xKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nFbt-BKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nFbt-RKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nFcVABKkEemxeNG9TDCtFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nFcVARKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nFcVAhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nFcVAxKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nFcVBBKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nFcVBRKkEemxeNG9TDCtFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nFcVBhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nFcVBxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nFcVCBKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nFcVCRKkEemxeNG9TDCtFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiEth.uml#_NOPhwGBQEeiBxvDM8HEDKw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nFbt8RKkEemxeNG9TDCtFQ" x="660" y="340" width="261" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nFq-gxKkEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_nFq-hBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nFq-hhKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NOPhwGBQEeiBxvDM8HEDKw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nFq-hRKkEemxeNG9TDCtFQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nGUewBKkEemxeNG9TDCtFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_nGUewhKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nGUewxKkEemxeNG9TDCtFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nGUexBKkEemxeNG9TDCtFQ" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nGUexRKkEemxeNG9TDCtFQ" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nGUexhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nGUexxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nGUeyBKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nGUeyRKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nGUeyhKkEemxeNG9TDCtFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nGUeyxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nGUezBKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nGUezRKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nGUezhKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_nGUezxKkEemxeNG9TDCtFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_nGUe0BKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_nGUe0RKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_nGUe0hKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nGUe0xKkEemxeNG9TDCtFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiEth.uml#_c7CKwGBQEeiBxvDM8HEDKw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nGUewRKkEemxeNG9TDCtFQ" x="660" y="500" width="261" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_nGkWYxKkEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_nGkWZBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nGkWZhKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c7CKwGBQEeiBxvDM8HEDKw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nGkWZRKkEemxeNG9TDCtFQ" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_opeTkBKkEemxeNG9TDCtFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_opeTkhKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
@@ -13629,7 +16485,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_opeToxKkEemxeNG9TDCtFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_HfynMFSJEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_opeTkRKkEemxeNG9TDCtFQ" x="20" y="200" width="201" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_opeTkRKkEemxeNG9TDCtFQ" x="140" y="220" width="201" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_opwAYxKkEemxeNG9TDCtFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_opwAZBKkEemxeNG9TDCtFQ"/>
@@ -13638,40 +16494,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_opwAZRKkEemxeNG9TDCtFQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_oqpYQBKkEemxeNG9TDCtFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_oqpYQhKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_oqpYQxKkEemxeNG9TDCtFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oqpYRBKkEemxeNG9TDCtFQ" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_oqpYRRKkEemxeNG9TDCtFQ" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_oqpYRhKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_oqpYRxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_oqpYSBKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqpYSRKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_oqpYShKkEemxeNG9TDCtFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_oqpYSxKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_oqpYTBKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_oqpYTRKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqpYThKkEemxeNG9TDCtFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_oqpYTxKkEemxeNG9TDCtFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_oqpYUBKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_oqpYURKkEemxeNG9TDCtFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_oqpYUhKkEemxeNG9TDCtFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqpYUxKkEemxeNG9TDCtFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqpYQRKkEemxeNG9TDCtFQ" x="20" y="340" width="201" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_oq7sIxKkEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_oq7sJBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oq8TMBKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oq7sJRKkEemxeNG9TDCtFQ" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_qNuUkBKkEemxeNG9TDCtFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_qNu7oBKkEemxeNG9TDCtFQ" type="Class_NameLabel"/>
@@ -13697,7 +16519,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qNu7sRKkEemxeNG9TDCtFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_noRbAE-xEeitY7qZgkO_XQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qNuUkRKkEemxeNG9TDCtFQ" x="20" y="60" width="201" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qNuUkRKkEemxeNG9TDCtFQ" x="820" y="220" width="201" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_qOB2kBKkEemxeNG9TDCtFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_qOB2kRKkEemxeNG9TDCtFQ"/>
@@ -13718,7 +16540,7 @@
     <children xmi:type="notation:Shape" xmi:id="_5WUDcBOYEemxeNG9TDCtFQ" type="NamedElement_DefaultShape">
       <children xmi:type="notation:DecorationNode" xmi:id="_5WUqgBOYEemxeNG9TDCtFQ" type="NamedElement_NameLabel"/>
       <element xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5WUDcROYEemxeNG9TDCtFQ" x="360" y="140" width="161" height="61"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5WUDcROYEemxeNG9TDCtFQ" x="500" y="160" width="161" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_5WiF4BOYEemxeNG9TDCtFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_5WiF4ROYEemxeNG9TDCtFQ"/>
@@ -13731,7 +16553,7 @@
     <children xmi:type="notation:Shape" xmi:id="_5a0wABOYEemxeNG9TDCtFQ" type="NamedElement_DefaultShape">
       <children xmi:type="notation:DecorationNode" xmi:id="_5a1XEBOYEemxeNG9TDCtFQ" type="NamedElement_NameLabel"/>
       <element xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5a0wAROYEemxeNG9TDCtFQ" x="360" y="260" width="161" height="61"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5a0wAROYEemxeNG9TDCtFQ" x="500" y="300" width="161" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_5a_vIxOYEemxeNG9TDCtFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_5a_vJBOYEemxeNG9TDCtFQ"/>
@@ -13744,7 +16566,7 @@
     <children xmi:type="notation:Shape" xmi:id="_5cb5kBOYEemxeNG9TDCtFQ" type="NamedElement_DefaultShape">
       <children xmi:type="notation:DecorationNode" xmi:id="_5cb5khOYEemxeNG9TDCtFQ" type="NamedElement_NameLabel"/>
       <element xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5cb5kROYEemxeNG9TDCtFQ" x="360" y="380" width="161" height="61"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5cb5kROYEemxeNG9TDCtFQ" x="500" y="440" width="161" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_5cmRoxOYEemxeNG9TDCtFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_5cmRpBOYEemxeNG9TDCtFQ"/>
@@ -13762,46 +16584,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_seY5VROZEemxeNG9TDCtFQ" x="220" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zPh18BOZEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zPh18ROZEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zPh18xOZEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qA1RwBOZEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zPh18hOZEemxeNG9TDCtFQ" x="220" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_OX_RAxOaEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OX_RBBOaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OX_4EBOaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AbzqABOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OX_RBROaEemxeNG9TDCtFQ" x="860" y="-40"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Pf3fEBOaEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Pf3fEROaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pf3fExOaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BIqI8BOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pf3fEhOaEemxeNG9TDCtFQ" x="860" y="100"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QuB7UxOaEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QuB7VBOaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QuB7VhOaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_B0J9ABOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QuB7VROaEemxeNG9TDCtFQ" x="860" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_fHpsQBOaEemxeNG9TDCtFQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_fHpsQROaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fHpsQxOaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_c6U5EBOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fHpsQhOaEemxeNG9TDCtFQ" x="860" y="400"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_y11_wBT7Eemlb5smEiStFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_y11_wRT7Eemlb5smEiStFg"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y11_wxT7Eemlb5smEiStFg" name="BASE_ELEMENT">
@@ -13817,46 +16599,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_34s1ohT7Eemlb5smEiStFg" x="220" y="100"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__psswBT7Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__psswRT7Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__psswxT7Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-lZXIBT7Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__psswhT7Eemlb5smEiStFg" x="220" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_DOMuQBT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_DOMuQRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DOMuQxT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BYg_ABT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DOMuQhT8Eemlb5smEiStFg" x="860" y="-40"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_F1x0gBT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_F1x0gRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F1ybkBT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_EzAI4BT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F1x0ghT8Eemlb5smEiStFg" x="860" y="100"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JOgq4BT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JOgq4RT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JOhR8BT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_HnJEcBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JOgq4hT8Eemlb5smEiStFg" x="860" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_MBAnsBT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MBAnsRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MBAnsxT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_K3yV0BT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MBAnshT8Eemlb5smEiStFg" x="860" y="400"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_v6DuoBT8Eemlb5smEiStFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_v6DuoRT8Eemlb5smEiStFg"/>
@@ -13874,46 +16616,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWojMhT8Eemlb5smEiStFg" x="220" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1yZbABT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1yZbART8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1yZbAxT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_0w-aQBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1yZbAhT8Eemlb5smEiStFg" x="220" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_5G21YBT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5G21YRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5G3ccBT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4KCAwBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5G21YhT8Eemlb5smEiStFg" x="860" y="-40"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_8KciMBT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_8KciMRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8KciMxT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6t7g4BT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8KciMhT8Eemlb5smEiStFg" x="860" y="100"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__HAZ8BT8Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__HBBABT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__HBBAhT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9u6loBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__HBBART8Eemlb5smEiStFg" x="860" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_B7i-IBT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_B7i-IRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B7i-IxT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Au8BEBT9Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B7i-IhT9Eemlb5smEiStFg" x="860" y="400"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_fD2xEBT9Eemlb5smEiStFg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_fD2xERT9Eemlb5smEiStFg"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fD2xExT9Eemlb5smEiStFg" name="BASE_ELEMENT">
@@ -13922,53 +16624,45 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fD2xEhT9Eemlb5smEiStFg" x="220" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_h9QAEBT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_h9QAERT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_h9QAExT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_g2nvMBT9Eemlb5smEiStFg"/>
+    <children xmi:type="notation:Shape" xmi:id="_wHiYIDkmEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_wHiYITkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wHiYIzkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_usMbgDkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h9QAEhT9Eemlb5smEiStFg" x="220" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wHiYIjkmEemjx6Nna_xyog" x="220" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kUpVQBT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kUpVQRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kUpVQxT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_jS9OwBT9Eemlb5smEiStFg"/>
+    <children xmi:type="notation:Shape" xmi:id="_K5jCEDknEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K5jCETknEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K5jCEzknEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Js7d8DknEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kUpVQhT9Eemlb5smEiStFg" x="220" y="240"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K5jCEjknEemjx6Nna_xyog" x="220" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_mqnuIBT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_mqnuIRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mqnuIxT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_lq7LsBT9Eemlb5smEiStFg"/>
+    <children xmi:type="notation:Shape" xmi:id="_WQwK4DknEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WQwK4TknEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WQwK4zknEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_UrsRkDknEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mqnuIhT9Eemlb5smEiStFg" x="860" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WQwK4jknEemjx6Nna_xyog" x="220" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_qbILUxT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_qbILVBT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qbIyYBT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_pPHrMBT9Eemlb5smEiStFg"/>
+    <children xmi:type="notation:Shape" xmi:id="_e1yuEDknEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e1yuETknEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e1yuEzknEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_d7zyEDknEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qbILVRT9Eemlb5smEiStFg" x="860" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e1yuEjknEemjx6Nna_xyog" x="220" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_svrn4BT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_svrn4RT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_svrn4xT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rw984BT9Eemlb5smEiStFg"/>
+    <children xmi:type="notation:Shape" xmi:id="_UBasEDlUEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UBasETlUEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UBasEzlUEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_SZH4kDlUEemSPvPXzEQ11A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_svrn4hT9Eemlb5smEiStFg" x="860" y="240"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_vc2_0xT9Eemlb5smEiStFg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_vc2_1BT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_vc3m4BT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uWd_gBT9Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vc2_1RT9Eemlb5smEiStFg" x="860" y="400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UBasEjlUEemSPvPXzEQ11A" x="340" y="120"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_pmPTQRKjEemxeNG9TDCtFQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_pmPTQhKjEemxeNG9TDCtFQ"/>
@@ -13986,46 +16680,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XkvAOhKkEemxeNG9TDCtFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XkvnQBKkEemxeNG9TDCtFQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_nETFhxKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_nEBYsBKkEemxeNG9TDCtFQ" target="_nETFgxKkEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_nETFiBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nETskhKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_J1lZwFiCEei2nODetmeP6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nETFiRKkEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nETskBKkEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nETskRKkEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_nE6wlxKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_nErgABKkEemxeNG9TDCtFQ" target="_nE6wkxKkEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_nE6wmBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nE6wnBKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c43ZEFhkEeiYiLRYKaTpTw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nE6wmRKkEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nE6wmhKkEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nE6wmxKkEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_nFrlkBKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_nFbt8BKkEemxeNG9TDCtFQ" target="_nFq-gxKkEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_nFrlkRKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nFrllRKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NOPhwGBQEeiBxvDM8HEDKw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nFrlkhKkEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nFrlkxKkEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nFrllBKkEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_nGkWZxKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_nGUewBKkEemxeNG9TDCtFQ" target="_nGkWYxKkEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_nGkWaBKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nGk9cBKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c7CKwGBQEeiBxvDM8HEDKw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nGkWaRKkEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nGkWahKkEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nGkWaxKkEemxeNG9TDCtFQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_opwAZxKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_opeTkBKkEemxeNG9TDCtFQ" target="_opwAYxKkEemxeNG9TDCtFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_opwAaBKkEemxeNG9TDCtFQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_opwAbBKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
@@ -14035,16 +16689,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_opwAaRKkEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_opwAahKkEemxeNG9TDCtFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_opwAaxKkEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_oq8TMRKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_oqpYQBKkEemxeNG9TDCtFQ" target="_oq7sIxKkEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_oq8TMhKkEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oq8TNhKkEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oq8TMxKkEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oq8TNBKkEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oq8TNRKkEemxeNG9TDCtFQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qOB2lBKkEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_qOB2kBKkEemxeNG9TDCtFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_qOB2lRKkEemxeNG9TDCtFQ"/>
@@ -14056,20 +16700,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qOB2lxKkEemxeNG9TDCtFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qOB2mBKkEemxeNG9TDCtFQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BJ58cBKlEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_BJ58cBKlEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_BJ58cxKlEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BJfr4BOZEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BJ58dBKlEemxeNG9TDCtFQ" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BJ58dRKlEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BKiNsBOZEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BJ58dhKlEemxeNG9TDCtFQ" x="2" y="-142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BJ58dhKlEemxeNG9TDCtFQ" x="22" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BJ58cRKlEemxeNG9TDCtFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_BJ2SEBKlEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BJ58chKlEemxeNG9TDCtFQ" points="[221, 80, -643984, -643984]$[280, 80, -643984, -643984]$[280, 40, -643984, -643984]$[360, 40, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BLreEBKlEemxeNG9TDCtFQ" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BLreERKlEemxeNG9TDCtFQ" id="(0.0,0.32786885245901637)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BJ58chKlEemxeNG9TDCtFQ" points="[20, 80, -643984, -643984]$[20, 40, -643984, -643984]$[500, 40, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BLreEBKlEemxeNG9TDCtFQ" id="(0.4975124378109453,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BLreERKlEemxeNG9TDCtFQ" id="(1.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_C589wRKlEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_BJ58cBKlEemxeNG9TDCtFQ" target="_C58WsBKlEemxeNG9TDCtFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_C589whKlEemxeNG9TDCtFQ"/>
@@ -14111,35 +16755,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5cmRqhOYEemxeNG9TDCtFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5cmRqxOYEemxeNG9TDCtFQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pCjEkBOZEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_pCjEkBOZEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_pCjroBOZEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7v9l8BOZEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pCjroROZEemxeNG9TDCtFQ" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_pCjrohOZEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7xDyIBOZEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pCjroxOZEemxeNG9TDCtFQ" x="-78" y="-142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pCjroxOZEemxeNG9TDCtFQ" x="38" y="-13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_pCjEkROZEemxeNG9TDCtFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_pCgoUBOZEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pCjEkhOZEemxeNG9TDCtFQ" points="[221, 220, -643984, -643984]$[280, 220, -643984, -643984]$[280, 20, -643984, -643984]$[360, 20, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pErykBOZEemxeNG9TDCtFQ" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pErykROZEemxeNG9TDCtFQ" id="(0.0,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qA2f4BOZEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_oqpYQBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_qA3G8BOZEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7XATYBOZEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qA3G8ROZEemxeNG9TDCtFQ" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qA3G8hOZEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_7YJi4BOZEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qA3G8xOZEemxeNG9TDCtFQ" x="-108" y="-142"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_qA2f4ROZEemxeNG9TDCtFQ"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_qA1RwBOZEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qA2f4hOZEemxeNG9TDCtFQ" points="[221, 360, -643984, -643984]$[280, 360, -643984, -643984]$[280, 60, -643984, -643984]$[360, 60, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qDDfUBOZEemxeNG9TDCtFQ" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qDEGYBOZEemxeNG9TDCtFQ" id="(0.0,0.6557377049180327)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pCjEkhOZEemxeNG9TDCtFQ" points="[240, 220, -643984, -643984]$[240, 40, -643984, -643984]$[500, 40, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pErykBOZEemxeNG9TDCtFQ" id="(0.4975124378109453,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pErykROZEemxeNG9TDCtFQ" id="(0.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_seZgYROZEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_pCjEkBOZEemxeNG9TDCtFQ" target="_seY5UxOZEemxeNG9TDCtFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_seZgYhOZEemxeNG9TDCtFQ"/>
@@ -14151,130 +16780,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_seZgZBOZEemxeNG9TDCtFQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_seZgZROZEemxeNG9TDCtFQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zPh19BOZEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_qA2f4BOZEemxeNG9TDCtFQ" target="_zPh18BOZEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zPh19ROZEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zPh1-ROZEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qA1RwBOZEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zPh19hOZEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zPh19xOZEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zPh1-BOZEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ab04IBOaEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_nEBYsBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ab04IxOaEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JMrCsBOaEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ab04JBOaEemxeNG9TDCtFQ" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ab1fMBOaEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JNzEEBOaEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ab1fMROaEemxeNG9TDCtFQ" x="-77" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ab04IROaEemxeNG9TDCtFQ"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_AbzqABOaEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ab04IhOaEemxeNG9TDCtFQ" points="[660, 80, -643984, -643984]$[600, 80, -643984, -643984]$[600, 40, -643984, -643984]$[521, 40, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AeMPoBOaEemxeNG9TDCtFQ" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AeMPoROaEemxeNG9TDCtFQ" id="(1.0,0.32786885245901637)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BIr-IBOaEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_nErgABKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BIr-IxOaEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ItiPoBOaEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BIr-JBOaEemxeNG9TDCtFQ" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BIr-JROaEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IutUUBOaEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BIr-JhOaEemxeNG9TDCtFQ" x="-17" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_BIr-IROaEemxeNG9TDCtFQ"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_BIqI8BOaEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BIr-IhOaEemxeNG9TDCtFQ" points="[660, 220, -643984, -643984]$[600, 220, -643984, -643984]$[600, 60, -643984, -643984]$[521, 60, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BLHAABOaEemxeNG9TDCtFQ" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BLHAAROaEemxeNG9TDCtFQ" id="(1.0,0.6557377049180327)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_B0LyMBOaEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_nFbt8BKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_B0LyMxOaEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oTLx8BT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_B0LyNBOaEemxeNG9TDCtFQ" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_B0LyNROaEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oWlrQBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_B0LyNhOaEemxeNG9TDCtFQ" x="24" y="139"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_B0LyMROaEemxeNG9TDCtFQ"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_B0J9ABOaEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B0LyMhOaEemxeNG9TDCtFQ" points="[660, 360, -643984, -643984]$[600, 360, -643984, -643984]$[600, 80, -643984, -643984]$[521, 80, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B2uv4BOaEemxeNG9TDCtFQ" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B2uv4ROaEemxeNG9TDCtFQ" id="(1.0,0.9836065573770492)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OX_4EROaEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_Ab04IBOaEemxeNG9TDCtFQ" target="_OX_RAxOaEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OX_4EhOaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OX_4FhOaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AbzqABOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OX_4ExOaEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OX_4FBOaEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OX_4FROaEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Pf3fFBOaEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_BIr-IBOaEemxeNG9TDCtFQ" target="_Pf3fEBOaEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Pf3fFROaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pf3fGROaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BIqI8BOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pf3fFhOaEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pf3fFxOaEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pf3fGBOaEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QuB7VxOaEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_B0LyMBOaEemxeNG9TDCtFQ" target="_QuB7UxOaEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QuB7WBOaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QuCiYhOaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_B0J9ABOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QuB7WROaEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QuCiYBOaEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QuCiYROaEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_c6WHMBOaEemxeNG9TDCtFQ" type="Abstraction_Edge" source="_nGUewBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_c6WuQBOaEemxeNG9TDCtFQ" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hf25wBOaEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_c6WuQROaEemxeNG9TDCtFQ" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_c6WuQhOaEemxeNG9TDCtFQ" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hhLvcBOaEemxeNG9TDCtFQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_c6WuQxOaEemxeNG9TDCtFQ" x="-187" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_c6WHMROaEemxeNG9TDCtFQ"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_c6U5EBOaEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c6WHMhOaEemxeNG9TDCtFQ" points="[660, 520, -643984, -643984]$[600, 520, -643984, -643984]$[600, 20, -643984, -643984]$[521, 20, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c9EEABOaEemxeNG9TDCtFQ" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c9EEAROaEemxeNG9TDCtFQ" id="(1.0,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_fHpsRBOaEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_c6WHMBOaEemxeNG9TDCtFQ" target="_fHpsQBOaEemxeNG9TDCtFQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_fHpsRROaEemxeNG9TDCtFQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fHpsSROaEemxeNG9TDCtFQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_c6U5EBOaEemxeNG9TDCtFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fHpsRhOaEemxeNG9TDCtFQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fHpsRxOaEemxeNG9TDCtFQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fHpsSBOaEemxeNG9TDCtFQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xSZQABT7Eemlb5smEiStFg" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_xSZQABT7Eemlb5smEiStFg" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_xSbsQBT7Eemlb5smEiStFg" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dNT7oBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xScTUBT7Eemlb5smEiStFg" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_xSc6YBT7Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dPpd8BT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xSc6YRT7Eemlb5smEiStFg" x="-4" y="142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xSc6YRT7Eemlb5smEiStFg" x="-8" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_xSZQART7Eemlb5smEiStFg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_xR_AUBT7Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xSZQAhT7Eemlb5smEiStFg" points="[221, 80, -643984, -643984]$[280, 80, -643984, -643984]$[280, 160, -643984, -643984]$[360, 160, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xXqxkBT7Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xXrYoBT7Eemlb5smEiStFg" id="(0.0,0.32786885245901637)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xSZQAhT7Eemlb5smEiStFg" points="[880, 220, -643984, -643984]$[880, 180, -643984, -643984]$[661, 180, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xXqxkBT7Eemlb5smEiStFg" id="(0.29850746268656714,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xXrYoBT7Eemlb5smEiStFg" id="(1.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_y11_xBT7Eemlb5smEiStFg" type="StereotypeCommentLink" source="_xSZQABT7Eemlb5smEiStFg" target="_y11_wBT7Eemlb5smEiStFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_y11_xRT7Eemlb5smEiStFg"/>
@@ -14286,20 +16805,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y11_xxT7Eemlb5smEiStFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y11_yBT7Eemlb5smEiStFg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_21jWkBT7Eemlb5smEiStFg" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_21jWkBT7Eemlb5smEiStFg" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_21j9oBT7Eemlb5smEiStFg" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fWICQBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_21j9oRT7Eemlb5smEiStFg" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_21j9ohT7Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fYOUABT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_21j9oxT7Eemlb5smEiStFg" x="-78" y="-142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_21j9oxT7Eemlb5smEiStFg" x="-12" y="-13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_21jWkRT7Eemlb5smEiStFg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_21hhYBT7Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_21jWkhT7Eemlb5smEiStFg" points="[221, 220, -643984, -643984]$[280, 220, -643984, -643984]$[280, 180, -643984, -643984]$[360, 180, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_24tYQBT7Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_24t_UBT7Eemlb5smEiStFg" id="(0.0,0.6557377049180327)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_21jWkhT7Eemlb5smEiStFg" points="[280, 220, -643984, -643984]$[280, 180, -643984, -643984]$[500, 180, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_24tYQBT7Eemlb5smEiStFg" id="(0.6965174129353234,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_24t_UBT7Eemlb5smEiStFg" id="(0.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_34tcsRT7Eemlb5smEiStFg" type="StereotypeCommentLink" source="_21jWkBT7Eemlb5smEiStFg" target="_34s1oBT7Eemlb5smEiStFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_34tcshT7Eemlb5smEiStFg"/>
@@ -14311,145 +16830,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_34tctBT7Eemlb5smEiStFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_34tctRT7Eemlb5smEiStFg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_-lbMUBT7Eemlb5smEiStFg" type="Abstraction_Edge" source="_oqpYQBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_-lbzYBT7Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eiSKgBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-lbzYRT7Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_-lbzYhT7Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ekxd0BT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-lcacBT7Eemlb5smEiStFg" x="-18" y="-142"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_-lbMURT7Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_-lZXIBT7Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-lbMUhT7Eemlb5smEiStFg" points="[221, 360, -643984, -643984]$[280, 360, -643984, -643984]$[280, 200, -643984, -643984]$[360, 200, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-pWqEBT7Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-pWqERT7Eemlb5smEiStFg" id="(0.0,0.9836065573770492)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__pssxBT7Eemlb5smEiStFg" type="StereotypeCommentLink" source="_-lbMUBT7Eemlb5smEiStFg" target="__psswBT7Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="__pssxRT7Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__pssyRT7Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-lZXIBT7Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__pssxhT7Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__pssxxT7Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__pssyBT7Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BYjbQBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nEBYsBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYkCUBT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hS_XkBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYkCURT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYkCUhT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hVTrwBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYkCUxT8Eemlb5smEiStFg" x="-83" y="-138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_BYjbQRT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_BYg_ABT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BYjbQhT8Eemlb5smEiStFg" points="[660, 80, -643984, -643984]$[600, 80, -643984, -643984]$[600, 160, -643984, -643984]$[521, 160, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcoC8BT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BcoC8RT8Eemlb5smEiStFg" id="(1.0,0.32786885245901637)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DOMuRBT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_BYjbQBT8Eemlb5smEiStFg" target="_DOMuQBT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_DOMuRRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DOMuSRT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BYg_ABT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DOMuRhT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DOMuRxT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DOMuSBT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_EzB-EBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nErgABKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_EzClIBT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jCp-YBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EzClIRT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_EzClIhT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_jEpicBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EzClIxT8Eemlb5smEiStFg" x="33" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_EzB-ERT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_EzAI4BT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EzB-EhT8Eemlb5smEiStFg" points="[660, 220, -643984, -643984]$[600, 220, -643984, -643984]$[600, 200, -643984, -643984]$[521, 200, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E3N6gBT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E3N6gRT8Eemlb5smEiStFg" id="(1.0,0.9836065573770492)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_F1ybkRT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_EzB-EBT8Eemlb5smEiStFg" target="_F1x0gBT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_F1ybkhT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_F1yblhT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_EzAI4BT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F1ybkxT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F1yblBT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F1yblRT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_HnLgsBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nFbt8BKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_HnLgsxT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lV3XIBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HnLgtBT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_HnLgtRT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lX8awBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HnLgthT8Eemlb5smEiStFg" x="-6" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_HnLgsRT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_HnJEcBT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HnLgshT8Eemlb5smEiStFg" points="[660, 360, -643984, -643984]$[600, 360, -643984, -643984]$[600, 140, -643984, -643984]$[521, 140, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HrmtsBT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HrmtsRT8Eemlb5smEiStFg" id="(1.0,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JOhR8RT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_HnLgsBT8Eemlb5smEiStFg" target="_JOgq4BT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JOhR8hT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JOhR9hT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_HnJEcBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JOhR8xT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JOhR9BT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JOhR9RT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_K30LABT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nGUewBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_K30yEBT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_nN6d4BT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_K30yERT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_K30yEhT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_nPt0sBT8Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_K30yExT8Eemlb5smEiStFg" x="-67" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_K30LART8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_K3yV0BT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K30LAhT8Eemlb5smEiStFg" points="[660, 520, -643984, -643984]$[600, 520, -643984, -643984]$[600, 180, -643984, -643984]$[521, 180, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K7piIBT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K7piIRT8Eemlb5smEiStFg" id="(1.0,0.6557377049180327)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MBAntBT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_K30LABT8Eemlb5smEiStFg" target="_MBAnsBT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MBAntRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MBBOwhT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_K3yV0BT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MBAnthT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MBBOwBT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MBBOwRT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_rZTgQBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_rZTgQBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_rZUHUBT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_O_GUABT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_rZUHURT8Eemlb5smEiStFg" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_rZUuYBT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PBikABT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rZUuYRT8Eemlb5smEiStFg" x="-84" y="142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rZUuYRT8Eemlb5smEiStFg" x="22" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_rZTgQRT8Eemlb5smEiStFg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_rZOnwBT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rZTgQhT8Eemlb5smEiStFg" points="[221, 80, -643984, -643984]$[280, 80, -643984, -643984]$[280, 280, -643984, -643984]$[360, 280, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rdHpQBT8Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rdIQUBT8Eemlb5smEiStFg" id="(0.0,0.32786885245901637)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rZTgQhT8Eemlb5smEiStFg" points="[860, 281, -643984, -643984]$[860, 320, -643984, -643984]$[661, 320, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rdHpQBT8Eemlb5smEiStFg" id="(0.19900497512437812,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rdIQUBT8Eemlb5smEiStFg" id="(1.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_v6EVsBT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_rZTgQBT8Eemlb5smEiStFg" target="_v6DuoBT8Eemlb5smEiStFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_v6EVsRT8Eemlb5smEiStFg"/>
@@ -14461,20 +16855,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v6EVsxT8Eemlb5smEiStFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v6EVtBT8Eemlb5smEiStFg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_yKNzYBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_yKNzYBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_yKNzYxT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P5ccYBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_yKNzZBT8Eemlb5smEiStFg" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_yKNzZRT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_P81HkBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_yKNzZhT8Eemlb5smEiStFg" x="-104" y="142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yKNzZhT8Eemlb5smEiStFg" x="37" y="-13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_yKNzYRT8Eemlb5smEiStFg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_yKL-MBT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yKNzYhT8Eemlb5smEiStFg" points="[221, 220, -643984, -643984]$[280, 220, -643984, -643984]$[280, 300, -643984, -643984]$[360, 300, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yOsDsBT8Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yOsqwBT8Eemlb5smEiStFg" id="(0.0,0.6557377049180327)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yKNzYhT8Eemlb5smEiStFg" points="[300, 281, -643984, -643984]$[300, 320, -643984, -643984]$[500, 320, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yOsDsBT8Eemlb5smEiStFg" id="(0.7960199004975125,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yOsqwBT8Eemlb5smEiStFg" id="(0.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_zWpKQRT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_yKNzYBT8Eemlb5smEiStFg" target="_zWojMBT8Eemlb5smEiStFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_zWpKQhT8Eemlb5smEiStFg"/>
@@ -14486,145 +16880,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWpKRBT8Eemlb5smEiStFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWpKRRT8Eemlb5smEiStFg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0xAPcBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_oqpYQBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_0xA2gBT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Si81QBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0xA2gRT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_0xA2ghT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SlkrcBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0xA2gxT8Eemlb5smEiStFg" x="-28" y="-142"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_0xAPcRT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_0w-aQBT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0xAPchT8Eemlb5smEiStFg" points="[221, 360, -643984, -643984]$[280, 360, -643984, -643984]$[280, 260, -643984, -643984]$[360, 260, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_029tgBT8Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_029tgRT8Eemlb5smEiStFg" id="(0.0,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1yZbBBT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_0xAPcBT8Eemlb5smEiStFg" target="_1yZbABT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1yZbBRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1yZbCRT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_0w-aQBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1yZbBhT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1yZbBxT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1yZbCBT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_4KDO4BT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nEBYsBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_4KD18BT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WWKoMBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4KD18RT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4KD18hT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Wag8sBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4KD18xT8Eemlb5smEiStFg" x="-83" y="-138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_4KDO4RT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_4KCAwBT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4KDO4hT8Eemlb5smEiStFg" points="[660, 80, -643984, -643984]$[600, 80, -643984, -643984]$[600, 280, -643984, -643984]$[521, 280, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4PCckBT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4PDDoBT8Eemlb5smEiStFg" id="(1.0,0.32786885245901637)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5G3ccRT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_4KDO4BT8Eemlb5smEiStFg" target="_5G21YBT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5G3cchT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5G3cdhT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4KCAwBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5G3ccxT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5G3cdBT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5G3cdRT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6t9WEBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nErgABKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_6t99IBT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VhQZcBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6t99IRT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_6t99IhT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VjhDQBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6t99IxT8Eemlb5smEiStFg" x="7" y="-138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_6t9WERT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_6t7g4BT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6t9WEhT8Eemlb5smEiStFg" points="[660, 220, -643984, -643984]$[600, 220, -643984, -643984]$[600, 320, -643984, -643984]$[521, 320, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zHi4BT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zHi4RT8Eemlb5smEiStFg" id="(1.0,0.9836065573770492)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_8KdJQBT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_6t9WEBT8Eemlb5smEiStFg" target="_8KciMBT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_8KdJQRT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8KdJRRT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6t7g4BT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8KdJQhT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8KdJQxT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8KdJRBT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9u7zwBT8Eemlb5smEiStFg" type="Abstraction_Edge" source="_nFbt8BKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_9u8a0BT8Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UZuJoBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9u8a0RT8Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_9u8a0hT8Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UchmABT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9u8a0xT8Eemlb5smEiStFg" x="13" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_9u7zwRT8Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_9u6loBT8Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9u7zwhT8Eemlb5smEiStFg" points="[660, 360, -643984, -643984]$[600, 360, -643984, -643984]$[600, 300, -643984, -643984]$[521, 300, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9zb5QBT8Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9zb5QRT8Eemlb5smEiStFg" id="(1.0,0.6557377049180327)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__HBBAxT8Eemlb5smEiStFg" type="StereotypeCommentLink" source="_9u7zwBT8Eemlb5smEiStFg" target="__HAZ8BT8Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="__HBBBBT8Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__HBBCBT8Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9u6loBT8Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__HBBBRT8Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__HBBBhT8Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__HBBBxT8Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Au9PMBT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_nGUewBKkEemxeNG9TDCtFQ" target="_5a0wABOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Au9PMxT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TWGwgBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Au9PNBT9Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Au9PNRT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TYumsBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Au9PNhT9Eemlb5smEiStFg" x="-47" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Au9PMRT9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Au8BEBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Au9PMhT9Eemlb5smEiStFg" points="[660, 520, -643984, -643984]$[600, 520, -643984, -643984]$[600, 260, -643984, -643984]$[521, 260, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Azr-MBT9Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Azr-MRT9Eemlb5smEiStFg" id="(1.0,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_B7jlMBT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_Au9PMBT9Eemlb5smEiStFg" target="_B7i-IBT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_B7jlMRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B7jlNRT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Au8BEBT9Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B7jlMhT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B7jlMxT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B7jlNBT9Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_d3rR0BT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
+    <edges xmi:type="notation:Connector" xmi:id="_d3rR0BT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_d3rR0xT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9TKoUBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_d3rR1BT9Eemlb5smEiStFg" y="40"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_d3rR1RT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_9V6aUBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_d3rR1hT9Eemlb5smEiStFg" x="-104" y="142"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_d3rR1hT9Eemlb5smEiStFg" x="42" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_d3rR0RT9Eemlb5smEiStFg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_d3nncBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d3rR0hT9Eemlb5smEiStFg" points="[221, 80, -643984, -643984]$[280, 80, -643984, -643984]$[280, 400, -643984, -643984]$[360, 400, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d8gugBT9Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d8hVkBT9Eemlb5smEiStFg" id="(0.0,0.32786885245901637)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d3rR0hT9Eemlb5smEiStFg" points="[880, 281, -643984, -643984]$[880, 460, -643984, -643984]$[661, 460, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d8gugBT9Eemlb5smEiStFg" id="(0.29850746268656714,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d8hVkBT9Eemlb5smEiStFg" id="(1.0,0.32786885245901637)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_fD2xFBT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_d3rR0BT9Eemlb5smEiStFg" target="_fD2xEBT9Eemlb5smEiStFg">
       <styles xmi:type="notation:FontStyle" xmi:id="_fD2xFRT9Eemlb5smEiStFg"/>
@@ -14636,155 +16905,130 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fD2xFxT9Eemlb5smEiStFg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fD2xGBT9Eemlb5smEiStFg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_g2o9UBT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_g2o9UxT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-TT2sBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_g2o9VBT9Eemlb5smEiStFg" y="40"/>
+    <edges xmi:type="notation:Connector" xmi:id="_usNpoDkmEemjx6Nna_xyog" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_usNpozkmEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eCGx4DkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_usNppDkmEemjx6Nna_xyog" y="38"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_g2o9VRT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-VzxEBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_g2o9VhT9Eemlb5smEiStFg" x="-84" y="142"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_usOQsDkmEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eHlu0DkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_usOQsTkmEemjx6Nna_xyog" x="18" y="7"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_g2o9URT9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_g2nvMBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g2o9UhT9Eemlb5smEiStFg" points="[221, 220, -643984, -643984]$[280, 220, -643984, -643984]$[280, 420, -643984, -643984]$[360, 420, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g7WeMBT9Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g7XFQBT9Eemlb5smEiStFg" id="(0.0,0.6557377049180327)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_usNpoTkmEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_usMbgDkmEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_usNpojkmEemjx6Nna_xyog" points="[260, 220, -643984, -643984]$[260, 60, -643984, -643984]$[500, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u08H0DkmEemjx6Nna_xyog" id="(0.5970149253731343,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u08H0TkmEemjx6Nna_xyog" id="(0.0,0.6557377049180327)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_h9QnIBT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_g2o9UBT9Eemlb5smEiStFg" target="_h9QAEBT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_h9QnIRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_h9QnJRT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_g2nvMBT9Eemlb5smEiStFg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_wHiYJDkmEemjx6Nna_xyog" type="StereotypeCommentLink" source="_usNpoDkmEemjx6Nna_xyog" target="_wHiYIDkmEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_wHiYJTkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wHiYKTkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_usMbgDkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_h9QnIhT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h9QnIxT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h9QnJBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wHiYJjkmEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wHiYJzkmEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wHiYKDkmEemjx6Nna_xyog"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jS_D8BT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_oqpYQBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_jS_D8xT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-7OyUBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jS_D9BT9Eemlb5smEiStFg" y="40"/>
+    <edges xmi:type="notation:Connector" xmi:id="_Js8sEDknEemjx6Nna_xyog" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_XkUJcBKkEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Js9TIDknEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eMutgDkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Js9TITknEemjx6Nna_xyog" y="39"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_jS_D9RT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_--5xYBT9Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jS_D9hT9Eemlb5smEiStFg" x="-143" y="7"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Js9TIjknEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eR79oDkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Js9TIzknEemjx6Nna_xyog" x="22" y="-7"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_jS_D8RT9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_jS9OwBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jS_D8hT9Eemlb5smEiStFg" points="[221, 360, -643984, -643984]$[280, 360, -643984, -643984]$[280, 380, -643984, -643984]$[360, 380, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jYf2EBT9Eemlb5smEiStFg" id="(1.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jYf2ERT9Eemlb5smEiStFg" id="(0.0,0.0)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Js8sETknEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Js7d8DknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Js8sEjknEemjx6Nna_xyog" points="[900, 220, -643984, -643984]$[900, 60, -643984, -643984]$[661, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1iAUDknEemjx6Nna_xyog" id="(0.39800995024875624,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1iAUTknEemjx6Nna_xyog" id="(1.0,0.6557377049180327)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kUpVRBT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_jS_D8BT9Eemlb5smEiStFg" target="_kUpVQBT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kUpVRRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kUpVSRT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_jS9OwBT9Eemlb5smEiStFg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_K5jCFDknEemjx6Nna_xyog" type="StereotypeCommentLink" source="_Js8sEDknEemjx6Nna_xyog" target="_K5jCEDknEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K5jCFTknEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K5jCGTknEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Js7d8DknEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kUpVRhT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kUpVRxT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kUpVSBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K5jCFjknEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5jCFzknEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5jCGDknEemjx6Nna_xyog"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lq8Z0BT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_nEBYsBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_lq8Z0xT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DIdnwBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lq8Z1BT9Eemlb5smEiStFg" y="40"/>
+    <edges xmi:type="notation:Connector" xmi:id="_UruGwDknEemjx6Nna_xyog" type="Abstraction_Edge" source="_qNuUkBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UruGwzknEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eiN1UDkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UruGxDknEemjx6Nna_xyog" x="2" y="37"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lq8Z1RT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DLMysBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lq8Z1hT9Eemlb5smEiStFg" x="17" y="-138"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UruGxTknEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_enW0ADkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UruGxjknEemjx6Nna_xyog" x="32" y="-7"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_lq8Z0RT9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_lq7LsBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lq8Z0hT9Eemlb5smEiStFg" points="[660, 80, -643984, -643984]$[600, 80, -643984, -643984]$[600, 400, -643984, -643984]$[521, 400, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwIb0BT9Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwIb0RT9Eemlb5smEiStFg" id="(1.0,0.32786885245901637)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UruGwTknEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_UrsRkDknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UruGwjknEemjx6Nna_xyog" points="[860, 220, -643984, -643984]$[860, 180, -643984, -643984]$[661, 180, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U0PwoDknEemjx6Nna_xyog" id="(0.19900497512437812,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U0PwoTknEemjx6Nna_xyog" id="(1.0,0.6557377049180327)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_mqnuJBT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_lq8Z0BT9Eemlb5smEiStFg" target="_mqnuIBT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_mqnuJRT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mqnuKRT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_lq7LsBT9Eemlb5smEiStFg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_WQwK5DknEemjx6Nna_xyog" type="StereotypeCommentLink" source="_UruGwDknEemjx6Nna_xyog" target="_WQwK4DknEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WQwK5TknEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WQwK6TknEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_UrsRkDknEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mqnuJhT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mqnuJxT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mqnuKBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WQwK5jknEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WQwK5zknEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WQwK6DknEemjx6Nna_xyog"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pPKHcBT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_nErgABKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_pPKugBT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CB0v0BT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pPKugRT9Eemlb5smEiStFg" y="40"/>
+    <edges xmi:type="notation:Connector" xmi:id="_d71AMDknEemjx6Nna_xyog" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5WUDcBOYEemxeNG9TDCtFQ" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_d71AMzknEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_esgZwDkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_d71ANDknEemjx6Nna_xyog" x="1" y="40"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_pPKughT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CEozQBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pPKugxT9Eemlb5smEiStFg" x="-3" y="-138"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_d71ANTknEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_exqmkDkoEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_d71ANjknEemjx6Nna_xyog" x="28" y="7"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_pPKHcRT9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_pPHrMBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pPKHchT9Eemlb5smEiStFg" points="[660, 220, -643984, -643984]$[600, 220, -643984, -643984]$[600, 420, -643984, -643984]$[521, 420, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pVIzoBT9Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pVJasBT9Eemlb5smEiStFg" id="(1.0,0.6557377049180327)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_d71AMTknEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_d7zyEDknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d71AMjknEemjx6Nna_xyog" points="[300, 220, -643984, -643984]$[300, 200, -643984, -643984]$[500, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eEdXwDknEemjx6Nna_xyog" id="(0.7960199004975125,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eEdXwTknEemjx6Nna_xyog" id="(0.0,0.6557377049180327)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qbIyYRT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_pPKHcBT9Eemlb5smEiStFg" target="_qbILUxT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_qbIyYhT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qbIyZhT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_pPHrMBT9Eemlb5smEiStFg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_e1yuFDknEemjx6Nna_xyog" type="StereotypeCommentLink" source="_d71AMDknEemjx6Nna_xyog" target="_e1yuEDknEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e1yuFTknEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e1yuGTknEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_d7zyEDknEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qbIyYxT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbIyZBT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbIyZRT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e1yuFjknEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e1yuFzknEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e1yuGDknEemjx6Nna_xyog"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_rw_LABT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_nFbt8BKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_rw_yEBT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AXAz0BT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rw_yERT9Eemlb5smEiStFg" y="40"/>
+    <edges xmi:type="notation:Connector" xmi:id="_SZKU0DlUEemSPvPXzEQ11A" type="Abstraction_Edge" source="_opeTkBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SZK74DlUEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XjXv4DlUEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SZK74TlUEemSPvPXzEQ11A" y="40"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_rw_yEhT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AagMsBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rw_yExT9Eemlb5smEiStFg" x="57" y="-138"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SZK74jlUEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XlJ4kDlUEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SZK74zlUEemSPvPXzEQ11A" x="37" y="-13"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_rw_LART9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_rw984BT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rw_LAhT9Eemlb5smEiStFg" points="[660, 360, -643984, -643984]$[600, 360, -643984, -643984]$[600, 440, -643984, -643984]$[521, 440, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r26z4BT9Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r26z4RT9Eemlb5smEiStFg" id="(1.0,0.9836065573770492)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_SZKU0TlUEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_SZH4kDlUEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SZKU0jlUEemSPvPXzEQ11A" points="[260, 281, -643984, -643984]$[260, 460, -643984, -643984]$[500, 460, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Sc4-QDlUEemSPvPXzEQ11A" id="(0.6965174129353234,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Sc4-QTlUEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_svrn5BT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_rw_LABT9Eemlb5smEiStFg" target="_svrn4BT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_svrn5RT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_svrn6RT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rw984BT9Eemlb5smEiStFg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_UBasFDlUEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_SZKU0DlUEemSPvPXzEQ11A" target="_UBasEDlUEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UBasFTlUEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UBasGTlUEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_SZH4kDlUEemSPvPXzEQ11A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_svrn5hT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_svrn5xT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_svrn6BT9Eemlb5smEiStFg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_uWfNoBT9Eemlb5smEiStFg" type="Abstraction_Edge" source="_nGUewBKkEemxeNG9TDCtFQ" target="_5cb5kBOYEemxeNG9TDCtFQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_uWf0sBT9Eemlb5smEiStFg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ABlWYBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_uWf0sRT9Eemlb5smEiStFg" y="40"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_uWf0shT9Eemlb5smEiStFg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AEncQBT-Eemlb5smEiStFg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_uWf0sxT9Eemlb5smEiStFg" x="53" y="138"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_uWfNoRT9Eemlb5smEiStFg"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_uWd_gBT9Eemlb5smEiStFg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uWfNohT9Eemlb5smEiStFg" points="[660, 520, -643984, -643984]$[600, 520, -643984, -643984]$[600, 380, -643984, -643984]$[521, 380, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ucAm0BT9Eemlb5smEiStFg" id="(0.0,0.4878048780487805)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ucAm0RT9Eemlb5smEiStFg" id="(1.0,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_vc3m4RT9Eemlb5smEiStFg" type="StereotypeCommentLink" source="_uWfNoBT9Eemlb5smEiStFg" target="_vc2_0xT9Eemlb5smEiStFg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_vc3m4hT9Eemlb5smEiStFg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_vc3m5hT9Eemlb5smEiStFg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uWd_gBT9Eemlb5smEiStFg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vc3m4xT9Eemlb5smEiStFg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vc3m5BT9Eemlb5smEiStFg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vc3m5RT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UBasFjlUEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UBasFzlUEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UBasGDlUEemSPvPXzEQ11A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_PZYKEBWeEemlb5smEiStFg" type="PapyrusUMLClassDiagram" name="EthInterfaceProfile" measurementUnit="Pixel">
@@ -15674,7 +17918,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gxHXRhQEem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gwgQRhQEem7b6CPWW1OrA" x="591" y="159" height="82"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gwgQRhQEem7b6CPWW1OrA" x="591" y="159" width="290" height="82"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_1g4cFxhQEem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_1g4cGBhQEem7b6CPWW1OrA"/>
@@ -15701,10 +17945,6 @@
         <children xmi:type="notation:Shape" xmi:id="_jbEQwBhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_mMroAU8HEeiW8t12GIRjqQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_jbEQwRhREem7b6CPWW1OrA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_jbE30BhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_TF9BE04-EeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbE30RhREem7b6CPWW1OrA"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_jbE30hhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
@@ -15771,10 +18011,6 @@
         <children xmi:type="notation:Shape" xmi:id="_jbQeAhhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WRqhYE45EeiMYveOdt1-rQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_jbQeAxhREem7b6CPWW1OrA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_jbRFEBhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_hJpKQBocEeeV4o0osG5stg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbRFERhREem7b6CPWW1OrA"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_jbRFEhhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_DzNYkBN3EemxeNG9TDCtFQ"/>
@@ -16036,7 +18272,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__OBPzhhQEem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_VUpVoFRyEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__OAosRhQEem7b6CPWW1OrA" x="900" y="480" height="221"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__OAosRhQEem7b6CPWW1OrA" x="860" y="480" height="221"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__OMO4xhQEem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__OMO5BhQEem7b6CPWW1OrA"/>
@@ -16086,7 +18322,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HVhiaRhREem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_F-hgMFRyEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HVg7URhREem7b6CPWW1OrA" x="543" y="483" height="101"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HVg7URhREem7b6CPWW1OrA" x="500" y="500" height="101"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_HVshgxhREem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_HVshhBhREem7b6CPWW1OrA"/>
@@ -16126,6 +18362,10 @@
           <element xmi:type="uml:Property" href="TapiEth.uml#_prGFsNdpEeidLb5WEUMFmw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_jbPP4RhREem7b6CPWW1OrA"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_z0QrMDobEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_zZMf0DobEemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_z0QrMTobEemSPvPXzEQ11A"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_H8BhthhREem7b6CPWW1OrA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_H8BhtxhREem7b6CPWW1OrA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_H8BhuBhREem7b6CPWW1OrA"/>
@@ -16144,7 +18384,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8BhwxhREem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_nTcS8FRxEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8BhsRhREem7b6CPWW1OrA" x="560" y="300" height="121"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8BhsRhREem7b6CPWW1OrA" x="500" y="300" height="141"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_H8OWABhREem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_H8OWARhREem7b6CPWW1OrA"/>
@@ -16198,13 +18438,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_LkSo5BhREem7b6CPWW1OrA" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_LkSo5RhREem7b6CPWW1OrA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_jbGtARhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_vZQJoGA8Eei7_-Uhq6CryQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbGtAhhREem7b6CPWW1OrA"/>
+        <children xmi:type="notation:Shape" xmi:id="_wAmfQDoOEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_ap5AYDoOEemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wAmfQToOEemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_jbGtAxhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_wAnGUDoOEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_vZQJoGA8Eei7_-Uhq6CryQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wAnGUToOEemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wAnGUjoOEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_zrY80AVGEemxeNG9TDCtFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbGtBBhREem7b6CPWW1OrA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wAnGUzoOEemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_LkSo5hhREem7b6CPWW1OrA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_LkSo5xhREem7b6CPWW1OrA"/>
@@ -16356,7 +18600,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_3bfuoRhQEem7b6CPWW1OrA"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_b2Z8kBXMEemlb5smEiStFg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3bfuohhQEem7b6CPWW1OrA" points="[800, 159, -643984, -643984]$[800, 101, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SK1fEBhREem7b6CPWW1OrA" id="(0.8293650793650794,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SK1fEBhREem7b6CPWW1OrA" id="(0.7206896551724138,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SK1fERhREem7b6CPWW1OrA" id="(0.21220159151193635,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3bu_NBhQEem7b6CPWW1OrA" type="StereotypeCommentLink" source="_3bfuoBhQEem7b6CPWW1OrA" target="_3bu_MBhQEem7b6CPWW1OrA">
@@ -16382,7 +18626,7 @@
     <edges xmi:type="notation:Connector" xmi:id="_68E5cBhQEem7b6CPWW1OrA" type="Dependency_Edge" source="_6fRBoBhQEem7b6CPWW1OrA" target="_3aoL8BhQEem7b6CPWW1OrA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_68E5cxhQEem7b6CPWW1OrA" type="Dependency_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SHw88BhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_68FggBhQEem7b6CPWW1OrA" x="3" y="38"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_68FggBhQEem7b6CPWW1OrA" x="3" y="78"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_68FggRhQEem7b6CPWW1OrA" type="Dependency_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_SJQKsBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -16417,11 +18661,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_8ShH8BhQEem7b6CPWW1OrA" type="Association_Edge" source="_0HBtMBhQEem7b6CPWW1OrA" target="_8RNgYBhQEem7b6CPWW1OrA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_8ShH8xhQEem7b6CPWW1OrA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TYBD4BhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8ShH9BhQEem7b6CPWW1OrA" x="70" y="51"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8ShH9BhQEem7b6CPWW1OrA" x="90" y="51"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8ShH9RhQEem7b6CPWW1OrA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TZcAMBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8ShH9hhQEem7b6CPWW1OrA" x="90" y="135"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8ShH9hhQEem7b6CPWW1OrA" x="70" y="135"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8ShH9xhQEem7b6CPWW1OrA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ta4xsBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -16437,7 +18681,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8ShH_RhQEem7b6CPWW1OrA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TfMC4BhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8ShH_hhQEem7b6CPWW1OrA" x="-37" y="-19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8ShH_hhQEem7b6CPWW1OrA" x="-13" y="-11"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_8ShH8RhQEem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_KtxnUBfzEem7b6CPWW1OrA"/>
@@ -16478,7 +18722,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8rpZpBhQEem7b6CPWW1OrA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TnseoBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8rpZpRhQEem7b6CPWW1OrA" x="-35" y="-19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8rpZpRhQEem7b6CPWW1OrA" x="-13" y="-11"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_8roykRhQEem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_ToWVoBfzEem7b6CPWW1OrA"/>
@@ -16499,11 +18743,11 @@
     <edges xmi:type="notation:Connector" xmi:id="__Pf2cBhQEem7b6CPWW1OrA" type="Association_Edge" source="_1gwgQBhQEem7b6CPWW1OrA" target="__OAosBhQEem7b6CPWW1OrA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__Pf2cxhQEem7b6CPWW1OrA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XsfJwBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__Pf2dBhQEem7b6CPWW1OrA" x="158" y="87"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__Pf2dBhQEem7b6CPWW1OrA" x="86" y="-49"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__Pf2dRhQEem7b6CPWW1OrA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Xt6tIBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__Pf2dhhQEem7b6CPWW1OrA" x="196" y="67"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__Pf2dhhQEem7b6CPWW1OrA" x="66" y="-107"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__Pf2dxhQEem7b6CPWW1OrA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XvUbUBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -16523,9 +18767,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__Pf2cRhQEem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_nqy6ABgkEem7b6CPWW1OrA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Pf2chhQEem7b6CPWW1OrA" points="[820, 273, -643984, -643984]$[820, 380, -643984, -643984]$[920, 380, -643984, -643984]$[920, 480, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X1FFEBhREem7b6CPWW1OrA" id="(0.9087301587301587,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X1FFERhREem7b6CPWW1OrA" id="(0.08264462809917356,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Pf2chhQEem7b6CPWW1OrA" points="[860, 241, -643984, -643984]$[860, 480, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X1FFEBhREem7b6CPWW1OrA" id="(0.9275862068965517,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X1FFERhREem7b6CPWW1OrA" id="(0.0,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_HVshhxhREem7b6CPWW1OrA" type="StereotypeCommentLink" source="_HVg7UBhREem7b6CPWW1OrA" target="_HVshgxhREem7b6CPWW1OrA">
       <styles xmi:type="notation:FontStyle" xmi:id="_HVshiBhREem7b6CPWW1OrA"/>
@@ -16540,11 +18784,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_HXHd0BhREem7b6CPWW1OrA" type="Association_Edge" source="_1gwgQBhQEem7b6CPWW1OrA" target="_HVg7UBhREem7b6CPWW1OrA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_HXHd0xhREem7b6CPWW1OrA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_W0aSQBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HXHd1BhREem7b6CPWW1OrA" x="85" y="51"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HXHd1BhREem7b6CPWW1OrA" x="96" y="51"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_HXHd1RhREem7b6CPWW1OrA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_W11OkBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HXHd1hhREem7b6CPWW1OrA" x="105" y="125"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HXHd1hhREem7b6CPWW1OrA" x="116" y="125"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_HXHd1xhREem7b6CPWW1OrA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_W3c_MBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -16564,9 +18808,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_HXHd0RhREem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_p-ez4BgkEem7b6CPWW1OrA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HXHd0hhREem7b6CPWW1OrA" points="[780, 273, -643984, -643984]$[780, 483, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W9iZEBhREem7b6CPWW1OrA" id="(0.75,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W9iZERhREem7b6CPWW1OrA" id="(0.716012084592145,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HXHd0hhREem7b6CPWW1OrA" points="[740, 241, -643984, -643984]$[740, 480, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W9iZEBhREem7b6CPWW1OrA" id="(0.5137931034482759,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W9iZERhREem7b6CPWW1OrA" id="(0.7250755287009063,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_H8OWBBhREem7b6CPWW1OrA" type="StereotypeCommentLink" source="_H8BhsBhREem7b6CPWW1OrA" target="_H8OWABhREem7b6CPWW1OrA">
       <styles xmi:type="notation:FontStyle" xmi:id="_H8OWBRhREem7b6CPWW1OrA"/>
@@ -16605,9 +18849,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_H95J8RhREem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_rgjDkBgkEem7b6CPWW1OrA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H95J8hhREem7b6CPWW1OrA" points="[660, 241, -643984, -643984]$[660, 300, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhi3wBhREem7b6CPWW1OrA" id="(0.27380952380952384,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhje0BhREem7b6CPWW1OrA" id="(0.49019607843137253,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H95J8hhREem7b6CPWW1OrA" points="[600, 241, -643984, -643984]$[600, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhi3wBhREem7b6CPWW1OrA" id="(0.03103448275862069,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhje0BhREem7b6CPWW1OrA" id="(0.4854368932038835,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IiymwRhREem7b6CPWW1OrA" type="StereotypeCommentLink" source="_IirSABhREem7b6CPWW1OrA" target="_Iix_txhREem7b6CPWW1OrA">
       <styles xmi:type="notation:FontStyle" xmi:id="_IiymwhhREem7b6CPWW1OrA"/>
@@ -16622,11 +18866,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_Ikf28BhREem7b6CPWW1OrA" type="Association_Edge" source="_6fRBoBhQEem7b6CPWW1OrA" target="_IirSABhREem7b6CPWW1OrA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Ikf28xhREem7b6CPWW1OrA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Uqv3EBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ikf29BhREem7b6CPWW1OrA" x="16" y="51"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ikf29BhREem7b6CPWW1OrA" x="16" y="71"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Ikf29RhREem7b6CPWW1OrA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UsKzYBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ikf29hhREem7b6CPWW1OrA" x="-4" y="41"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ikf29hhREem7b6CPWW1OrA" x="-4" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_IkgeABhREem7b6CPWW1OrA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UtlIoBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -16638,11 +18882,11 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_IkgeBBhREem7b6CPWW1OrA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UwcPYBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IkgeBRhREem7b6CPWW1OrA" x="7" y="-5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IkgeBRhREem7b6CPWW1OrA" x="6" y="-25"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_IkgeBhhREem7b6CPWW1OrA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ux2koBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IkgeBxhREem7b6CPWW1OrA" x="-13" y="-11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IkgeBxhREem7b6CPWW1OrA" x="-13" y="-31"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Ikf28RhREem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_tX4YoBgkEem7b6CPWW1OrA"/>
@@ -16679,11 +18923,11 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MpPexBhREem7b6CPWW1OrA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Tu0aUBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MpPexRhREem7b6CPWW1OrA" x="58" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MpPexRhREem7b6CPWW1OrA" x="53" y="15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MpPexhhREem7b6CPWW1OrA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TwZHoBhREem7b6CPWW1OrA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MpPexxhREem7b6CPWW1OrA" x="-53" y="9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MpPexxhREem7b6CPWW1OrA" x="-53" y="15"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_MpO3sRhREem7b6CPWW1OrA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_2FM4oBglEem7b6CPWW1OrA"/>
@@ -16761,18 +19005,20 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_10Jf5RhcEem7b6CPWW1OrA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_10Jf5hhcEem7b6CPWW1OrA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_mr6XMB3HEemKheKmU0GLKg" type="Abstraction_Edge" source="_0HBtMBhQEem7b6CPWW1OrA" target="_228QEBhQEem7b6CPWW1OrA">
+    <edges xmi:type="notation:Connector" xmi:id="_mr6XMB3HEemKheKmU0GLKg" type="Abstraction_Edge" source="_0HBtMBhQEem7b6CPWW1OrA" target="_228QEBhQEem7b6CPWW1OrA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_mr8zcB3HEemKheKmU0GLKg" type="Abstraction_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mr8zcR3HEemKheKmU0GLKg" x="38" y="102"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_v3vC0Dh8Eem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mr8zcR3HEemKheKmU0GLKg" x="3" y="119"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mr8zch3HEemKheKmU0GLKg" type="Abstraction_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mr8zcx3HEemKheKmU0GLKg" x="19" y="107"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wDY5MDh8Eem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mr8zcx3HEemKheKmU0GLKg" x="-17" y="78"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_mr6XMR3HEemKheKmU0GLKg"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_mrvYEB3HEemKheKmU0GLKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mr6XMh3HEemKheKmU0GLKg" points="[240, 80, -643984, -643984]$[240, 21, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m5VIIB3HEemKheKmU0GLKg" id="(0.5783132530120482,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m5VIIR3HEemKheKmU0GLKg" id="(0.6278026905829597,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_m5VIIR3HEemKheKmU0GLKg" id="(0.5511811023622047,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_paonQR3HEemKheKmU0GLKg" type="StereotypeCommentLink" source="_mr6XMB3HEemKheKmU0GLKg" target="_paoAMB3HEemKheKmU0GLKg">
       <styles xmi:type="notation:FontStyle" xmi:id="_paonQh3HEemKheKmU0GLKg"/>
@@ -16783,6 +19029,3485 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_paonQx3HEemKheKmU0GLKg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_paonRB3HEemKheKmU0GLKg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_paonRR3HEemKheKmU0GLKg"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_3g9ZkDaxEem8b5f98b_cVw" type="PapyrusUMLClassDiagram" name="EthInterfaceConnectivity" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_B9nlsDayEem8b5f98b_cVw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_B9nlsjayEem8b5f98b_cVw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B9nlsTayEem8b5f98b_cVw" x="680" y="80" width="221" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B9_ZIDayEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_B9_ZITayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B9_ZIzayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B9_ZIjayEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B-PQwDayEem8b5f98b_cVw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_B-PQwjayEem8b5f98b_cVw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B-PQwTayEem8b5f98b_cVw" x="960" y="80" width="221" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B-Zo0DayEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_B-Zo0TayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B-Zo0zayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B-Zo0jayEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B-qukDayEem8b5f98b_cVw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_B-qukjayEem8b5f98b_cVw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B-qukTayEem8b5f98b_cVw" x="680" y="360" width="221" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B-1GozayEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_B-1GpDayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B-1GpjayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B-1GpTayEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B_QkcDayEem8b5f98b_cVw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_B_QkcjayEem8b5f98b_cVw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B_QkcTayEem8b5f98b_cVw" x="960" y="360" width="221" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B_bjkDayEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_B_bjkTayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B_bjkzayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B_bjkjayEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PLkYQDazEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PLkYQjazEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PLkYQzazEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PLkYRDazEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PLkYRTazEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PLkYRjazEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PLkYRzazEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PLkYSDazEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PLkYSTazEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PLkYSjazEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PLkYSzazEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PLkYTDazEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PLkYTTazEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PLkYTjazEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PLkYTzazEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_PLkYUDazEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_PLkYUTazEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_PLkYUjazEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PLkYUzazEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_9DICoDamEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PLkYQTazEem8b5f98b_cVw" x="980" y="220" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PL2sIDazEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PL2sITazEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PL2sIzazEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_9DICoDamEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PL2sIjazEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WgYD0DbNEem8b5f98b_cVw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WgYq4DbNEem8b5f98b_cVw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WgYD0TbNEem8b5f98b_cVw" x="324" y="83" width="217" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WgxFYDbNEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WgxFYTbNEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WgxFYzbNEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WgxFYjbNEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YPiUUDbNEem8b5f98b_cVw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_YPi7YDbNEem8b5f98b_cVw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YPiUUTbNEem8b5f98b_cVw" x="60" y="80" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_YPvIozbNEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YPvIpDbNEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YPvIpjbNEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YPvIpTbNEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rWcB0DbPEem8b5f98b_cVw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rWco4DbPEem8b5f98b_cVw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rWco4TbPEem8b5f98b_cVw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rWco4jbPEem8b5f98b_cVw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rWco4zbPEem8b5f98b_cVw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rWco5DbPEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rWco5TbPEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rWco5jbPEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rWco5zbPEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rWco6DbPEem8b5f98b_cVw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rWco6TbPEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rWco6jbPEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rWco6zbPEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rWco7DbPEem8b5f98b_cVw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rWco7TbPEem8b5f98b_cVw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rWco7jbPEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rWco7zbPEem8b5f98b_cVw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rWco8DbPEem8b5f98b_cVw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rWco8TbPEem8b5f98b_cVw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_h4caMDbLEem8b5f98b_cVw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rWcB0TbPEem8b5f98b_cVw" x="180" y="220" width="221" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rWlLwzbPEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rWlLxDbPEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rWlLxjbPEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_h4caMDbLEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rWlLxTbPEem8b5f98b_cVw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CVKnYDbQEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CVKnYTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CVKnYzbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wkieYDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CVKnYjbQEem8b5f98b_cVw" x="380" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PUKNYjbQEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PUKNYzbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PUKNZTbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_zMRVoDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PUKNZDbQEem8b5f98b_cVw" x="1000" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_V1WpgDbQEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_V1WpgTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_V1WpgzbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z7X3UDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V1WpgjbQEem8b5f98b_cVw" x="1000" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tYT9gDbQEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tYT9gTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tYT9gzbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_0lkD0DbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tYT9gjbQEem8b5f98b_cVw" x="1000" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3cxFADbQEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3cxFATbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3cxFAzbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qNckADbQEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3cxFAjbQEem8b5f98b_cVw" x="1000" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8pTbUDbQEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8pTbUTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8pTbUzbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_1rtzkDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8pTbUjbQEem8b5f98b_cVw" x="1000" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_x9wscDiCEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_x9xTgDiCEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_x9xTgTiCEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_x9x6kDiCEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_x9x6kTiCEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_x9x6kjiCEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_x9x6kziCEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_x9x6lDiCEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9x6lTiCEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_x9x6ljiCEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_x9x6lziCEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_x9x6mDiCEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_x9x6mTiCEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9x6mjiCEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_x9yhoDiCEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_x9yhoTiCEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_x9yhojiCEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_x9yhoziCEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9yhpDiCEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_M-QGADh9Eem1lYbrIE6BNw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9wscTiCEem1lYbrIE6BNw" x="640" y="220" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_x-OmgziCEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_x-OmhDiCEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x-OmhjiCEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_M-QGADh9Eem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x-OmhTiCEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_M2PKwDiDEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_M2PKwTiDEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_M2PKwziDEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_J_wF0DiDEem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M2PKwjiDEem1lYbrIE6BNw" x="840" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_awPngDiDEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_awPngTiDEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_awPngziDEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_XkjHkDiDEem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_awPngjiDEem1lYbrIE6BNw" x="840" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yshvkDiFEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yshvkTiFEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yshvkziFEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rB4YEDiFEem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yshvkjiFEem1lYbrIE6BNw" x="840" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7j1GYzlUEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7j1GZDlUEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7j1GZjlUEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6ZqZUDlUEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7j1GZTlUEemSPvPXzEQ11A" x="380" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_R7_bMDlVEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_R7_bMTlVEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_R7_bMzlVEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RFR1oDlVEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R7_bMjlVEemSPvPXzEQ11A" x="840" y="120"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_i4lfMDlVEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_i4lfMTlVEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i4lfMzlVEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_hHFFUDlVEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i4lfMjlVEemSPvPXzEQ11A" x="1180" y="120"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_3g9ZkTaxEem8b5f98b_cVw" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_3g9ZkjaxEem8b5f98b_cVw"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_3g9ZkzaxEem8b5f98b_cVw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_B9_ZJDayEem8b5f98b_cVw" type="StereotypeCommentLink" source="_B9nlsDayEem8b5f98b_cVw" target="_B9_ZIDayEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_B9_ZJTayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B9_ZKTayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B9_ZJjayEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B9_ZJzayEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B9_ZKDayEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_B-Zo1DayEem8b5f98b_cVw" type="StereotypeCommentLink" source="_B-PQwDayEem8b5f98b_cVw" target="_B-Zo0DayEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_B-Zo1TayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B-Zo2TayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B-Zo1jayEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B-Zo1zayEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B-Zo2DayEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_B-1GpzayEem8b5f98b_cVw" type="StereotypeCommentLink" source="_B-qukDayEem8b5f98b_cVw" target="_B-1GozayEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_B-1GqDayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B-1tsDayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B-1GqTayEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B-1GqjayEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B-1GqzayEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_B_bjlDayEem8b5f98b_cVw" type="StereotypeCommentLink" source="_B_QkcDayEem8b5f98b_cVw" target="_B_bjkDayEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_B_bjlTayEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_B_bjmTayEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B_bjljayEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B_bjlzayEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B_bjmDayEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PL2sJDazEem8b5f98b_cVw" type="StereotypeCommentLink" source="_PLkYQDazEem8b5f98b_cVw" target="_PL2sIDazEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PL2sJTazEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PL2sKTazEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_9DICoDamEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PL2sJjazEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PL2sJzazEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PL2sKDazEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WgxFZDbNEem8b5f98b_cVw" type="StereotypeCommentLink" source="_WgYD0DbNEem8b5f98b_cVw" target="_WgxFYDbNEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WgxFZTbNEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WgxFaTbNEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WgxFZjbNEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WgxFZzbNEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WgxFaDbNEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YPvIpzbNEem8b5f98b_cVw" type="StereotypeCommentLink" source="_YPiUUDbNEem8b5f98b_cVw" target="_YPvIozbNEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YPvIqDbNEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YPvvsDbNEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YPvIqTbNEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YPvIqjbNEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YPvIqzbNEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rWlLxzbPEem8b5f98b_cVw" type="StereotypeCommentLink" source="_rWcB0DbPEem8b5f98b_cVw" target="_rWlLwzbPEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rWlLyDbPEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rWlLzDbPEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_h4caMDbLEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rWlLyTbPEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rWlLyjbPEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rWlLyzbPEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_wkk6oDbPEem8b5f98b_cVw" type="Abstraction_Edge" source="_rWcB0DbPEem8b5f98b_cVw" target="_YPiUUDbNEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_wklhsDbPEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8UxyQDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wklhsTbPEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_wklhsjbPEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8V3XYDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wklhszbPEem8b5f98b_cVw" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_wkk6oTbPEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_wkieYDbPEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wkk6ojbPEem8b5f98b_cVw" points="[200, 220, -643984, -643984]$[200, 141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wmwE4DbPEem8b5f98b_cVw" id="(0.09049773755656108,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wmwE4TbPEem8b5f98b_cVw" id="(0.6965174129353234,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zMTK0DbPEem8b5f98b_cVw" type="Abstraction_Edge" source="_PLkYQDazEem8b5f98b_cVw" target="_B9nlsDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_zMTK0zbPEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4eCxQDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zMTK1DbPEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_zMTK1TbPEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4fJkgDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zMTK1jbPEem8b5f98b_cVw" x="-18" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_zMTK0TbPEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_zMRVoDbPEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zMTK0jbPEem8b5f98b_cVw" points="[1000, 220, -643984, -643984]$[1000, 180, -643984, -643984]$[860, 180, -643984, -643984]$[860, 141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zO06YDbPEem8b5f98b_cVw" id="(0.08298755186721991,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zO06YTbPEem8b5f98b_cVw" id="(0.9049773755656109,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_z7ZsgDbPEem8b5f98b_cVw" type="Abstraction_Edge" source="_PLkYQDazEem8b5f98b_cVw" target="_B-PQwDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_z7ZsgzbPEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_4zJekDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z7ZshDbPEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_z7ZshTbPEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_40PqwDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z7ZshjbPEem8b5f98b_cVw" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_z7ZsgTbPEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_z7X3UDbPEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z7ZsgjbPEem8b5f98b_cVw" points="[1160, 220, -643984, -643984]$[1160, 141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z9ld0DbPEem8b5f98b_cVw" id="(0.7468879668049793,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z9ld0TbPEem8b5f98b_cVw" id="(0.9049773755656109,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0lmgEDbPEem8b5f98b_cVw" type="Abstraction_Edge" source="_PLkYQDazEem8b5f98b_cVw" target="_B-qukDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_0lmgEzbPEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_57veUDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0lmgFDbPEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_0lmgFTbPEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_581qgDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0lmgFjbPEem8b5f98b_cVw" x="-29" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_0lmgETbPEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_0lkD0DbPEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0lmgEjbPEem8b5f98b_cVw" points="[1000, 281, -643984, -643984]$[1000, 300, -643984, -643984]$[860, 300, -643984, -643984]$[860, 360, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0o32gDbPEem8b5f98b_cVw" id="(0.08298755186721991,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0o4dkDbPEem8b5f98b_cVw" id="(0.8144796380090498,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1rvowDbPEem8b5f98b_cVw" type="Abstraction_Edge" source="_PLkYQDazEem8b5f98b_cVw" target="_B_QkcDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1rvowzbPEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5MB4oDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1rvoxDbPEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1rwP0DbPEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5NLIIDbPEem8b5f98b_cVw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_1rwP0TbPEem8b5f98b_cVw" x="-14" y="-16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_1rvowTbPEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_1rtzkDbPEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1rvowjbPEem8b5f98b_cVw" points="[1160, 281, -643984, -643984]$[1160, 360, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1t6zADbPEem8b5f98b_cVw" id="(0.7468879668049793,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1t6zATbPEem8b5f98b_cVw" id="(0.9049773755656109,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CVKnZDbQEem8b5f98b_cVw" type="StereotypeCommentLink" source="_wkk6oDbPEem8b5f98b_cVw" target="_CVKnYDbQEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CVKnZTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CVKnaTbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wkieYDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CVKnZjbQEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CVKnZzbQEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CVKnaDbQEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_PUK0cDbQEem8b5f98b_cVw" type="StereotypeCommentLink" source="_zMTK0DbPEem8b5f98b_cVw" target="_PUKNYjbQEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PUK0cTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PUK0dTbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_zMRVoDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PUK0cjbQEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PUK0czbQEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PUK0dDbQEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_V1WphDbQEem8b5f98b_cVw" type="StereotypeCommentLink" source="_z7ZsgDbPEem8b5f98b_cVw" target="_V1WpgDbQEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_V1WphTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_V1WpiTbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z7X3UDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_V1WphjbQEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V1WphzbQEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V1WpiDbQEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qNfnUDbQEem8b5f98b_cVw" type="Abstraction_Edge" source="_PLkYQDazEem8b5f98b_cVw" target="_B_QkcDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_qNgOYDbQEem8b5f98b_cVw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3LFs8DiCEem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qNgOYTbQEem8b5f98b_cVw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qNgOYjbQEem8b5f98b_cVw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3M0LQDiCEem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qNgOYzbQEem8b5f98b_cVw" x="-34" y="-76"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_qNfnUTbQEem8b5f98b_cVw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_qNckADbQEem8b5f98b_cVw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qNfnUjbQEem8b5f98b_cVw" points="[1140, 281, -643984, -643984]$[1140, 360, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qQ0BEDbQEem8b5f98b_cVw" id="(0.6639004149377593,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qQ0BETbQEem8b5f98b_cVw" id="(0.8144796380090498,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tYT9hDbQEem8b5f98b_cVw" type="StereotypeCommentLink" source="_0lmgEDbPEem8b5f98b_cVw" target="_tYT9gDbQEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tYT9hTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tYT9iTbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_0lkD0DbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tYT9hjbQEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tYT9hzbQEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tYT9iDbQEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3cxFBDbQEem8b5f98b_cVw" type="StereotypeCommentLink" source="_qNfnUDbQEem8b5f98b_cVw" target="_3cxFADbQEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3cxFBTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3cxsEjbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qNckADbQEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3cxFBjbQEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3cxsEDbQEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3cxsETbQEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8pTbVDbQEem8b5f98b_cVw" type="StereotypeCommentLink" source="_1rvowDbPEem8b5f98b_cVw" target="_8pTbUDbQEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8pTbVTbQEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8pUCYDbQEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_1rtzkDbPEem8b5f98b_cVw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8pTbVjbQEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8pTbVzbQEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8pTbWDbQEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_x-PNkDiCEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_x9wscDiCEem1lYbrIE6BNw" target="_x-OmgziCEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_x-PNkTiCEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x-PNlTiCEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_M-QGADh9Eem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_x-PNkjiCEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x-PNkziCEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x-PNlDiCEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_J_zJIDiDEem1lYbrIE6BNw" type="Abstraction_Edge" source="_x9wscDiCEem1lYbrIE6BNw" target="_B9nlsDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_J_zwMDiDEem1lYbrIE6BNw" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_J_zwMTiDEem1lYbrIE6BNw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_J_0XQDiDEem1lYbrIE6BNw" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_J_0XQTiDEem1lYbrIE6BNw" x="-7" y="-62"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_J_zJITiDEem1lYbrIE6BNw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_J_wF0DiDEem1lYbrIE6BNw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J_zJIjiDEem1lYbrIE6BNw" points="[760, 220, -643984, -643984]$[760, 141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KDf9YDiDEem1lYbrIE6BNw" id="(0.4979253112033195,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KDf9YTiDEem1lYbrIE6BNw" id="(0.36199095022624433,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_M2PKxDiDEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_J_zJIDiDEem1lYbrIE6BNw" target="_M2PKwDiDEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_M2PKxTiDEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_M2PKyTiDEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_J_wF0DiDEem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M2PKxjiDEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M2PKxziDEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M2PKyDiDEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Xkk8wDiDEem1lYbrIE6BNw" type="Abstraction_Edge" source="_x9wscDiCEem1lYbrIE6BNw" target="_B-PQwDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Xklj0DiDEem1lYbrIE6BNw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hht7UDiDEem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xklj0TiDEem1lYbrIE6BNw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Xklj0jiDEem1lYbrIE6BNw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_hkZb4DiDEem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Xklj0ziDEem1lYbrIE6BNw" x="-72" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Xkk8wTiDEem1lYbrIE6BNw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_XkjHkDiDEem1lYbrIE6BNw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xkk8wjiDEem1lYbrIE6BNw" points="[800, 220, -643984, -643984]$[800, 200, -643984, -643984]$[1020, 200, -643984, -643984]$[1020, 141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XolTADiDEem1lYbrIE6BNw" id="(0.6639004149377593,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xol6EDiDEem1lYbrIE6BNw" id="(0.27149321266968324,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_awPnhDiDEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_Xkk8wDiDEem1lYbrIE6BNw" target="_awPngDiDEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_awPnhTiDEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_awQOkTiDEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_XkjHkDiDEem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_awPnhjiDEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_awPnhziDEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_awQOkDiDEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rB6NQDiFEem1lYbrIE6BNw" type="Abstraction_Edge" source="_x9wscDiCEem1lYbrIE6BNw" target="_B_QkcDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rB60UDiFEem1lYbrIE6BNw" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_41eDwDiFEem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rB60UTiFEem1lYbrIE6BNw" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rB60UjiFEem1lYbrIE6BNw" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_43kVgDiFEem1lYbrIE6BNw" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rB60UziFEem1lYbrIE6BNw" x="-53" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_rB6NQTiFEem1lYbrIE6BNw"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_rB4YEDiFEem1lYbrIE6BNw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rB6NQjiFEem1lYbrIE6BNw" points="[740, 281, -643984, -643984]$[740, 340, -643984, -643984]$[1000, 340, -643984, -643984]$[1000, 360, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rGGJsDiFEem1lYbrIE6BNw" id="(0.4149377593360996,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rGGJsTiFEem1lYbrIE6BNw" id="(0.18099547511312217,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ysiWoDiFEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_rB6NQDiFEem1lYbrIE6BNw" target="_yshvkDiFEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ysiWoTiFEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysiWpTiFEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rB4YEDiFEem1lYbrIE6BNw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ysiWojiFEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysiWoziFEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysiWpDiFEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6Zs1kDlUEemSPvPXzEQ11A" type="Abstraction_Edge" source="_rWcB0DbPEem8b5f98b_cVw" target="_WgYD0DbNEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6Zs1kzlUEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AqvV0DlVEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6Zs1lDlUEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6Zs1lTlUEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_AssdoDlVEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6Zs1ljlUEemSPvPXzEQ11A" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_6Zs1kTlUEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_6ZqZUDlUEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Zs1kjlUEemSPvPXzEQ11A" points="[380, 220, -643984, -643984]$[380, 141, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6eG0cDlUEemSPvPXzEQ11A" id="(0.9049773755656109,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6eG0cTlUEemSPvPXzEQ11A" id="(0.25806451612903225,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7j1GZzlUEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_6Zs1kDlUEemSPvPXzEQ11A" target="_7j1GYzlUEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7j1GaDlUEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7j1tcjlUEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6ZqZUDlUEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7j1GaTlUEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7j1tcDlUEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7j1tcTlUEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RFScsDlVEemSPvPXzEQ11A" type="Abstraction_Edge" source="_x9wscDiCEem1lYbrIE6BNw" target="_B-qukDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_RFTDwDlVEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VMHvMDlVEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RFTDwTlVEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RFTDwjlVEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VOLksDlVEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RFTDwzlVEemSPvPXzEQ11A" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_RFScsTlVEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_RFR1oDlVEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RFScsjlVEemSPvPXzEQ11A" points="[720, 281, -643984, -643984]$[720, 360, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RJ7sIDlVEemSPvPXzEQ11A" id="(0.33195020746887965,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RJ7sITlVEemSPvPXzEQ11A" id="(0.18099547511312217,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_R7_bNDlVEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_RFScsDlVEemSPvPXzEQ11A" target="_R7_bMDlVEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_R7_bNTlVEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_R7_bOTlVEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_RFR1oDlVEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_R7_bNjlVEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_R7_bNzlVEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_R7_bODlVEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hHGTcDlVEemSPvPXzEQ11A" type="Abstraction_Edge" source="_PLkYQDazEem8b5f98b_cVw" target="_B-qukDayEem8b5f98b_cVw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_hHGTczlVEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_nmn7oDlVEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hHGTdDlVEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_hHGTdTlVEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_nolqgDlVEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hHG6gDlVEemSPvPXzEQ11A" x="-39" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_hHGTcTlVEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_hHFFUDlVEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hHGTcjlVEemSPvPXzEQ11A" points="[1040, 281, -643984, -643984]$[1040, 320, -643984, -643984]$[880, 320, -643984, -643984]$[880, 360, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hLPMkDlVEemSPvPXzEQ11A" id="(0.24896265560165975,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hLPMkTlVEemSPvPXzEQ11A" id="(0.9049773755656109,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_i4lfNDlVEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_hHGTcDlVEemSPvPXzEQ11A" target="_i4lfMDlVEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_i4lfNTlVEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i4lfOTlVEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_hHFFUDlVEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i4lfNjlVEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i4lfNzlVEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i4lfODlVEemSPvPXzEQ11A"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_vL3gsDiPEem1lYbrIE6BNw" type="PapyrusUMLClassDiagram" name="EthInterfaceOamService" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_2hts4DiPEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_2huT8DiPEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2huT8TiPEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2huT8jiPEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2huT8ziPEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2huT9DiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2huT9TiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2huT9jiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2huT9ziPEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2huT-DiPEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2huT-TiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2huT-jiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2huT-ziPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2huT_DiPEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2huT_TiPEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2huT_jiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2huT_ziPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2huUADiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2huUATiPEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_NoBnwBXLEemlb5smEiStFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2hts4TiPEem1lYbrIE6BNw" x="140" y="160" width="241" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_2iAAwziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_2iAAxDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2iAAxjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NoBnwBXLEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2iAAxTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_24a8sDiPEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_24a8sjiPEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_24a8sziPEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_24a8tDiPEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_24a8tTiPEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_24a8tjiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_24a8tziPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_24a8uDiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_24a8uTiPEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_24a8ujiPEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_24a8uziPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_24a8vDiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_24a8vTiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_24a8vjiPEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_24a8vziPEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_24a8wDiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_24a8wTiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_24a8wjiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_24a8wziPEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_24a8sTiPEem1lYbrIE6BNw" x="420" y="160" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_24sCcziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_24sCdDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_24sCdjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_24sCdTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3ODOcDiPEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3OD1gDiPEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3OD1gTiPEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3OD1gjiPEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3OD1gziPEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3OD1hDiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3OD1hTiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3OD1hjiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3OD1hziPEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3OD1iDiPEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3OD1iTiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3OD1ijiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3OD1iziPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3OD1jDiPEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3OD1jTiPEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3OD1jjiPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3OD1jziPEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3OD1kDiPEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3OD1kTiPEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ODOcTiPEem1lYbrIE6BNw" x="-140" y="160" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3OTtIziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3OUUMDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3OUUMjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3OUUMTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5OAUADiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5OA7EDiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5OAUATiPEem1lYbrIE6BNw" x="40" y="300" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5OLTIziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5OLTJDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OL6MDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5OLTJTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5x32EDiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5x32EjiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5x32ETiPEem1lYbrIE6BNw" x="40" y="20" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5yBnEDiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5yBnETiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5yBnEziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5yBnEjiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6O6-cDiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6O7lgDiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6O6-cTiPEem1lYbrIE6BNw" x="300" y="20" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6PEvcziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6PEvdDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6PFWgDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6PEvdTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6nB8cDiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6nB8cjiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6nB8cTiPEem1lYbrIE6BNw" x="300" y="300" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6nLtcDiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6nLtcTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6nLtcziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6nLtcjiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7IWg0DiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7IWg0jiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7IWg0TiPEem1lYbrIE6BNw" x="760" y="300" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7IgR0DiPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7IgR0TiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7IgR0ziPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7IgR0jiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8QZuADiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8QZuAjiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8QZuATiPEem1lYbrIE6BNw" x="1120" y="300" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8QjfAziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8QjfBDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8QjfBjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8QjfBTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8t2fADiPEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8t2fAjiPEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8t2fATiPEem1lYbrIE6BNw" x="940" y="20" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8uAQAziPEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8uAQBDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8uAQBjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8uAQBTiPEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nyBv4DiQEem1lYbrIE6BNw" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nyBv4jiQEem1lYbrIE6BNw" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyBv4TiQEem1lYbrIE6BNw" x="40" y="540" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nyMH8DiQEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nyMH8TiQEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyMH8ziQEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyMH8jiQEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QErM8DiUEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QErM8jiUEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QEr0ADiUEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QEr0ATiUEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QEr0AjiUEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QEr0AziUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QEr0BDiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QEr0BTiUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QEr0BjiUEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QEr0BziUEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QEr0CDiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QEr0CTiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QEr0CjiUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QEr0CziUEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QEr0DDiUEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QEr0DTiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QEr0DjiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QEr0DziUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QEr0EDiUEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_lJFbwE-xEeitY7qZgkO_XQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QErM8TiUEem1lYbrIE6BNw" x="380" y="640" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QE9g0ziUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QE9g1DiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QE9g1jiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_lJFbwE-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QE9g1TiUEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QmI7QDiUEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QmJiUDiUEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QmJiUTiUEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QmJiUjiUEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QmJiUziUEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QmJiVDiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QmJiVTiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QmJiVjiUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QmJiVziUEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QmJiWDiUEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QmJiWTiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QmJiWjiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QmJiWziUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QmJiXDiUEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QmJiXTiUEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QmJiXjiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QmJiXziUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QmJiYDiUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QmJiYTiUEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_jrxwQE-xEeitY7qZgkO_XQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QmI7QTiUEem1lYbrIE6BNw" x="380" y="540" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QmZZ8ziUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QmZZ9DiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QmZZ9jiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_jrxwQE-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QmZZ9TiUEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Rcab8DiUEem1lYbrIE6BNw" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Rcab8jiUEem1lYbrIE6BNw" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Rcab8ziUEem1lYbrIE6BNw" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Rcab9DiUEem1lYbrIE6BNw" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Rcab9TiUEem1lYbrIE6BNw" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Rcab9jiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Rcab9ziUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Rcab-DiUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Rcab-TiUEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RcbDADiUEem1lYbrIE6BNw" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RcbDATiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RcbDAjiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RcbDAziUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RcbDBDiUEem1lYbrIE6BNw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RcbDBTiUEem1lYbrIE6BNw" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RcbDBjiUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RcbDBziUEem1lYbrIE6BNw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RcbDCDiUEem1lYbrIE6BNw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RcbDCTiUEem1lYbrIE6BNw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_iN418E-xEeitY7qZgkO_XQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Rcab8TiUEem1lYbrIE6BNw" x="380" y="440" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Rct98ziUEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Rct99DiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Rct99jiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_iN418E-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Rct99TiUEem1lYbrIE6BNw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0EsjgDkhEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_0EsjgTkhEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0EsjgzkhEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_l-v8gDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0EsjgjkhEemjx6Nna_xyog" x="340" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7a5VADkhEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7a5VATkhEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7a5VAzkhEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_nagI0DkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7a5VAjkhEemjx6Nna_xyog" x="340" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KT2tUDkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KT2tUTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KT2tUzkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_JRFowDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KT2tUjkiEemjx6Nna_xyog" x="860" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RWuTIDkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_RWuTITkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RWuTIzkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_QUL4EDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RWuTIjkiEemjx6Nna_xyog" x="1140" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_cULfMDkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_cULfMTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cULfMzkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_bNLa4DkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cULfMjkiEemjx6Nna_xyog" x="60" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fa0gADkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fa0gATkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fa1HEDkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_eYaAwDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fa0gAjkiEemjx6Nna_xyog" x="620" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tsf14DkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tsf14TkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tsf14zkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sohQYDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tsf14jkiEemjx6Nna_xyog" x="60" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xclcUDkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_xclcUTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xclcUzkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wDwBIDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xclcUjkiEemjx6Nna_xyog" x="620" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3kZIEDkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3kZIETkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3kZIEzkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_16iOUDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3kZIEjkiEemjx6Nna_xyog" x="60" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-c9iYzkiEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-c9iZDkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-c9iZjkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_oOE60DkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-c9iZTkiEemjx6Nna_xyog" x="340" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E0azsDkjEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E0azsTkjEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0azszkjEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_tLugkDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E0azsjkjEemjx6Nna_xyog" x="340" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KBmqQzkjEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KBmqRDkjEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KBnRUDkjEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uEvzQDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KBmqRTkjEemjx6Nna_xyog" x="340" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QT8yEDkjEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QT8yETkjEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QT8yEzkjEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_o_tzIDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QT8yEjkjEemjx6Nna_xyog" x="340" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iZdJcDkkEemjx6Nna_xyog" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_iZdwgDkkEemjx6Nna_xyog" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iZdwgTkkEemjx6Nna_xyog" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iZdwgjkkEemjx6Nna_xyog" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_iZdwgzkkEemjx6Nna_xyog" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_iZdwhDkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_iZdwhTkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_iZdwhjkkEemjx6Nna_xyog"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZdwhzkkEemjx6Nna_xyog"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_iZeXkDkkEemjx6Nna_xyog" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_iZeXkTkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_iZeXkjkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_iZeXkzkkEemjx6Nna_xyog"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZeXlDkkEemjx6Nna_xyog"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_iZeXlTkkEemjx6Nna_xyog" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_iZeXljkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_iZeXlzkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_iZeXmDkkEemjx6Nna_xyog"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZeXmTkkEemjx6Nna_xyog"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZdJcTkkEemjx6Nna_xyog" x="740" y="160" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iZ7qkzkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iZ7qlDkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iZ8RoDkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZ7qlTkkEemjx6Nna_xyog" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_id2hQDkkEemjx6Nna_xyog" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_id3IUDkkEemjx6Nna_xyog" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_id3IUTkkEemjx6Nna_xyog" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_id3IUjkkEemjx6Nna_xyog" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_id3IUzkkEemjx6Nna_xyog" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_id3IVDkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_id3IVTkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_id3IVjkkEemjx6Nna_xyog"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_id3IVzkkEemjx6Nna_xyog"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_id3IWDkkEemjx6Nna_xyog" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_id3IWTkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_id3IWjkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_id3IWzkkEemjx6Nna_xyog"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_id3IXDkkEemjx6Nna_xyog"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_id3IXTkkEemjx6Nna_xyog" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_id3IXjkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_id3IXzkkEemjx6Nna_xyog"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_id3IYDkkEemjx6Nna_xyog"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_id3IYTkkEemjx6Nna_xyog"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_id2hQTkkEemjx6Nna_xyog" x="1100" y="160" width="241" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ieIOEDkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ieIOETkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ieIOEzkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ieIOEjkkEemjx6Nna_xyog" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_sN438DkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_sN438TkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sN438zkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rDBAQDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sN438jkkEemjx6Nna_xyog" x="940" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v6NYsDkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v6NYsTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v6NYszkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uxTP4DkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v6NYsjkkEemjx6Nna_xyog" x="1300" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3GgAQDkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3GgAQTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3GgAQzkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_10m6kDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3GgAQjkkEemjx6Nna_xyog" x="940" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_53L_MDkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_53L_MTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_53L_MzkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4yhdMDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_53L_MjkkEemjx6Nna_xyog" x="1300" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-WNIMDkkEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-WNIMTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-WNIMzkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9InTsDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-WNIMjkkEemjx6Nna_xyog" x="940" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BB7HkDklEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BB7HkTklEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BB7HkzklEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#__0Y9cDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BB7HkjklEemjx6Nna_xyog" x="1300" y="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ReB4MzkmEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ReCfQDkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ReCfQjkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_KtbHEDkmEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ReCfQTkmEemjx6Nna_xyog" x="580" y="340"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XrRdkDkmEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XrRdkTkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XrRdkzkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Lb7L0DkmEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XrRdkjkmEemjx6Nna_xyog" x="580" y="440"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_aqiEADkmEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_aqiEATkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aqiEAzkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MJVEYDkmEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aqiEAjkmEemjx6Nna_xyog" x="580" y="540"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NTyrkDlWEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NTyrkTlWEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NTyrkzlWEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MF8YYDlWEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NTyrkjlWEemSPvPXzEQ11A" x="620" y="60"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_vL3gsTiPEem1lYbrIE6BNw" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_vL3gsjiPEem1lYbrIE6BNw"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_vL3gsziPEem1lYbrIE6BNw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_2iAAxziPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_2hts4DiPEem1lYbrIE6BNw" target="_2iAAwziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_2iAAyDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2iAAzDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NoBnwBXLEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2iAAyTiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2iAAyjiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2iAAyziPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_24sCdziPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_24a8sDiPEem1lYbrIE6BNw" target="_24sCcziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_24sCeDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_24sCfDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_24sCeTiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_24sCejiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_24sCeziPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3OUUMziPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_3ODOcDiPEem1lYbrIE6BNw" target="_3OTtIziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3OUUNDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3OUUODiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3OUUNTiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3OUUNjiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3OUUNziPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5OL6MTiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_5OAUADiPEem1lYbrIE6BNw" target="_5OLTIziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5OL6MjiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OL6NjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5OL6MziPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OL6NDiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OL6NTiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5yBnFDiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_5x32EDiPEem1lYbrIE6BNw" target="_5yBnEDiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5yBnFTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5yBnGTiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5yBnFjiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5yBnFziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5yBnGDiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6PFWgTiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_6O6-cDiPEem1lYbrIE6BNw" target="_6PEvcziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6PFWgjiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6PFWhjiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6PFWgziPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6PFWhDiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6PFWhTiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6nLtdDiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_6nB8cDiPEem1lYbrIE6BNw" target="_6nLtcDiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6nLtdTiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6nLteTiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6nLtdjiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6nLtdziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6nLteDiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7IgR1DiPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_7IWg0DiPEem1lYbrIE6BNw" target="_7IgR0DiPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7IgR1TiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7IgR2TiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7IgR1jiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7IgR1ziPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7IgR2DiPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8QjfBziPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_8QZuADiPEem1lYbrIE6BNw" target="_8QjfAziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8QjfCDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8QjfDDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8QjfCTiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8QjfCjiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8QjfCziPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8uAQBziPEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_8t2fADiPEem1lYbrIE6BNw" target="_8uAQAziPEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8uAQCDiPEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8uAQDDiPEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8uAQCTiPEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8uAQCjiPEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8uAQCziPEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nyMH9DiQEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_nyBv4DiQEem1lYbrIE6BNw" target="_nyMH8DiQEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nyMH9TiQEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyMH-TiQEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nyMH9jiQEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyMH9ziQEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyMH-DiQEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QE9g1ziUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_QErM8DiUEem1lYbrIE6BNw" target="_QE9g0ziUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QE9g2DiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QE-H4DiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_lJFbwE-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QE9g2TiUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QE9g2jiUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QE9g2ziUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QmaBADiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_QmI7QDiUEem1lYbrIE6BNw" target="_QmZZ8ziUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QmaBATiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QmaBBTiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_jrxwQE-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QmaBAjiUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QmaBAziUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QmaBBDiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RculADiUEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_Rcab8DiUEem1lYbrIE6BNw" target="_Rct98ziUEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RculATiUEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RculBTiUEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_iN418E-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RculAjiUEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RculAziUEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RculBDiUEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_l-2qMDkhEemjx6Nna_xyog" type="Abstraction_Edge" source="_2hts4DiPEem1lYbrIE6BNw" target="_5x32EDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_l-4fYDkhEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ywS8YDkhEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l-5GcDkhEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_l-5GcTkhEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yyYAADkhEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l-5GcjkhEemjx6Nna_xyog" x="-27" y="38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_l-2qMTkhEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_l-v8gDkhEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l-2qMjkhEemjx6Nna_xyog" points="[160, 160, -643984, -643984]$[160, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mCVcADkhEemjx6Nna_xyog" id="(0.08298755186721991,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mCVcATkhEemjx6Nna_xyog" id="(0.5970149253731343,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nah-ADkhEemjx6Nna_xyog" type="Abstraction_Edge" source="_2hts4DiPEem1lYbrIE6BNw" target="_6O6-cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nah-AzkhEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6I_BMDkhEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nah-BDkhEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nah-BTkhEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_6Ky_EDkhEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nah-BjkhEemjx6Nna_xyog" x="-27" y="-2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nah-ATkhEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_nagI0DkhEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nah-AjkhEemjx6Nna_xyog" points="[360, 160, -643984, -643984]$[360, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_neR1kDkhEemjx6Nna_xyog" id="(0.9128630705394191,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_neR1kTkhEemjx6Nna_xyog" id="(0.29850746268656714,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_oOGwADkhEemjx6Nna_xyog" type="Abstraction_Edge" source="_2hts4DiPEem1lYbrIE6BNw" target="_5OAUADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_oOGwAzkhEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u7T88DkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oOGwBDkhEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_oOGwBTkhEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_u-UNoDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oOGwBjkhEemjx6Nna_xyog" x="8" y="22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_oOGwATkhEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_oOE60DkhEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oOGwAjkhEemjx6Nna_xyog" points="[160, 217, -643984, -643984]$[160, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oRkTsDkhEemjx6Nna_xyog" id="(0.08298755186721991,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oRkTsTkhEemjx6Nna_xyog" id="(0.5970149253731343,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_o_voUDkhEemjx6Nna_xyog" type="Abstraction_Edge" source="_2hts4DiPEem1lYbrIE6BNw" target="_6nB8cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_voUzkhEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1dP_8DkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_voVDkhEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_wPYDkhEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1gSF0DkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_wPYTkhEemjx6Nna_xyog" x="-32" y="-38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_o_voUTkhEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_o_tzIDkhEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_o_voUjkhEemjx6Nna_xyog" points="[360, 217, -643984, -643984]$[360, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pDijMDkhEemjx6Nna_xyog" id="(0.9128630705394191,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pDijMTkhEemjx6Nna_xyog" id="(0.29850746268656714,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tLwVwDkhEemjx6Nna_xyog" type="Abstraction_Edge" source="_2hts4DiPEem1lYbrIE6BNw" target="_5OAUADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_tLwVwzkhEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vpWHoDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tLwVxDkhEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_tLw80DkhEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vsTVADkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tLw80TkhEemjx6Nna_xyog" x="-32" y="-38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_tLwVwTkhEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_tLugkDkhEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tLwVwjkhEemjx6Nna_xyog" points="[200, 217, -643984, -643984]$[200, 260, -643984, -643984]$[180, 260, -643984, -643984]$[180, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tPQVsDkhEemjx6Nna_xyog" id="(0.24896265560165975,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tPQVsTkhEemjx6Nna_xyog" id="(0.7960199004975125,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uExBYDkhEemjx6Nna_xyog" type="Abstraction_Edge" source="_2hts4DiPEem1lYbrIE6BNw" target="_6nB8cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uExocDkhEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0wF_ADkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uExocTkhEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uExocjkhEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0zIr8DkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uExoczkhEemjx6Nna_xyog" x="-12" y="42"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_uExBYTkhEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_uEvzQDkhEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uExBYjkhEemjx6Nna_xyog" points="[320, 217, -643984, -643984]$[320, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIu7YDkhEemjx6Nna_xyog" id="(0.7468879668049793,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIu7YTkhEemjx6Nna_xyog" id="(0.09950248756218906,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0EsjhDkhEemjx6Nna_xyog" type="StereotypeCommentLink" source="_l-2qMDkhEemjx6Nna_xyog" target="_0EsjgDkhEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0EsjhTkhEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0EtKkzkhEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_l-v8gDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0EtKkDkhEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0EtKkTkhEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0EtKkjkhEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7a5VBDkhEemjx6Nna_xyog" type="StereotypeCommentLink" source="_nah-ADkhEemjx6Nna_xyog" target="_7a5VADkhEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7a5VBTkhEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7a5VCTkhEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_nagI0DkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7a5VBjkhEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7a5VBzkhEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7a5VCDkhEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JRHd8DkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_3ODOcDiPEem1lYbrIE6BNw" target="_5x32EDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JRHd8zkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VuVzoDkiEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JRHd9DkiEemjx6Nna_xyog" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JRHd9TkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VxMTUDkiEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JRHd9jkiEemjx6Nna_xyog" x="13" y="38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_JRHd8TkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_JRFowDkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JRHd8jkiEemjx6Nna_xyog" points="[60, 160, -643984, -643984]$[60, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWP1kDkiEemjx6Nna_xyog" id="(0.8298755186721992,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWP1kTkiEemjx6Nna_xyog" id="(0.09950248756218906,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KT2tVDkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_JRHd8DkiEemjx6Nna_xyog" target="_KT2tUDkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KT2tVTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KT3UYjkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_JRFowDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KT2tVjkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KT3UYDkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KT3UYTkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QUNGMDkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_24a8sDiPEem1lYbrIE6BNw" target="_5x32EDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QUNtQDkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Wl9YIDkiEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QUNtQTkiEemjx6Nna_xyog" x="-2" y="37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QUNtQjkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WoP3IDkiEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QUNtQzkiEemjx6Nna_xyog" x="-18" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_QUNGMTkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_QUL4EDkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QUNGMjkiEemjx6Nna_xyog" points="[520, 160, -643984, -643984]$[520, -20, -643984, -643984]$[220, -20, -643984, -643984]$[220, 20, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYZCoDkiEemjx6Nna_xyog" id="(0.4149377593360996,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYZCoTkiEemjx6Nna_xyog" id="(0.8955223880597015,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RWuTJDkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_QUNGMDkiEemjx6Nna_xyog" target="_RWuTIDkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RWuTJTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RWuTKTkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_QUL4EDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RWuTJjkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RWuTJzkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RWuTKDkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bNNQEDkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_3ODOcDiPEem1lYbrIE6BNw" target="_6O6-cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bNNQEzkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZI9q8DkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bNNQFDkiEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bNNQFTkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZL6RQDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bNNQFjkiEemjx6Nna_xyog" x="-22" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_bNNQETkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_bNLa4DkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bNNQEjkiEemjx6Nna_xyog" points="[20, 160, -643984, -643984]$[20, 0, -643984, -643984]$[320, 0, -643984, -643984]$[320, 20, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bSD64DkiEemjx6Nna_xyog" id="(0.6639004149377593,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bSEh8DkiEemjx6Nna_xyog" id="(0.09950248756218906,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_cULfNDkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_bNNQEDkiEemjx6Nna_xyog" target="_cULfMDkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_cULfNTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cULfOTkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_bNLa4DkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cULfNjkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cULfNzkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cULfODkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eYb18DkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_24a8sDiPEem1lYbrIE6BNw" target="_6O6-cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_eYb18zkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eVKqEDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eYb19DkiEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eYb19TkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eYJsoDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eYb19jkiEemjx6Nna_xyog" x="13" y="-2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_eYb18TkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_eYaAwDkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eYb18jkiEemjx6Nna_xyog" points="[460, 160, -643984, -643984]$[460, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ec6tUDkiEemjx6Nna_xyog" id="(0.16597510373443983,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ec6tUTkiEemjx6Nna_xyog" id="(0.7960199004975125,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fa1HETkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_eYb18DkiEemjx6Nna_xyog" target="_fa0gADkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fa1HEjkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fa1HFjkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_eYaAwDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fa1HEzkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fa1HFDkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fa1HFTkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sojFkDkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_3ODOcDiPEem1lYbrIE6BNw" target="_5OAUADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_sojFkzkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qAb-YDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sojFlDkiEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sojFlTkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qDYksDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sojFljkiEemjx6Nna_xyog" x="-34" y="-38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_sojFkTkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_sohQYDkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sojFkjkiEemjx6Nna_xyog" points="[60, 221, -643984, -643984]$[60, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_stZwYDkiEemjx6Nna_xyog" id="(0.8298755186721992,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_stZwYTkiEemjx6Nna_xyog" id="(0.09950248756218906,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tsf15DkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_sojFkDkiEemjx6Nna_xyog" target="_tsf14DkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tsf15TkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tsf16TkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sohQYDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tsf15jkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tsf15zkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tsf16DkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_wDx2UDkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_24a8sDiPEem1lYbrIE6BNw" target="_5OAUADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_wDx2UzkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tseLQDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wDx2VDkiEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_wDx2VTkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tvaKgDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wDx2VjkiEemjx6Nna_xyog" x="-18" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_wDx2UTkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_wDwBIDkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wDx2UjkiEemjx6Nna_xyog" points="[500, 221, -643984, -643984]$[500, 400, -643984, -643984]$[220, 400, -643984, -643984]$[220, 361, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wImr8DkiEemjx6Nna_xyog" id="(0.4149377593360996,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wImr8TkiEemjx6Nna_xyog" id="(0.8955223880597015,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_xclcVDkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_wDx2UDkiEemjx6Nna_xyog" target="_xclcUDkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_xclcVTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xclcWTkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wDwBIDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xclcVjkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xclcVzkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xclcWDkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_16kDgDkiEemjx6Nna_xyog" type="Abstraction_Edge" source="_3ODOcDiPEem1lYbrIE6BNw" target="_6nB8cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_16kDgzkiEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rMaCQDkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_16kDhDkiEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_16kDhTkiEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_rPZr4DkjEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_16kDhjkiEemjx6Nna_xyog" x="-32" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_16kDgTkiEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_16iOUDkiEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_16kDgjkiEemjx6Nna_xyog" points="[20, 221, -643984, -643984]$[20, 380, -643984, -643984]$[340, 380, -643984, -643984]$[340, 361, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1_jRMDkiEemjx6Nna_xyog" id="(0.6639004149377593,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1_jRMTkiEemjx6Nna_xyog" id="(0.19900497512437812,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3kZIFDkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_16kDgDkiEemjx6Nna_xyog" target="_3kZIEDkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3kZIFTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3kZIGTkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_16iOUDkiEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3kZIFjkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3kZIFzkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3kZIGDkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-c-JcDkiEemjx6Nna_xyog" type="StereotypeCommentLink" source="_oOGwADkhEemjx6Nna_xyog" target="_-c9iYzkiEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-c-JcTkiEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-c-JdTkiEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_oOE60DkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-c-JcjkiEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-c-JczkiEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-c-JdDkiEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E0aztDkjEemjx6Nna_xyog" type="StereotypeCommentLink" source="_tLwVwDkhEemjx6Nna_xyog" target="_E0azsDkjEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E0aztTkjEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0azuTkjEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_tLugkDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E0aztjkjEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0aztzkjEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0azuDkjEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KBnRUTkjEemjx6Nna_xyog" type="StereotypeCommentLink" source="_uExBYDkhEemjx6Nna_xyog" target="_KBmqQzkjEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KBnRUjkjEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KBnRVjkjEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uEvzQDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KBnRUzkjEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KBnRVDkjEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KBnRVTkjEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QT8yFDkjEemjx6Nna_xyog" type="StereotypeCommentLink" source="_o_voUDkhEemjx6Nna_xyog" target="_QT8yEDkjEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QT8yFTkjEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QT8yGTkjEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_o_tzIDkhEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QT8yFjkjEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QT8yFzkjEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QT8yGDkjEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iZ8RoTkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_iZdJcDkkEemjx6Nna_xyog" target="_iZ7qkzkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iZ8RojkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iZ8RpjkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iZ8RozkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZ8RpDkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZ8RpTkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ieIOFDkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_id2hQDkkEemjx6Nna_xyog" target="_ieIOEDkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ieIOFTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ieIOGTkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ieIOFjkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ieIOFzkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ieIOGDkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rDC1cDkkEemjx6Nna_xyog" type="Abstraction_Edge" source="_iZdJcDkkEemjx6Nna_xyog" target="_8t2fADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rDC1czkkEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DvZacDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rDC1dDkkEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rDC1dTkkEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DzR04DklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rDC1djkkEemjx6Nna_xyog" x="-7" y="-2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_rDC1cTkkEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_rDBAQDkkEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rDC1cjkkEemjx6Nna_xyog" points="[960, 160, -643984, -643984]$[960, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rJ6ScDkkEemjx6Nna_xyog" id="(0.9128630705394191,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rJ6ScTkkEemjx6Nna_xyog" id="(0.09950248756218906,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sN439DkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_rDC1cDkkEemjx6Nna_xyog" target="_sN438DkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sN439TkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sN5fATkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rDBAQDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sN439jkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sN439zkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sN5fADkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uxVFEDkkEemjx6Nna_xyog" type="Abstraction_Edge" source="_id2hQDkkEemjx6Nna_xyog" target="_8t2fADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uxVFEzkkEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D3XDoDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uxVFFDkkEemjx6Nna_xyog" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uxVFFTkkEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D7KlkDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uxVFFjkkEemjx6Nna_xyog" x="-7" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_uxVFETkkEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_uxTP4DkkEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uxVFEjkkEemjx6Nna_xyog" points="[1120, 160, -643984, -643984]$[1120, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u4WTEDkkEemjx6Nna_xyog" id="(0.08298755186721991,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u4W6IDkkEemjx6Nna_xyog" id="(0.8955223880597015,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v6NYtDkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_uxVFEDkkEemjx6Nna_xyog" target="_v6NYsDkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v6NYtTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v6NYuTkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uxTP4DkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v6NYtjkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v6NYtzkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v6NYuDkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_10ovwDkkEemjx6Nna_xyog" type="Abstraction_Edge" source="_iZdJcDkkEemjx6Nna_xyog" target="_7IWg0DiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_10pW0DkkEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Kp5ucDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_10pW0TkkEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_10pW0jkkEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Kt0lIDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_10pW0zkkEemjx6Nna_xyog" x="-14" y="2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_10ovwTkkEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_10m6kDkkEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_10ovwjkkEemjx6Nna_xyog" points="[800, 221, -643984, -643984]$[800, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_17toIDkkEemjx6Nna_xyog" id="(0.24896265560165975,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_17toITkkEemjx6Nna_xyog" id="(0.19900497512437812,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3GgARDkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_10ovwDkkEemjx6Nna_xyog" target="_3GgAQDkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3GgARTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3GgASTkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_10m6kDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3GgARjkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3GgARzkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3GgASDkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4yirUDkkEemjx6Nna_xyog" type="Abstraction_Edge" source="_id2hQDkkEemjx6Nna_xyog" target="_7IWg0DiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4yjSYDkkEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4yjSYTkkEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4yjSYjkkEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4yjSYzkkEemjx6Nna_xyog" x="-19" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_4yirUTkkEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_4yhdMDkkEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4yirUjkkEemjx6Nna_xyog" points="[1160, 221, -643984, -643984]$[880, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4520QDkkEemjx6Nna_xyog" id="(0.24896265560165975,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4520QTkkEemjx6Nna_xyog" id="(0.5970149253731343,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_53L_NDkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_4yirUDkkEemjx6Nna_xyog" target="_53L_MDkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_53L_NTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_53MmQDkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4yhdMDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_53L_NjkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_53L_NzkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_53L_ODkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9Ioh0DkkEemjx6Nna_xyog" type="Abstraction_Edge" source="_iZdJcDkkEemjx6Nna_xyog" target="_8QZuADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9IpI4DkkEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_L8ibADklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9IpI4TkkEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9IpI4jkkEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MAXLEDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9IpI4zkkEemjx6Nna_xyog" x="-3" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_9Ioh0TkkEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_9InTsDkkEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9Ioh0jkkEemjx6Nna_xyog" points="[860, 221, -643984, -643984]$[860, 240, -643984, -643984]$[1180, 240, -643984, -643984]$[1180, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9QGbwDkkEemjx6Nna_xyog" id="(0.4979253112033195,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9QHC0DkkEemjx6Nna_xyog" id="(0.29850746268656714,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-WNINDkkEemjx6Nna_xyog" type="StereotypeCommentLink" source="_9Ioh0DkkEemjx6Nna_xyog" target="_-WNIMDkkEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-WNINTkkEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-WNIOTkkEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9InTsDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-WNINjkkEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-WNINzkkEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-WNIODkkEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__0aLkDkkEemjx6Nna_xyog" type="Abstraction_Edge" source="_id2hQDkkEemjx6Nna_xyog" target="_8QZuADiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="__0aLkzkkEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_M04YQDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__0aLlDkkEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="__0aLlTkkEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_M4uWcDklEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__0aLljkkEemjx6Nna_xyog" x="-14" y="2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="__0aLkTkkEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#__0Y9cDkkEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__0aLkjkkEemjx6Nna_xyog" points="[1280, 221, -643984, -643984]$[1280, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__7-MIDkkEemjx6Nna_xyog" id="(0.7468879668049793,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__7-MITkkEemjx6Nna_xyog" id="(0.7960199004975125,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BB7HlDklEemjx6Nna_xyog" type="StereotypeCommentLink" source="__0aLkDkkEemjx6Nna_xyog" target="_BB7HkDklEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BB7HlTklEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BB7HmTklEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#__0Y9cDkkEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BB7HljklEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BB7HlzklEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BB7HmDklEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KtcVMDkmEemjx6Nna_xyog" type="Abstraction_Edge" source="_Rcab8DiUEem1lYbrIE6BNw" target="_nyBv4DiQEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ktc8QjkmEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_OtmX8DkmEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ktc8QzkmEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ktc8RDkmEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_OxeLUDkmEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ktc8RTkmEemjx6Nna_xyog" x="-28" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ktc8QDkmEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_KtbHEDkmEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ktc8QTkmEemjx6Nna_xyog" points="[380, 480, -643984, -643984]$[140, 480, -643984, -643984]$[140, 540, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K1YJMDkmEemjx6Nna_xyog" id="(0.0,0.6557377049180327)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K1YJMTkmEemjx6Nna_xyog" id="(0.4975124378109453,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Lb8Z8DkmEemjx6Nna_xyog" type="Abstraction_Edge" source="_QmI7QDiUEem1lYbrIE6BNw" target="_nyBv4DiQEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Lb9BADkmEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Lb9BATkmEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Lb9BAjkmEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Lb9BAzkmEemjx6Nna_xyog" x="-8" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Lb8Z8TkmEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Lb7L0DkmEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Lb8Z8jkmEemjx6Nna_xyog" points="[380, 580, -643984, -643984]$[241, 580, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LjpkcDkmEemjx6Nna_xyog" id="(0.0,0.6557377049180327)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LjpkcTkmEemjx6Nna_xyog" id="(1.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MJWSgDkmEemjx6Nna_xyog" type="Abstraction_Edge" source="_QErM8DiUEem1lYbrIE6BNw" target="_nyBv4DiQEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MJWSgzkmEemjx6Nna_xyog" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PMkL4DkmEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MJWShDkmEemjx6Nna_xyog" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MJWShTkmEemjx6Nna_xyog" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PQZjADkmEemjx6Nna_xyog" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MJWShjkmEemjx6Nna_xyog" x="-38" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_MJWSgTkmEemjx6Nna_xyog"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_MJVEYDkmEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MJWSgjkmEemjx6Nna_xyog" points="[380, 680, -643984, -643984]$[140, 680, -643984, -643984]$[140, 601, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MQ-kgDkmEemjx6Nna_xyog" id="(0.0,0.6557377049180327)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MQ-kgTkmEemjx6Nna_xyog" id="(0.4975124378109453,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ReCfQzkmEemjx6Nna_xyog" type="StereotypeCommentLink" source="_KtcVMDkmEemjx6Nna_xyog" target="_ReB4MzkmEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ReCfRDkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ReCfSDkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_KtbHEDkmEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ReCfRTkmEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ReCfRjkmEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ReCfRzkmEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XrRdlDkmEemjx6Nna_xyog" type="StereotypeCommentLink" source="_Lb8Z8DkmEemjx6Nna_xyog" target="_XrRdkDkmEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XrRdlTkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XrRdmTkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Lb7L0DkmEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XrRdljkmEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrRdlzkmEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrRdmDkmEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_aqiEBDkmEemjx6Nna_xyog" type="StereotypeCommentLink" source="_MJWSgDkmEemjx6Nna_xyog" target="_aqiEADkmEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_aqiEBTkmEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aqiECTkmEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MJVEYDkmEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aqiEBjkmEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aqiEBzkmEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aqiECDkmEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MF-NkDlWEemSPvPXzEQ11A" type="Abstraction_Edge" source="_24a8sDiPEem1lYbrIE6BNw" target="_6nB8cDiPEem1lYbrIE6BNw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MF-NkzlWEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MF-NlDlWEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MF-NlTlWEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MF-NljlWEemSPvPXzEQ11A" x="6" y="22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_MF-NkTlWEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_MF8YYDlWEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MF-NkjlWEemSPvPXzEQ11A" points="[480, 221, -643984, -643984]$[480, 300, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MODLgDlWEemSPvPXzEQ11A" id="(0.24896265560165975,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MODLgTlWEemSPvPXzEQ11A" id="(0.8955223880597015,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NTyrlDlWEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_MF-NkDlWEemSPvPXzEQ11A" target="_NTyrkDlWEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NTyrlTlWEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NTyrmTlWEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MF8YYDlWEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NTyrljlWEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NTyrlzlWEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NTyrmDlWEemSPvPXzEQ11A"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_eRRhYDlLEemSPvPXzEQ11A" type="PapyrusUMLClassDiagram" name="EthInterfaceProActJobs" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_fJEFGzlLEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEFHDlLEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEFOzlLEemSPvPXzEQ11A" x="480" y="120" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJEFPDlLEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEFPTlLEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEFXDlLEemSPvPXzEQ11A" x="480" y="260" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJEsEDlLEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEsETlLEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEsMDlLEemSPvPXzEQ11A" x="480" y="-20" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJEsMTlLEemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEsMjlLEemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEsMzlLEemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJEsNDlLEemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_fJEsNTlLEemSPvPXzEQ11A" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_fJEsNjlLEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_fJEsNzlLEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_fJEsODlLEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEsOTlLEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_fJEsOjlLEemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_fJEsOzlLEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_fJEsPDlLEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_fJEsPTlLEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEsPjlLEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_fJEsPzlLEemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_fJEsQDlLEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_fJEsQTlLEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_fJEsQjlLEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEsQzlLEemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_J1lZwFiCEei2nODetmeP6A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJEsbTlLEemSPvPXzEQ11A" x="60" y="40" width="261" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJFTIDlLEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJFTITlLEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJFTQDlLEemSPvPXzEQ11A" x="480" y="-160" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJQSQDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fJQSQTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fJQSQzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJQSQjlLEemSPvPXzEQ11A" x="710" y="310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJb4cDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fJb4cTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fJb4czlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJb4cjlLEemSPvPXzEQ11A" x="710" y="450"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fJoswDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fJoswTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fJoswzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fJoswjlLEemSPvPXzEQ11A" x="710" y="170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKg2gDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKg2gTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKg2gzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_J1lZwFiCEei2nODetmeP6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKg2gjlLEemSPvPXzEQ11A" x="1250" y="-210"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKlH8DlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKlH8TlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKlH8zlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AbzqABOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKlH8jlLEemSPvPXzEQ11A" x="1250" y="-310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKmWEDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKmWETlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKmWEzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BYg_ABT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKmWEjlLEemSPvPXzEQ11A" x="1250" y="-310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKoLQDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKoLQTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKoLQzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_xLfTADknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKoLQjlLEemSPvPXzEQ11A" x="1250" y="-310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKpZYDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKpZYTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKpZYzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_J22ZgDkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKpZYjlLEemSPvPXzEQ11A" x="1250" y="-310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKrOkDlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKrOkTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKrOkzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4KCAwBT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKrOkjlLEemSPvPXzEQ11A" x="1250" y="-310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fKtq0DlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fKtq0TlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKuR4DlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_lq7LsBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fKtq0jlLEemSPvPXzEQ11A" x="1250" y="-310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fLMzADlLEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fLMzATlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fLMzAzlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fLMzAjlLEemSPvPXzEQ11A" x="710" y="30"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UfclnDlMEemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UfclnTlMEemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UfclnjlMEemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UfclnzlMEemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_UfcloDlMEemSPvPXzEQ11A" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UfcloTlMEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_UfclojlMEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_UfclozlMEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UfclpDlMEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_UfclpTlMEemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UfclpjlMEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_UfclpzlMEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_UfclqDlMEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UfclqTlMEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_UfclqjlMEemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UfclqzlMEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_UfclrDlMEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_UfclrTlMEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UfclrjlMEemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_c43ZEFhkEeiYiLRYKaTpTw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ufcl2DlMEemSPvPXzEQ11A" x="800" y="40" width="261" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UgWkcDlMEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UgWkcTlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UgWkczlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c43ZEFhkEeiYiLRYKaTpTw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UgWkcjlMEemSPvPXzEQ11A" x="1530" y="290"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Uga14DlMEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Uga14TlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Uga14zlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_1768IDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Uga14jlMEemSPvPXzEQ11A" x="1530" y="190"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UgcEAjlMEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UgcEAzlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UgcEBTlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_V0OxgDkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UgcEBDlMEemSPvPXzEQ11A" x="1530" y="190"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UgfuZjlMEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UgfuZzlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UggVcDlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_EzAI4BT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UgfuaDlMEemSPvPXzEQ11A" x="1530" y="190"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UgixsDlMEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UgixsTlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UgixszlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BIqI8BOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UgixsjlMEemSPvPXzEQ11A" x="1530" y="190"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UgjYxzlMEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UgjYyDlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ugj_0DlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6t7g4BT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UgjYyTlMEemSPvPXzEQ11A" x="1530" y="190"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_lQk8MDlTEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_lQk8MTlTEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lQk8MzlTEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_kOlTsDlTEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lQk8MjlTEemSPvPXzEQ11A" x="1000" y="-60"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_eRRhYTlLEemSPvPXzEQ11A" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_eRRhYjlLEemSPvPXzEQ11A"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_eRRhYzlLEemSPvPXzEQ11A" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_fJC24DlLEemSPvPXzEQ11A" type="Abstraction_Edge" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fJFTIDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJC24TlLEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJC24jlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJC24zlLEemSPvPXzEQ11A" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJC25DlLEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJC25TlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJC25jlLEemSPvPXzEQ11A" x="8" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJC25zlLEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_xLfTADknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJC26zlLEemSPvPXzEQ11A" points="[220, 40, -643984, -643984]$[220, -120, -643984, -643984]$[480, -120, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJC27DlLEemSPvPXzEQ11A" id="(0.6130268199233716,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJC27TlLEemSPvPXzEQ11A" id="(0.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJDd8DlLEemSPvPXzEQ11A" type="Abstraction_Edge" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fJEFGzlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJDd8TlLEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJDd8jlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJDd8zlLEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJDd9DlLEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJDd9TlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJDd9jlLEemSPvPXzEQ11A" x="27" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJDd9zlLEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_4KCAwBT8Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJDd-zlLEemSPvPXzEQ11A" points="[260, 101, -643984, -643984]$[260, 140, -643984, -643984]$[480, 140, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJDd_DlLEemSPvPXzEQ11A" id="(0.7662835249042146,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJDd_TlLEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJDd_jlLEemSPvPXzEQ11A" type="Abstraction_Edge" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fJEsEDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJDd_zlLEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJDeADlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJDeATlLEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJDeAjlLEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJDeAzlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJDeBDlLEemSPvPXzEQ11A" x="-22" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJDeBTlLEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_BYg_ABT8Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJDeCTlLEemSPvPXzEQ11A" points="[240, 40, -643984, -643984]$[240, 0, -643984, -643984]$[480, 0, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJDeCjlLEemSPvPXzEQ11A" id="(0.6896551724137931,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJDeCzlLEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJDeDDlLEemSPvPXzEQ11A" type="Abstraction_Edge" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fJEFPDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEFADlLEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJEFATlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJEFAjlLEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEFAzlLEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJEFBDlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJEFBTlLEemSPvPXzEQ11A" x="47" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJEFBjlLEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_lq7LsBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJEFCjlLEemSPvPXzEQ11A" points="[240, 101, -643984, -643984]$[240, 280, -643984, -643984]$[480, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJEFCzlLEemSPvPXzEQ11A" id="(0.6896551724137931,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJEFDDlLEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJEFDTlLEemSPvPXzEQ11A" type="Abstraction_Edge" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fJFTIDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEFDjlLEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJEFDzlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJEFEDlLEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJEFETlLEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJEFEjlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJEFEzlLEemSPvPXzEQ11A" x="8" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJEFFDlLEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_AbzqABOaEemxeNG9TDCtFQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJEFGDlLEemSPvPXzEQ11A" points="[200, 40, -643984, -643984]$[200, -140, -643984, -643984]$[480, -140, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJEFGTlLEemSPvPXzEQ11A" id="(0.5363984674329502,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJEFGjlLEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJFTQTlLEemSPvPXzEQ11A" type="Abstraction_Edge" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fJEsEDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJFTQjlLEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJFTQzlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJFTRDlLEemSPvPXzEQ11A" x="-2" y="37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fJFTRTlLEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_fJFTRjlLEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fJFTRzlLEemSPvPXzEQ11A" x="38" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJFTSDlLEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_J22ZgDkoEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJFTTDlLEemSPvPXzEQ11A" points="[260, 40, -643984, -643984]$[260, 20, -643984, -643984]$[480, 20, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJFTTTlLEemSPvPXzEQ11A" id="(0.7662835249042146,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJFTTjlLEemSPvPXzEQ11A" id="(0.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJQSRDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJEFGzlLEemSPvPXzEQ11A" target="_fJQSQDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJQSRTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fJQ5UTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJQSRjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJQSRzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJQ5UDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJcfgDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJEFPDlLEemSPvPXzEQ11A" target="_fJb4cDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJcfgTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fJcfhTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJcfgjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJcfgzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJcfhDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fJosxDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJEsEDlLEemSPvPXzEQ11A" target="_fJoswDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fJpT0DlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fJpT1DlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fJpT0TlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJpT0jlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fJpT0zlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKhdkDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJEsMTlLEemSPvPXzEQ11A" target="_fKg2gDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKhdkTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKhdlTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_J1lZwFiCEei2nODetmeP6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKhdkjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKhdkzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKhdlDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKlH9DlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJEFDTlLEemSPvPXzEQ11A" target="_fKlH8DlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKlH9TlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKlvAjlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AbzqABOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKlH9jlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKlvADlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKlvATlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKmWFDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJDd_jlLEemSPvPXzEQ11A" target="_fKmWEDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKmWFTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKm9IDlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BYg_ABT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKmWFjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKmWFzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKmWGDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKoyUDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJC24DlLEemSPvPXzEQ11A" target="_fKoLQDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKoyUTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKoyVTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_xLfTADknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKoyUjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKoyUzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKoyVDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKpZZDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJFTQTlLEemSPvPXzEQ11A" target="_fKpZYDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKpZZTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKpZaTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_J22ZgDkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKpZZjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKpZZzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKpZaDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKrOlDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJDd8DlLEemSPvPXzEQ11A" target="_fKrOkDlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKrOlTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKrOmTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4KCAwBT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKrOljlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKrOlzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKrOmDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fKuR4TlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJDeDDlLEemSPvPXzEQ11A" target="_fKtq0DlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fKuR4jlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fKuR5jlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_lq7LsBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fKuR4zlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKuR5DlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fKuR5TlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fLMzBDlLEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_fJFTIDlLEemSPvPXzEQ11A" target="_fLMzADlLEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fLMzBTlLEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fLMzCTlLEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fLMzBjlLEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fLMzBzlLEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fLMzCDlLEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ufb-cDlMEemSPvPXzEQ11A" type="Abstraction_Edge" source="_UfclnDlMEemSPvPXzEQ11A" target="_fJFTIDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ufb-cTlMEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ufb-cjlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ufb-czlMEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ufb-dDlMEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ufb-dTlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ufb-djlMEemSPvPXzEQ11A" x="42" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ufb-dzlMEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_BIqI8BOaEemxeNG9TDCtFQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ufb-ezlMEemSPvPXzEQ11A" points="[980, 40, -643984, -643984]$[980, -140, -643984, -643984]$[641, -140, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ufb-fDlMEemSPvPXzEQ11A" id="(0.3831417624521073,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ufb-fTlMEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UfdMsTlMEemSPvPXzEQ11A" type="Abstraction_Edge" source="_UfclnDlMEemSPvPXzEQ11A" target="_fJFTIDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UfdMsjlMEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UfdMszlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UfdMtDlMEemSPvPXzEQ11A" x="-2" y="37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UfdMtTlMEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UfdMtjlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UfdMtzlMEemSPvPXzEQ11A" x="22" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UfdMuDlMEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_1768IDknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UfdMvDlMEemSPvPXzEQ11A" points="[880, 40, -643984, -643984]$[880, -120, -643984, -643984]$[641, -120, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfdMvTlMEemSPvPXzEQ11A" id="(0.3065134099616858,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfdMvjlMEemSPvPXzEQ11A" id="(1.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UfeasDlMEemSPvPXzEQ11A" type="Abstraction_Edge" source="_UfclnDlMEemSPvPXzEQ11A" target="_fJEsEDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UfeasTlMEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UfeasjlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UfeaszlMEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UfeatDlMEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UfeatTlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UfeatjlMEemSPvPXzEQ11A" x="-8" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UfeatzlMEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_EzAI4BT8Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UfeauzlMEemSPvPXzEQ11A" points="[860, 40, -643984, -643984]$[860, 0, -643984, -643984]$[641, 0, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfeavDlMEemSPvPXzEQ11A" id="(0.22988505747126436,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfeavTlMEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ufea3zlMEemSPvPXzEQ11A" type="Abstraction_Edge" source="_UfclnDlMEemSPvPXzEQ11A" target="_fJEsEDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ufea4DlMEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ufea4TlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ufea4jlMEemSPvPXzEQ11A" x="-1" y="37"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ufea4zlMEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Ufea5DlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ufea5TlMEemSPvPXzEQ11A" x="12" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ufea5jlMEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_V0OxgDkoEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ufea6jlMEemSPvPXzEQ11A" points="[840, 40, -643984, -643984]$[840, 20, -643984, -643984]$[641, 20, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ufea6zlMEemSPvPXzEQ11A" id="(0.1532567049808429,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ufea7DlMEemSPvPXzEQ11A" id="(1.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UffBwDlMEemSPvPXzEQ11A" type="Abstraction_Edge" source="_UfclnDlMEemSPvPXzEQ11A" target="_fJEFGzlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UffBwTlMEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UffBwjlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UffBwzlMEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UffBxDlMEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UffBxTlMEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UffBxjlMEemSPvPXzEQ11A" x="22" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UffBxzlMEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_6t7g4BT8Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UffByzlMEemSPvPXzEQ11A" points="[840, 101, -643984, -643984]$[840, 140, -643984, -643984]$[641, 140, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UffBzDlMEemSPvPXzEQ11A" id="(0.1532567049808429,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UffBzTlMEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UgWkdDlMEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_UfclnDlMEemSPvPXzEQ11A" target="_UgWkcDlMEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UgWkdTlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UgWkeTlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c43ZEFhkEeiYiLRYKaTpTw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UgWkdjlMEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UgWkdzlMEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UgWkeDlMEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Uga15DlMEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_UfdMsTlMEemSPvPXzEQ11A" target="_Uga14DlMEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Uga15TlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ugbc8jlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_1768IDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uga15jlMEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ugbc8DlMEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ugbc8TlMEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UgcEBjlMEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_Ufea3zlMEemSPvPXzEQ11A" target="_UgcEAjlMEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UgcEBzlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UgcrEDlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_V0OxgDkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UgcECDlMEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UgcECTlMEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UgcECjlMEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UggVcTlMEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_UfeasDlMEemSPvPXzEQ11A" target="_UgfuZjlMEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UggVcjlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UggVdjlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_EzAI4BT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UggVczlMEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UggVdDlMEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UggVdTlMEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UgixtDlMEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_Ufb-cDlMEemSPvPXzEQ11A" target="_UgixsDlMEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UgixtTlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UgjYwDlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_BIqI8BOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UgixtjlMEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UgixtzlMEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UgixuDlMEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ugj_0TlMEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_UffBwDlMEemSPvPXzEQ11A" target="_UgjYxzlMEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ugj_0jlMEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ugj_1jlMEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6t7g4BT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ugj_0zlMEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ugj_1DlMEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ugj_1TlMEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_kOmh0DlTEemSPvPXzEQ11A" type="Abstraction_Edge" source="_UfclnDlMEemSPvPXzEQ11A" target="_fJEFPDlLEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_kOmh0zlTEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oDMNwDlTEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kOmh1DlTEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_kOmh1TlTEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_oE7TIDlTEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_kOmh1jlTEemSPvPXzEQ11A" x="42" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_kOmh0TlTEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_kOlTsDlTEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kOmh0jlTEemSPvPXzEQ11A" points="[860, 101, -643984, -643984]$[860, 280, -643984, -643984]$[641, 280, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kSF6sDlTEemSPvPXzEQ11A" id="(0.22988505747126436,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kSF6sTlTEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_lQk8NDlTEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_kOmh0DlTEemSPvPXzEQ11A" target="_lQk8MDlTEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_lQk8NTlTEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lQk8OTlTEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_kOlTsDlTEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lQk8NjlTEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lQk8NzlTEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lQk8ODlTEemSPvPXzEQ11A"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_TIhZYDlNEemSPvPXzEQ11A" type="PapyrusUMLClassDiagram" name="EthInterfaceOnDmdJobs" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_e9OWjjlNEemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9OWjzlNEemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9OWkDlNEemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9OWkTlNEemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e9OWkjlNEemSPvPXzEQ11A" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e9OWkzlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e9OWlDlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e9OWlTlNEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9OWljlNEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e9OWlzlNEemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e9OWmDlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e9OWmTlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e9OWmjlNEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9OWmzlNEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e9OWnDlNEemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e9OWnTlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e9OWnjlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e9OWnzlNEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9OWoDlNEemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_NOPhwGBQEeiBxvDM8HEDKw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9OWyjlNEemSPvPXzEQ11A" x="800" y="220" width="261" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9O9rDlNEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O9rTlNEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9O9zDlNEemSPvPXzEQ11A" x="480" y="20" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9PkrjlNEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9PkrzlNEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9PkzjlNEemSPvPXzEQ11A" x="480" y="440" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9QLsDlNEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QLsTlNEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9QL0DlNEemSPvPXzEQ11A" x="480" y="300" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9QL0TlNEemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QL0jlNEemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QL0zlNEemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9QL1DlNEemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e9QL1TlNEemSPvPXzEQ11A" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e9QL1jlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e9QL1zlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e9QL2DlNEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9QL2TlNEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e9QL2jlNEemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e9QL2zlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e9QL3DlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e9QL3TlNEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9QL3jlNEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e9QL3zlNEemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e9QL4DlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e9QL4TlNEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e9QL4jlNEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9QL4zlNEemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_c7CKwGBQEeiBxvDM8HEDKw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9QMDTlNEemSPvPXzEQ11A" x="60" y="220" width="261" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9Qy5TlNEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9Qy5jlNEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9QzBTlNEemSPvPXzEQ11A" x="480" y="160" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9k70DlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e9k70TlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9k70zlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NOPhwGBQEeiBxvDM8HEDKw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9k70jlNEemSPvPXzEQ11A" x="1450" y="630"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9n_IDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e9n_ITlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9n_IzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9u6loBT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9n_IjlNEemSPvPXzEQ11A" x="1450" y="530"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9pNSTlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e9pNSjlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9p0UDlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rw984BT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9pNSzlNEemSPvPXzEQ11A" x="1450" y="530"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9qbYDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e9qbYTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9qbYzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_B0J9ABOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9qbYjlNEemSPvPXzEQ11A" x="1450" y="530"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9rCczlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e9rCdDlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9rCdjlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6zhkQDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9rCdTlNEemSPvPXzEQ11A" x="1450" y="530"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e9sQkDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e9sQkTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9sQkzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_ALaO8DkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e9sQkjlNEemSPvPXzEQ11A" x="1450" y="530"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e-KKoDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e-KKoTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e-KKozlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e-KKojlNEemSPvPXzEQ11A" x="710" y="30"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e-eTsDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e-eTsTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e-eTszlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e-eTsjlNEemSPvPXzEQ11A" x="710" y="450"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e-xOoDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e-xOoTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e-xOozlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e-xOojlNEemSPvPXzEQ11A" x="710" y="310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_jRwDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_jRwTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_jRwzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c7CKwGBQEeiBxvDM8HEDKw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_jRwjlNEemSPvPXzEQ11A" x="1150" y="850"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_m8IDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_m8ITlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_m8IzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Au8BEBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_m8IjlNEemSPvPXzEQ11A" x="1150" y="750"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_oxUDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_oxUTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_oxUzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sSlDUDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_oxUjlNEemSPvPXzEQ11A" x="1150" y="750"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_qmgDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_qmgTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_rNkDlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uWd_gBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_qmgjlNEemSPvPXzEQ11A" x="1150" y="750"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_sbsDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_sbsTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_sbszlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_c6U5EBOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_sbsjlNEemSPvPXzEQ11A" x="1150" y="750"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_uQ4DlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_uQ4TlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_uQ4zlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_QNOFsDkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_uQ4jlNEemSPvPXzEQ11A" x="1150" y="750"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e_u3-DlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e_u3-TlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_u3-zlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_K3yV0BT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_u3-jlNEemSPvPXzEQ11A" x="1150" y="750"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fAaNYDlNEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_fAaNYTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fAaNYzlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fAaNYjlNEemSPvPXzEQ11A" x="710" y="170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_01_nUDlSEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_01_nUTlSEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_01_nUzlSEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z38DoDlSEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_01_nUjlSEemSPvPXzEQ11A" x="1000" y="120"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_TIhZYTlNEemSPvPXzEQ11A" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_TIhZYjlNEemSPvPXzEQ11A"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_TIhZYzlNEemSPvPXzEQ11A" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_e9NIYDlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9O9rDlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9NIYTlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9NIYjlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9NIYzlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9NvcDlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9NvcTlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9NvcjlNEemSPvPXzEQ11A" x="32" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9NvczlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_B0J9ABOaEemxeNG9TDCtFQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9NvdzlNEemSPvPXzEQ11A" points="[920, 220, -643984, -643984]$[920, 40, -643984, -643984]$[641, 40, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9NveDlNEemSPvPXzEQ11A" id="(0.45977011494252873,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9NveTlNEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9OWgDlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9O9rDlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9OWgTlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9OWgjlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9OWgzlNEemSPvPXzEQ11A" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9OWhDlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9OWhTlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9OWhjlNEemSPvPXzEQ11A" x="52" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9OWhzlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_6zhkQDknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9OWizlNEemSPvPXzEQ11A" points="[900, 220, -643984, -643984]$[900, 60, -643984, -643984]$[641, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9OWjDlNEemSPvPXzEQ11A" id="(0.3831417624521073,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9OWjTlNEemSPvPXzEQ11A" id="(1.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9O9kDlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9QLsDlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O9kTlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9O9kjlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9O9kzlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O9lDlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9O9lTlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9O9ljlNEemSPvPXzEQ11A" x="32" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9O9lzlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_9u6loBT8Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9O9mzlNEemSPvPXzEQ11A" points="[860, 281, -643984, -643984]$[860, 320, -643984, -643984]$[641, 320, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9O9nDlNEemSPvPXzEQ11A" id="(0.22988505747126436,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9O9nTlNEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9O9njlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e9Qy5TlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O9nzlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9O9oDlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9O9oTlNEemSPvPXzEQ11A" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O9ojlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9O9ozlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9O9pDlNEemSPvPXzEQ11A" x="38" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9O9pTlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_QNOFsDkoEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9O9qTlNEemSPvPXzEQ11A" points="[260, 220, -643984, -643984]$[260, 180, -643984, -643984]$[480, 180, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9O9qjlNEemSPvPXzEQ11A" id="(0.7662835249042146,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9O9qzlNEemSPvPXzEQ11A" id="(0.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9O9zTlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e9PkrjlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O9zjlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9O9zzlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9O90DlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9O90TlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9O90jlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9O90zlNEemSPvPXzEQ11A" x="37" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9O91DlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_uWd_gBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9O92DlNEemSPvPXzEQ11A" points="[240, 281, -643984, -643984]$[240, 440, -643984, -643984]$[480, 440, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9O92TlNEemSPvPXzEQ11A" id="(0.6896551724137931,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9O92jlNEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9PkoDlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e9O9rDlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9PkoTlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9PkojlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9PkozlNEemSPvPXzEQ11A" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9PkpDlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9PkpTlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9PkpjlNEemSPvPXzEQ11A" x="28" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9PkpzlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_sSlDUDknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9PkqzlNEemSPvPXzEQ11A" points="[220, 220, -643984, -643984]$[220, 60, -643984, -643984]$[480, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9PkrDlNEemSPvPXzEQ11A" id="(0.6130268199233716,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9PkrTlNEemSPvPXzEQ11A" id="(0.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9PkzzlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9PkrjlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9Pk0DlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9Pk0TlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9Pk0jlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9Pk0zlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9Pk1DlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9Pk1TlNEemSPvPXzEQ11A" x="42" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9Pk1jlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_rw984BT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9Pk2jlNEemSPvPXzEQ11A" points="[880, 281, -643984, -643984]$[880, 440, -643984, -643984]$[641, 440, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9Pk2zlNEemSPvPXzEQ11A" id="(0.3065134099616858,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9Pk3DlNEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9Pk3TlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9Qy5TlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9Pk3jlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9Pk3zlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9Pk4DlNEemSPvPXzEQ11A" x="-1" y="38"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9Pk4TlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9Pk4jlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9Pk4zlNEemSPvPXzEQ11A" x="22" y="-7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9Pk5DlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_ALaO8DkoEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9Pk6DlNEemSPvPXzEQ11A" points="[860, 220, -643984, -643984]$[860, 200, -643984, -643984]$[641, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9Pk6TlNEemSPvPXzEQ11A" id="(0.22988505747126436,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9Pk6jlNEemSPvPXzEQ11A" id="(1.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9QMDjlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e9Qy5TlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QMDzlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9QMEDlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9QMETlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QMEjlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9QywDlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9QywTlNEemSPvPXzEQ11A" x="-22" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9QywjlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_K3yV0BT8Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9QyxjlNEemSPvPXzEQ11A" points="[240, 220, -643984, -643984]$[240, 200, -643984, -643984]$[480, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9QyxzlNEemSPvPXzEQ11A" id="(0.6896551724137931,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9QyyDlNEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9QyyTlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e9O9rDlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QyyjlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9QyyzlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9QyzDlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9QyzTlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9QyzjlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9QyzzlNEemSPvPXzEQ11A" x="28" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9Qy0DlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_c6U5EBOaEemxeNG9TDCtFQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9Qy1DlNEemSPvPXzEQ11A" points="[200, 220, -643984, -643984]$[200, 40, -643984, -643984]$[480, 40, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9Qy1TlNEemSPvPXzEQ11A" id="(0.5363984674329502,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9Qy1jlNEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9RZ0DlNEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e9QLsDlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9RZ0TlNEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9RZ0jlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9RZ0zlNEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e9RZ1DlNEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_e9RZ1TlNEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e9RZ1jlNEemSPvPXzEQ11A" x="27" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9RZ1zlNEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Au8BEBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9RZ2zlNEemSPvPXzEQ11A" points="[260, 281, -643984, -643984]$[260, 320, -643984, -643984]$[480, 320, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9RZ3DlNEemSPvPXzEQ11A" id="(0.7662835249042146,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9RZ3TlNEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9k71DlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9k70DlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9k71TlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9k72TlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NOPhwGBQEeiBxvDM8HEDKw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9k71jlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9k71zlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9k72DlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9n_JDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9O9kDlNEemSPvPXzEQ11A" target="_e9n_IDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9n_JTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9omMjlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9u6loBT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9n_JjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9omMDlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9omMTlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9p0UTlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9PkzzlNEemSPvPXzEQ11A" target="_e9pNSTlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9p0UjlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9p0VjlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rw984BT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9p0UzlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9p0VDlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9p0VTlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9qbZDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9NIYDlNEemSPvPXzEQ11A" target="_e9qbYDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9qbZTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9qbaTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_B0J9ABOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9qbZjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9qbZzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9qbaDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9rpgDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9OWgDlNEemSPvPXzEQ11A" target="_e9rCczlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9rpgTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9rphTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_6zhkQDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9rpgjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9rpgzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9rphDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e9sQlDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9Pk3TlNEemSPvPXzEQ11A" target="_e9sQkDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e9sQlTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e9s3oTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_ALaO8DkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e9sQljlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9sQlzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e9s3oDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e-KKpDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9O9rDlNEemSPvPXzEQ11A" target="_e-KKoDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e-KKpTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e-KxsDlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e-KKpjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-KKpzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-KKqDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e-eTtDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9PkrjlNEemSPvPXzEQ11A" target="_e-eTsDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e-eTtTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e-e6wjlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e-eTtjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-e6wDlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-e6wTlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e-xOpDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9QLsDlNEemSPvPXzEQ11A" target="_e-xOoDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e-xOpTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e-xOqTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e-xOpjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-xOpzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-xOqDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_jRxDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9QL0TlNEemSPvPXzEQ11A" target="_e_jRwDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_jRxTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_jRyTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c7CKwGBQEeiBxvDM8HEDKw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_jRxjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_jRxzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_jRyDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_m8JDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9RZ0DlNEemSPvPXzEQ11A" target="_e_m8IDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_m8JTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_m8KTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Au8BEBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_m8JjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_m8JzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_m8KDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_oxVDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9PkoDlNEemSPvPXzEQ11A" target="_e_oxUDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_oxVTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_oxWTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sSlDUDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_oxVjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_oxVzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_oxWDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_rNkTlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9O9zTlNEemSPvPXzEQ11A" target="_e_qmgDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_rNkjlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_rNljlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uWd_gBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_rNkzlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_rNlDlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_rNlTlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_tCwDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9QyyTlNEemSPvPXzEQ11A" target="_e_sbsDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_tCwTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_tCxTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_c6U5EBOaEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_tCwjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_tCwzlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_tCxDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_uQ5DlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9O9njlNEemSPvPXzEQ11A" target="_e_uQ4DlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_uQ5TlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_u38TlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_QNOFsDkoEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_uQ5jlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_uQ5zlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_u38DlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_e_u3_DlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9QMDjlNEemSPvPXzEQ11A" target="_e_u3-DlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e_u3_TlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_vfAjlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_K3yV0BT8Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_u3_jlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_vfADlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_vfATlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_fAa0cDlNEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_e9Qy5TlNEemSPvPXzEQ11A" target="_fAaNYDlNEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_fAa0cTlNEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fAa0dTlNEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fAa0cjlNEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fAa0czlNEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fAa0dDlNEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_z3940DlSEemSPvPXzEQ11A" type="Abstraction_Edge" source="_e9OWjjlNEemSPvPXzEQ11A" target="_e9Qy5TlNEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_z3940zlSEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3goooDlSEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z3941DlSEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_z3941TlSEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_3iTckDlSEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_z3941jlSEemSPvPXzEQ11A" x="-18" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_z3940TlSEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_z38DoDlSEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z3940jlSEemSPvPXzEQ11A" points="[880, 220, -643984, -643984]$[880, 180, -643984, -643984]$[641, 180, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z7iKMDlSEemSPvPXzEQ11A" id="(0.3065134099616858,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z7iKMTlSEemSPvPXzEQ11A" id="(1.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_01_nVDlSEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_z3940DlSEemSPvPXzEQ11A" target="_01_nUDlSEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_01_nVTlSEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_01_nWTlSEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z38DoDlSEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_01_nVjlSEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_01_nVzlSEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_01_nWDlSEemSPvPXzEQ11A"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_5vcw8DlPEemSPvPXzEQ11A" type="PapyrusUMLClassDiagram" name="EthInterfaceTestJob" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_60j-7jlPEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60j-7zlPEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60j_DjlPEemSPvPXzEQ11A" x="520" y="320" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_60j_DzlPEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60j_EDlPEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60j_LzlPEemSPvPXzEQ11A" x="520" y="460" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_60kmGjlPEemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60kmGzlPEemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_60kmHDlPEemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60kmHTlPEemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_60kmHjlPEemSPvPXzEQ11A" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_60kmHzlPEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_60kmIDlPEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_60kmITlPEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60kmIjlPEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_60kmIzlPEemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_60kmJDlPEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_60kmJTlPEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_60kmJjlPEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60kmJzlPEemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_60kmKDlPEemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_60kmKTlPEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_60kmKjlPEemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_60kmKzlPEemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60kmLDlPEemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60kmVjlPEemSPvPXzEQ11A" x="160" y="240" width="201" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_60lNADlPEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60lNATlPEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60lNIDlPEemSPvPXzEQ11A" x="520" y="40" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_60lNLzlPEemSPvPXzEQ11A" type="NamedElement_DefaultShape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60lNMDlPEemSPvPXzEQ11A" type="NamedElement_NameLabel"/>
+      <element xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60lNTzlPEemSPvPXzEQ11A" x="520" y="180" width="161" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_60wzMDlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_60wzMTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_60wzMzlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_60wzMjlPEemSPvPXzEQ11A" x="710" y="310"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_609ngDlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_609ngTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_609ngzlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_609ngjlPEemSPvPXzEQ11A" x="710" y="450"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_61krgDlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_61krgTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61krgzlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61krgjlPEemSPvPXzEQ11A" x="1090" y="230"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_61nHwDlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_61nHwTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61nu0DlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qA1RwBOZEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61nHwjlPEemSPvPXzEQ11A" x="1090" y="130"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_61oV4DlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_61oV4TlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61oV4zlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_PRbBQDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61oV4jlPEemSPvPXzEQ11A" x="1090" y="130"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_61pkAjlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_61pkAzlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61pkBTlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-lZXIBT7Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61pkBDlPEemSPvPXzEQ11A" x="1090" y="130"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_61rZMDlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_61rZMTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61sAQDlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_jS9OwBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61rZMjlPEemSPvPXzEQ11A" x="1090" y="130"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_62HeEDlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_62HeETlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_62HeEzlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_62HeEjlPEemSPvPXzEQ11A" x="710" y="30"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_62iU0DlPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_62iU0TlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_62i74DlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_62iU0jlPEemSPvPXzEQ11A" x="710" y="170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_T1GZQDlSEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T1GZQTlSEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1GZQzlSEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Svn-8DlSEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T1GZQjlSEemSPvPXzEQ11A" x="360" y="140"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_i_NL8DlSEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_i_NL8TlSEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i_NL8zlSEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_iEM8QDlSEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_NL8jlSEemSPvPXzEQ11A" x="360" y="140"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_5vcw8TlPEemSPvPXzEQ11A" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_5vcw8jlPEemSPvPXzEQ11A"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_5vcw8zlPEemSPvPXzEQ11A" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
+      <owner xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_60jX0DlPEemSPvPXzEQ11A" type="Abstraction_Edge" source="_60kmGjlPEemSPvPXzEQ11A" target="_60j_DzlPEemSPvPXzEQ11A" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60jX0TlPEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60jX0jlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60jX0zlPEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_60jX1DlPEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60jX1TlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60jX1jlPEemSPvPXzEQ11A" x="47" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_60jX1zlPEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_jS9OwBT9Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_60jX2zlPEemSPvPXzEQ11A" points="[280, 301, -643984, -643984]$[280, 480, -643984, -643984]$[520, 480, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60jX3DlPEemSPvPXzEQ11A" id="(0.5970149253731343,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60jX3TlPEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_60j-4DlPEemSPvPXzEQ11A" type="Abstraction_Edge" source="_60kmGjlPEemSPvPXzEQ11A" target="_60lNADlPEemSPvPXzEQ11A" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60j-4TlPEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60j-4jlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60j-4zlPEemSPvPXzEQ11A" y="39"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_60j-5DlPEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60j-5TlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60j-5jlPEemSPvPXzEQ11A" x="8" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_60j-5zlPEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_PRbBQDknEemjx6Nna_xyog"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_60j-6zlPEemSPvPXzEQ11A" points="[260, 240, -643984, -643984]$[260, 80, -643984, -643984]$[520, 80, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60j-7DlPEemSPvPXzEQ11A" id="(0.4975124378109453,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60j-7TlPEemSPvPXzEQ11A" id="(0.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_60kl8DlPEemSPvPXzEQ11A" type="Abstraction_Edge" source="_60kmGjlPEemSPvPXzEQ11A" target="_60lNADlPEemSPvPXzEQ11A" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60kl8TlPEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60kl8jlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60kl8zlPEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_60kl9DlPEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60kl9TlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60kl9jlPEemSPvPXzEQ11A" x="8" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_60kl9zlPEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_qA1RwBOZEemxeNG9TDCtFQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_60kl-zlPEemSPvPXzEQ11A" points="[240, 240, -643984, -643984]$[240, 60, -643984, -643984]$[520, 60, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60kl_DlPEemSPvPXzEQ11A" id="(0.39800995024875624,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60kl_TlPEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_60kmDDlPEemSPvPXzEQ11A" type="Abstraction_Edge" source="_60kmGjlPEemSPvPXzEQ11A" target="_60lNLzlPEemSPvPXzEQ11A" routing="Rectilinear" lineColor="0">
+      <children xmi:type="notation:DecorationNode" xmi:id="_60kmDTlPEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60kmDjlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60kmDzlPEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_60kmEDlPEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_60kmETlPEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_60kmEjlPEemSPvPXzEQ11A" x="38" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_60kmEzlPEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_-lZXIBT7Eemlb5smEiStFg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_60kmFzlPEemSPvPXzEQ11A" points="[280, 240, -643984, -643984]$[280, 200, -643984, -643984]$[520, 200, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60kmGDlPEemSPvPXzEQ11A" id="(0.5970149253731343,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60kmGTlPEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_60wzNDlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60j-7jlPEemSPvPXzEQ11A" target="_60wzMDlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_60wzNTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_60xaQDlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_60wzNjlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60wzNzlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_60wzODlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_609nhDlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60j_DzlPEemSPvPXzEQ11A" target="_609ngDlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_609nhTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_609niTlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_609nhjlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_609nhzlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_609niDlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_61krhDlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60kmGjlPEemSPvPXzEQ11A" target="_61krgDlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_61krhTlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61kriTlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_61krhjlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61krhzlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61kriDlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_61nu0TlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60kl8DlPEemSPvPXzEQ11A" target="_61nHwDlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_61nu0jlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61nu1jlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qA1RwBOZEemxeNG9TDCtFQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_61nu0zlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61nu1DlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61nu1TlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_61oV5DlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60j-4DlPEemSPvPXzEQ11A" target="_61oV4DlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_61oV5TlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61oV6TlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_PRbBQDknEemjx6Nna_xyog"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_61oV5jlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61oV5zlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61oV6DlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_61pkBjlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60kmDDlPEemSPvPXzEQ11A" target="_61pkAjlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_61pkBzlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61pkCzlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-lZXIBT7Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_61pkCDlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61pkCTlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61pkCjlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_61sAQTlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60jX0DlPEemSPvPXzEQ11A" target="_61rZMDlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_61sAQjlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61sARjlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_jS9OwBT9Eemlb5smEiStFg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_61sAQzlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61sARDlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61sARTlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_62IFIDlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60lNADlPEemSPvPXzEQ11A" target="_62HeEDlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_62IFITlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_62IFJTlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_62IFIjlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_62IFIzlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_62IFJDlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_62i74TlPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_60lNLzlPEemSPvPXzEQ11A" target="_62iU0DlPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_62i74jlPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_62i75jlPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_62i74zlPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_62i75DlPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_62i75TlPEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SvvTsDlSEemSPvPXzEQ11A" type="Abstraction_Edge" source="_60kmGjlPEemSPvPXzEQ11A" target="_60lNLzlPEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Svxv8DlSEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_X1fskDlSEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Svxv8TlSEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SvyXADlSEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_X2nt8DlSEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SvyXATlSEemSPvPXzEQ11A" x="38" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_SvvTsTlSEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_Svn-8DlSEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SvvTsjlSEemSPvPXzEQ11A" points="[300, 240, -643984, -643984]$[300, 220, -643984, -643984]$[520, 220, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SyIgYDlSEemSPvPXzEQ11A" id="(0.6965174129353234,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SyIgYTlSEemSPvPXzEQ11A" id="(0.0,0.6557377049180327)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_T1GZRDlSEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_SvvTsDlSEemSPvPXzEQ11A" target="_T1GZQDlSEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T1GZRTlSEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1HAUDlSEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Svn-8DlSEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T1GZRjlSEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1GZRzlSEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1GZSDlSEemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iEOxcDlSEemSPvPXzEQ11A" type="Abstraction_Edge" source="_60kmGjlPEemSPvPXzEQ11A" target="_60j-7jlPEemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_iEPYgDlSEemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mFQW4DlSEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iEPYgTlSEemSPvPXzEQ11A" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iEPYgjlSEemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mGbbkDlSEemSPvPXzEQ11A" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_iEPYgzlSEemSPvPXzEQ11A" x="67" y="7"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_iEOxcTlSEemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_iEM8QDlSEemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iEOxcjlSEemSPvPXzEQ11A" points="[300, 301, -643984, -643984]$[300, 340, -643984, -643984]$[520, 340, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iGNucDlSEemSPvPXzEQ11A" id="(0.6965174129353234,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iGNucTlSEemSPvPXzEQ11A" id="(0.0,0.32786885245901637)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_i_NL9DlSEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_iEOxcDlSEemSPvPXzEQ11A" target="_i_NL8DlSEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_i_NL9TlSEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i_NzAjlSEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_iEM8QDlSEemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i_NL9jlSEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i_NzADlSEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i_NzATlSEemSPvPXzEQ11A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -12,101 +12,6 @@ License: This module is distributed under the Apache License 2.0</body>
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SdNnUZKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
       <packagedElement xmi:type="uml:Class" xmi:id="_7ySKwOuGEeGZr5p9Vdkojw" name="EthCtpPac">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7ySKweuGEeGZr5p9Vdkojw" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Osz7EOuHEeGZr5p9Vdkojw" name="auxiliaryFunctionPositionSequence" visibility="public" isOrdered="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_UtlxwOuHEeGZr5p9Vdkojw" annotatedElement="_Osz7EOuHEeGZr5p9Vdkojw">
-            <body>This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_njp40OuHEeGZr5p9Vdkojw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_njp40euHEeGZr5p9Vdkojw" value="*"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTGRcCFqEeWrHvhCHfosZA" value="">
-            <name xsi:nil="true"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_VAOosziEEeGKKvtWtO2aIg" name="vlanConfig" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_VAOotDiEEeGKKvtWtO2aIg" annotatedElement="_VAOosziEEeGKKvtWtO2aIg">
-            <body>This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTer8CFqEeWrHvhCHfosZA" value="NA">
-            <name xsi:nil="true"/>
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-A0TI5MuEeCKK9uc7Khnmg" name="csfRdiFdiEnable" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_hbwIsMNpEeCUp9m8vv2E5A" annotatedElement="_-A0TI5MuEeCKK9uc7Khnmg">
-            <body>This attribute models the MI_CSFrdifdiEnable information defined in G.8021.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_j0ycoMNpEeCUp9m8vv2E5A">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hBZhA5MvEeCKK9uc7Khnmg" name="csfReport" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_HVNoMMNqEeCUp9m8vv2E5A" annotatedElement="_hBZhA5MvEeCKK9uc7Khnmg">
-            <body>This attribute models the MI_CSF_Reported information defined in G.8021.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_JSFkkMNqEeCUp9m8vv2E5A">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_LpAAEJMvEeCKK9uc7Khnmg" name="filterConfigSnk" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_LpAAEZMvEeCKK9uc7Khnmg" annotatedElement="_LpAAEJMvEeCKK9uc7Khnmg">
-            <body>This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:&#xD;
-01-80-C2-00-00-10, &#xD;
-01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and &#xD;
-01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
-The filter action is Pass or Block. &#xD;
-If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
-If none of the above addresses match, the ETH_CI_D is passed.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_t9NOIOuCEeGZr5p9Vdkojw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_t9NOIeuCEeGZr5p9Vdkojw" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xo3rYJMvEeCKK9uc7Khnmg" name="macLength" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_eyLeYMNpEeCUp9m8vv2E5A" annotatedElement="_Xo3rYJMvEeCKK9uc7Khnmg">
-            <body>This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3lSysMNpEeCUp9m8vv2E5A" value="2000">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__7TK8C01EeC5VOR5P4wONQ" name="filterConfig" visibility="public" type="_s3CEAK2EEeKoWKjPsL4xyQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_YiP1YI3gEeGyj-TNVzlOGQ" annotatedElement="__7TK8C01EeC5VOR5P4wONQ">
-            <body>This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:&#xD;
-- All bridges address: 01-80-C2-00-00-10,&#xD;
-- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,&#xD;
-- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
-The filter action is Pass or Block. &#xD;
-If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
-If none of the above addresses match, the ETH_CI_D is passed.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDbuEOt8EeGPOswgCwFOKw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDbuEet8EeGPOswgCwFOKw" value="1"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSTAMSFqEeWrHvhCHfosZA" type="_s3CEAK2EEeKoWKjPsL4xyQ" value="See data type">
-            <name xsi:nil="true"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_0_3YIC01EeC5VOR5P4wONQ" name="isSsfReported" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_M0ktUI3gEeGyj-TNVzlOGQ" annotatedElement="_0_3YIC01EeC5VOR5P4wONQ">
-            <body>This attribute provisions whether the SSF defect should be reported as fault cause or not.&#xD;
-It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_NSrloI3gEeGyj-TNVzlOGQ">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_pU1bwC0yEeC5VOR5P4wONQ" name="pllThr" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_u4IrADBNEeC_I_YldZCMxA" annotatedElement="_pU1bwC0yEeC5VOR5P4wONQ">
-            <body>This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6WJhwEXMEeKyK7rRd9C5sg" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6WJhwUXMEeKyK7rRd9C5sg" value="1"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Styy4C0xEeC5VOR5P4wONQ" name="actorOperKey" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_5QEaEDBLEeC_I_YldZCMxA" annotatedElement="_Styy4C0xEeC5VOR5P4wONQ">
             <body>See 802.1AX:&#xD;
@@ -135,28 +40,6 @@ Indicating the priority associated with the Actors System ID.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSTnQSFqEeWrHvhCHfosZA" value="NA">
-            <name xsi:nil="true"/>
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_dOaR8C0xEeC5VOR5P4wONQ" name="collectorMaxDelay" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Bywz4DBMEeC_I_YldZCMxA" annotatedElement="_dOaR8C0xEeC5VOR5P4wONQ">
-            <body>See 802.1AX:&#xD;
-The value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSVccCFqEeWrHvhCHfosZA" value="NA">
-            <name xsi:nil="true"/>
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_bXqLsC0xEeC5VOR5P4wONQ" name="dataRate" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_BRiWIDBMEeC_I_YldZCMxA" annotatedElement="_bXqLsC0xEeC5VOR5P4wONQ">
-            <body>See 802.1AX:&#xD;
-The current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSU1YSFqEeWrHvhCHfosZA" value="NA">
             <name xsi:nil="true"/>
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           </defaultValue>
@@ -192,18 +75,20 @@ Indicates the priority associated with the Partners System ID. If the aggregatio
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ukk3kDqaEeCu35lketJ8Yg" name="csfConfig" visibility="public" type="_10eLcKNEEeKZoeGA12VHIQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_4eC1EMNoEeCUp9m8vv2E5A" annotatedElement="_ukk3kDqaEeCu35lketJ8Yg">
-            <body>This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.</body>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_bXqLsC0xEeC5VOR5P4wONQ" name="dataRate" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_BRiWIDBMEeC_I_YldZCMxA" annotatedElement="_bXqLsC0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+The current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links.</body>
           </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSU1YSFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AbyakjO6Eea40e5DA9KE3w" name="_trafficShaping" type="_8QIrYK4wEeGjbtFXtCFKWg" aggregation="composite" association="_AbxMcDO6Eea40e5DA9KE3w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C7qWUDO6Eea40e5DA9KE3w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C7ySIDO6Eea40e5DA9KE3w" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3D1zwTO5Eea40e5DA9KE3w" name="_trafficConditioning" type="_8QR1UK4wEeGjbtFXtCFKWg" aggregation="composite" association="_3Dz-kDO5Eea40e5DA9KE3w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pTncDO5Eea40e5DA9KE3w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pcxYDO5Eea40e5DA9KE3w" value="1"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4n8egjarEem8b5f98b_cVw" name="_ethCtpCommonPac" type="_RLND0DaqEem8b5f98b_cVw" association="_4n7QYDarEem8b5f98b_cVw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4n9soDarEem8b5f98b_cVw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4n9soTarEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_T7cP0DN7Eea40e5DA9KE3w" name="EthConnectionEndPointSpec">
@@ -225,98 +110,17 @@ Indicates the priority associated with the Partners System ID. If the aggregatio
         <ownedComment xmi:type="uml:Comment" xmi:id="_ACUEMuxFEeGzwM2Uvwf5Xw" annotatedElement="_ACUEMOxFEeGzwM2Uvwf5Xw">
           <body>This object class models the Ethernet Flow Termination function located at a layer boundary.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_upySMHnOEd2GobjTM4neEA" name="priorityRegenerate" visibility="public" type="_GjpskCbKEd-tK43JMxNtYw">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_kYZu0CEkEd-ysdtezPKi3w" annotatedElement="_upySMHnOEd2GobjTM4neEA">
-            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AEiUECbKEd-tK43JMxNtYw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AEiUESbKEd-tK43JMxNtYw" value="1"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTdd0CFqEeWrHvhCHfosZA" type="_GjpskCbKEd-tK43JMxNtYw" value="NA">
-            <name xsi:nil="true"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_vOIbgHp1Ed2F76X026nNcA" name="etherType" visibility="public" type="_kQIFACelEd-sQoLP0EY2BQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_musQwCEkEd-ysdtezPKi3w" annotatedElement="_vOIbgHp1Ed2F76X026nNcA">
-            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTeE4CFqEeWrHvhCHfosZA" type="_kQIFACelEd-sQoLP0EY2BQ" value="NA">
-            <name xsi:nil="true"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__KuU8HnOEd2GobjTM4neEA" name="filterConfig1" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_odulcCEkEd-ysdtezPKi3w" annotatedElement="__KuU8HnOEd2GobjTM4neEA">
-            <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.&#xD;
-It indicates the configured filter action for each of the 33 group MAC addresses for control frames.&#xD;
-&#xD;
-The 33 MAC addresses are:&#xD;
-01-80-C2-00-00-10, &#xD;
-01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and &#xD;
-01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
-&#xD;
-The filter action is Pass or Block. &#xD;
-If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
-If none of the above addresses match, the ETH_CI_D is passed.&#xD;
-</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fJJ9YOxmEeGzwM2Uvwf5Xw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fJJ9YexmEeGzwM2Uvwf5Xw" value="*"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTeE4SFqEeWrHvhCHfosZA" type="_hYZs0BWEEd-Si5Ih_dYBog" value="NA">
-            <name xsi:nil="true"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_0_GOcHnOEd2GobjTM4neEA" name="frametypeConfig" visibility="public" type="_n3YdgCEsEd-ysdtezPKi3w">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_n4a48CEkEd-ysdtezPKi3w" annotatedElement="_0_GOcHnOEd2GobjTM4neEA">
-            <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_zkGjUCEsEd-ysdtezPKi3w" name="AllowUntaggedOnly" type="_n3YdgCEsEd-ysdtezPKi3w" instance="_tKgkACEsEd-ysdtezPKi3w"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_zDHp8HnOEd2GobjTM4neEA" name="portVid" visibility="public" type="_d1LyACbNEd-tK43JMxNtYw">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_lDqSUCEkEd-ysdtezPKi3w" annotatedElement="_zDHp8HnOEd2GobjTM4neEA">
-            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021.</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_G82S4CbOEd-tK43JMxNtYw" type="_d1LyACbNEd-tK43JMxNtYw" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_q7yL8nnNEd2GobjTM4neEA" name="priorityCodePointConfig" visibility="public" type="_tjBD8CdpEd-sQoLP0EY2BQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_loFOACEkEd-ysdtezPKi3w" annotatedElement="_q7yL8nnNEd2GobjTM4neEA">
-            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.</body>
-          </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rkBnITapEem8b5f98b_cVw" name="_ethTerminationCommonPac" type="_nsU80DapEem8b5f98b_cVw" association="_rj_x8DapEem8b5f98b_cVw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rkC1QDapEem8b5f98b_cVw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rkDcUDapEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_fzLz0OxQEeGzwM2Uvwf5Xw" name="EtyTerminationPac">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fzLz0exQEeGzwM2Uvwf5Xw" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_J3_wsHzUEd2S7rQMqMRYLA" name="isFtsEnabled" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_vwvUUOxeEeGzwM2Uvwf5Xw" annotatedElement="_J3_wsHzUEd2S7rQMqMRYLA">
-            <body>This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_yCn3YOxeEeGzwM2Uvwf5Xw">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ibtJIC0kEeC5VOR5P4wONQ" name="isTxPauseEnabled" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_yXiUQOxaEeGzwM2Uvwf5Xw" annotatedElement="_ibtJIC0kEeC5VOR5P4wONQ">
-            <body>This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_4Xiu4OxaEeGzwM2Uvwf5Xw">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PFLnQHzUEd2S7rQMqMRYLA" name="phyType" visibility="public" type="_AdKOUOxfEeGzwM2Uvwf5Xw" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_39t80OxeEeGzwM2Uvwf5Xw" annotatedElement="_PFLnQHzUEd2S7rQMqMRYLA">
-            <body>This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2.</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_iICjoNHUEeKzI4N0oSjmcw" name="UNKNOWN" type="_AdKOUOxfEeGzwM2Uvwf5Xw" instance="_I44dcOxfEeGzwM2Uvwf5Xw"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_QoRxsHzUEd2S7rQMqMRYLA" name="phyTypeList" visibility="public" type="_AdKOUOxfEeGzwM2Uvwf5Xw" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_q3xvYOxgEeGzwM2Uvwf5Xw" annotatedElement="_QoRxsHzUEd2S7rQMqMRYLA">
-            <body>This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_R5yc4HzUEd2S7rQMqMRYLA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_R5yc4XzUEd2S7rQMqMRYLA" value="*"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSlUECFqEeWrHvhCHfosZA" type="_AdKOUOxfEeGzwM2Uvwf5Xw" value="NA">
-            <name xsi:nil="true"/>
-          </defaultValue>
+        <generalization xmi:type="uml:Generalization" xmi:id="_z61MIDbMEem8b5f98b_cVw" general="_myT2sDbMEem8b5f98b_cVw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_mN_ogDanEem8b5f98b_cVw" name="_etyTerminationCommonPac" type="_KIJ_MDanEem8b5f98b_cVw" aggregation="composite" association="_mN4TwDanEem8b5f98b_cVw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mOA2oDanEem8b5f98b_cVw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mOA2oTanEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_8QR1UK4wEeGjbtFXtCFKWg" name="TrafficConditioningPac">
@@ -327,7 +131,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
         <ownedComment xmi:type="uml:Comment" xmi:id="_I4OBgFBDEeWBGOds9dR2yw" annotatedElement="_8QR1UK4wEeGjbtFXtCFKWg">
           <body>Basic attributes: codirectional, condConfigList, prioConfigList</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_4ctfoOuSEeGZr5p9Vdkojw" annotatedElement="_Tg7zoOhhEeG35t-G7oiZlg">
             <body>This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.</body>
           </ownedComment>
@@ -337,7 +141,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QR1U64wEeGjbtFXtCFKWg" name="condConfigList" visibility="public" type="_l70IMK5FEeGvr_m5yJYoog" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QR1U64wEeGjbtFXtCFKWg" name="condConfigList" visibility="public" type="_l70IMK5FEeGvr_m5yJYoog">
           <ownedComment xmi:type="uml:Comment" xmi:id="_aeY1QOuTEeGZr5p9Vdkojw" annotatedElement="_8QR1U64wEeGjbtFXtCFKWg">
             <body>This attribute indicates for the conditioner process the conditioning parameters:&#xD;
 - Queue ID: Indicates the Queue ID&#xD;
@@ -354,7 +158,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional" visibility="public" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_XllKMOuVEeGZr5p9Vdkojw" annotatedElement="_PHrv4LoIEeGh2ojTLz6Azw">
             <body>This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.</body>
           </ownedComment>
@@ -373,7 +177,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
         <ownedComment xmi:type="uml:Comment" xmi:id="_Ql3CoFBDEeWBGOds9dR2yw" annotatedElement="_8QIrYK4wEeGjbtFXtCFKWg">
           <body>Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QIrYq4wEeGjbtFXtCFKWg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QIrYq4wEeGjbtFXtCFKWg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_nCRhsOuVEeGZr5p9Vdkojw" annotatedElement="_8QIrYq4wEeGjbtFXtCFKWg">
             <body>This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.</body>
           </ownedComment>
@@ -383,7 +187,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QIrY64wEeGjbtFXtCFKWg" name="queueConfigList" visibility="public" type="_fDoLkK5JEeGXRumldg-1oA" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QIrY64wEeGjbtFXtCFKWg" name="queueConfigList" visibility="public" type="_fDoLkK5JEeGXRumldg-1oA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_6ePLIOuVEeGZr5p9Vdkojw" annotatedElement="_8QIrY64wEeGjbtFXtCFKWg">
             <body>This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.</body>
           </ownedComment>
@@ -393,7 +197,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_UtUisLoIEeGh2ojTLz6Azw" name="schedConfig" visibility="public" type="_ZadywOuWEeGZr5p9Vdkojw" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UtUisLoIEeGh2ojTLz6Azw" name="schedConfig" visibility="public" type="_ZadywOuWEeGZr5p9Vdkojw">
           <ownedComment xmi:type="uml:Comment" xmi:id="_T7Y68OuWEeGZr5p9Vdkojw" annotatedElement="_UtUisLoIEeGh2ojTLz6Azw">
             <body>This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.&#xD;
 Scheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).&#xD;
@@ -403,7 +207,7 @@ Note that the only significance of the GTCS function defined in G.8021 is the us
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_u4pyoOuWEeGZr5p9Vdkojw" name="codirectional" visibility="public" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u4pyoOuWEeGZr5p9Vdkojw" name="codirectional" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_u4pyoeuWEeGZr5p9Vdkojw" annotatedElement="_u4pyoOuWEeGZr5p9Vdkojw">
             <body>This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP.</body>
           </ownedComment>
@@ -549,6 +353,13 @@ G.8052:&#xD;
 This attribute contains the identifier of the MEP.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zZMf0DobEemSPvPXzEQ11A" name="codirectional">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_fweXUDocEemSPvPXzEQ11A" annotatedElement="_zZMf0DobEemSPvPXzEQ11A">
+            <body>This attribute specifies the directionality of the Ethernet MEP with respect to the associated CEP. The value of TRUE means that the sink part of the MEP terminates the same signal direction as the sink part of the CEP. The Source part behaves similarly. This attribute is meaningful only when CEP is bidirectional.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_6dLf8DobEemSPvPXzEQ11A" value="true"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_VUpVoFRyEeitkMFXBYQFcg" name="EthMepSink">
@@ -930,7 +741,7 @@ The attribute is not used in case of 2-way loss measurement.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_1D9gokRyEeKsbYfVW3kmQQ" annotatedElement="_1D9goERyEeKsbYfVW3kmQQ">
           <body>This object class represents the PM current data collected in a pro-active delay measurement job (using 1DM).</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_eZFOskRzEeKsbYfVW3kmQQ" name="proActiveNearEnd1DmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_eZFOskRzEeKsbYfVW3kmQQ" name="statisticalNearEnd1DmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_eZFOs0RzEeKsbYfVW3kmQQ" annotatedElement="_eZFOskRzEeKsbYfVW3kmQQ">
             <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
@@ -941,7 +752,7 @@ The attribute is not used in case of 2-way loss measurement.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_6gIJAkRfEeKsbYfVW3kmQQ" annotatedElement="_6gIJAERfEeKsbYfVW3kmQQ">
           <body>This object class represents the PM current data collected in a pro-active loss measurement job (using 1SL).</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_VF54UkRhEeKsbYfVW3kmQQ" name="proActiveNearEnd1LmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VF54UkRhEeKsbYfVW3kmQQ" name="statisticalNearEnd1LmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_VF54U0RhEeKsbYfVW3kmQQ" annotatedElement="_VF54UkRhEeKsbYfVW3kmQQ">
             <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
@@ -952,17 +763,17 @@ The attribute is not used in case of 2-way loss measurement.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_9ue9kERuEeKsbYfVW3kmQQ" annotatedElement="_OUb0kLF-Ed2MOdzuQUV2bQ">
           <body>This object class represents the PM current data collected in a pro-active delay measurement job (using DMM/DMR).</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_HZhU8ERuEeKsbYfVW3kmQQ" name="proActiveBiDirDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HZhU8ERuEeKsbYfVW3kmQQ" name="statisticalBiDirDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_HZhU8URuEeKsbYfVW3kmQQ" annotatedElement="_HZhU8ERuEeKsbYfVW3kmQQ">
             <body>This attribute contains the statistical bidirectional performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ecldZERtEeKsbYfVW3kmQQ" name="proActiveFarEndDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ecldZERtEeKsbYfVW3kmQQ" name="statisticalFarEndDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_ecldZURtEeKsbYfVW3kmQQ" annotatedElement="_ecldZERtEeKsbYfVW3kmQQ">
             <body>This attribute contains the statistical far end performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ecldYkRtEeKsbYfVW3kmQQ" name="proActiveNearEndDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ecldYkRtEeKsbYfVW3kmQQ" name="statisticalNearEndDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_ecldY0RtEeKsbYfVW3kmQQ" annotatedElement="_ecldYkRtEeKsbYfVW3kmQQ">
             <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
@@ -973,12 +784,12 @@ The attribute is not used in case of 2-way loss measurement.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_kdmr0OxhEeGzwM2Uvwf5Xw" annotatedElement="_n4NGYLFVEd2MOdzuQUV2bQ">
           <body>This object class represents the PM current data collected in a pro-active loss measurement job (using LMM/LMR or SLM/SLR).</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_CxiCtERZEeKtRKTHZgJhIg" name="proActiveFarEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_CxiCtERZEeKtRKTHZgJhIg" name="statisticalFarEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_CxiCtURZEeKtRKTHZgJhIg" annotatedElement="_CxiCtERZEeKtRKTHZgJhIg">
             <body>This attribute contains the statistical far end performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_CxiCsURZEeKtRKTHZgJhIg" name="proActiveNearEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_CxiCsURZEeKtRKTHZgJhIg" name="statisticalNearEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_CxiCskRZEeKtRKTHZgJhIg" annotatedElement="_CxiCsURZEeKtRKTHZgJhIg">
             <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
@@ -994,41 +805,97 @@ The attribute is not used in case of 2-way loss measurement.</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_vqsqAFesEeiqWMdX2ZZi3w" name="EthOnDemand1DmPerformanceData">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_VIVkcosyEeK2NvDLt60gDw" name="onDemandNearEnd1DmParameters" visibility="public" type="_zeuZsFEbEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BFQU8DafEem8b5f98b_cVw" name="statisticalNearEnd1DmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_BFQU8TafEem8b5f98b_cVw" annotatedElement="_BFQU8DafEem8b5f98b_cVw">
+            <body>This attribute contains the statistical near end performnace parameters.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VIVkcosyEeK2NvDLt60gDw" name="samplesNearEnd1DmParameters" visibility="public" type="_zeuZsFEbEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_VIVkc4syEeK2NvDLt60gDw" annotatedElement="_VIVkcosyEeK2NvDLt60gDw">
             <body>This attribute contains the results of an on-demand frame delay measurement job in the ingress direction.</body>
           </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RgwTgDaeEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RhG40DaeEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_w8GAcFesEeiqWMdX2ZZi3w" name="EthOnDemand1LmPerformanceData">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ABzeMEN2EeKtRKTHZgJhIg" name="onDemandNearEnd1LmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZDAHgDafEem8b5f98b_cVw" name="statisticalNearEnd1LmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ZDAHgTafEem8b5f98b_cVw" annotatedElement="_ZDAHgDafEem8b5f98b_cVw">
+            <body>This attribute contains the statistical near end performnace parameters.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ABzeMEN2EeKtRKTHZgJhIg" name="totalCountersNearEnd1LmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_ABzeMUN2EeKtRKTHZgJhIg" annotatedElement="_ABzeMEN2EeKtRKTHZgJhIg">
             <body>This attribute contains the results of an on-demand synthetic loss measurement job in the ingress direction.</body>
           </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_li3-ADaeEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ljOjUDaeEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_tDn6EFesEeiqWMdX2ZZi3w" name="EthOnDemandDmPerformanceData">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_pjlxIIu1EeK2NvDLt60gDw" name="onDemandFarEndDmParameters" visibility="public" type="_zeuZsFEbEd6VSrclB-Ybig">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_pjlxIYu1EeK2NvDLt60gDw" annotatedElement="_pjlxIIu1EeK2NvDLt60gDw">
-            <body>This attribute contains the results of an on-demand frame delay measurement job in the ingress direction.</body>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rCx8QDaeEem8b5f98b_cVw" name="statisticalBiDirDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rCx8QTaeEem8b5f98b_cVw" annotatedElement="_rCx8QDaeEem8b5f98b_cVw">
+            <body>This attribute contains the statistical bidirectional performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_c0CVUou1EeK2NvDLt60gDw" name="onDemandNearEndDmParameters" visibility="public" type="_zeuZsFEbEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rCnkMDaeEem8b5f98b_cVw" name="statisticalNearEndDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rCnkMTaeEem8b5f98b_cVw" annotatedElement="_rCnkMDaeEem8b5f98b_cVw">
+            <body>This attribute contains the statistical near end performnace parameters.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rCtq0DaeEem8b5f98b_cVw" name="statisticalFarEndDmParameters" visibility="public" type="_3FTVAERsEeKsbYfVW3kmQQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rCtq0TaeEem8b5f98b_cVw" annotatedElement="_rCtq0DaeEem8b5f98b_cVw">
+            <body>This attribute contains the statistical far end performnace parameters.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_c0CVUou1EeK2NvDLt60gDw" name="samplesNearEndDmParameters" visibility="public" type="_zeuZsFEbEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_c0CVU4u1EeK2NvDLt60gDw" annotatedElement="_c0CVUou1EeK2NvDLt60gDw">
             <body>This attribute contains the results of an on-demand frame delay measurement job in the ingress direction.</body>
           </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PhvCEDaeEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PiHckDaeEem8b5f98b_cVw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pjlxIIu1EeK2NvDLt60gDw" name="samplesFarEndDmParameters" visibility="public" type="_zeuZsFEbEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pjlxIYu1EeK2NvDLt60gDw" annotatedElement="_pjlxIIu1EeK2NvDLt60gDw">
+            <body>This attribute contains the results of an on-demand frame delay measurement job in the ingress direction.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OZ4CIDaeEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OaMLMDaeEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_u10QcFesEeiqWMdX2ZZi3w" name="EthOnDemandLmPerformanceData">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_in3Is0N1EeKtRKTHZgJhIg" name="onDemandFarEndLmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_in3ItEN1EeKtRKTHZgJhIg" annotatedElement="_in3Is0N1EeKtRKTHZgJhIg">
-            <body>This attribute contains the results of an on-demand synthetic loss measurement job in the egress direction.</body>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HziK0DafEem8b5f98b_cVw" name="bidirectionalUas" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Hzix4DafEem8b5f98b_cVw" annotatedElement="_HziK0DafEem8b5f98b_cVw">
+            <body>This attribute contains the bidirectional UAS (unavailable seconds) detected in the monitoring interval.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_Hzix4TafEem8b5f98b_cVw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HzmcQDafEem8b5f98b_cVw" name="statisticalNearEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_HzmcQTafEem8b5f98b_cVw" annotatedElement="_HzmcQDafEem8b5f98b_cVw">
+            <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_in3IsEN1EeKtRKTHZgJhIg" name="onDemandNearEndLmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HzegcDafEem8b5f98b_cVw" name="statisticalFarEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_HzegcTafEem8b5f98b_cVw" annotatedElement="_HzegcDafEem8b5f98b_cVw">
+            <body>This attribute contains the statistical far end performnace parameters.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_in3IsEN1EeKtRKTHZgJhIg" name="totalCountersNearEndLmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_in3IsUN1EeKtRKTHZgJhIg" annotatedElement="_in3IsEN1EeKtRKTHZgJhIg">
             <body>This attribute contains the results of an on-demand synthetic loss measurement job in the ingress direction.</body>
           </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WRNx0DaeEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WRgswDaeEem8b5f98b_cVw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_in3Is0N1EeKtRKTHZgJhIg" name="totalCountersFarEndLmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_in3ItEN1EeKtRKTHZgJhIg" annotatedElement="_in3Is0N1EeKtRKTHZgJhIg">
+            <body>This attribute contains the results of an on-demand synthetic loss measurement job in the egress direction.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VMoIUDaeEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VNPzYDaeEem8b5f98b_cVw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_J1lZwFiCEei2nODetmeP6A" name="EthProActiveDualEndedMeasurementJob">
@@ -1534,12 +1401,15 @@ If the particular ifAlias object does not contain any values, another chassis id
       <packagedElement xmi:type="uml:Class" xmi:id="__VkGMBgkEem7b6CPWW1OrA" name="EthMipCommon">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_i_B8wMWWEeiWCKGKl1wb8w" name="isFullMip" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_i_B8wcWWEeiWCKGKl1wb8w" annotatedElement="_i_B8wMWWEeiWCKGKl1wb8w">
-            <body>This attribute indicates whether the MIP is a full MIP (true) or a down-half MIP (false).</body>
+            <body>This attribute indicates whether the MIP is a full MIP (true) or a down-half MIP (false). Up-half MIP is not foreseen by G.8052</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_oZZ3ABglEem7b6CPWW1OrA" name="EthMegCommon">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ap5AYDoOEemSPvPXzEQ11A" name="megLevel">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_vZQJoGA8Eei7_-Uhq6CryQ" name="clientMel">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
@@ -1617,6 +1487,253 @@ Note that a value of 0 means not applicable (NA), which is for the cases of sing
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_q5_sMDW4Eem8b5f98b_cVw" name="EthProActive1DmSourcePerformanceData">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_FznaADW5Eem8b5f98b_cVw" annotatedElement="_q5_sMDW4Eem8b5f98b_cVw">
+          <body>This object class represents the PM current data collected in a pro-active delay measurement job (using 1DM), on the source or controller MEP.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_3CgWIDW4Eem8b5f98b_cVw" name="EthProActive1LmSourcePerformanceData">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_DITDQDW5Eem8b5f98b_cVw" annotatedElement="_3CgWIDW4Eem8b5f98b_cVw">
+          <body>This object class represents the PM current data collected in a pro-active loss measurement job (using 1SL), on the source or controller MEP.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_Sj9_QDY2Eem8b5f98b_cVw" name="EthOnDemand1LmSourcePerformanceData"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_d1y40DY2Eem8b5f98b_cVw" name="EthOnDemand1DmSourcePerformanceData"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_9DICoDamEem8b5f98b_cVw" name="EthConnectivityServiceEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_CdmR0TaoEem8b5f98b_cVw" name="_etyTerminationCommonPac" type="_KIJ_MDanEem8b5f98b_cVw" association="_CdjOgDaoEem8b5f98b_cVw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Cdm44DaoEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Cdm44TaoEem8b5f98b_cVw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_DGyG0jaqEem8b5f98b_cVw" name="ethTerminationCommonPac" type="_nsU80DapEem8b5f98b_cVw" association="_DGw4sDaqEem8b5f98b_cVw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DGzU8DaqEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DGzU8TaqEem8b5f98b_cVw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PA_5QjauEem8b5f98b_cVw" name="_ethCtpCommonPac" type="_RLND0DaqEem8b5f98b_cVw" association="_PA9dADauEem8b5f98b_cVw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PBBHYDauEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PBBucDauEem8b5f98b_cVw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KIJ_MDanEem8b5f98b_cVw" name="EtyTerminationCommonPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Vu71EDanEem8b5f98b_cVw" name="isFtsEnabled" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Vu71ETanEem8b5f98b_cVw" annotatedElement="_Vu71EDanEem8b5f98b_cVw">
+            <body>This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_Vu71EjanEem8b5f98b_cVw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZG6dgDanEem8b5f98b_cVw" name="isTxPauseEnabled" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ZG7EkDanEem8b5f98b_cVw" annotatedElement="_ZG6dgDanEem8b5f98b_cVw">
+            <body>This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_ZG7EkTanEem8b5f98b_cVw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_nsU80DapEem8b5f98b_cVw" name="EthTerminationCommonPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rPDQDapEem8b5f98b_cVw" name="priorityRegenerate" visibility="public" type="_GjpskCbKEd-tK43JMxNtYw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0rPDQTapEem8b5f98b_cVw" annotatedElement="_0rPDQDapEem8b5f98b_cVw">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0rPDQjapEem8b5f98b_cVw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0rPDQzapEem8b5f98b_cVw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_0rPDRDapEem8b5f98b_cVw" type="_GjpskCbKEd-tK43JMxNtYw" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rSGkDapEem8b5f98b_cVw" name="priorityCodePointConfig" visibility="public" type="_tjBD8CdpEd-sQoLP0EY2BQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0rSGkTapEem8b5f98b_cVw" annotatedElement="_0rSGkDapEem8b5f98b_cVw">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rVJ4DapEem8b5f98b_cVw" name="etherType" visibility="public" type="_kQIFACelEd-sQoLP0EY2BQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0rVJ4TapEem8b5f98b_cVw" annotatedElement="_0rVJ4DapEem8b5f98b_cVw">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_0rVw8DapEem8b5f98b_cVw" type="_kQIFACelEd-sQoLP0EY2BQ" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rZbUDapEem8b5f98b_cVw" name="frametypeConfig" visibility="public" type="_n3YdgCEsEd-ysdtezPKi3w">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0rZbUTapEem8b5f98b_cVw" annotatedElement="_0rZbUDapEem8b5f98b_cVw">
+            <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_0rZbUjapEem8b5f98b_cVw" name="AllowUntaggedOnly" type="_n3YdgCEsEd-ysdtezPKi3w" instance="_tKgkACEsEd-ysdtezPKi3w"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rceoDapEem8b5f98b_cVw" name="filterConfig1" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0rceoTapEem8b5f98b_cVw" annotatedElement="_0rceoDapEem8b5f98b_cVw">
+            <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.&#xD;
+It indicates the configured filter action for each of the 33 group MAC addresses for control frames.&#xD;
+&#xD;
+The 33 MAC addresses are:&#xD;
+01-80-C2-00-00-10, &#xD;
+01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and &#xD;
+01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
+&#xD;
+The filter action is Pass or Block. &#xD;
+If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
+If none of the above addresses match, the ETH_CI_D is passed.&#xD;
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0rceojapEem8b5f98b_cVw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0rceozapEem8b5f98b_cVw" value="*"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_0rcepDapEem8b5f98b_cVw" type="_hYZs0BWEEd-Si5Ih_dYBog" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rhXIDapEem8b5f98b_cVw" name="portVid" visibility="public" type="_d1LyACbNEd-tK43JMxNtYw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0rhXITapEem8b5f98b_cVw" annotatedElement="_0rhXIDapEem8b5f98b_cVw">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_0rhXIjapEem8b5f98b_cVw" type="_d1LyACbNEd-tK43JMxNtYw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_RLND0DaqEem8b5f98b_cVw" name="EthCtpCommonPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Osz7EOuHEeGZr5p9Vdkojw" name="auxiliaryFunctionPositionSequence" visibility="public" isOrdered="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_UtlxwOuHEeGZr5p9Vdkojw" annotatedElement="_Osz7EOuHEeGZr5p9Vdkojw">
+            <body>This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_njp40OuHEeGZr5p9Vdkojw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_njp40euHEeGZr5p9Vdkojw" value="*"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTGRcCFqEeWrHvhCHfosZA" value="">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dOaR8C0xEeC5VOR5P4wONQ" name="collectorMaxDelay" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Bywz4DBMEeC_I_YldZCMxA" annotatedElement="_dOaR8C0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+The value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSVccCFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ukk3kDqaEeCu35lketJ8Yg" name="csfConfig" visibility="public" type="_10eLcKNEEeKZoeGA12VHIQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4eC1EMNoEeCUp9m8vv2E5A" annotatedElement="_ukk3kDqaEeCu35lketJ8Yg">
+            <body>This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-A0TI5MuEeCKK9uc7Khnmg" name="csfRdiFdiEnable" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hbwIsMNpEeCUp9m8vv2E5A" annotatedElement="_-A0TI5MuEeCKK9uc7Khnmg">
+            <body>This attribute models the MI_CSFrdifdiEnable information defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_j0ycoMNpEeCUp9m8vv2E5A">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hBZhA5MvEeCKK9uc7Khnmg" name="csfReport" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_HVNoMMNqEeCUp9m8vv2E5A" annotatedElement="_hBZhA5MvEeCKK9uc7Khnmg">
+            <body>This attribute models the MI_CSF_Reported information defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_JSFkkMNqEeCUp9m8vv2E5A">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__7TK8C01EeC5VOR5P4wONQ" name="filterConfig" visibility="public" type="_s3CEAK2EEeKoWKjPsL4xyQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_YiP1YI3gEeGyj-TNVzlOGQ" annotatedElement="__7TK8C01EeC5VOR5P4wONQ">
+            <body>This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:&#xD;
+- All bridges address: 01-80-C2-00-00-10,&#xD;
+- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,&#xD;
+- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
+The filter action is Pass or Block. &#xD;
+If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
+If none of the above addresses match, the ETH_CI_D is passed.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDbuEOt8EeGPOswgCwFOKw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDbuEet8EeGPOswgCwFOKw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSTAMSFqEeWrHvhCHfosZA" type="_s3CEAK2EEeKoWKjPsL4xyQ" value="See data type">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LpAAEJMvEeCKK9uc7Khnmg" name="filterConfigSnk" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_LpAAEZMvEeCKK9uc7Khnmg" annotatedElement="_LpAAEJMvEeCKK9uc7Khnmg">
+            <body>This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:&#xD;
+01-80-C2-00-00-10, &#xD;
+01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and &#xD;
+01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
+The filter action is Pass or Block. &#xD;
+If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
+If none of the above addresses match, the ETH_CI_D is passed.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_t9NOIOuCEeGZr5p9Vdkojw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_t9NOIeuCEeGZr5p9Vdkojw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0_3YIC01EeC5VOR5P4wONQ" name="isSsfReported" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_M0ktUI3gEeGyj-TNVzlOGQ" annotatedElement="_0_3YIC01EeC5VOR5P4wONQ">
+            <body>This attribute provisions whether the SSF defect should be reported as fault cause or not.&#xD;
+It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_NSrloI3gEeGyj-TNVzlOGQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xo3rYJMvEeCKK9uc7Khnmg" name="macLength" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_eyLeYMNpEeCUp9m8vv2E5A" annotatedElement="_Xo3rYJMvEeCKK9uc7Khnmg">
+            <body>This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3lSysMNpEeCUp9m8vv2E5A" value="2000">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pU1bwC0yEeC5VOR5P4wONQ" name="pllThr" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_u4IrADBNEeC_I_YldZCMxA" annotatedElement="_pU1bwC0yEeC5VOR5P4wONQ">
+            <body>This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6WJhwEXMEeKyK7rRd9C5sg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6WJhwUXMEeKyK7rRd9C5sg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VAOosziEEeGKKvtWtO2aIg" name="vlanConfig" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_VAOotDiEEeGKKvtWtO2aIg" annotatedElement="_VAOosziEEeGKKvtWtO2aIg">
+            <body>This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTer8CFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AbyakjO6Eea40e5DA9KE3w" name="_trafficShapingPac" type="_8QIrYK4wEeGjbtFXtCFKWg" aggregation="composite" association="_AbxMcDO6Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C7qWUDO6Eea40e5DA9KE3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C7ySIDO6Eea40e5DA9KE3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3D1zwTO5Eea40e5DA9KE3w" name="_trafficConditioningPac" type="_8QR1UK4wEeGjbtFXtCFKWg" aggregation="composite" association="_3Dz-kDO5Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pTncDO5Eea40e5DA9KE3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pcxYDO5Eea40e5DA9KE3w" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_h4caMDbLEem8b5f98b_cVw" name="EthServiceIntefacePointSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_1mUdkDbMEem8b5f98b_cVw" general="_myT2sDbMEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_myT2sDbMEem8b5f98b_cVw" name="EtyPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PFLnQHzUEd2S7rQMqMRYLA" name="phyType" visibility="public" type="_AdKOUOxfEeGzwM2Uvwf5Xw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_39t80OxeEeGzwM2Uvwf5Xw" annotatedElement="_PFLnQHzUEd2S7rQMqMRYLA">
+            <body>This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_iICjoNHUEeKzI4N0oSjmcw" name="UNKNOWN" type="_AdKOUOxfEeGzwM2Uvwf5Xw" instance="_I44dcOxfEeGzwM2Uvwf5Xw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QoRxsHzUEd2S7rQMqMRYLA" name="phyTypeList" visibility="public" type="_AdKOUOxfEeGzwM2Uvwf5Xw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_q3xvYOxgEeGzwM2Uvwf5Xw" annotatedElement="_QoRxsHzUEd2S7rQMqMRYLA">
+            <body>This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_R5yc4HzUEd2S7rQMqMRYLA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_R5yc4XzUEd2S7rQMqMRYLA" value="*"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSlUECFqEeWrHvhCHfosZA" type="_AdKOUOxfEeGzwM2Uvwf5Xw" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_M-QGADh9Eem1lYbrIE6BNw" name="EthConnectivityService"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_dP6U4JKmEdybINoKQq_hfQ" name="TypeDefinitions">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dQAbgJKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
@@ -2351,7 +2468,7 @@ The value 0 means that the value is not relevant.</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_d-uu0FyhEeG9K6GVnuYc0w" name="SINGLE_SERIES"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_fjBMEFyhEeG9K6GVnuYc0w" name="REPETITIVE_SERIES"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_zeuZsFEbEd6VSrclB-Ybig" name="OnDemandDmPerformanceParameters">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_zeuZsFEbEd6VSrclB-Ybig" name="SamplesDmPerformanceParameters">
         <ownedComment xmi:type="uml:Comment" xmi:id="_NUvNsEOTEeKtRKTHZgJhIg" annotatedElement="_zeuZsFEbEd6VSrclB-Ybig">
           <body>This data type contains the results of an on-demand delay measurement job.</body>
         </ownedComment>
@@ -2378,7 +2495,7 @@ The value 0 means that the value is not relevant.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tyhCQUOAEeKtRKTHZgJhIg" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_uyMrEFEZEd6VSrclB-Ybig" name="OnDemandLmPerformanceParameters">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_uyMrEFEZEd6VSrclB-Ybig" name="TotalCountersLmPerformanceParameters">
         <ownedComment xmi:type="uml:Comment" xmi:id="_TtVSEELQEeKtRKTHZgJhIg" annotatedElement="_uyMrEFEZEd6VSrclB-Ybig">
           <body>This data type contains the results of an on-demand loss measurement job.</body>
         </ownedComment>
@@ -2870,6 +2987,38 @@ Bit 8 (MSB).</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iokckBjwEemR9Pg4e1yNpA" name="PRBS-2^31-1-WITHOUT-CRC-32"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_m1H8kBjwEemR9Pg4e1yNpA" name="PRBS-2^31-1-WITH-CRC-32"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_peSK0DjnEem1lYbrIE6BNw" name="BandwidthProfileType">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_twb8gDjnEem1lYbrIE6BNw" name="MEF_10.x"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vqnxQDjnEem1lYbrIE6BNw" name="RFC_2697"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_xhdXEDjnEem1lYbrIE6BNw" name="RFC_2698"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_y9KgEDjnEem1lYbrIE6BNw" name="RFC_4115"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_t77v8DjpEem1lYbrIE6BNw" name="BandwidthProfile">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EmpNUDjqEem1lYbrIE6BNw" name="bwProfileType" type="_peSK0DjnEem1lYbrIE6BNw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Fpjb0DjqEem1lYbrIE6BNw" name="committedInformationRate">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_ReBfoFs7EeexvMtO2oNM9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GoS8ADjqEem1lYbrIE6BNw" name="committedBurstSize">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_ReBfoFs7EeexvMtO2oNM9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Il4DADjqEem1lYbrIE6BNw" name="peakInformationRate">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_ReBfoFs7EeexvMtO2oNM9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_J7EUUDjqEem1lYbrIE6BNw" name="peakBurstSize">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_ReBfoFs7EeexvMtO2oNM9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LHK7EDjqEem1lYbrIE6BNw" name="colorAware">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_achUcDjqEem1lYbrIE6BNw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MQ144DjqEem1lYbrIE6BNw" name="couplingFlag">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_dQNkEDjqEem1lYbrIE6BNw"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_tmC3ADp_EemSPvPXzEQ11A" name="BandwidthProfileAugmentsCapacity" client="_t77v8DjpEem1lYbrIE6BNw">
+        <supplier xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_x3G-wDxBEeaRI-H69PghuA" name="Associations">
       <packagedElement xmi:type="uml:Association" xmi:id="_ITi4QDN-Eea40e5DA9KE3w" name="EthCepSpecHasCtpPac" memberEnd="_ITjfUjN-Eea40e5DA9KE3w _ITkGYDN-Eea40e5DA9KE3w">
@@ -2878,17 +3027,17 @@ Bit 8 (MSB).</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_ITkGYDN-Eea40e5DA9KE3w" name="_lpSpec" type="_T7cP0DN7Eea40e5DA9KE3w" association="_ITi4QDN-Eea40e5DA9KE3w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_3Dz-kDO5Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficCondPac" memberEnd="_3D1zwTO5Eea40e5DA9KE3w _3D3B4DO5Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_3Dz-kDO5Eea40e5DA9KE3w" name="EthCtpCommonPacHasTrafficCondPac" memberEnd="_3D1zwTO5Eea40e5DA9KE3w _3D3B4DO5Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3D1MsDO5Eea40e5DA9KE3w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3D1zwDO5Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_3D3B4DO5Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_3Dz-kDO5Eea40e5DA9KE3w"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_3D3B4DO5Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_RLND0DaqEem8b5f98b_cVw" association="_3Dz-kDO5Eea40e5DA9KE3w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_AbxMcDO6Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficShapingPac" memberEnd="_AbyakjO6Eea40e5DA9KE3w _AbzosDO6Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_AbxMcDO6Eea40e5DA9KE3w" name="EthCtpCommonPacHasTrafficShapingPac" memberEnd="_AbyakjO6Eea40e5DA9KE3w _AbzosDO6Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AbyakDO6Eea40e5DA9KE3w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AbyakTO6Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_AbzosDO6Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_AbxMcDO6Eea40e5DA9KE3w"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_AbzosDO6Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_RLND0DaqEem8b5f98b_cVw" association="_AbxMcDO6Eea40e5DA9KE3w"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="__17LsDN9Eea40e5DA9KE3w" name="EthCepSpecHasTermPac" memberEnd="__18Z0jN9Eea40e5DA9KE3w __19A4DN9Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__18Z0DN9Eea40e5DA9KE3w" source="org.eclipse.papyrus">
@@ -2992,7 +3141,7 @@ Bit 8 (MSB).</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="__v0l4GAwEei7_-Uhq6CryQ" name="EthOnDemand1DmAugmentsCurrentData" client="_vqsqAFesEeiqWMdX2ZZi3w">
         <supplier xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_MLrkcGBDEei7_-Uhq6CryQ" name="EthProActive1DmAugmentsCurrentData" client="_1D9goERyEeKsbYfVW3kmQQ">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_MLrkcGBDEei7_-Uhq6CryQ" name="EthProActive1DmAugmentsCurrentData" client="_MP5wgJKmEdybINoKQq_hfQ">
         <supplier xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_wt8VkGBFEei7_-Uhq6CryQ" name="EthProActive1DmAugmentsHistoryData" client="_1D9goERyEeKsbYfVW3kmQQ">
@@ -3146,9 +3295,6 @@ Bit 8 (MSB).</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_EzAI4BT8Eemlb5smEiStFg" client="_c43ZEFhkEeiYiLRYKaTpTw">
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_HnJEcBT8Eemlb5smEiStFg" client="_NOPhwGBQEeiBxvDM8HEDKw">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_K3yV0BT8Eemlb5smEiStFg" client="_c7CKwGBQEeiBxvDM8HEDKw">
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
       </packagedElement>
@@ -3156,9 +3302,6 @@ Bit 8 (MSB).</body>
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_yKL-MBT8Eemlb5smEiStFg" client="_HfynMFSJEeitkMFXBYQFcg">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_0w-aQBT8Eemlb5smEiStFg" client="_oj4vsFSIEeitkMFXBYQFcg">
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_4KCAwBT8Eemlb5smEiStFg" client="_J1lZwFiCEei2nODetmeP6A">
@@ -3176,16 +3319,10 @@ Bit 8 (MSB).</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_d3nncBT9Eemlb5smEiStFg" client="_noRbAE-xEeitY7qZgkO_XQ">
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_g2nvMBT9Eemlb5smEiStFg" client="_HfynMFSJEeitkMFXBYQFcg">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_jS9OwBT9Eemlb5smEiStFg" client="_oj4vsFSIEeitkMFXBYQFcg">
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_lq7LsBT9Eemlb5smEiStFg" client="_J1lZwFiCEei2nODetmeP6A">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_pPHrMBT9Eemlb5smEiStFg" client="_c43ZEFhkEeiYiLRYKaTpTw">
         <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_rw984BT9Eemlb5smEiStFg" client="_NOPhwGBQEeiBxvDM8HEDKw">
@@ -3316,6 +3453,266 @@ Bit 8 (MSB).</body>
       </packagedElement>
       <packagedElement xmi:type="uml:Usage" xmi:id="_vkDtMB8zEem5B__-Dm9B_g" client="_BLIbAIb5Eeil5oKL3Vgl-g" supplier="_3FTVAERsEeKsbYfVW3kmQQ"/>
       <packagedElement xmi:type="uml:Usage" xmi:id="_-67wkB8zEem5B__-Dm9B_g" client="_E6_X8Ib5Eeil5oKL3Vgl-g" supplier="_oF4ZgFEYEd6VSrclB-Ybig"/>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ZrMocDW5Eem8b5f98b_cVw" client="_q5_sMDW4Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_fxhGcDW5Eem8b5f98b_cVw" client="_q5_sMDW4Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_sAu1UDW5Eem8b5f98b_cVw" client="_3CgWIDW4Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_x_PbIDW5Eem8b5f98b_cVw" client="_3CgWIDW4Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_kqPBEDY2Eem8b5f98b_cVw" client="_d1y40DY2Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_mJJPEDY2Eem8b5f98b_cVw" client="_d1y40DY2Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ox5aADY2Eem8b5f98b_cVw" client="_Sj9_QDY2Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_qNaVwDY2Eem8b5f98b_cVw" client="_Sj9_QDY2Eem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_mN4TwDanEem8b5f98b_cVw" name="EtyTerminationPacHasEtyTerminationCommonPac" memberEnd="_mN_ogDanEem8b5f98b_cVw _mOA2ojanEem8b5f98b_cVw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_mN9zUDanEem8b5f98b_cVw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_mN9zUTanEem8b5f98b_cVw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_mOA2ojanEem8b5f98b_cVw" name="etyterminationpac" type="_fzLz0OxQEeGzwM2Uvwf5Xw" association="_mN4TwDanEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_CdjOgDaoEem8b5f98b_cVw" name="EthCsepSpecHasEtyTerminationCommonPac" memberEnd="_CdmR0TaoEem8b5f98b_cVw _Cdm44jaoEem8b5f98b_cVw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CdlqwDaoEem8b5f98b_cVw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CdmR0DaoEem8b5f98b_cVw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Cdm44jaoEem8b5f98b_cVw" name="ethconnectivityserviceendpointspec" type="_9DICoDamEem8b5f98b_cVw" association="_CdjOgDaoEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_XPJ1MDaoEem8b5f98b_cVw" name="EthCsepSpecAugmentsCsep" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_rj_x8DapEem8b5f98b_cVw" name="EthTerminationPacHasEthTerminationCommonPac" memberEnd="_rkBnITapEem8b5f98b_cVw _rkDcUTapEem8b5f98b_cVw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rkBAEDapEem8b5f98b_cVw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rkBnIDapEem8b5f98b_cVw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_rkDcUTapEem8b5f98b_cVw" name="ethterminationpac" type="_ACUEMOxFEeGzwM2Uvwf5Xw" association="_rj_x8DapEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_DGw4sDaqEem8b5f98b_cVw" name="EthCsepSpecHasEthTerminationCommonPac" memberEnd="_DGyG0jaqEem8b5f98b_cVw _DGz8ADaqEem8b5f98b_cVw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_DGyG0DaqEem8b5f98b_cVw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_DGyG0TaqEem8b5f98b_cVw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_DGz8ADaqEem8b5f98b_cVw" name="ethconnectivityserviceendpointspec" type="_9DICoDamEem8b5f98b_cVw" association="_DGw4sDaqEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_4n7QYDarEem8b5f98b_cVw" name="EthCtpPacHasEthCtpCommonPac" memberEnd="_4n8egjarEem8b5f98b_cVw _4n-TsDarEem8b5f98b_cVw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4n8egDarEem8b5f98b_cVw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4n8egTarEem8b5f98b_cVw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_4n-TsDarEem8b5f98b_cVw" name="ethctppac" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_4n7QYDarEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_PA9dADauEem8b5f98b_cVw" name="EthCsepSpecHasEthCtpCommonPac" memberEnd="_PA_5QjauEem8b5f98b_cVw _PBBucTauEem8b5f98b_cVw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PA_5QDauEem8b5f98b_cVw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PA_5QTauEem8b5f98b_cVw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_PBBucTauEem8b5f98b_cVw" name="ethconnectivityserviceendpointspec" type="_9DICoDamEem8b5f98b_cVw" association="_PA9dADauEem8b5f98b_cVw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_Xt0n0DagEem8b5f98b_cVw" client="_tDn6EFesEeiqWMdX2ZZi3w" supplier="_3FTVAERsEeKsbYfVW3kmQQ"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_ZetWoDagEem8b5f98b_cVw" client="_vqsqAFesEeiqWMdX2ZZi3w" supplier="_3FTVAERsEeKsbYfVW3kmQQ"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_ctjRMDagEem8b5f98b_cVw" client="_u10QcFesEeiqWMdX2ZZi3w" supplier="_oF4ZgFEYEd6VSrclB-Ybig"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_eXbZEDagEem8b5f98b_cVw" client="_w8GAcFesEeiqWMdX2ZZi3w" supplier="_oF4ZgFEYEd6VSrclB-Ybig"/>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_wNHZsDbLEem8b5f98b_cVw" name="EthSipAugmentsSip" client="_h4caMDbLEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_wkieYDbPEem8b5f98b_cVw" client="_h4caMDbLEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_zMRVoDbPEem8b5f98b_cVw" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_z7X3UDbPEem8b5f98b_cVw" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_0lkD0DbPEem8b5f98b_cVw" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_1rtzkDbPEem8b5f98b_cVw" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_qNckADbQEem8b5f98b_cVw" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_UpR4ADh9Eem1lYbrIE6BNw" client="_M-QGADh9Eem1lYbrIE6BNw">
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_J_wF0DiDEem1lYbrIE6BNw" client="_M-QGADh9Eem1lYbrIE6BNw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_XkjHkDiDEem1lYbrIE6BNw" client="_M-QGADh9Eem1lYbrIE6BNw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_rB4YEDiFEem1lYbrIE6BNw" client="_M-QGADh9Eem1lYbrIE6BNw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_U4WqQDiHEem1lYbrIE6BNw" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_91tjIDiIEem1lYbrIE6BNw" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_DscF8DiJEem1lYbrIE6BNw" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_JOYrkDiJEem1lYbrIE6BNw" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_B2zkkDiKEem1lYbrIE6BNw" client="_PONicBXLEemlb5smEiStFg" supplier="_MP5wgJKmEdybINoKQq_hfQ"/>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_DJcRIDiKEem1lYbrIE6BNw" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_EPhvcDiKEem1lYbrIE6BNw" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Fb3mwDiKEem1lYbrIE6BNw" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_GQL_oDiKEem1lYbrIE6BNw" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_HRBKgDiKEem1lYbrIE6BNw" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_l-v8gDkhEemjx6Nna_xyog" client="_NoBnwBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_nagI0DkhEemjx6Nna_xyog" client="_NoBnwBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_oOE60DkhEemjx6Nna_xyog" client="_NoBnwBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_o_tzIDkhEemjx6Nna_xyog" client="_NoBnwBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_tLugkDkhEemjx6Nna_xyog" client="_NoBnwBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_uEvzQDkhEemjx6Nna_xyog" client="_NoBnwBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_JRFowDkiEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_QUL4EDkiEemjx6Nna_xyog" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_bNLa4DkiEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_eYaAwDkiEemjx6Nna_xyog" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_sohQYDkiEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_wDwBIDkiEemjx6Nna_xyog" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_16iOUDkiEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_rDBAQDkkEemjx6Nna_xyog" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_uxTP4DkkEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_10m6kDkkEemjx6Nna_xyog" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_4yhdMDkkEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_9InTsDkkEemjx6Nna_xyog" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="__0Y9cDkkEemjx6Nna_xyog" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_KtbHEDkmEemjx6Nna_xyog" client="_iN418E-xEeitY7qZgkO_XQ">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Lb7L0DkmEemjx6Nna_xyog" client="_jrxwQE-xEeitY7qZgkO_XQ">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_MJVEYDkmEemjx6Nna_xyog" client="_lJFbwE-xEeitY7qZgkO_XQ">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_usMbgDkmEemjx6Nna_xyog" client="_HfynMFSJEeitkMFXBYQFcg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Js7d8DknEemjx6Nna_xyog" client="_noRbAE-xEeitY7qZgkO_XQ">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_PRbBQDknEemjx6Nna_xyog" client="_oj4vsFSIEeitkMFXBYQFcg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_UrsRkDknEemjx6Nna_xyog" client="_noRbAE-xEeitY7qZgkO_XQ">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_d7zyEDknEemjx6Nna_xyog" client="_HfynMFSJEeitkMFXBYQFcg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_sSlDUDknEemjx6Nna_xyog" client="_c7CKwGBQEeiBxvDM8HEDKw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_xLfTADknEemjx6Nna_xyog" client="_J1lZwFiCEei2nODetmeP6A">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_1768IDknEemjx6Nna_xyog" client="_c43ZEFhkEeiYiLRYKaTpTw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_6zhkQDknEemjx6Nna_xyog" client="_NOPhwGBQEeiBxvDM8HEDKw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_mF1sQMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ALaO8DkoEemjx6Nna_xyog" client="_NOPhwGBQEeiBxvDM8HEDKw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_J22ZgDkoEemjx6Nna_xyog" client="_J1lZwFiCEei2nODetmeP6A">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_QNOFsDkoEemjx6Nna_xyog" client="_c7CKwGBQEeiBxvDM8HEDKw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_V0OxgDkoEemjx6Nna_xyog" client="_c43ZEFhkEeiYiLRYKaTpTw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Svn-8DlSEemSPvPXzEQ11A" client="_oj4vsFSIEeitkMFXBYQFcg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_z38DoDlSEemSPvPXzEQ11A" client="_NOPhwGBQEeiBxvDM8HEDKw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_5HQ4ME5CEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_kOlTsDlTEemSPvPXzEQ11A" client="_c43ZEFhkEeiYiLRYKaTpTw">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_SZH4kDlUEemSPvPXzEQ11A" client="_HfynMFSJEeitkMFXBYQFcg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_gxN8sBKKEemxeNG9TDCtFQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_6ZqZUDlUEemSPvPXzEQ11A" client="_h4caMDbLEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_RFR1oDlVEemSPvPXzEQ11A" client="_M-QGADh9Eem1lYbrIE6BNw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_hHFFUDlVEemSPvPXzEQ11A" client="_9DICoDamEem8b5f98b_cVw">
+        <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_MF8YYDlWEemSPvPXzEQ11A" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_iEM8QDlSEemSPvPXzEQ11A" client="_oj4vsFSIEeitkMFXBYQFcg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_SrzDgMOfEeaFfJxGCRaf4A"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_fhZtAEWoEeaB8vMnkFQLXQ" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_kV26gEWoEeaB8vMnkFQLXQ">
@@ -6866,15 +7263,7 @@ Bit 8 (MSB).</body>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJKyxM1Eee0L_IMWjydgQ" base_StructuralFeature="__18Z0jN9Eea40e5DA9KE3w"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJKzBM1Eee0L_IMWjydgQ" base_StructuralFeature="_ITjfUjN-Eea40e5DA9KE3w"/>
   <OpenModel_Profile_3:OpenModelClass xmi:id="_xbJKzRM1Eee0L_IMWjydgQ" base_Class="_ACUEMOxFEeGzwM2Uvwf5Xw"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJKzhM1Eee0L_IMWjydgQ" base_StructuralFeature="_upySMHnOEd2GobjTM4neEA"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJKzxM1Eee0L_IMWjydgQ" base_StructuralFeature="_vOIbgHp1Ed2F76X026nNcA"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK0BM1Eee0L_IMWjydgQ" base_StructuralFeature="__KuU8HnOEd2GobjTM4neEA"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK0RM1Eee0L_IMWjydgQ" base_StructuralFeature="_0_GOcHnOEd2GobjTM4neEA"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK0hM1Eee0L_IMWjydgQ" base_StructuralFeature="_zDHp8HnOEd2GobjTM4neEA"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK0xM1Eee0L_IMWjydgQ" base_StructuralFeature="_q7yL8nnNEd2GobjTM4neEA"/>
   <OpenModel_Profile_3:OpenModelClass xmi:id="_xbJK1BM1Eee0L_IMWjydgQ" base_Class="_fzLz0OxQEeGzwM2Uvwf5Xw"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK1RM1Eee0L_IMWjydgQ" base_StructuralFeature="_J3_wsHzUEd2S7rQMqMRYLA"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK1hM1Eee0L_IMWjydgQ" base_StructuralFeature="_ibtJIC0kEeC5VOR5P4wONQ"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK1xM1Eee0L_IMWjydgQ" base_StructuralFeature="_PFLnQHzUEd2S7rQMqMRYLA"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_xbJK2BM1Eee0L_IMWjydgQ" base_StructuralFeature="_QoRxsHzUEd2S7rQMqMRYLA"/>
   <OpenModel_Profile_3:OpenModelClass xmi:id="_xbJK2RM1Eee0L_IMWjydgQ" base_Class="_8QR1UK4wEeGjbtFXtCFKWg"/>
@@ -7076,14 +7465,6 @@ Bit 8 (MSB).</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7olhhsEeewCs0lkpWskw" base_Property="_3D1zwTO5Eea40e5DA9KE3w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7olxhsEeewCs0lkpWskw" base_Property="__18Z0jN9Eea40e5DA9KE3w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7omBhsEeewCs0lkpWskw" base_Property="_ITjfUjN-Eea40e5DA9KE3w"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7omRhsEeewCs0lkpWskw" base_Property="_upySMHnOEd2GobjTM4neEA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7omhhsEeewCs0lkpWskw" base_Property="_vOIbgHp1Ed2F76X026nNcA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7omxhsEeewCs0lkpWskw" base_Property="__KuU8HnOEd2GobjTM4neEA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7onBhsEeewCs0lkpWskw" base_Property="_0_GOcHnOEd2GobjTM4neEA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7onRhsEeewCs0lkpWskw" base_Property="_zDHp8HnOEd2GobjTM4neEA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7onhhsEeewCs0lkpWskw" base_Property="_q7yL8nnNEd2GobjTM4neEA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7onxhsEeewCs0lkpWskw" base_Property="_J3_wsHzUEd2S7rQMqMRYLA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7ooBhsEeewCs0lkpWskw" base_Property="_ibtJIC0kEeC5VOR5P4wONQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7ooRhsEeewCs0lkpWskw" base_Property="_PFLnQHzUEd2S7rQMqMRYLA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7oohhsEeewCs0lkpWskw" base_Property="_QoRxsHzUEd2S7rQMqMRYLA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7ooxhsEeewCs0lkpWskw" base_Property="_Tg7zoOhhEeG35t-G7oiZlg"/>
@@ -7727,67 +8108,51 @@ Bit 8 (MSB).</body>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Y4ZeoQVKEemxeNG9TDCtFQ" base_StructuralFeature="_Y4Y3kAVKEemxeNG9TDCtFQ"/>
   <OpenModel_Profile_3:Specify xmi:id="_C40VUBKlEemxeNG9TDCtFQ" base_Abstraction="_BJ2SEBKlEemxeNG9TDCtFQ">
     <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+    <target></target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_sdJjMBOZEemxeNG9TDCtFQ" base_Abstraction="_pCgoUBOZEemxeNG9TDCtFQ">
-    <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+    <target>/TapiOam::createOamJob/TapiOam::input</target>
+    <target></target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_zOJ88BOZEemxeNG9TDCtFQ" base_Abstraction="_qA1RwBOZEemxeNG9TDCtFQ">
     <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_OWpNMBOaEemxeNG9TDCtFQ" base_Abstraction="_AbzqABOaEemxeNG9TDCtFQ">
     <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_Peb7sBOaEemxeNG9TDCtFQ" base_Abstraction="_BIqI8BOaEemxeNG9TDCtFQ">
     <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_Qsm_ABOaEemxeNG9TDCtFQ" base_Abstraction="_B0J9ABOaEemxeNG9TDCtFQ">
     <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_fGJ3cBOaEemxeNG9TDCtFQ" base_Abstraction="_c6U5EBOaEemxeNG9TDCtFQ">
     <target>/TapiOam::createOamJob/TapiOam::input/</target>
-    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+    <target></target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_yzNigBT7Eemlb5smEiStFg" base_Abstraction="_xR_AUBT7Eemlb5smEiStFg">
     <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+    <target></target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_32OwcBT7Eemlb5smEiStFg" base_Abstraction="_21hhYBT7Eemlb5smEiStFg">
     <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="__nj-wBT7Eemlb5smEiStFg" base_Abstraction="_-lZXIBT7Eemlb5smEiStFg">
     <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_DMGcgBT8Eemlb5smEiStFg" base_Abstraction="_BYg_ABT8Eemlb5smEiStFg">
     <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_FzYn0BT8Eemlb5smEiStFg" base_Abstraction="_EzAI4BT8Eemlb5smEiStFg">
     <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
-  </OpenModel_Profile_3:Specify>
-  <OpenModel_Profile_3:Specify xmi:id="_JMQoIBT8Eemlb5smEiStFg" base_Abstraction="_HnJEcBT8Eemlb5smEiStFg">
-    <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_L-v94BT8Eemlb5smEiStFg" base_Abstraction="_K3yV0BT8Eemlb5smEiStFg">
     <target>/TapiOam::updateOamJob/TapiOam::input/</target>
-    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_v2ZWoBT8Eemlb5smEiStFg" base_Abstraction="_rZOnwBT8Eemlb5smEiStFg">
     <target>/TapiOam::getOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_zUOIYBT8Eemlb5smEiStFg" base_Abstraction="_yKL-MBT8Eemlb5smEiStFg">
-    <target>/TapiOam::getOamJob/TapiOam::output/TapiOam::oamJob</target>
-  </OpenModel_Profile_3:Specify>
-  <OpenModel_Profile_3:Specify xmi:id="_1vyy8BT8Eemlb5smEiStFg" base_Abstraction="_0w-aQBT8Eemlb5smEiStFg">
     <target>/TapiOam::getOamJob/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_5D_HkBT8Eemlb5smEiStFg" base_Abstraction="_4KCAwBT8Eemlb5smEiStFg">
@@ -7805,16 +8170,10 @@ Bit 8 (MSB).</body>
   <OpenModel_Profile_3:Specify xmi:id="_fBFJ4BT9Eemlb5smEiStFg" base_Abstraction="_d3nncBT9Eemlb5smEiStFg">
     <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
-  <OpenModel_Profile_3:Specify xmi:id="_h6VO8BT9Eemlb5smEiStFg" base_Abstraction="_g2nvMBT9Eemlb5smEiStFg">
-    <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
-  </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_kRbpMBT9Eemlb5smEiStFg" base_Abstraction="_jS9OwBT9Eemlb5smEiStFg">
     <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_mnndcBT9Eemlb5smEiStFg" base_Abstraction="_lq7LsBT9Eemlb5smEiStFg">
-    <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
-  </OpenModel_Profile_3:Specify>
-  <OpenModel_Profile_3:Specify xmi:id="_qYH6oBT9Eemlb5smEiStFg" base_Abstraction="_pPHrMBT9Eemlb5smEiStFg">
     <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:Specify xmi:id="_ss5ZoBT9Eemlb5smEiStFg" base_Abstraction="_rw984BT9Eemlb5smEiStFg">
@@ -7968,4 +8327,329 @@ Bit 8 (MSB).</body>
   <OpenModel_Profile_3:OpenModelClass xmi:id="_QzXEoB3JEemKheKmU0GLKg" base_Class="_QzWdkB3JEemKheKmU0GLKg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_wuC7wB3NEemKheKmU0GLKg" base_Property="_wuCUsB3NEemKheKmU0GLKg"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_wuEJ4B3NEemKheKmU0GLKg" base_StructuralFeature="_wuCUsB3NEemKheKmU0GLKg"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_q6A6UDW4Eem8b5f98b_cVw" base_Class="_q5_sMDW4Eem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_q6GZ4DW4Eem8b5f98b_cVw" base_Class="_q5_sMDW4Eem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_3ChkQDW4Eem8b5f98b_cVw" base_Class="_3CgWIDW4Eem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_3CiLUDW4Eem8b5f98b_cVw" base_Class="_3CgWIDW4Eem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_bvc_MDW5Eem8b5f98b_cVw" base_Abstraction="_ZrMocDW5Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_l79PcDW5Eem8b5f98b_cVw" base_Abstraction="_fxhGcDW5Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData/TapiOam:PmCurrentData:_pmHistoryData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_t1R8IDW5Eem8b5f98b_cVw" base_Abstraction="_sAu1UDW5Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_0C0ccDW5Eem8b5f98b_cVw" base_Abstraction="_x_PbIDW5Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData/TapiOam:PmCurrentData:_pmHistoryData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_Sj-mUDY2Eem8b5f98b_cVw" base_Class="_Sj9_QDY2Eem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_Sj_NYDY2Eem8b5f98b_cVw" base_Class="_Sj9_QDY2Eem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_d1zf4DY2Eem8b5f98b_cVw" base_Class="_d1y40DY2Eem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_d10G8DY2Eem8b5f98b_cVw" base_Class="_d1y40DY2Eem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_LcDRADacEem8b5f98b_cVw" base_Abstraction="_kqPBEDY2Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_RA1IMDacEem8b5f98b_cVw" base_Abstraction="_ox5aADY2Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_WzdOIDacEem8b5f98b_cVw" base_Abstraction="_mJJPEDY2Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData/TapiOam:PmCurrentData:_pmHistoryData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_aGTe8DacEem8b5f98b_cVw" base_Abstraction="_qNaVwDY2Eem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_oamJob/TapiOam:OamJob:_pmCurrentData/TapiOam:PmCurrentData:_pmHistoryData</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_rCoLQDaeEem8b5f98b_cVw" base_StructuralFeature="_rCnkMDaeEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_rCoyUDaeEem8b5f98b_cVw" base_Property="_rCnkMDaeEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_rCuR4DaeEem8b5f98b_cVw" base_StructuralFeature="_rCtq0DaeEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_rCuR4TaeEem8b5f98b_cVw" base_Property="_rCtq0DaeEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_rCx8QjaeEem8b5f98b_cVw" base_StructuralFeature="_rCx8QDaeEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_rCyjUDaeEem8b5f98b_cVw" base_Property="_rCx8QDaeEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_BFQU8jafEem8b5f98b_cVw" base_StructuralFeature="_BFQU8DafEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_BFQ8ADafEem8b5f98b_cVw" base_Property="_BFQU8DafEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_HzfHgDafEem8b5f98b_cVw" base_StructuralFeature="_HzegcDafEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HzfukDafEem8b5f98b_cVw" base_Property="_HzegcDafEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Hzix4jafEem8b5f98b_cVw" base_StructuralFeature="_HziK0DafEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Hzix4zafEem8b5f98b_cVw" base_Property="_HziK0DafEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_HznDUDafEem8b5f98b_cVw" base_StructuralFeature="_HzmcQDafEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HznDUTafEem8b5f98b_cVw" base_Property="_HzmcQDafEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_ZDAHgjafEem8b5f98b_cVw" base_StructuralFeature="_ZDAHgDafEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ZDAukDafEem8b5f98b_cVw" base_Property="_ZDAHgDafEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_9DICoTamEem8b5f98b_cVw" base_Class="_9DICoDamEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_9DJQwDamEem8b5f98b_cVw" base_Class="_9DICoDamEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_KIJ_MTanEem8b5f98b_cVw" base_Class="_KIJ_MDanEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_KIJ_MjanEem8b5f98b_cVw" base_Class="_KIJ_MDanEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Vu8cIDanEem8b5f98b_cVw" base_StructuralFeature="_Vu71EDanEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Vu8cITanEem8b5f98b_cVw" base_Property="_Vu71EDanEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_ZG7EkjanEem8b5f98b_cVw" base_StructuralFeature="_ZG6dgDanEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ZG7EkzanEem8b5f98b_cVw" base_Property="_ZG6dgDanEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_mOAPkDanEem8b5f98b_cVw" base_StructuralFeature="_mN_ogDanEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_mOAPkTanEem8b5f98b_cVw" base_Property="_mN_ogDanEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_mOA2ozanEem8b5f98b_cVw" base_StructuralFeature="_mOA2ojanEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_mOBdsDanEem8b5f98b_cVw" base_Property="_mOA2ojanEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="__Qrp4DanEem8b5f98b_cVw" base_Association="_mN4TwDanEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_CdmR0jaoEem8b5f98b_cVw" base_StructuralFeature="_CdmR0TaoEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_CdmR0zaoEem8b5f98b_cVw" base_Property="_CdmR0TaoEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Cdnf8DaoEem8b5f98b_cVw" base_StructuralFeature="_Cdm44jaoEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Cdnf8TaoEem8b5f98b_cVw" base_Property="_Cdm44jaoEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_Sd4ekDaoEem8b5f98b_cVw" base_Association="_CdjOgDaoEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_Ydi68DaoEem8b5f98b_cVw" base_Abstraction="_XPJ1MDaoEem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_nsU80TapEem8b5f98b_cVw" base_Class="_nsU80DapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_nsU80japEem8b5f98b_cVw" base_Class="_nsU80DapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_rkBnIjapEem8b5f98b_cVw" base_StructuralFeature="_rkBnITapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_rkCOMDapEem8b5f98b_cVw" base_Property="_rkBnITapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_rkEDYDapEem8b5f98b_cVw" base_StructuralFeature="_rkDcUTapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_rkEDYTapEem8b5f98b_cVw" base_Property="_rkDcUTapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_0rPDRTapEem8b5f98b_cVw" base_StructuralFeature="_0rPDQDapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0rPDRjapEem8b5f98b_cVw" base_Property="_0rPDQDapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_0rStoDapEem8b5f98b_cVw" base_StructuralFeature="_0rSGkDapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0rStoTapEem8b5f98b_cVw" base_Property="_0rSGkDapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_0rVw8TapEem8b5f98b_cVw" base_StructuralFeature="_0rVJ4DapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0rVw8japEem8b5f98b_cVw" base_Property="_0rVJ4DapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_0rZbUzapEem8b5f98b_cVw" base_StructuralFeature="_0rZbUDapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0rZbVDapEem8b5f98b_cVw" base_Property="_0rZbUDapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_0rcepTapEem8b5f98b_cVw" base_StructuralFeature="_0rceoDapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0rdFsDapEem8b5f98b_cVw" base_Property="_0rceoDapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_0rhXIzapEem8b5f98b_cVw" base_StructuralFeature="_0rhXIDapEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0rhXJDapEem8b5f98b_cVw" base_Property="_0rhXIDapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_DGyt4DaqEem8b5f98b_cVw" base_StructuralFeature="_DGyG0jaqEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DGyt4TaqEem8b5f98b_cVw" base_Property="_DGyG0jaqEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_DGz8ATaqEem8b5f98b_cVw" base_StructuralFeature="_DGz8ADaqEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DGz8AjaqEem8b5f98b_cVw" base_Property="_DGz8ADaqEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_RLNq4DaqEem8b5f98b_cVw" base_Class="_RLND0DaqEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_RLNq4TaqEem8b5f98b_cVw" base_Class="_RLND0DaqEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_4n9FkDarEem8b5f98b_cVw" base_StructuralFeature="_4n8egjarEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_4n9FkTarEem8b5f98b_cVw" base_Property="_4n8egjarEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_4n-TsTarEem8b5f98b_cVw" base_StructuralFeature="_4n-TsDarEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_4n-TsjarEem8b5f98b_cVw" base_Property="_4n-TsDarEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_PBAgUDauEem8b5f98b_cVw" base_StructuralFeature="_PA_5QjauEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PBAgUTauEem8b5f98b_cVw" base_Property="_PA_5QjauEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_PBBucjauEem8b5f98b_cVw" base_StructuralFeature="_PBBucTauEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PBCVgDauEem8b5f98b_cVw" base_Property="_PBBucTauEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_dn-7UDavEem8b5f98b_cVw" base_Association="_4n7QYDarEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_gaEocDavEem8b5f98b_cVw" base_Association="_rj_x8DapEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_jM7KkDavEem8b5f98b_cVw" base_Association="_DGw4sDaqEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_lzfkMDavEem8b5f98b_cVw" base_Association="_PA9dADauEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_h4ePYDbLEem8b5f98b_cVw" base_Class="_h4caMDbLEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_h4groDbLEem8b5f98b_cVw" base_Class="_h4caMDbLEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_yHv6YDbLEem8b5f98b_cVw" base_Abstraction="_wNHZsDbLEem8b5f98b_cVw">
+    <target>/TapiCommon:Context:_context/TapiCommon:Context:_serviceInterfacePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_myUdwDbMEem8b5f98b_cVw" base_Class="_myT2sDbMEem8b5f98b_cVw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_myUdwTbMEem8b5f98b_cVw" base_Class="_myT2sDbMEem8b5f98b_cVw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_CTrZoDbQEem8b5f98b_cVw" base_Abstraction="_wkieYDbPEem8b5f98b_cVw">
+    <target>/TapiCommon:TapiService:getServiceInterfacePointList/TapiCommon::output/TapiCommon::sip</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_PSbvEDbQEem8b5f98b_cVw" base_Abstraction="_zMRVoDbPEem8b5f98b_cVw">
+    <target>/TapiConnectivity:ConnectivityService:getConnectivityServiceList/TapiConnectivity::output/TapiConnectivity::service/TapiConnectivity::_endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_VzdzIDbQEem8b5f98b_cVw" base_Abstraction="_z7X3UDbPEem8b5f98b_cVw">
+    <target>/TapiConnectivity:ConnectivityService:getConnectivityServiceDetails/TapiConnectivity::output/TapiConnectivity::service/TapiConnectivity::_endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_tWbuMDbQEem8b5f98b_cVw" base_Abstraction="_0lkD0DbPEem8b5f98b_cVw">
+    <target>/TapiConnectivity:ConnectivityService:createConnectivityService/TapiConnectivity::input/TapiConnectivity::endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_3aHZoDbQEem8b5f98b_cVw" base_Abstraction="_qNckADbQEem8b5f98b_cVw">
+    <target>/TapiConnectivity:ConnectivityService:updateConnectivityService/TapiConnectivity::input/TapiConnectivity::endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_8nL7cDbQEem8b5f98b_cVw" base_Abstraction="_1rtzkDbPEem8b5f98b_cVw">
+    <target>/TapiConnectivity:ConnectivityService:updateConnectivityService/TapiConnectivity::output/TapiConnectivity::service/TapiConnectivity::_endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_M-VlkDh9Eem1lYbrIE6BNw" base_Class="_M-QGADh9Eem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelClass xmi:id="_M-YB0Dh9Eem1lYbrIE6BNw" base_Class="_M-QGADh9Eem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_dB03UDh9Eem1lYbrIE6BNw" base_Abstraction="_UpR4ADh9Eem1lYbrIE6BNw">
+    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_M0YwoDiDEem1lYbrIE6BNw" base_Abstraction="_J_wF0DiDEem1lYbrIE6BNw">
+    <target>/TapiConnectivity:ConnectivityService:getConnectivityServiceList/TapiConnectivity::output/TapiConnectivity::service</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_auQDcDiDEem1lYbrIE6BNw" base_Abstraction="_XkjHkDiDEem1lYbrIE6BNw">
+    <target>/TapiConnectivity:ConnectivityService:getConnectivityServiceDetails/TapiConnectivity::output/TapiConnectivity::service</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_yqWlUDiFEem1lYbrIE6BNw" base_Abstraction="_rB4YEDiFEem1lYbrIE6BNw">
+    <target>/TapiConnectivity:ConnectivityService:updateConnectivityService/TapiConnectivity::output/TapiConnectivity::service</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_5sHQgDiIEem1lYbrIE6BNw" base_Abstraction="_U4WqQDiHEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::input/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_-5y2UDiIEem1lYbrIE6BNw" base_Abstraction="_91tjIDiIEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_FJddkDiJEem1lYbrIE6BNw" base_Abstraction="_DscF8DiJEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_LUy-cDiJEem1lYbrIE6BNw" base_Abstraction="_JOYrkDiJEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::input/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_K4Zg4DiKEem1lYbrIE6BNw" base_Abstraction="_B2zkkDiKEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_NTS2ADiKEem1lYbrIE6BNw" base_Abstraction="_DJcRIDiKEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_Pt3bADiKEem1lYbrIE6BNw" base_Abstraction="_EPhvcDiKEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_TfWIkDiKEem1lYbrIE6BNw" base_Abstraction="_Fb3mwDiKEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_WLatQDiKEem1lYbrIE6BNw" base_Abstraction="_GQL_oDiKEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_YnFecDiKEem1lYbrIE6BNw" base_Abstraction="_HRBKgDiKEem1lYbrIE6BNw">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_EmpNUTjqEem1lYbrIE6BNw" base_Property="_EmpNUDjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Emp0YDjqEem1lYbrIE6BNw" base_StructuralFeature="_EmpNUDjqEem1lYbrIE6BNw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Fpjb0TjqEem1lYbrIE6BNw" base_Property="_Fpjb0DjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_FpkC4DjqEem1lYbrIE6BNw" base_StructuralFeature="_Fpjb0DjqEem1lYbrIE6BNw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_GoTjEDjqEem1lYbrIE6BNw" base_Property="_GoS8ADjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_GoTjETjqEem1lYbrIE6BNw" base_StructuralFeature="_GoS8ADjqEem1lYbrIE6BNw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Il4DATjqEem1lYbrIE6BNw" base_Property="_Il4DADjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Il4qEDjqEem1lYbrIE6BNw" base_StructuralFeature="_Il4DADjqEem1lYbrIE6BNw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_J7EUUTjqEem1lYbrIE6BNw" base_Property="_J7EUUDjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_J7E7YDjqEem1lYbrIE6BNw" base_StructuralFeature="_J7EUUDjqEem1lYbrIE6BNw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_LHK7ETjqEem1lYbrIE6BNw" base_Property="_LHK7EDjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_LHLiIDjqEem1lYbrIE6BNw" base_StructuralFeature="_LHK7EDjqEem1lYbrIE6BNw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MQ2f8DjqEem1lYbrIE6BNw" base_Property="_MQ144DjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_MQ2f8TjqEem1lYbrIE6BNw" base_StructuralFeature="_MQ144DjqEem1lYbrIE6BNw"/>
+  <OpenModel_Profile_3:Specify xmi:id="_0CjOcDkhEemjx6Nna_xyog" base_Abstraction="_l-v8gDkhEemjx6Nna_xyog">
+    <target>/TapiOam::getOamService/TapiOam::output/TapiOam::oamService</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_7Y6YADkhEemjx6Nna_xyog" base_Abstraction="_nagI0DkhEemjx6Nna_xyog">
+    <target>/TapiOam::getOamServiceList/TapiOam::output/TapiOam::oamService</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_KRpG0DkiEemjx6Nna_xyog" base_Abstraction="_JRFowDkiEemjx6Nna_xyog">
+    <target>/TapiOam::getOamService/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_RUgsoDkiEemjx6Nna_xyog" base_Abstraction="_QUL4EDkiEemjx6Nna_xyog">
+    <target>/TapiOam::getOamService/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_cR61YDkiEemjx6Nna_xyog" base_Abstraction="_bNLa4DkiEemjx6Nna_xyog">
+    <target>/TapiOam::getOamServiceList/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_fX9ZQDkiEemjx6Nna_xyog" base_Abstraction="_eYaAwDkiEemjx6Nna_xyog">
+    <target>/TapiOam::getOamServiceList/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_tp9fQDkiEemjx6Nna_xyog" base_Abstraction="_sohQYDkiEemjx6Nna_xyog">
+    <target>/TapiOam::createOamService/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_xaDswDkiEemjx6Nna_xyog" base_Abstraction="_wDwBIDkiEemjx6Nna_xyog">
+    <target>/TapiOam::createOamService/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_3hu1oDkiEemjx6Nna_xyog" base_Abstraction="_16iOUDkiEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamService/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_-aMiQDkiEemjx6Nna_xyog" base_Abstraction="_oOE60DkhEemjx6Nna_xyog">
+    <target>/TapiOam::createOamService/TapiOam::input/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_ExgCkDkjEemjx6Nna_xyog" base_Abstraction="_tLugkDkhEemjx6Nna_xyog">
+    <target>/TapiOam::createOamService/TapiOam::output/TapiOam::oamService</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_J-qrADkjEemjx6Nna_xyog" base_Abstraction="_uEvzQDkhEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamService/TapiOam::input/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_QQ7TQDkjEemjx6Nna_xyog" base_Abstraction="_o_tzIDkhEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamService/TapiOam::output/TapiOam::oamService</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_sKciYDkkEemjx6Nna_xyog" base_Abstraction="_rDBAQDkkEemjx6Nna_xyog">
+    <target>/TapiOam::getOamServicePoint/TapiOam::output/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_v2lc8DkkEemjx6Nna_xyog" base_Abstraction="_uxTP4DkkEemjx6Nna_xyog">
+    <target>/TapiOam::getOamServicePoint/TapiOam::output/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_3BmSIDkkEemjx6Nna_xyog" base_Abstraction="_10m6kDkkEemjx6Nna_xyog">
+    <target>/TapiOam::createOamServicePoint/TapiOam::output/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_5zgZEDkkEemjx6Nna_xyog" base_Abstraction="_4yhdMDkkEemjx6Nna_xyog">
+    <target>/TapiOam::createOamServicePoint/TapiOam::output/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_-SHSYDkkEemjx6Nna_xyog" base_Abstraction="_9InTsDkkEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamServicePoint/TapiOam::output/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_A-G-kDklEemjx6Nna_xyog" base_Abstraction="__0Y9cDkkEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamServicePoint/TapiOam::output/TapiOam::oamServicePoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_RaHBgDkmEemjx6Nna_xyog" base_Abstraction="_KtbHEDkmEemjx6Nna_xyog">
+    <target>/TapiOam::getMeg/TapiOam::output/TapiOam::meg</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_XnOrEDkmEemjx6Nna_xyog" base_Abstraction="_Lb7L0DkmEemjx6Nna_xyog">
+    <target>/TapiOam::getMeg/TapiOam::output/TapiOam::meg/TapiOam:_mep</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_amZK4DkmEemjx6Nna_xyog" base_Abstraction="_MJVEYDkmEemjx6Nna_xyog">
+    <target>New String</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_wDatIDkmEemjx6Nna_xyog" base_Abstraction="_usMbgDkmEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_K1VQcDknEemjx6Nna_xyog" base_Abstraction="_Js7d8DknEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_QYFHUDknEemjx6Nna_xyog" base_Abstraction="_PRbBQDknEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_WMYBMDknEemjx6Nna_xyog" base_Abstraction="_UrsRkDknEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_ew2jsDknEemjx6Nna_xyog" base_Abstraction="_d7zyEDknEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_tWYCoDknEemjx6Nna_xyog" base_Abstraction="_sSlDUDknEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_yc20QDknEemjx6Nna_xyog" base_Abstraction="_xLfTADknEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_3DgPQDknEemjx6Nna_xyog" base_Abstraction="_1768IDknEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_7-HIEDknEemjx6Nna_xyog" base_Abstraction="_6zhkQDknEemjx6Nna_xyog">
+    <target>/TapiOam::createOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_Bb4_YDkoEemjx6Nna_xyog" base_Abstraction="_ALaO8DkoEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_K_if4DkoEemjx6Nna_xyog" base_Abstraction="_J22ZgDkoEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_RXpRcDkoEemjx6Nna_xyog" base_Abstraction="_QNOFsDkoEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_XBDxADkoEemjx6Nna_xyog" base_Abstraction="_V0OxgDkoEemjx6Nna_xyog">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_Tzt5MDlSEemSPvPXzEQ11A" base_Abstraction="_Svn-8DlSEemSPvPXzEQ11A">
+    <target>/TapiOam::updateOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_i9-c4DlSEemSPvPXzEQ11A" base_Abstraction="_iEM8QDlSEemSPvPXzEQ11A">
+    <target>/TapiOam::getOamJob/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_00P64DlSEemSPvPXzEQ11A" base_Abstraction="_z38DoDlSEemSPvPXzEQ11A">
+    <target>/TapiOam::updateOamJob/TapiOam::input/</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_lO1PwDlTEemSPvPXzEQ11A" base_Abstraction="_kOlTsDlTEemSPvPXzEQ11A">
+    <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_T_qYkDlUEemSPvPXzEQ11A" base_Abstraction="_SZH4kDlUEemSPvPXzEQ11A">
+    <target>/TapiOam::getOamJobList/TapiOam::output/TapiOam::oamJob</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_7huNkDlUEemSPvPXzEQ11A" base_Abstraction="_6ZqZUDlUEemSPvPXzEQ11A">
+    <target>/TapiCommon:TapiService:getServiceInterfacePointDetails/TapiCommon::output/TapiCommon::sip</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_R5vYcDlVEemSPvPXzEQ11A" base_Abstraction="_RFR1oDlVEemSPvPXzEQ11A">
+    <target>/TapiConnectivity:ConnectivityService:createConnectivityService/TapiConnectivity::output/TapiConnectivity::service</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_i2a8ADlVEemSPvPXzEQ11A" base_Abstraction="_hHFFUDlVEemSPvPXzEQ11A">
+    <target>/TapiConnectivity:ConnectivityService:createConnectivityService/TapiConnectivity::output/TapiConnectivity::service/TapiConnectivity::_endPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_NPuq8DlWEemSPvPXzEQ11A" base_Abstraction="_MF8YYDlWEemSPvPXzEQ11A">
+    <target>/TapiOam::updateOamService/TapiOam::output/TapiOam::oamService/TapiOam:_oamServiceEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ap5AYToOEemSPvPXzEQ11A" base_Property="_ap5AYDoOEemSPvPXzEQ11A"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_ap5AYjoOEemSPvPXzEQ11A" base_StructuralFeature="_ap5AYDoOEemSPvPXzEQ11A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zZMf0TobEemSPvPXzEQ11A" base_Property="_zZMf0DobEemSPvPXzEQ11A"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_zZNG4DobEemSPvPXzEQ11A" base_StructuralFeature="_zZMf0DobEemSPvPXzEQ11A"/>
+  <OpenModel_Profile_3:Specify xmi:id="_0OB3oDp_EemSPvPXzEQ11A" base_Abstraction="_tmC3ADp_EemSPvPXzEQ11A"/>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -917,7 +917,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD_w84UxEeiYFOBVMQg1QQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD_w4YUxEeiYFOBVMQg1QQ" x="37" y="-134" width="128" height="57"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CD_w4YUxEeiYFOBVMQg1QQ" x="26" y="-187" width="128" height="57"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l72084VFEeiYFOBVMQg1QQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_l7209IVFEeiYFOBVMQg1QQ" showTitle="true"/>
@@ -964,40 +964,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ZqhRYbhEeil5oKL3Vgl-g" x="206" y="-174"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QU_QsobmEeil5oKL3Vgl-g" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_QU_QtIbmEeil5oKL3Vgl-g" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_QU_QtYbmEeil5oKL3Vgl-g" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QU_QtobmEeil5oKL3Vgl-g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_QU_Qt4bmEeil5oKL3Vgl-g" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QU_QuIbmEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_QU_QuYbmEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_QU_QuobmEeil5oKL3Vgl-g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU_Qu4bmEeil5oKL3Vgl-g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_QU_QvIbmEeil5oKL3Vgl-g" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QU_QvYbmEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_QU_QvobmEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_QU_Qv4bmEeil5oKL3Vgl-g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU_QwIbmEeil5oKL3Vgl-g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_QU_QwYbmEeil5oKL3Vgl-g" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QU_QwobmEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_QU_Qw4bmEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_QU_QxIbmEeil5oKL3Vgl-g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU_QxYbmEeil5oKL3Vgl-g"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU_Qs4bmEeil5oKL3Vgl-g" x="-24" y="-45" height="56"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QVLeCYbmEeil5oKL3Vgl-g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QVLeCobmEeil5oKL3Vgl-g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVLeDIbmEeil5oKL3Vgl-g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVLeC4bmEeil5oKL3Vgl-g" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0qGjY4b4Eeil5oKL3Vgl-g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0qGjZIb4Eeil5oKL3Vgl-g" showTitle="true"/>
@@ -1070,14 +1036,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hV9v8ot8Eeiu6boZkiJHCA" x="115" y="-417"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_izDZAIt8Eeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_izDZAYt8Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_izDZA4t8Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_izDZAot8Eeiu6boZkiJHCA" x="115" y="-417"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_kHAUMIt8Eeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_kHAUMYt8Eeiu6boZkiJHCA"/>
@@ -1198,6 +1156,30 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bcvI8iD8EemsM5ohGqY7Gw" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_z65hADYxEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_z65hATYxEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_z66IEDYxEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z65hAjYxEem8b5f98b_cVw" x="237" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_U2AtMDkREemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_U2AtMTkREemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_U2AtMzkREemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U2AtMjkREemjx6Nna_xyog" x="226" y="-187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_wpl8cDoPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_wpl8cToPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wpl8czoPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wpl8cjoPEemSPvPXzEQ11A" x="226" y="-187"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_dPf-21dMEeejsLaQeGcDdg"/>
@@ -1570,16 +1552,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ZqhSobhEeil5oKL3Vgl-g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ZqhS4bhEeil5oKL3Vgl-g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QVLeDYbmEeil5oKL3Vgl-g" type="StereotypeCommentLink" source="_QU_QsobmEeil5oKL3Vgl-g" target="_QVLeCYbmEeil5oKL3Vgl-g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QVLeDobmEeil5oKL3Vgl-g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVLeEobmEeil5oKL3Vgl-g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QVLeD4bmEeil5oKL3Vgl-g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVLeEIbmEeil5oKL3Vgl-g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVLeEYbmEeil5oKL3Vgl-g"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0qGjZ4b4Eeil5oKL3Vgl-g" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_0qGjY4b4Eeil5oKL3Vgl-g">
       <styles xmi:type="notation:FontStyle" xmi:id="_0qGjaIb4Eeil5oKL3Vgl-g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0qGjbIb4Eeil5oKL3Vgl-g" name="BASE_ELEMENT">
@@ -1877,17 +1849,17 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f9W-Sot8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f9W-S4t8Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_hVVd0It8Eeiu6boZkiJHCA" type="Association_Edge" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_CD_w4IUxEeiYFOBVMQg1QQ" lineColor="0">
+    <edges xmi:type="notation:Connector" xmi:id="_hVVd0It8Eeiu6boZkiJHCA" type="Association_Edge" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_CD_w4IUxEeiYFOBVMQg1QQ" routing="Rectilinear" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dhcOgMWdEeiWCKGKl1wb8w" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dhiVIMWdEeiWCKGKl1wb8w" key="lineColor" value="true"/>
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_hVVd04t8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qJ-t0It9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hVVd1It8Eeiu6boZkiJHCA" x="-11" y="-2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hVVd1It8Eeiu6boZkiJHCA" x="16" y="49"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hVVd1Yt8Eeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qLFhEIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hVWE4It8Eeiu6boZkiJHCA" x="-31" y="-8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hVWE4It8Eeiu6boZkiJHCA" x="1" y="26"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hVWE4Yt8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qMM7YIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1907,8 +1879,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_hVVd0Yt8Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hVVd0ot8Eeiu6boZkiJHCA" points="[21, -260, -643984, -643984]$[81, -161, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J-mLcIt9Eeiu6boZkiJHCA" id="(0.9111111111111111,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hVVd0ot8Eeiu6boZkiJHCA" points="[68, -260, -643984, -643984]$[68, -187, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J-mLcIt9Eeiu6boZkiJHCA" id="(0.85,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KT334It9Eeiu6boZkiJHCA" id="(0.328125,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hV9v9It8Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_hVVd0It8Eeiu6boZkiJHCA" target="_hV9v8It8Eeiu6boZkiJHCA">
@@ -1920,47 +1892,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hV9v9ot8Eeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hV9v94t8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hV9v-It8Eeiu6boZkiJHCA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iyG90It8Eeiu6boZkiJHCA" type="Association_Edge" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_QU_QsobmEeil5oKL3Vgl-g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_iyG904t8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qQ-GoIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iyG91It8Eeiu6boZkiJHCA" x="-17" y="4"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_iyG91Yt8Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qS29AIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iyG91ot8Eeiu6boZkiJHCA" x="-32" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_iyHk4It8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qUjmIIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iyHk4Yt8Eeiu6boZkiJHCA" x="28" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_iyHk4ot8Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qWT5oIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iyHk44t8Eeiu6boZkiJHCA" x="-28" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_iyHk5It8Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qYRBcIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iyHk5Yt8Eeiu6boZkiJHCA" x="12" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_iyHk5ot8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_qZ9qkIt9Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_iyHk54t8Eeiu6boZkiJHCA" x="-11" y="-25"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_iyG90Yt8Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iyG90ot8Eeiu6boZkiJHCA" points="[7, -260, -643984, -643984]$[23, -72, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qcXeUIt9Eeiu6boZkiJHCA" id="(0.5277777777777778,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JIAhsIt9Eeiu6boZkiJHCA" id="(0.34,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_izDZBIt8Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_iyG90It8Eeiu6boZkiJHCA" target="_izDZAIt8Eeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_izDZBYt8Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_izDZCYt8Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_izDZBot8Eeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_izDZB4t8Eeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_izDZCIt8Eeiu6boZkiJHCA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_kGunYIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPewT1dMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg">
       <children xmi:type="notation:DecorationNode" xmi:id="_kGunY4t8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -2044,14 +1975,14 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mZ9OQIt8Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mZ9OQYt8Eeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_vK44YIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_vK44YIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5fcIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wPgXEIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fcYt8Eeiu6boZkiJHCA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5fcot8Eeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wRFEYIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fc4t8Eeiu6boZkiJHCA" x="-31" y="11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fc4t8Eeiu6boZkiJHCA" x="-18" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5fdIt8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wTVHIIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2063,26 +1994,26 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5feIt8Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wWE5IIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5feYt8Eeiu6boZkiJHCA" x="13" y="22"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5feYt8Eeiu6boZkiJHCA" x="8" y="48"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_vK5feot8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_wXNhkIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fe4t8Eeiu6boZkiJHCA" x="-14" y="-14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_vK5fe4t8Eeiu6boZkiJHCA" x="-11" y="-20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_vK44YYt8Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_GTLxYD2kEeihCtCrhJZ45g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vK44Yot8Eeiu6boZkiJHCA" points="[-101, -114, -643984, -643984]$[-101, 40, -643984, -643984]$[-350, 40, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wNuOYIt8Eeiu6boZkiJHCA" id="(0.5,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wNuOYYt8Eeiu6boZkiJHCA" id="(1.0,0.3448275862068966)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vK44Yot8Eeiu6boZkiJHCA" points="[-43, -87, -643984, -643984]$[-43, 108, -643984, -643984]$[-413, 108, -643984, -643984]$[-413, 78, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wNuOYIt8Eeiu6boZkiJHCA" id="(0.8372093023255814,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wNuOYYt8Eeiu6boZkiJHCA" id="(0.475,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_w_XGsIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_w_XGsIt8Eeiu6boZkiJHCA" type="Association_Edge" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_w_XtwIt8Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ynLZEIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_w_XtwYt8Eeiu6boZkiJHCA" x="-1" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_w_Xtwot8Eeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ypGrsIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_w_Xtw4t8Eeiu6boZkiJHCA" x="20" y="40"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_w_Xtw4t8Eeiu6boZkiJHCA" x="-28" y="83"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_w_XtxIt8Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yq0i8It8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2094,7 +2025,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_w_XtyIt8Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yum2wIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_w_XtyYt8Eeiu6boZkiJHCA" x="10" y="-21"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_w_XtyYt8Eeiu6boZkiJHCA" x="9" y="-47"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_w_Xtyot8Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ywMyMIt8Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2102,9 +2033,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_w_XGsYt8Eeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_-sPnoHMgEeeSiaQ95-6r9w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_w_XGsot8Eeiu6boZkiJHCA" points="[-57, -114, -643984, -643984]$[-57, 59, -643984, -643984]$[-185, 59, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ylyR8It8Eeiu6boZkiJHCA" id="(0.7558139534883721,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yly5AIt8Eeiu6boZkiJHCA" id="(1.0,0.65)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_w_XGsot8Eeiu6boZkiJHCA" points="[-70, -87, -643984, -643984]$[-70, 38, -643984, -643984]$[-185, 38, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ylyR8It8Eeiu6boZkiJHCA" id="(0.6744186046511628,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yly5AIt8Eeiu6boZkiJHCA" id="(1.0,0.3)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_5HzJRIuDEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_5HzJQIuDEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_5HzJRYuDEeiu6boZkiJHCA"/>
@@ -2133,7 +2064,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_wwS5pZsXEeid4dfn4JFJZg" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_13hSIJsXEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5ppsXEeid4dfn4JFJZg" x="-94" y="64"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_wwS5ppsXEeid4dfn4JFJZg" x="18" y="-12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_wwS5p5sXEeid4dfn4JFJZg" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_15avkJsXEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2153,9 +2084,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_wwS5oZsXEeid4dfn4JFJZg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_wd3s4JsXEeid4dfn4JFJZg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wwS5opsXEeid4dfn4JFJZg" points="[178, -259, -643984, -643984]$[178, -123, -643984, -643984]$[-15, -123, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w0utsJsXEeid4dfn4JFJZg" id="(0.4552238805970149,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w0utsZsXEeid4dfn4JFJZg" id="(1.0,0.3620689655172414)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wwS5opsXEeid4dfn4JFJZg" points="[200, -259, -643984, -643984]$[200, -115, -643984, -643984]$[-15, -115, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w0utsJsXEeid4dfn4JFJZg" id="(0.6194029850746269,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w0utsZsXEeid4dfn4JFJZg" id="(1.0,0.5172413793103449)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YdXKQJwUEeidac_mNnugIw" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_YdVVEJwUEeidac_mNnugIw">
       <styles xmi:type="notation:FontStyle" xmi:id="_YdXKQZwUEeidac_mNnugIw"/>
@@ -2267,6 +2198,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bcyMRCD8EemsM5ohGqY7Gw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bcyMRSD8EemsM5ohGqY7Gw"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_z66IETYxEem8b5f98b_cVw" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_z65hADYxEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_z66IEjYxEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_z66IFjYxEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z66IEzYxEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z66IFDYxEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z66IFTYxEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_U2AtNDkREemjx6Nna_xyog" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_U2AtMDkREemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_U2AtNTkREemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_U2AtOTkREemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U2AtNjkREemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U2AtNzkREemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U2AtODkREemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_wpl8dDoPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_wpl8cDoPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_wpl8dToPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wpmjgDoPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wpl8djoPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wpl8dzoPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wpl8eDoPEemSPvPXzEQ11A"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_LeWqMHMLEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_LeWqknMLEeeSiaQ95-6r9w" type="Class_Shape">
@@ -2293,10 +2254,6 @@
         <children xmi:type="notation:Shape" xmi:id="_Z4owMG6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_EBqfUE46EeiMYveOdt1-rQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Z4owMW6HEeivMcJ3aRh7eg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Z4pXQG6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_IJQGIE5CEeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z4pXQW6HEeivMcJ3aRh7eg"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_Z4qlYm6HEeivMcJ3aRh7eg" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
@@ -2468,29 +2425,29 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_xp1GwHMLEeeSiaQ95-6r9w" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_xp1GwXMLEeeSiaQ95-6r9w" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_oF0cAIVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_4FNfoDnyEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_yrGnYDnyEemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4FNfoTnyEemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_4FOGsDnyEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_bsmIshP7EeepnPPr_BcZKg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_oF0cAYVOEeiYFOBVMQg1QQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4FOGsTnyEemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_oF0cAoVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_4FOGsjnyEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#__n5DwNzDEeaMV83ubDcSig"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_oF0cA4VOEeiYFOBVMQg1QQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4FOGsznyEemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_oF0cBIVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_4FOGtDnyEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_mMroAU8HEeiW8t12GIRjqQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_oF0cBYVOEeiYFOBVMQg1QQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4FOGtTnyEemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_oF0cBoVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_TF9BE04-EeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_oF0cB4VOEeiYFOBVMQg1QQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_oF0cCoVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_4FOtwjnyEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_oF0cC4VOEeiYFOBVMQg1QQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4FOtwznyEemSPvPXzEQ11A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_oF0cDIVOEeiYFOBVMQg1QQ" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_4FOtxDnyEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_oF0cDYVOEeiYFOBVMQg1QQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4FOtxTnyEemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_LeWs0HMLEeeSiaQ95-6r9w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_LeWs0XMLEeeSiaQ95-6r9w"/>
@@ -2724,7 +2681,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXRXHMLEeeSiaQ95-6r9w"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXRc3MLEeeSiaQ95-6r9w" x="-384" y="-980" width="1579" height="206"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LeXRc3MLEeeSiaQ95-6r9w" x="-384" y="-980" width="1622" height="206"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LeXRdHMLEeeSiaQ95-6r9w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_LeXRdXMLEeeSiaQ95-6r9w" showTitle="true"/>
@@ -2824,10 +2781,6 @@
         <children xmi:type="notation:Shape" xmi:id="_9v3iBsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WRqhYE45EeiMYveOdt1-rQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iB8WWEeiWCKGKl1wb8w"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9v3iCMWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_hJpKQBocEeeV4o0osG5stg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9v3iCcWWEeiWCKGKl1wb8w"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_9v3iDsWWEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
@@ -3269,10 +3222,6 @@
           <element xmi:type="uml:Property" href="TapiOam.uml#_B9eEoIHDEeeh4KO3PMo8Rw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkE8WcEeiWCKGKl1wb8w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ysvkFMWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_A0XLAJPsEeePQIrrJoWPZA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkFcWcEeiWCKGKl1wb8w"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_ysvkGsWcEeiWCKGKl1wb8w" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ysvkG8WcEeiWCKGKl1wb8w"/>
@@ -3416,52 +3365,6 @@
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GDqiYU4xEeiMYveOdt1-rQ" x="548" y="-471" height="199"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_GVfmUE4-EeiMYveOdt1-rQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_GVfmUk4-EeiMYveOdt1-rQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_GVfmU04-EeiMYveOdt1-rQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GVfmVE4-EeiMYveOdt1-rQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_GVfmVU4-EeiMYveOdt1-rQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_bhETlE47EeiMYveOdt1-rQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_W0CjwE47EeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bhETlU47EeiMYveOdt1-rQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_psfToE4_EeiMYveOdt1-rQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_oQNi4E4_EeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_psfToU4_EeiMYveOdt1-rQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_pslaQE4_EeiMYveOdt1-rQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_i4OKgE4_EeiMYveOdt1-rQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_pslaQU4_EeiMYveOdt1-rQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_GVfmVk4-EeiMYveOdt1-rQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_GVfmV04-EeiMYveOdt1-rQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_GVfmWE4-EeiMYveOdt1-rQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GVfmWU4-EeiMYveOdt1-rQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_GVfmWk4-EeiMYveOdt1-rQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_GVfmW04-EeiMYveOdt1-rQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_GVfmXE4-EeiMYveOdt1-rQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_GVfmXU4-EeiMYveOdt1-rQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GVfmXk4-EeiMYveOdt1-rQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_GVfmX04-EeiMYveOdt1-rQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_GVfmYE4-EeiMYveOdt1-rQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_GVfmYU4-EeiMYveOdt1-rQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_GVfmYk4-EeiMYveOdt1-rQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GVfmY04-EeiMYveOdt1-rQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_GVZfsE4-EeiMYveOdt1-rQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GVfmUU4-EeiMYveOdt1-rQ" x="-102" y="-58" width="267" height="107"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_GVltCU4-EeiMYveOdt1-rQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_GVltCk4-EeiMYveOdt1-rQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GVltDE4-EeiMYveOdt1-rQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_GVZfsE4-EeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GVltC04-EeiMYveOdt1-rQ" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_vAO2s1nbEeitcM-j9IIMGg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_vAO2tFnbEeitcM-j9IIMGg" showTitle="true"/>
@@ -3688,10 +3591,6 @@
         <children xmi:type="notation:Shape" xmi:id="_U34XoIbnEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_GGYEY4U1EeiYFOBVMQg1QQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_U34XoYbnEeil5oKL3Vgl-g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_U34XoobnEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_UVLIoYbmEeil5oKL3Vgl-g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_U34Xo4bnEeil5oKL3Vgl-g"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_U34XpIbnEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
@@ -3936,14 +3835,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9c3eUot-Eeiu6boZkiJHCA" x="-110" y="-376"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_ArZP04t_Eeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ArZP1It_Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ArZP1ot_Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_TF9BEE4-EeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ArZP1Yt_Eeiu6boZkiJHCA" x="-110" y="-376"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_IVoXo4t_Eeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_IVo-sIt_Eeiu6boZkiJHCA"/>
@@ -4333,6 +4224,46 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_80BTMiD7EemsM5ohGqY7Gw" x="748" y="-471"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_DcW7EDUyEem_pr37XaewKQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DcW7ETUyEem_pr37XaewKQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DcXiIDUyEem_pr37XaewKQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DcW7EjUyEem_pr37XaewKQ" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KFk9oDXpEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KFk9oTXpEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KFk9ozXpEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KFk9ojXpEem8b5f98b_cVw" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MJcj8DiIEem1lYbrIE6BNw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MJcj8TiIEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MJdLADiIEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MJcj8jiIEem1lYbrIE6BNw" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_feon0DkIEemjx6Nna_xyog" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_feon0TkIEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_feon0zkIEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_feon0jkIEemjx6Nna_xyog" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CFK2kDnQEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CFK2kTnQEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CFLdoDnQEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CFK2kjnQEemSPvPXzEQ11A" x="748" y="-471"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_LeXWvXMLEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJ-HEIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -4526,7 +4457,7 @@
       <element xmi:type="uml:InterfaceRealization" href="TapiOam.uml#_ojz6oFrnEeexvMtO2oNM9g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LeX5gnMLEeeSiaQ95-6r9w" points="[-299, -443, -643984, -643984]$[-299, -774, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeX5g3MLEeeSiaQ95-6r9w" id="(0.23432343234323433,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeX5hHMLEeeSiaQ95-6r9w" id="(0.05383153894870171,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LeX5hHMLEeeSiaQ95-6r9w" id="(0.05240443896424168,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LeX6K3MLEeeSiaQ95-6r9w" type="StereotypeCommentLink" target="_LeXVunMLEeeSiaQ95-6r9w">
       <styles xmi:type="notation:FontStyle" xmi:id="_LeX6LHMLEeeSiaQ95-6r9w"/>
@@ -4577,16 +4508,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GD6aCU4xEeiMYveOdt1-rQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GD6aCk4xEeiMYveOdt1-rQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GD6aC04xEeiMYveOdt1-rQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_GVltDU4-EeiMYveOdt1-rQ" type="StereotypeCommentLink" source="_GVfmUE4-EeiMYveOdt1-rQ" target="_GVltCU4-EeiMYveOdt1-rQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_GVltDk4-EeiMYveOdt1-rQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GVltEk4-EeiMYveOdt1-rQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_GVZfsE4-EeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GVltD04-EeiMYveOdt1-rQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GVltEE4-EeiMYveOdt1-rQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GVltEU4-EeiMYveOdt1-rQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_l_l55IVPEeiYFOBVMQg1QQ" type="StereotypeCommentLink" source="_l_ZsoIVPEeiYFOBVMQg1QQ" target="_l_l54IVPEeiYFOBVMQg1QQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_l_l55YVPEeiYFOBVMQg1QQ"/>
@@ -4884,47 +4805,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9c3eVot-Eeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9c3eV4t-Eeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9c3eWIt-Eeiu6boZkiJHCA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ap73QIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeWsy3MLEeeSiaQ95-6r9w" target="_GVfmUE4-EeiMYveOdt1-rQ" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ap73Q4t_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DmdSwIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ap73RIt_Eeiu6boZkiJHCA" x="-63" y="57"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ap8eUIt_Eeiu6boZkiJHCA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DtSTgIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ap8eUYt_Eeiu6boZkiJHCA" x="-81" y="39"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ap8eUot_Eeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DzfpMIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ap8eU4t_Eeiu6boZkiJHCA" x="14" y="-18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ap8eVIt_Eeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D3zhcIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ap8eVYt_Eeiu6boZkiJHCA" x="-17" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ap8eVot_Eeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_D-djEIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ap8eV4t_Eeiu6boZkiJHCA" x="14" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Ap8eWIt_Eeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EFLPEIt_Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ap8eWYt_Eeiu6boZkiJHCA" x="-12" y="18"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ap73QYt_Eeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_TF9BEE4-EeiMYveOdt1-rQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ap73Qot_Eeiu6boZkiJHCA" points="[-22, -146, -643984, -643984]$[80, -146, -643984, -643984]$[80, -59, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Dh_CcIt_Eeiu6boZkiJHCA" id="(0.9896551724137931,0.9142857142857143)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Dh_CcYt_Eeiu6boZkiJHCA" id="(0.6816479400749064,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ArZ24It_Eeiu6boZkiJHCA" type="StereotypeCommentLink" source="_Ap73QIt_Eeiu6boZkiJHCA" target="_ArZP04t_Eeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ArZ24Yt_Eeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ArZ25Yt_Eeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_TF9BEE4-EeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ArZ24ot_Eeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ArZ244t_Eeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ArZ25It_Eeiu6boZkiJHCA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IT9jsIt_Eeiu6boZkiJHCA" type="Association_Edge" source="_LeWsy3MLEeeSiaQ95-6r9w" target="_LeWqknMLEeeSiaQ95-6r9w">
       <children xmi:type="notation:DecorationNode" xmi:id="_IT-KwIt_Eeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -5254,9 +5134,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__fO-oRKJEemxeNG9TDCtFQ"/>
       <element xmi:type="uml:InterfaceRealization" href="TapiOam.uml#__AAE8BKJEemxeNG9TDCtFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__fO-ohKJEemxeNG9TDCtFQ" points="[752, -471, -643984, -643984]$[752, -632, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6f-UBKJEemxeNG9TDCtFQ" id="(0.7481751824817519,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6f-URKJEemxeNG9TDCtFQ" id="(0.6706484641638225,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__fO-ohKJEemxeNG9TDCtFQ" points="[753, -471, -643984, -643984]$[753, -632, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6f-UBKJEemxeNG9TDCtFQ" id="(0.7445255474452555,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6f-URKJEemxeNG9TDCtFQ" id="(0.630016051364366,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DcOYpxKKEemxeNG9TDCtFQ" type="StereotypeCommentLink" source="_Db9S4BKKEemxeNG9TDCtFQ" target="_DcOYoxKKEemxeNG9TDCtFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_DcOYqBKKEemxeNG9TDCtFQ"/>
@@ -5342,6 +5222,56 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_80BTNiD7EemsM5ohGqY7Gw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_80BTNyD7EemsM5ohGqY7Gw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_80BTOCD7EemsM5ohGqY7Gw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DcYwQDUyEem_pr37XaewKQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_DcW7EDUyEem_pr37XaewKQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DcYwQTUyEem_pr37XaewKQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DcZXUDUyEem_pr37XaewKQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DcYwQjUyEem_pr37XaewKQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DcYwQzUyEem_pr37XaewKQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DcYwRDUyEem_pr37XaewKQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KFk9pDXpEem8b5f98b_cVw" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_KFk9oDXpEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KFk9pTXpEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KFlksTXpEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KFk9pjXpEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KFk9pzXpEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KFlksDXpEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MJdLATiIEem1lYbrIE6BNw" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_MJcj8DiIEem1lYbrIE6BNw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MJdLAjiIEem1lYbrIE6BNw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MJdLBjiIEem1lYbrIE6BNw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MJdLAziIEem1lYbrIE6BNw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MJdLBDiIEem1lYbrIE6BNw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MJdLBTiIEem1lYbrIE6BNw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_feon1DkIEemjx6Nna_xyog" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_feon0DkIEemjx6Nna_xyog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_feon1TkIEemjx6Nna_xyog"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_feon2TkIEemjx6Nna_xyog" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_feon1jkIEemjx6Nna_xyog" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_feon1zkIEemjx6Nna_xyog"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_feon2DkIEemjx6Nna_xyog"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CFLdoTnQEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_CFK2kDnQEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CFLdojnQEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CFLdpjnQEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CFLdoznQEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFLdpDnQEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFLdpTnQEemSPvPXzEQ11A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_QUOkQHMcEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamJobDetails" measurementUnit="Pixel">
@@ -5449,7 +5379,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qvBSMU8EEeiW8t12GIRjqQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qvArEU8EEeiW8t12GIRjqQ" x="352" y="336" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qvArEU8EEeiW8t12GIRjqQ" x="464" y="299" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_qvUNEE8EEeiW8t12GIRjqQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_qvUNEU8EEeiW8t12GIRjqQ" showTitle="true"/>
@@ -5505,33 +5435,29 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_vn-sxF0IEeipas1p-rFJBA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_vn-sxV0IEeipas1p-rFJBA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_NKZVwF6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKZVwV6eEeitO-Stqhyn1g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_NKZ80F6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_HLiWIH2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKZ80V6eEeitO-Stqhyn1g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_NKaj4F6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GoWCMDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_WztYsLFXEd2MOdzuQUV2bQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKaj4V6eEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GoWCMTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_NKaj4l6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GoXQUDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_uGZgsH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKaj416eEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GoXQUTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_NKbK8F6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_n-WkYH2REd23zLSjbYwcFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKbK8V6eEeitO-Stqhyn1g"/>
+        <children xmi:type="notation:Shape" xmi:id="_GoXQUjVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_b23MADU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GoXQUzVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_NKbK8l6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GoX3YDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_d_RCQl0LEeipas1p-rFJBA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GoX3YTVvEem8b5f98b_cVw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GoX3YjVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKbK816eEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GoX3YzVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_NKbK9F6eEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_GoYecDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NKbK9V6eEeitO-Stqhyn1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GoYecTVvEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_vn-sxl0IEeipas1p-rFJBA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_vn-sx10IEeipas1p-rFJBA"/>
@@ -5567,29 +5493,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_-2fMZ10KEeipas1p-rFJBA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_-2fMaF0KEeipas1p-rFJBA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_toD3QCC3Eem5B__-Dm9B_g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_AJG_wH20Ed2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_toD3QSC3Eem5B__-Dm9B_g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_toFscCC3Eem5B__-Dm9B_g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_XsKvkDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_oesicNl2EeidLb5WEUMFmw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_toFscSC3Eem5B__-Dm9B_g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XsKvkTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_toGTgCC3Eem5B__-Dm9B_g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_XsL9sDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_9dJv0H2zEd2CEuIB5xoW6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_toGTgSC3Eem5B__-Dm9B_g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XsL9sTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_toGTgiC3Eem5B__-Dm9B_g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_3ZT3I0RhEeKsbYfVW3kmQQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_toGTgyC3Eem5B__-Dm9B_g"/>
+        <children xmi:type="notation:Shape" xmi:id="_XsMkwDVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_ugy7kTU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XsMkwTVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_toGThCC3Eem5B__-Dm9B_g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_XsNL0DVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_toGThSC3Eem5B__-Dm9B_g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XsNL0TVvEem8b5f98b_cVw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_toG6kCC3Eem5B__-Dm9B_g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_XsNL0jVvEem8b5f98b_cVw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_toG6kSC3Eem5B__-Dm9B_g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XsNL0zVvEem8b5f98b_cVw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_-2fMaV0KEeipas1p-rFJBA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_-2fMal0KEeipas1p-rFJBA"/>
@@ -5609,7 +5531,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2fMdl0KEeipas1p-rFJBA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2fMZF0KEeipas1p-rFJBA" x="101" y="524" width="236" height="127"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2fMZF0KEeipas1p-rFJBA" x="101" y="524" width="236" height="109"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_-2rZuV0KEeipas1p-rFJBA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_-2rZul0KEeipas1p-rFJBA" showTitle="true"/>
@@ -6162,10 +6084,6 @@
           <element xmi:type="uml:Property" href="TapiOam.uml#_GGYEY4U1EeiYFOBVMQg1QQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_u-D2UYbnEeil5oKL3Vgl-g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_u-D2UobnEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_UVLIoYbmEeil5oKL3Vgl-g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_u-D2U4bnEeil5oKL3Vgl-g"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_u-D2VIbnEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_u-D2VYbnEeil5oKL3Vgl-g"/>
@@ -6208,21 +6126,21 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3MGFVIVTEeiYFOBVMQg1QQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_3MGFVYVTEeiYFOBVMQg1QQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_WesQMIXxEei9lKa7hpARAQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_FW7W4IVVEeiYFOBVMQg1QQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WesQMYXxEei9lKa7hpARAQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_WeyW0IXxEei9lKa7hpARAQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WeyW0YXxEei9lKa7hpARAQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_WeyW0oXxEei9lKa7hpARAQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WeyW04XxEei9lKa7hpARAQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_hNPs4JAeEei1rofSed2vtg" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_IOoNQDqCEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_hDc3sJAeEei1rofSed2vtg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_hNQT8JAeEei1rofSed2vtg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_IOoNQTqCEemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_IOpbYDqCEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_FW7W4IVVEeiYFOBVMQg1QQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_IOpbYTqCEemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_IOpbYjqCEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_IOpbYzqCEemSPvPXzEQ11A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_IOqCcDqCEemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_IOqCcTqCEemSPvPXzEQ11A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_3MGFVoVTEeiYFOBVMQg1QQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_3MGFV4VTEeiYFOBVMQg1QQ"/>
@@ -6332,52 +6250,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_52fnX4bhEeil5oKL3Vgl-g" x="598" y="208"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1GkssIbnEeil5oKL3Vgl-g" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_1GkssobnEeil5oKL3Vgl-g" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_1Gkss4bnEeil5oKL3Vgl-g" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_1GkstIbnEeil5oKL3Vgl-g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_1GkstYbnEeil5oKL3Vgl-g" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_BH4tAIbpEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_-wpv4IboEeil5oKL3Vgl-g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_BH4tAYbpEeil5oKL3Vgl-g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_BH4tAobpEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_BH4tA4bpEeil5oKL3Vgl-g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_BH4tBIbpEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_BH4tBYbpEeil5oKL3Vgl-g"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_1GkstobnEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_1Gkst4bnEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_1GksuIbnEeil5oKL3Vgl-g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1GksuYbnEeil5oKL3Vgl-g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_1GksuobnEeil5oKL3Vgl-g" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_1Gksu4bnEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_1GksvIbnEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_1GksvYbnEeil5oKL3Vgl-g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1GksvobnEeil5oKL3Vgl-g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_1Gksv4bnEeil5oKL3Vgl-g" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_1GkswIbnEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_1GkswYbnEeil5oKL3Vgl-g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_1GkswobnEeil5oKL3Vgl-g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1Gksw4bnEeil5oKL3Vgl-g"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1GkssYbnEeil5oKL3Vgl-g" x="636" y="178" height="77"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_1Gw584bnEeil5oKL3Vgl-g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1Gw59IbnEeil5oKL3Vgl-g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Gw59obnEeil5oKL3Vgl-g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1Gw59YbnEeil5oKL3Vgl-g" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_0_3_E4b4Eeil5oKL3Vgl-g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0_3_FIb4Eeil5oKL3Vgl-g" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0_3_Fob4Eeil5oKL3Vgl-g" name="BASE_ELEMENT">
@@ -6433,14 +6305,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Aa4nQYuCEeiu6boZkiJHCA" x="772" y="-231"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_DJN1wouCEeiu6boZkiJHCA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_DJN1w4uCEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DJN1xYuCEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DJN1xIuCEeiu6boZkiJHCA" x="772" y="-231"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_G9HlMIuCEeiu6boZkiJHCA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_G9HlMYuCEeiu6boZkiJHCA"/>
@@ -6585,6 +6449,88 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QRLAUiC4EemsM5ohGqY7Gw" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Oi1jcDU2Eem_pr37XaewKQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Oi1jcTU2Eem_pr37XaewKQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oi3YoDU2Eem_pr37XaewKQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Oi1jcjU2Eem_pr37XaewKQ" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RVrsQDU7Eem_pr37XaewKQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_RVvWoDU7Eem_pr37XaewKQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RVvWoTU7Eem_pr37XaewKQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RVvWojU7Eem_pr37XaewKQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RVv9sDU7Eem_pr37XaewKQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_3ZYs4DU7Eem_pr37XaewKQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_3ZL4kDU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZYs4TU7Eem_pr37XaewKQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6WR70DU7Eem_pr37XaewKQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_6WMcQDU7Eem_pr37XaewKQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6WSi4DU7Eem_pr37XaewKQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RVv9sTU7Eem_pr37XaewKQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RVv9sjU7Eem_pr37XaewKQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RVv9szU7Eem_pr37XaewKQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVv9tDU7Eem_pr37XaewKQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RVv9tTU7Eem_pr37XaewKQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RVv9tjU7Eem_pr37XaewKQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RVv9tzU7Eem_pr37XaewKQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RVv9uDU7Eem_pr37XaewKQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVv9uTU7Eem_pr37XaewKQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RVv9ujU7Eem_pr37XaewKQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RVv9uzU7Eem_pr37XaewKQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RVv9vDU7Eem_pr37XaewKQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RVv9vTU7Eem_pr37XaewKQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVv9vjU7Eem_pr37XaewKQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVrsQTU7Eem_pr37XaewKQ" x="436" y="467"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RV-AIDU7Eem_pr37XaewKQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_RV-AITU7Eem_pr37XaewKQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RV-AIzU7Eem_pr37XaewKQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RV-AIjU7Eem_pr37XaewKQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ERIRADVgEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ERIRATVgEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ERSpEDVgEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ERIRAjVgEem8b5f98b_cVw" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DvRfsDXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DvRfsTXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvSGwDXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvRfsjXlEem8b5f98b_cVw" x="301" y="191"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JVKxMjXlEem8b5f98b_cVw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JVKxMzXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JVKxNTXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JVKxNDXlEem8b5f98b_cVw" x="301" y="424"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zIBtwDoPEemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zIBtwToPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zIBtwzoPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zIBtwjoPEemSPvPXzEQ11A" x="300" y="47"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_QUOkQXMcEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_QUOkQnMcEeeSiaQ95-6r9w"/>
@@ -6957,16 +6903,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_51042obhEeil5oKL3Vgl-g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_510424bhEeil5oKL3Vgl-g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1Gw594bnEeil5oKL3Vgl-g" type="StereotypeCommentLink" source="_1GkssIbnEeil5oKL3Vgl-g" target="_1Gw584bnEeil5oKL3Vgl-g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1Gw5-IbnEeil5oKL3Vgl-g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Gw5_IbnEeil5oKL3Vgl-g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_QU5KEIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1Gw5-YbnEeil5oKL3Vgl-g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Gw5-obnEeil5oKL3Vgl-g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Gw5-4bnEeil5oKL3Vgl-g"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0_3_F4b4Eeil5oKL3Vgl-g" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_0_3_E4b4Eeil5oKL3Vgl-g">
       <styles xmi:type="notation:FontStyle" xmi:id="_0_3_GIb4Eeil5oKL3Vgl-g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0_3_HIb4Eeil5oKL3Vgl-g" name="BASE_ELEMENT">
@@ -7086,7 +7022,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8dvcQIuBEeiu6boZkiJHCA" id="(1.0,0.11855670103092783)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8dvcQYuBEeiu6boZkiJHCA" id="(0.13636363636363635,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AVz6AIuCEeiu6boZkiJHCA" type="Association_Edge" source="_03rBEIVSEeiYFOBVMQg1QQ" target="_3MGFUIVTEeiYFOBVMQg1QQ">
+    <edges xmi:type="notation:Connector" xmi:id="_AVz6AIuCEeiu6boZkiJHCA" type="Association_Edge" source="_03rBEIVSEeiYFOBVMQg1QQ" target="_3MGFUIVTEeiYFOBVMQg1QQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_AVz6A4uCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_AV0hEIuCEeiu6boZkiJHCA" x="-4" y="5"/>
       </children>
@@ -7121,64 +7057,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Aa4nRouCEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Aa4nR4uCEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DC4kQIuCEeiu6boZkiJHCA" type="Association_Edge" source="_03rBEIVSEeiYFOBVMQg1QQ" target="_1GkssIbnEeil5oKL3Vgl-g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_DC5LUIuCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DC5LUYuCEeiu6boZkiJHCA" x="-20" y="-6"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DC5LUouCEeiu6boZkiJHCA" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DC5LU4uCEeiu6boZkiJHCA" x="-35" y="-7"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DC5LVIuCEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DC5LVYuCEeiu6boZkiJHCA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DC5LVouCEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DC5LV4uCEeiu6boZkiJHCA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DC5LWIuCEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DC5LWYuCEeiu6boZkiJHCA" x="-20" y="-15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DC5LWouCEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DC5LW4uCEeiu6boZkiJHCA" x="17" y="-17"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_DC4kQYuCEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DC4kQouCEeiu6boZkiJHCA" points="[709, -39, -643984, -643984]$[736, 178, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_2nQIuCEeiu6boZkiJHCA" id="(0.8939393939393939,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYz1YIuCEeiu6boZkiJHCA" id="(0.819047619047619,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DJN1xouCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_DC4kQIuCEeiu6boZkiJHCA" target="_DJN1wouCEeiu6boZkiJHCA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_DJN1x4uCEeiu6boZkiJHCA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DJN1y4uCEeiu6boZkiJHCA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_UVFCAIbmEeil5oKL3Vgl-g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DJN1yIuCEeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DJN1yYuCEeiu6boZkiJHCA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DJN1youCEeiu6boZkiJHCA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G87X8IuCEeiu6boZkiJHCA" type="Association_Edge" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_vn-swF0IEeipas1p-rFJBA">
+    <edges xmi:type="notation:Connector" xmi:id="_G87X8IuCEeiu6boZkiJHCA" type="Association_Edge" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_vn-swF0IEeipas1p-rFJBA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_G87X84uCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A1hQIDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_G87X9IuCEeiu6boZkiJHCA" x="9" y="-65"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_G87X9YuCEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_A9sUsDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_G87X9ouCEeiu6boZkiJHCA" x="-9" y="-73"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_G87X94uCEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87X-IuCEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BGgScDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87X-IuCEeiu6boZkiJHCA" x="8" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_G87X-YuCEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87X-ouCEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BOnFkDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87X-ouCEeiu6boZkiJHCA" x="-7" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_G87_AIuCEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87_AYuCEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BW2bkDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87_AYuCEeiu6boZkiJHCA" x="8" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_G87_AouCEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87_A4uCEeiu6boZkiJHCA" y="25"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_BfuqwDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_G87_A4uCEeiu6boZkiJHCA" x="-7" y="25"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_G87X8YuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G87X8ouCEeiu6boZkiJHCA" points="[240, 219, -643984, -643984]$[231, 291, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IGpZEIuCEeiu6boZkiJHCA" id="(0.40728476821192056,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G87X8ouCEeiu6boZkiJHCA" points="[224, 241, -643984, -643984]$[224, 291, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IGpZEIuCEeiu6boZkiJHCA" id="(0.4139072847682119,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AtOPwDU8Eem_pr37XaewKQ" id="(0.5740740740740741,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_G9HlNIuCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_G87X8IuCEeiu6boZkiJHCA" target="_G9HlMIuCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_G9HlNYuCEeiu6boZkiJHCA"/>
@@ -7190,7 +7098,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G9HlN4uCEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G9HlOIuCEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JcS9YIuCEeiu6boZkiJHCA" type="Association_Edge" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_qvArEE8EEeiW8t12GIRjqQ">
+    <edges xmi:type="notation:Connector" xmi:id="_JcS9YIuCEeiu6boZkiJHCA" type="Association_Edge" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_qvArEE8EEeiW8t12GIRjqQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_JcS9Y4uCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KhXvEIuCEeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_JcTkcIuCEeiu6boZkiJHCA" x="65" y="-62"/>
@@ -7217,9 +7125,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_JcS9YYuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_KAXjIE4eEeiMYveOdt1-rQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JcS9YouCEeiu6boZkiJHCA" points="[402, 176, -643984, -643984]$[486, 194, -643984, -643984]$[478, 336, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JcS9YouCEeiu6boZkiJHCA" points="[402, 193, -643984, -643984]$[486, 193, -643984, -643984]$[486, 299, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KaaLcIuCEeiu6boZkiJHCA" id="(1.0,0.7525773195876289)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KaaLcYuCEeiu6boZkiJHCA" id="(0.5114503816793893,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KaaLcYuCEeiu6boZkiJHCA" id="(0.08396946564885496,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JcZrF4uCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_JcS9YIuCEeiu6boZkiJHCA" target="_JcZrE4uCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_JcZrGIuCEeiu6boZkiJHCA"/>
@@ -7231,30 +7139,36 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JcZrGouCEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JcZrG4uCEeiu6boZkiJHCA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PUQPQIuCEeiu6boZkiJHCA" type="Association_Edge" source="_vn-swF0IEeipas1p-rFJBA" target="_-2fMY10KEeipas1p-rFJBA">
+    <edges xmi:type="notation:Connector" xmi:id="_PUQPQIuCEeiu6boZkiJHCA" type="Association_Edge" source="_vn-swF0IEeipas1p-rFJBA" target="_-2fMY10KEeipas1p-rFJBA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_PUQ2UIuCEeiu6boZkiJHCA" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Civm8DU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2UYuCEeiu6boZkiJHCA" x="2" y="-62"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_PUQ2UouCEeiu6boZkiJHCA" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CraawDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2U4uCEeiu6boZkiJHCA" x="-18" y="-78"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_PUQ2VIuCEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2VYuCEeiu6boZkiJHCA" y="-20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_C0NKYDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2VYuCEeiu6boZkiJHCA" x="12" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_PUQ2VouCEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2V4uCEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_C8Od8DU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2V4uCEeiu6boZkiJHCA" x="-12" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_PUQ2WIuCEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2WYuCEeiu6boZkiJHCA" y="20"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DEg3QDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2WYuCEeiu6boZkiJHCA" x="12" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_PUQ2WouCEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2W4uCEeiu6boZkiJHCA" x="2" y="22"/>
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_DNFkcDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PUQ2W4uCEeiu6boZkiJHCA" x="-10" y="22"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_PUQPQYuCEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PUQPQouCEeiu6boZkiJHCA" points="[227, 447, -643984, -643984]$[221, 535, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RAd5cIuCEeiu6boZkiJHCA" id="(0.4896265560165975,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o5Mb4NN9EeidMu8ST4Ma3w" id="(0.5042372881355932,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PUQPQouCEeiu6boZkiJHCA" points="[204, 447, -643984, -643984]$[204, 524, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RAd5cIuCEeiu6boZkiJHCA" id="(0.48148148148148145,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o5Mb4NN9EeidMu8ST4Ma3w" id="(0.4406779661016949,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_PVp9d4uCEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_PUQPQIuCEeiu6boZkiJHCA" target="_PVp9c4uCEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_PVp9eIuCEeiu6boZkiJHCA"/>
@@ -7415,6 +7329,128 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QRRG8iC4EemsM5ohGqY7Gw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QRRuACC4EemsM5ohGqY7Gw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QRRuASC4EemsM5ohGqY7Gw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Oi3_sDU2Eem_pr37XaewKQ" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_Oi1jcDU2Eem_pr37XaewKQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Oi3_sTU2Eem_pr37XaewKQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oi3_tTU2Eem_pr37XaewKQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Oi3_sjU2Eem_pr37XaewKQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oi3_szU2Eem_pr37XaewKQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oi3_tDU2Eem_pr37XaewKQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RV-AJDU7Eem_pr37XaewKQ" type="StereotypeCommentLink" source="_RVrsQDU7Eem_pr37XaewKQ" target="_RV-AIDU7Eem_pr37XaewKQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RV-AJTU7Eem_pr37XaewKQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RV-nMDU7Eem_pr37XaewKQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RV-AJjU7Eem_pr37XaewKQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RV-AJzU7Eem_pr37XaewKQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RV-AKDU7Eem_pr37XaewKQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_b_yegDU7Eem_pr37XaewKQ" type="Association_Edge" source="_vn-swF0IEeipas1p-rFJBA" target="_RVrsQDU7Eem_pr37XaewKQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_yegzU7Eem_pr37XaewKQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EQHHsDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_yehDU7Eem_pr37XaewKQ" x="-5" y="16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_yehTU7Eem_pr37XaewKQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EYLekDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_yehjU7Eem_pr37XaewKQ" x="-17" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_yehzU7Eem_pr37XaewKQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Eg25cDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_yeiDU7Eem_pr37XaewKQ" x="34" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_yeiTU7Eem_pr37XaewKQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Eo1JsDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_yeijU7Eem_pr37XaewKQ" x="-34" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_yeizU7Eem_pr37XaewKQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_EwyL0DU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_yejDU7Eem_pr37XaewKQ" x="10" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_b_zFkDU7Eem_pr37XaewKQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_E5rpIDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_b_zFkTU7Eem_pr37XaewKQ" x="-13" y="-21"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_b_yegTU7Eem_pr37XaewKQ"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b_yegjU7Eem_pr37XaewKQ" points="[317, 419, -643984, -643984]$[494, 419, -643984, -643984]$[494, 467, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cRUTYDU7Eem_pr37XaewKQ" id="(1.0,0.8205128205128205)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cRUTYTU7Eem_pr37XaewKQ" id="(0.23651452282157676,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_upSwQDU7Eem_pr37XaewKQ" type="Association_Edge" source="_-2fMY10KEeipas1p-rFJBA" target="_RVrsQDU7Eem_pr37XaewKQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_upTXUDU7Eem_pr37XaewKQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HjOeQDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_upTXUTU7Eem_pr37XaewKQ" x="-14" y="-10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_upTXUjU7Eem_pr37XaewKQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HrOjsDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_upTXUzU7Eem_pr37XaewKQ" x="-22" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_upTXVDU7Eem_pr37XaewKQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_HzThoDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_upTXVTU7Eem_pr37XaewKQ" x="27" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_upTXVjU7Eem_pr37XaewKQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_H72ZoDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_upTXVzU7Eem_pr37XaewKQ" x="-27" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_upTXWDU7Eem_pr37XaewKQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ID47UDU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_upTXWTU7Eem_pr37XaewKQ" x="11" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_upTXWjU7Eem_pr37XaewKQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_IL5n0DU8Eem_pr37XaewKQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_upTXWzU7Eem_pr37XaewKQ" x="-13" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_upSwQTU7Eem_pr37XaewKQ"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_upSwQjU7Eem_pr37XaewKQ" points="[337, 604, -643984, -643984]$[498, 604, -643984, -643984]$[498, 567, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u6vFkDU7Eem_pr37XaewKQ" id="(1.0,0.7339449541284404)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u6vsoDU7Eem_pr37XaewKQ" id="(0.25311203319502074,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ERTQIDVgEem8b5f98b_cVw" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_ERIRADVgEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ERTQITVgEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ERUeQTVgEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ERT3MDVgEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ERT3MTVgEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ERUeQDVgEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DvSt0DXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_b_yegDU7Eem_pr37XaewKQ" target="_DvRfsDXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DvSt0TXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvSt1TXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvSt0jXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvSt0zXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvSt1DXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JVKxNjXlEem8b5f98b_cVw" type="StereotypeCommentLink" source="_upSwQDU7Eem_pr37XaewKQ" target="_JVKxMjXlEem8b5f98b_cVw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JVKxNzXlEem8b5f98b_cVw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JVLYQjXlEem8b5f98b_cVw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JVKxODXlEem8b5f98b_cVw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JVLYQDXlEem8b5f98b_cVw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JVLYQTXlEem8b5f98b_cVw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zIBtxDoPEemSPvPXzEQ11A" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_zIBtwDoPEemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zIBtxToPEemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zIBtyToPEemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zIBtxjoPEemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zIBtxzoPEemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zIBtyDoPEemSPvPXzEQ11A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_DvMJsINfEeelF8AE_WZtHQ" type="PapyrusUMLClassDiagram" name="OamConnSkeleton" measurementUnit="Pixel">

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -19,9 +19,6 @@ License: This module is distributed under the Apache License 2.0</body>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_B9eEoIHDEeeh4KO3PMo8Rw" name="layerProtocolName" isReadOnly="true">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_A0XLAJPsEeePQIrrJoWPZA" name="direction" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_2-15sEI6EeiDweqmZm-ZXQ" name="OamJob" isLeaf="true">
         <generalization xmi:type="uml:Generalization" xmi:id="_X_Zp0E4eEeiMYveOdt1-rQ">
@@ -86,9 +83,6 @@ optionally one additional configurable (&lt; 15min)</body>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_EBqfUE46EeiMYveOdt1-rQ" name="layerProtocolName" isReadOnly="true">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_IJQGIE5CEeiMYveOdt1-rQ" name="direction" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_k-OoENzEEeaMV83ubDcSig" name="Mip">
         <generalization xmi:type="uml:Generalization" xmi:id="_bPpzsPLuEeaAIfPpmDwI5Q">
@@ -102,6 +96,9 @@ optionally one additional configurable (&lt; 15min)</body>
         <generalization xmi:type="uml:Generalization" xmi:id="_6pojwPLtEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
         </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yrGnYDnyEemSPvPXzEQ11A" name="layerProtocolName">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_bsmIshP7EeepnPPr_BcZKg" name="_oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" aggregation="composite" association="_bsgCEBP7EeepnPPr_BcZKg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kW8CoBP7EeepnPPr_BcZKg" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kXCJQBP7EeepnPPr_BcZKg" value="*"/>
@@ -113,7 +110,6 @@ optionally one additional configurable (&lt; 15min)</body>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_mMroAU8HEeiW8t12GIRjqQ" name="_state" aggregation="composite" association="_mMqZ4E8HEeiW8t12GIRjqQ">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_TF9BE04-EeiMYveOdt1-rQ" name="_oamConstraint" type="_GVZfsE4-EeiMYveOdt1-rQ" aggregation="composite" association="_TF9BEE4-EeiMYveOdt1-rQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_1qX4MOwNEealldJ4rm6P_g" name="OamContext">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_qX1LIuxIEeaTUPmcu3rLwA" name="_oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" aggregation="composite" association="_qXvEgOxIEeaTUPmcu3rLwA">
@@ -162,9 +158,6 @@ optionally one additional configurable (&lt; 15min)</body>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_WRqhYE45EeiMYveOdt1-rQ" name="layerProtocolName">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hJpKQBocEeeV4o0osG5stg" name="direction">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_DzNYkBN3EemxeNG9TDCtFQ" name="isMip">
           <ownedComment xmi:type="uml:Comment" xmi:id="_RuiD8BN3EemxeNG9TDCtFQ" annotatedElement="_DzNYkBN3EemxeNG9TDCtFQ">
             <body>If true, the object is related to a MIP.&#xD;
@@ -183,38 +176,10 @@ If false, the object is related to a MEP.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qjmqoGNXEee0bPnI-Gt-mQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_GVZfsE4-EeiMYveOdt1-rQ" name="OamConstraint">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_W0CjwE47EeiMYveOdt1-rQ" name="layerProtocolName">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_oQNi4E4_EeiMYveOdt1-rQ" name="direction">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_i4OKgE4_EeiMYveOdt1-rQ" name="megLevel">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-        </ownedAttribute>
-      </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_vnyfgF0IEeipas1p-rFJBA" name="CurrentData">
         <generalization xmi:type="uml:Generalization" xmi:id="_E-00wF6ZEeitO-Stqhyn1g">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_d_RCQl0LEeipas1p-rFJBA" name="_historyData" type="_-2fMYF0KEeipas1p-rFJBA" isReadOnly="true" aggregation="composite" association="_d_K7oF0LEeipas1p-rFJBA">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_zH_kQIUzEeiYFOBVMQg1QQ" annotatedElement="_d_RCQl0LEeipas1p-rFJBA">
-            <body>in case of 24hr Current Data, at least 1 History Data.&#xD;
-In case of 15min Current Data, at least 16 History Data.&#xD;
-In case of &lt;15min, the number of History Data shall be able to cover a span of 4 hours.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nt2AYF0LEeipas1p-rFJBA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nt2AYV0LEeipas1p-rFJBA" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_HLiWIH2zEd2CEuIB5xoW6g" name="granularityPeriod" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_BITSwIUzEeiYFOBVMQg1QQ" annotatedElement="_HLiWIH2zEd2CEuIB5xoW6g">
-            <body></body>
-          </ownedComment>
-          <type xmi:type="uml:DataType" href="TapiCommon.uml#_Ay2V0F6UEeitO-Stqhyn1g"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iYZccLFqEeKY9r1KmoVLlQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iYZccbFqEeKY9r1KmoVLlQ" value="1"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_WztYsLFXEd2MOdzuQUV2bQ" name="periodStartTime" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_uTH0ALFYEd2MOdzuQUV2bQ" annotatedElement="_WztYsLFXEd2MOdzuQUV2bQ">
             <body>This attribute indicates the start of the current monitoring interval.&#xD;
@@ -225,29 +190,24 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
         <ownedAttribute xmi:type="uml:Property" xmi:id="_uGZgsH2REd23zLSjbYwcFw" name="elapsedTime" visibility="public">
           <type xmi:type="uml:DataType" href="TapiCommon.uml#__aY_AF6cEeitO-Stqhyn1g"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_n-WkYH2REd23zLSjbYwcFw" name="suspectIntervalFlag" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_z1WRALFZEd2MOdzuQUV2bQ" annotatedElement="_n-WkYH2REd23zLSjbYwcFw">
-            <body>This attribute is used to indicate that the performance data for the current period may not be reliable. Some reasons for this to occur are:&#xD;
-– Suspect data were detected by the actual resource doing data collection.&#xD;
-– Transition of the administrativeState attribute to/from the 'lock' state.&#xD;
-– Transition of the operationalState to/from the 'disabled' state.&#xD;
-– Scheduler setting that inhibits the collection function.&#xD;
-– The performance counters were reset during the interval.&#xD;
-– The currentData (or subclass) object instance was created during the monitoring period.</body>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_b23MADU7Eem_pr37XaewKQ" name="_pmDataPac" type="_RRNb8DU7Eem_pr37XaewKQ" aggregation="composite" association="_b2xscDU7Eem_pr37XaewKQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b25BMDU7Eem_pr37XaewKQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_b25BMTU7Eem_pr37XaewKQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_d_RCQl0LEeipas1p-rFJBA" name="_historyData" type="_-2fMYF0KEeipas1p-rFJBA" isReadOnly="true" aggregation="composite" association="_d_K7oF0LEeipas1p-rFJBA">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_zH_kQIUzEeiYFOBVMQg1QQ" annotatedElement="_d_RCQl0LEeipas1p-rFJBA">
+            <body>in case of 24hr Current Data, at least 1 History Data.&#xD;
+In case of 15min Current Data, at least 16 History Data.&#xD;
+In case of &lt;15min, the number of History Data shall be able to cover a span of 4 hours.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_aH9s0LFZEd2MOdzuQUV2bQ">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nt2AYF0LEeipas1p-rFJBA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nt2AYV0LEeipas1p-rFJBA" value="*"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_-2fMYF0KEeipas1p-rFJBA" name="HistoryData">
         <generalization xmi:type="uml:Generalization" xmi:id="_F1sLUF6ZEeitO-Stqhyn1g">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AJG_wH20Ed2CEuIB5xoW6g" name="granularityPeriod" visibility="public">
-          <type xmi:type="uml:DataType" href="TapiCommon.uml#_Ay2V0F6UEeitO-Stqhyn1g"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_oesicNl2EeidLb5WEUMFmw" name="periodStartTime">
           <ownedComment xmi:type="uml:Comment" xmi:id="_0Cy3wNl2EeidLb5WEUMFmw" annotatedElement="_oesicNl2EeidLb5WEUMFmw">
             <body>This attribute indicates the start of the monitoring interval.&#xD;
@@ -258,11 +218,9 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
         <ownedAttribute xmi:type="uml:Property" xmi:id="_9dJv0H2zEd2CEuIB5xoW6g" name="periodEndTime" visibility="public">
           <type xmi:type="uml:DataType" href="TapiCommon.uml#_6iCS8O-fEeWLlrwIF3w0vA"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3ZT3I0RhEeKsbYfVW3kmQQ" name="suspectIntervalFlag" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_3ZT3JERhEeKsbYfVW3kmQQ" annotatedElement="_3ZT3I0RhEeKsbYfVW3kmQQ">
-            <body>This attribute indicates that the performance data may not be reliable.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ugy7kTU7Eem_pr37XaewKQ" name="_pmDataPac" type="_RRNb8DU7Eem_pr37XaewKQ" aggregation="composite" association="_ugxtcDU7Eem_pr37XaewKQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ugzioTU7Eem_pr37XaewKQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ug0JsDU7Eem_pr37XaewKQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_bgGpwIUvEeiYFOBVMQg1QQ" name="OamProfile">
@@ -273,64 +231,79 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dDC_AIU2EeiYFOBVMQg1QQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dDC_AYU2EeiYFOBVMQg1QQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_UVLIoYbmEeil5oKL3Vgl-g" name="_pmBinData" type="_QU5KEIbmEeil5oKL3Vgl-g" aggregation="composite" association="_UVFCAIbmEeil5oKL3Vgl-g">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aQAIUIbmEeil5oKL3Vgl-g" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aQAIUYbmEeil5oKL3Vgl-g" value="*"/>
-        </ownedAttribute>
         <interfaceRealization xmi:type="uml:InterfaceRealization" xmi:id="_J4ZK0BKKEemxeNG9TDCtFQ" client="_bgGpwIUvEeiYFOBVMQg1QQ" supplier="_Db62oBKKEemxeNG9TDCtFQ" contract="_Db62oBKKEemxeNG9TDCtFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_CD5qQIUxEeiYFOBVMQg1QQ" name="PmThresholdData">
         <generalization xmi:type="uml:Generalization" xmi:id="_Wuza8IVQEeiYFOBVMQg1QQ">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_FW7W4IVVEeiYFOBVMQg1QQ" name="granularityPeriod">
-          <type xmi:type="uml:DataType" href="TapiCommon.uml#_Ay2V0F6UEeitO-Stqhyn1g"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hDc3sJAeEei1rofSed2vtg" name="isTransient">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
         </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_QU5KEIbmEeil5oKL3Vgl-g" name="PmBinData">
-        <generalization xmi:type="uml:Generalization" xmi:id="_PRoEUIboEeil5oKL3Vgl-g">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-        </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-wpv4IboEeil5oKL3Vgl-g" name="granularityPeriod">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FW7W4IVVEeiYFOBVMQg1QQ" name="granularityPeriod">
           <type xmi:type="uml:DataType" href="TapiCommon.uml#_Ay2V0F6UEeitO-Stqhyn1g"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_RRNb8DU7Eem_pr37XaewKQ" name="PmDataPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3ZL4kDU7Eem_pr37XaewKQ" name="granularityPeriod" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3ZL4kTU7Eem_pr37XaewKQ" annotatedElement="_3ZL4kDU7Eem_pr37XaewKQ">
+            <body></body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_Ay2V0F6UEeitO-Stqhyn1g"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3ZL4kjU7Eem_pr37XaewKQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3ZL4kzU7Eem_pr37XaewKQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6WMcQDU7Eem_pr37XaewKQ" name="suspectIntervalFlag" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6WMcQTU7Eem_pr37XaewKQ" annotatedElement="_6WMcQDU7Eem_pr37XaewKQ">
+            <body>This attribute is used to indicate that the performance data for the current period may not be reliable. Some reasons for this to occur are:&#xD;
+– Suspect data were detected by the actual resource doing data collection.&#xD;
+– Transition of the administrativeState attribute to/from the 'lock' state.&#xD;
+– Transition of the operationalState to/from the 'disabled' state.&#xD;
+– Scheduler setting that inhibits the collection function.&#xD;
+– The performance counters were reset during the interval.&#xD;
+– The currentData (or subclass) object instance was created during the monitoring period.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_6WMcQjU7Eem_pr37XaewKQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_zf2PwMOcEeaFfJxGCRaf4A" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_Nm0qoOxYEeaTUPmcu3rLwA" name="OamService">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_r-PDAMOdEeaFfJxGCRaf4A" name="createOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_nNQpEE-oEeitY7qZgkO_XQ" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_nNQpEE-oEeitY7qZgkO_XQ" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s39iEE-oEeitY7qZgkO_XQ" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s3_-UE-oEeitY7qZgkO_XQ" value="*"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_w5FjQE-qEeitY7qZgkO_XQ" name="oamConstraint" type="_GVZfsE4-EeiMYveOdt1-rQ"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_uTCfUDoQEemSPvPXzEQ11A" name="layer">
+            <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_1gB5ME-qEeitY7qZgkO_XQ" name="state">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_65htcE-qEeitY7qZgkO_XQ" name="service" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_65htcE-qEeitY7qZgkO_XQ" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_NbJpQMOfEeaFfJxGCRaf4A" name="deleteOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_knARIE-rEeitY7qZgkO_XQ" name="serviceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_knARIE-rEeitY7qZgkO_XQ" name="oamServiceId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_zn1cMMOeEeaFfJxGCRaf4A" name="getOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_grnEAFg6Eei9GrLbn4i8vw" name="serviceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_grnEAFg6Eei9GrLbn4i8vw" name="oamServiceId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_UjLSkFg6Eei9GrLbn4i8vw" name="service" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_UjLSkFg6Eei9GrLbn4i8vw" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_lSsioMOeEeaFfJxGCRaf4A" name="getOamServiceList">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_o7pAgFg6Eei9GrLbn4i8vw" name="service" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_o7pAgFg6Eei9GrLbn4i8vw" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="read">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qCeFsFg6Eei9GrLbn4i8vw"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qCeFsVg6Eei9GrLbn4i8vw" value="*"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_ssZqINzDEeaMV83ubDcSig" name="getMeg">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_hFaOoFg7Eei9GrLbn4i8vw" name="serviceId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_hFaOoFg7Eei9GrLbn4i8vw" name="oamServiceId">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_nVxZcFg7Eei9GrLbn4i8vw" name="meg" type="_zR-agMbLEeaVKq30FmMykA" direction="out">
@@ -339,26 +312,22 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_FHkjAE4wEeiMYveOdt1-rQ" name="updateOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2xUFcE-rEeitY7qZgkO_XQ" name="serviceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2xUFcE-rEeitY7qZgkO_XQ" name="oamServiceId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_6GkKAE-rEeitY7qZgkO_XQ" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg" effect="update">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_6GkKAE-rEeitY7qZgkO_XQ" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" effect="update">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PuVOEFg7Eei9GrLbn4i8vw"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PuVOEVg7Eei9GrLbn4i8vw" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_84Uf8E-rEeitY7qZgkO_XQ" name="oamConstraint" type="_GVZfsE4-EeiMYveOdt1-rQ" effect="update">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_R-mAgFg7Eei9GrLbn4i8vw"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_R-mAgVg7Eei9GrLbn4i8vw" value="1"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Ev1OwE-sEeitY7qZgkO_XQ" name="state" effect="update">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UM0LkFg7Eei9GrLbn4i8vw"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UM0LkVg7Eei9GrLbn4i8vw" value="1"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_HAebsE-sEeitY7qZgkO_XQ" name="service" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="update"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_HAebsE-sEeitY7qZgkO_XQ" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="update"/>
         </ownedOperation>
-        <ownedOperation xmi:type="uml:Operation" xmi:id="_CXyBUE5DEeiMYveOdt1-rQ" name="createOamServiceEndPoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_AnXO8Fg7Eei9GrLbn4i8vw" name="serviceId" effect="read">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_CXyBUE5DEeiMYveOdt1-rQ" name="createOamServicePoint">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_AnXO8Fg7Eei9GrLbn4i8vw" name="oamServiceId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_PETkMFg8Eei9GrLbn4i8vw" name="sipId" effect="read">
@@ -374,37 +343,24 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_C4LJEFg9Eei9GrLbn4i8vw" name="layer">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_HAwvEFg9Eei9GrLbn4i8vw" name="direction">
-            <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
-          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_86ebkFg8Eei9GrLbn4i8vw" name="state" effect="update">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Sz5VcMWXEeiWCKGKl1wb8w" name="mepIdentifier">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UytLgMWXEeiWCKGKl1wb8w"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UzLsoMWXEeiWCKGKl1wb8w" value="1"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_c_SycMWXEeiWCKGKl1wb8w" name="peerMepIdentifier">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eM84YMWXEeiWCKGKl1wb8w"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eNbZgMWXEeiWCKGKl1wb8w" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_I2LDcFg7Eei9GrLbn4i8vw" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_I2LDcFg7Eei9GrLbn4i8vw" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out"/>
         </ownedOperation>
-        <ownedOperation xmi:type="uml:Operation" xmi:id="_GGP3IE5DEeiMYveOdt1-rQ" name="deleteOamServiceEndPoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_e_xs8Fg9Eei9GrLbn4i8vw" name="serviceId">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_GGP3IE5DEeiMYveOdt1-rQ" name="deleteOamServicePoint">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_e_xs8Fg9Eei9GrLbn4i8vw" name="oamServiceId">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5J47UFg7Eei9GrLbn4i8vw" name="oSepId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5J47UFg7Eei9GrLbn4i8vw" name="oamServicePointId" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
         </ownedOperation>
-        <ownedOperation xmi:type="uml:Operation" xmi:id="_JRx_AE5DEeiMYveOdt1-rQ" name="updateOamServiceEndPoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WegGAFkaEei2nODetmeP6A" name="serviceId" effect="read">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_JRx_AE5DEeiMYveOdt1-rQ" name="updateOamServicePoint">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WegGAFkaEei2nODetmeP6A" name="oamServiceId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_ZrwsMFkaEei2nODetmeP6A" name="oSepId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_ZrwsMFkaEei2nODetmeP6A" name="oamServicePointId" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_dNUHYFkaEei2nODetmeP6A" name="state" effect="update">
@@ -412,23 +368,27 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d81f0FkaEei2nODetmeP6A"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d838EFkaEei2nODetmeP6A" value="1"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_tbTY8FkaEei2nODetmeP6A" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out" effect="update"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_tbTY8FkaEei2nODetmeP6A" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out" effect="update"/>
         </ownedOperation>
-        <ownedOperation xmi:type="uml:Operation" xmi:id="_M-C1YE5DEeiMYveOdt1-rQ" name="getOamServiceEndPoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_99OlEFkYEei2nODetmeP6A" name="serviceId" effect="read">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_M-C1YE5DEeiMYveOdt1-rQ" name="getOamServicePoint">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_99OlEFkYEei2nODetmeP6A" name="oamServiceId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_A5gwAFkZEei2nODetmeP6A" name="oSepId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_A5gwAFkZEei2nODetmeP6A" name="oamServicePointId" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_GY6_AFkZEei2nODetmeP6A" name="endPoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_GY6_AFkZEei2nODetmeP6A" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out" effect="read"/>
         </ownedOperation>
       </packagedElement>
       <packagedElement xmi:type="uml:Interface" xmi:id="_rH__wBKJEemxeNG9TDCtFQ" name="OamJob">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_mF1sQMOdEeaFfJxGCRaf4A" name="createOamJob">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_VJFbIJsZEeid4dfn4JFJZg" name="oamJobType" type="_tqiDYF3eEeit4-HSxnZlvw" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0LKokJsYEeid4dfn4JFJZg" name="oamServiceEndPoint" type="_W48McBP7EeepnPPr_BcZKg">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CtmUJsYEeid4dfn4JFJZg" value="2"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_i7Ow4DkQEemjx6Nna_xyog" name="oamServiceId">
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0LKokJsYEeid4dfn4JFJZg" name="oamServicePointId">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CtmUJsYEeid4dfn4JFJZg" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5C_6MJsYEeid4dfn4JFJZg" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_bdSkIJsZEeid4dfn4JFJZg" name="oamProfileId" effect="read">
@@ -443,7 +403,7 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_HxvqoFg-Eei9GrLbn4i8vw" name="oamJob" type="_2-15sEI6EeiDweqmZm-ZXQ" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_5HQ4ME5CEeiMYveOdt1-rQ" name="updateOamJob">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_j56-wFkZEei2nODetmeP6A" name="jobId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_j56-wFkZEei2nODetmeP6A" name="oamJobId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_kgDlIJsZEeid4dfn4JFJZg" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" effect="read"/>
@@ -460,12 +420,12 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_yCmJoFkZEei2nODetmeP6A" name="oamJob" type="_2-15sEI6EeiDweqmZm-ZXQ" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_zpm8sE5CEeiMYveOdt1-rQ" name="deleteOamJob">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_z-ENQFkYEei2nODetmeP6A" name="jobId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_z-ENQFkYEei2nODetmeP6A" name="oamJobId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_SrzDgMOfEeaFfJxGCRaf4A" name="getOamJob" visibility="public">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Es2zUFisEei2nODetmeP6A" name="jobId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Es2zUFisEei2nODetmeP6A" name="oamJobId" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_NCTbUFisEei2nODetmeP6A" name="oamJob" type="_2-15sEI6EeiDweqmZm-ZXQ" direction="out" effect="read"/>
@@ -480,12 +440,8 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
       <packagedElement xmi:type="uml:Interface" xmi:id="_Db62oBKKEemxeNG9TDCtFQ" name="OamProfile">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_PgmJcBKKEemxeNG9TDCtFQ" name="createOamProfile">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_AvfgEBKfEemxeNG9TDCtFQ" name="pmThresholdData" type="_CD5qQIUxEeiYFOBVMQg1QQ">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Lp2U0BKfEemxeNG9TDCtFQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Lp2U0BKfEemxeNG9TDCtFQ" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LqiRUBKfEemxeNG9TDCtFQ" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_E-hsUBKfEemxeNG9TDCtFQ" name="pmBinData" type="_QU5KEIbmEeil5oKL3Vgl-g">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zeOB0BKfEemxeNG9TDCtFQ"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ze7McBKfEemxeNG9TDCtFQ" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_KhUmgBKfEemxeNG9TDCtFQ" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" direction="out">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6G-egBKfEemxeNG9TDCtFQ" value="1"/>
@@ -493,26 +449,22 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_Q6sI4BKKEemxeNG9TDCtFQ" name="updateOamProfile">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Gdw1ABKgEemxeNG9TDCtFQ" name="serviceId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Gdw1ABKgEemxeNG9TDCtFQ" name="oamProfileId">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_ODLHMBKgEemxeNG9TDCtFQ" name="pmThresholdData" type="_CD5qQIUxEeiYFOBVMQg1QQ">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WTrk0BKgEemxeNG9TDCtFQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WTrk0BKgEemxeNG9TDCtFQ" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WUSBwBKgEemxeNG9TDCtFQ" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_QpiFcBKgEemxeNG9TDCtFQ" name="pmBinData" type="_QU5KEIbmEeil5oKL3Vgl-g">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X3rHIBKgEemxeNG9TDCtFQ"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X4SLIBKgEemxeNG9TDCtFQ" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_U2jfgBKgEemxeNG9TDCtFQ" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_SIbHUBKKEemxeNG9TDCtFQ" name="deleteOamProfile">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_c5sPgBKgEemxeNG9TDCtFQ" name="serviceId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_c5sPgBKgEemxeNG9TDCtFQ" name="oamProfileId">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_ZqMPoBKKEemxeNG9TDCtFQ" name="getOamProfile">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_gNBBcBKgEemxeNG9TDCtFQ" name="serviceId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_gNBBcBKgEemxeNG9TDCtFQ" name="oamProfileId">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_pksigBKgEemxeNG9TDCtFQ" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" direction="out"/>
@@ -643,12 +595,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_04lUQU4hEeiMYveOdt1-rQ" name="oamcontext" type="_1qX4MOwNEealldJ4rm6P_g" association="_04fNoE4hEeiMYveOdt1-rQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_TF9BEE4-EeiMYveOdt1-rQ" name="OamServiceHasOamConstraints" memberEnd="_TF9BE04-EeiMYveOdt1-rQ _TGDHsU4-EeiMYveOdt1-rQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TF9BEU4-EeiMYveOdt1-rQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TF9BEk4-EeiMYveOdt1-rQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_TGDHsU4-EeiMYveOdt1-rQ" name="oamservice" type="_NgYmEOxFEeaTUPmcu3rLwA" association="_TF9BEE4-EeiMYveOdt1-rQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_d_iSUE8FEeiW8t12GIRjqQ" name="MEPHasStatePac" memberEnd="_d_jgcU8FEeiW8t12GIRjqQ _d_kukE8FEeiW8t12GIRjqQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_d_i5YE8FEeiW8t12GIRjqQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_d_jgcE8FEeiW8t12GIRjqQ" key="nature" value="UML_Nature"/>
@@ -697,12 +643,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_GGYEZoU1EeiYFOBVMQg1QQ" name="pmthresholdprofile" type="_bgGpwIUvEeiYFOBVMQg1QQ" association="_GGYEYIU1EeiYFOBVMQg1QQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_UVFCAIbmEeil5oKL3Vgl-g" name="OamProfileHasPmBin" memberEnd="_UVLIoYbmEeil5oKL3Vgl-g _UVLIpIbmEeil5oKL3Vgl-g">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_UVFCAYbmEeil5oKL3Vgl-g" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_UVLIoIbmEeil5oKL3Vgl-g" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_UVLIpIbmEeil5oKL3Vgl-g" name="oamprofile" type="_bgGpwIUvEeiYFOBVMQg1QQ" association="_UVFCAIbmEeil5oKL3Vgl-g"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_w25csIbmEeil5oKL3Vgl-g" name="OamJobHasOamProfile" memberEnd="_w2_jUobmEeil5oKL3Vgl-g _w2_jVYbmEeil5oKL3Vgl-g">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_w2_jUIbmEeil5oKL3Vgl-g" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_w2_jUYbmEeil5oKL3Vgl-g" key="nature" value="UML_Nature"/>
@@ -720,6 +660,18 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JsAJQJsYEeid4dfn4JFJZg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JsZK0JsYEeid4dfn4JFJZg" value="*"/>
         </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_b2xscDU7Eem_pr37XaewKQ" name="CurrentDataHasPmDataPac" memberEnd="_b23MADU7Eem_pr37XaewKQ _b25oQDU7Eem_pr37XaewKQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_b21W0DU7Eem_pr37XaewKQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_b2194DU7Eem_pr37XaewKQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_b25oQDU7Eem_pr37XaewKQ" name="currentdata" type="_vnyfgF0IEeipas1p-rFJBA" association="_b2xscDU7Eem_pr37XaewKQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ugxtcDU7Eem_pr37XaewKQ" name="HistoryDataHasPmDataPac" memberEnd="_ugy7kTU7Eem_pr37XaewKQ _ug0JsTU7Eem_pr37XaewKQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ugyUgDU7Eem_pr37XaewKQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ugy7kDU7Eem_pr37XaewKQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ug0JsTU7Eem_pr37XaewKQ" name="historydata" type="_-2fMYF0KEeipas1p-rFJBA" association="_ugxtcDU7Eem_pr37XaewKQ"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_-MPC0OvREealldJ4rm6P_g" name="Imports">
@@ -807,8 +759,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfpBhsEeewCs0lkpWskw" base_Property="__n7gANzDEeaMV83ubDcSig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfphhsEeewCs0lkpWskw" base_Property="_qX7RwexIEeaTUPmcu3rLwA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HHPfqhhsEeewCs0lkpWskw" base_Property="_bssPUBP7EeepnPPr_BcZKg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_hJpKQRocEeeV4o0osG5stg" base_StructuralFeature="_hJpKQBocEeeV4o0osG5stg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hJpKQhocEeeV4o0osG5stg" base_Property="_hJpKQBocEeeV4o0osG5stg"/>
   <OpenModel_Profile:StrictComposite xmi:id="_Hi0EoEyeEeeBqfKxLidrUg" base_Association="_qXvEgOxIEeaTUPmcu3rLwA"/>
   <OpenModel_Profile:StrictComposite xmi:id="_K2_yMEyeEeeBqfKxLidrUg" base_Association="_1i2mEMbNEeaVKq30FmMykA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_FeHh4FqoEeexvMtO2oNM9g" base_Class="_CE0kkLwmEeSpn78DYJKtkA"/>
@@ -851,8 +801,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelAttribute xmi:id="_B9eEooHDEeeh4KO3PMo8Rw" base_StructuralFeature="_B9eEoIHDEeeh4KO3PMo8Rw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_DOXbMILIEeelF8AE_WZtHQ" base_StructuralFeature="_DOW0IILIEeelF8AE_WZtHQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DOYCQILIEeelF8AE_WZtHQ" base_Property="_DOW0IILIEeelF8AE_WZtHQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_A0XLAZPsEeePQIrrJoWPZA" base_Property="_A0XLAJPsEeePQIrrJoWPZA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_A0dRoJPsEeePQIrrJoWPZA" base_StructuralFeature="_A0XLAJPsEeePQIrrJoWPZA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GTWJcD2kEeihCtCrhJZ45g" base_StructuralFeature="_GTViYD2kEeihCtCrhJZ45g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_GTYlsD2kEeihCtCrhJZ45g" base_Property="_GTViYD2kEeihCtCrhJZ45g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GTaa4D2kEeihCtCrhJZ45g" base_StructuralFeature="_GTZz0D2kEeihCtCrhJZ45g"/>
@@ -876,21 +824,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelAttribute xmi:id="_WRqhYk45EeiMYveOdt1-rQ" base_StructuralFeature="_WRqhYE45EeiMYveOdt1-rQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_EBqfUU46EeiMYveOdt1-rQ" base_Property="_EBqfUE46EeiMYveOdt1-rQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_EBqfUk46EeiMYveOdt1-rQ" base_StructuralFeature="_EBqfUE46EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_W0CjwU47EeiMYveOdt1-rQ" base_Property="_W0CjwE47EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_W0Cjwk47EeiMYveOdt1-rQ" base_StructuralFeature="_W0CjwE47EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_GVZfsU4-EeiMYveOdt1-rQ" base_Class="_GVZfsE4-EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_GVZfsk4-EeiMYveOdt1-rQ" base_Class="_GVZfsE4-EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TF9BFE4-EeiMYveOdt1-rQ" base_Property="_TF9BE04-EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_TGDHsE4-EeiMYveOdt1-rQ" base_StructuralFeature="_TF9BE04-EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TGDHsk4-EeiMYveOdt1-rQ" base_Property="_TGDHsU4-EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_TGDHs04-EeiMYveOdt1-rQ" base_StructuralFeature="_TGDHsU4-EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_ZuFLoE4-EeiMYveOdt1-rQ" base_Association="_TF9BEE4-EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_i4OKgU4_EeiMYveOdt1-rQ" base_Property="_i4OKgE4_EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_i4OKgk4_EeiMYveOdt1-rQ" base_StructuralFeature="_i4OKgE4_EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_oQNi4U4_EeiMYveOdt1-rQ" base_Property="_oQNi4E4_EeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_oQNi4k4_EeiMYveOdt1-rQ" base_StructuralFeature="_oQNi4E4_EeiMYveOdt1-rQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IJQGIU5CEeiMYveOdt1-rQ" base_Property="_IJQGIE5CEeiMYveOdt1-rQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_IJQGIk5CEeiMYveOdt1-rQ" base_StructuralFeature="_IJQGIE5CEeiMYveOdt1-rQ"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_zptDUE5CEeiMYveOdt1-rQ" base_Operation="_zpm8sE5CEeiMYveOdt1-rQ"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_5HQ4MU5CEeiMYveOdt1-rQ" base_Operation="_5HQ4ME5CEeiMYveOdt1-rQ"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_CXyBUU5DEeiMYveOdt1-rQ" base_Operation="_CXyBUE5DEeiMYveOdt1-rQ"/>
@@ -910,13 +843,11 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2_oAwE8HEeiW8t12GIRjqQ" base_Property="_2_nZsk8HEeiW8t12GIRjqQ"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_7PdeQE8HEeiW8t12GIRjqQ" base_Association="_2_myoE8HEeiW8t12GIRjqQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_nQ4k0E-oEeitY7qZgkO_XQ" base_Parameter="_nNQpEE-oEeitY7qZgkO_XQ"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_w5GKUE-qEeitY7qZgkO_XQ" base_Parameter="_w5FjQE-qEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_1gB5MU-qEeitY7qZgkO_XQ" base_Parameter="_1gB5ME-qEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_65htcU-qEeitY7qZgkO_XQ" base_Parameter="_65htcE-qEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_knARIU-rEeitY7qZgkO_XQ" base_Parameter="_knARIE-rEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_2xUsgE-rEeitY7qZgkO_XQ" base_Parameter="_2xUFcE-rEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_6GkxEE-rEeitY7qZgkO_XQ" base_Parameter="_6GkKAE-rEeitY7qZgkO_XQ"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_84VuEE-rEeitY7qZgkO_XQ" base_Parameter="_84Uf8E-rEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_Ev110E-sEeitY7qZgkO_XQ" base_Parameter="_Ev1OwE-sEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_HAfCwE-sEeitY7qZgkO_XQ" base_Parameter="_HAebsE-sEeitY7qZgkO_XQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_UjRZMFg6Eei9GrLbn4i8vw" base_Parameter="_UjLSkFg6Eei9GrLbn4i8vw"/>
@@ -930,7 +861,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelParameter xmi:id="_PETkMVg8Eei9GrLbn4i8vw" base_Parameter="_PETkMFg8Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_86ebkVg8Eei9GrLbn4i8vw" base_Parameter="_86ebkFg8Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_C4LJEVg9Eei9GrLbn4i8vw" base_Parameter="_C4LJEFg9Eei9GrLbn4i8vw"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_HAwvEVg9Eei9GrLbn4i8vw" base_Parameter="_HAwvEFg9Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_e_xs8Vg9Eei9GrLbn4i8vw" base_Parameter="_e_xs8Fg9Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_C140oVg-Eei9GrLbn4i8vw" base_Parameter="_C140oFg-Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_FCcLwVg-Eei9GrLbn4i8vw" base_Parameter="_FCcLwFg-Eei9GrLbn4i8vw"/>
@@ -962,20 +892,12 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:StrictComposite xmi:id="_xMtHgF0LEeipas1p-rFJBA" base_Association="_ufJVEF0LEeipas1p-rFJBA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_5cYg0V3eEeit4-HSxnZlvw" base_StructuralFeature="_5cYg0F3eEeit4-HSxnZlvw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5cYg0l3eEeit4-HSxnZlvw" base_Property="_5cYg0F3eEeit4-HSxnZlvw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DfbbYF6VEeitO-Stqhyn1g" base_Property="_HLiWIH2zEd2CEuIB5xoW6g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_DfbbYV6VEeitO-Stqhyn1g" base_StructuralFeature="_HLiWIH2zEd2CEuIB5xoW6g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TGzY4F6VEeitO-Stqhyn1g" base_Property="_uGZgsH2REd23zLSjbYwcFw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TGzY4V6VEeitO-Stqhyn1g" base_StructuralFeature="_uGZgsH2REd23zLSjbYwcFw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_YObaAF6VEeitO-Stqhyn1g" base_Property="_n-WkYH2REd23zLSjbYwcFw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_YObaAV6VEeitO-Stqhyn1g" base_StructuralFeature="_n-WkYH2REd23zLSjbYwcFw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_chOE4F6VEeitO-Stqhyn1g" base_Property="_WztYsLFXEd2MOdzuQUV2bQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_chOE4V6VEeitO-Stqhyn1g" base_StructuralFeature="_WztYsLFXEd2MOdzuQUV2bQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vDcp8F6VEeitO-Stqhyn1g" base_Property="_AJG_wH20Ed2CEuIB5xoW6g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_vDiwkF6VEeitO-Stqhyn1g" base_StructuralFeature="_AJG_wH20Ed2CEuIB5xoW6g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vjbxkF6VEeitO-Stqhyn1g" base_Property="_9dJv0H2zEd2CEuIB5xoW6g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_vjbxkV6VEeitO-Stqhyn1g" base_StructuralFeature="_9dJv0H2zEd2CEuIB5xoW6g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_xMYsYF6VEeitO-Stqhyn1g" base_Property="_3ZT3I0RhEeKsbYfVW3kmQQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_xMYsYV6VEeitO-Stqhyn1g" base_StructuralFeature="_3ZT3I0RhEeKsbYfVW3kmQQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_q7vCEGRFEeikqoAaJ65uUg" base_Property="_d_kukE8FEeiW8t12GIRjqQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_q7vCEWRFEeikqoAaJ65uUg" base_StructuralFeature="_d_kukE8FEeiW8t12GIRjqQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_q7vCEmRFEeikqoAaJ65uUg" base_Property="_spDV4E8EEeiW8t12GIRjqQ"/>
@@ -1007,19 +929,10 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:StrictComposite xmi:id="_1qVGsIVKEeiYFOBVMQg1QQ" base_Association="_GGYEYIU1EeiYFOBVMQg1QQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_FXBdgIVVEeiYFOBVMQg1QQ" base_Property="_FW7W4IVVEeiYFOBVMQg1QQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_FXBdgYVVEeiYFOBVMQg1QQ" base_StructuralFeature="_FW7W4IVVEeiYFOBVMQg1QQ"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_QU_QsIbmEeil5oKL3Vgl-g" base_Class="_QU5KEIbmEeil5oKL3Vgl-g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_QU_QsYbmEeil5oKL3Vgl-g" base_Class="_QU5KEIbmEeil5oKL3Vgl-g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_UVLIoobmEeil5oKL3Vgl-g" base_StructuralFeature="_UVLIoYbmEeil5oKL3Vgl-g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UVLIo4bmEeil5oKL3Vgl-g" base_Property="_UVLIoYbmEeil5oKL3Vgl-g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_UVLIpYbmEeil5oKL3Vgl-g" base_StructuralFeature="_UVLIpIbmEeil5oKL3Vgl-g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UVLIpobmEeil5oKL3Vgl-g" base_Property="_UVLIpIbmEeil5oKL3Vgl-g"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_nZbcsIbmEeil5oKL3Vgl-g" base_Association="_UVFCAIbmEeil5oKL3Vgl-g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_w2_jU4bmEeil5oKL3Vgl-g" base_StructuralFeature="_w2_jUobmEeil5oKL3Vgl-g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w2_jVIbmEeil5oKL3Vgl-g" base_Property="_w2_jUobmEeil5oKL3Vgl-g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_w2_jVobmEeil5oKL3Vgl-g" base_StructuralFeature="_w2_jVYbmEeil5oKL3Vgl-g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_w2_jV4bmEeil5oKL3Vgl-g" base_Property="_w2_jVYbmEeil5oKL3Vgl-g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_-wpv4YboEeil5oKL3Vgl-g" base_StructuralFeature="_-wpv4IboEeil5oKL3Vgl-g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_-wpv4oboEeil5oKL3Vgl-g" base_Property="_-wpv4IboEeil5oKL3Vgl-g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hDdewJAeEei1rofSed2vtg" base_Property="_hDc3sJAeEei1rofSed2vtg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_hDeF0JAeEei1rofSed2vtg" base_StructuralFeature="_hDc3sJAeEei1rofSed2vtg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wd6wMJsXEeid4dfn4JFJZg" base_StructuralFeature="_wd6JIZsXEeid4dfn4JFJZg"/>
@@ -1030,8 +943,6 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelParameter xmi:id="_VJFbIZsZEeid4dfn4JFJZg" base_Parameter="_VJFbIJsZEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_bdSkIZsZEeid4dfn4JFJZg" base_Parameter="_bdSkIJsZEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_kgDlIZsZEeid4dfn4JFJZg" base_Parameter="_kgDlIJsZEeid4dfn4JFJZg"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_Sz5VccWXEeiWCKGKl1wb8w" base_Parameter="_Sz5VcMWXEeiWCKGKl1wb8w"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_c_SyccWXEeiWCKGKl1wb8w" base_Parameter="_c_SycMWXEeiWCKGKl1wb8w"/>
   <OpenModel_Profile:Experimental xmi:id="_Xp_JQMcZEeiSV9wVm02xsw" base_Element="_2-15sEI6EeiDweqmZm-ZXQ"/>
   <OpenModel_Profile:Experimental xmi:id="_eUiVsMcZEeiSV9wVm02xsw" base_Element="_bgGpwIUvEeiYFOBVMQg1QQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ohZ4MNl2EeidLb5WEUMFmw" base_Property="_oesicNl2EeidLb5WEUMFmw"/>
@@ -1046,11 +957,9 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelOperation xmi:id="_l74qwBKKEemxeNG9TDCtFQ" base_Operation="_l74DsBKKEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_Cld6UBKLEemxeNG9TDCtFQ" base_Parameter="_CldTQBKLEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_AvhVQBKfEemxeNG9TDCtFQ" base_Parameter="_AvfgEBKfEemxeNG9TDCtFQ"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_E-hsURKfEemxeNG9TDCtFQ" base_Parameter="_E-hsUBKfEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_KhUmgRKfEemxeNG9TDCtFQ" base_Parameter="_KhUmgBKfEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_Gdw1ARKgEemxeNG9TDCtFQ" base_Parameter="_Gdw1ABKgEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_ODLHMRKgEemxeNG9TDCtFQ" base_Parameter="_ODLHMBKgEemxeNG9TDCtFQ"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_QpiFcRKgEemxeNG9TDCtFQ" base_Parameter="_QpiFcBKgEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_U2ktoBKgEemxeNG9TDCtFQ" base_Parameter="_U2jfgBKgEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_c5s2kBKgEemxeNG9TDCtFQ" base_Parameter="_c5sPgBKgEemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_gNBogBKgEemxeNG9TDCtFQ" base_Parameter="_gNBBcBKgEemxeNG9TDCtFQ"/>
@@ -1058,4 +967,24 @@ The value is bound to the quarter of an hour in case of a 15 minute interval and
   <OpenModel_Profile:OpenModelParameter xmi:id="_pksigRKgEemxeNG9TDCtFQ" base_Parameter="_pksigBKgEemxeNG9TDCtFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_DzN_oBN3EemxeNG9TDCtFQ" base_Property="_DzNYkBN3EemxeNG9TDCtFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_DzN_oRN3EemxeNG9TDCtFQ" base_StructuralFeature="_DzNYkBN3EemxeNG9TDCtFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_RVDaIDU7Eem_pr37XaewKQ" base_Class="_RRNb8DU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_RVEBMDU7Eem_pr37XaewKQ" base_Class="_RRNb8DU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b23zEDU7Eem_pr37XaewKQ" base_StructuralFeature="_b23MADU7Eem_pr37XaewKQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_b24aIDU7Eem_pr37XaewKQ" base_Property="_b23MADU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b25oQTU7Eem_pr37XaewKQ" base_StructuralFeature="_b25oQDU7Eem_pr37XaewKQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_b26PUDU7Eem_pr37XaewKQ" base_Property="_b25oQDU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ugy7kjU7Eem_pr37XaewKQ" base_StructuralFeature="_ugy7kTU7Eem_pr37XaewKQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ugzioDU7Eem_pr37XaewKQ" base_Property="_ugy7kTU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ug0wwDU7Eem_pr37XaewKQ" base_StructuralFeature="_ug0JsTU7Eem_pr37XaewKQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ug0wwTU7Eem_pr37XaewKQ" base_Property="_ug0JsTU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3ZMfoDU7Eem_pr37XaewKQ" base_StructuralFeature="_3ZL4kDU7Eem_pr37XaewKQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3ZNGsDU7Eem_pr37XaewKQ" base_Property="_3ZL4kDU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6WMcQzU7Eem_pr37XaewKQ" base_StructuralFeature="_6WMcQDU7Eem_pr37XaewKQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6WNDUDU7Eem_pr37XaewKQ" base_Property="_6WMcQDU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_DkSXsDXlEem8b5f98b_cVw" base_Association="_b2xscDU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_JK-6cDXlEem8b5f98b_cVw" base_Association="_ugxtcDU7Eem_pr37XaewKQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_i7QmEDkQEemjx6Nna_xyog" base_Parameter="_i7Ow4DkQEemjx6Nna_xyog"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_yrHOcDnyEemSPvPXzEQ11A" base_Property="_yrGnYDnyEemSPvPXzEQ11A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yrH1gDnyEemSPvPXzEQ11A" base_StructuralFeature="_yrGnYDnyEemSPvPXzEQ11A"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_uTCfUToQEemSPvPXzEQ11A" base_Parameter="_uTCfUDoQEemSPvPXzEQ11A"/>
 </xmi:XMI>

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -4265,6 +4265,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_knPxYh_jEem5B__-Dm9B_g" x="-42" y="-54"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_JZa2wDoREemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JZa2wToREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JZd6EDoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JZa2wjoREemSPvPXzEQ11A" x="208" y="-68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JgAm8DoREemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JgAm8ToREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JgAm8zoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JgAm8joREemSPvPXzEQ11A" x="-42" y="-54"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Y9l7gIuXEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -6764,6 +6780,26 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_knQYdB_jEem5B__-Dm9B_g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_knQYdR_jEem5B__-Dm9B_g"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JZd6EToREemSPvPXzEQ11A" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_JZa2wDoREemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JZd6EjoREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JZd6FjoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JZd6EzoREemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JZd6FDoREemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JZd6FToREemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JgAm9DoREemSPvPXzEQ11A" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_JgAm8DoREemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JgAm9ToREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JgAm-ToREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JgAm9joREemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JgAm9zoREemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JgAm-DoREemSPvPXzEQ11A"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_lW6NAJQPEeebLvYqX3NA2Q" type="PapyrusUMLClassDiagram" name="OduOamSpec" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_YM5NUJQQEeebLvYqX3NA2Q" type="Class_Shape">
@@ -7150,6 +7186,10 @@
           <element xmi:type="uml:Property" href="TapiOdu.uml#_IbKAoJQVEeebLvYqX3NA2Q"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_fKTcoZQWEeebLvYqX3NA2Q"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_4Y5fkDoREemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_4Y11MDoREemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4Y5fkToREemSPvPXzEQ11A"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__HUlJpQREeebLvYqX3NA2Q"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__HUlJ5QREeebLvYqX3NA2Q"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="__HUlKJQREeebLvYqX3NA2Q"/>
@@ -7168,7 +7208,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__HUlM5QREeebLvYqX3NA2Q"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOdu.uml#__HPsoJQREeebLvYqX3NA2Q"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__HUlIZQREeebLvYqX3NA2Q" x="874" y="399" width="171" height="70"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__HUlIZQREeebLvYqX3NA2Q" x="860" y="380" width="185" height="89"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__Har0pQREeebLvYqX3NA2Q" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__Har05QREeebLvYqX3NA2Q" showTitle="true"/>
@@ -7491,6 +7531,86 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z5N_AouYEeiu6boZkiJHCA" x="987" y="50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OMqjUDoREemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OMqjUjoREemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_OMqjUzoREemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OMqjVDoREemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OMqjVToREemSPvPXzEQ11A" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OMqjVjoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OMqjVzoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OMqjWDoREemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OMqjWToREemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OMrKYDoREemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OMrKYToREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OMrKYjoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OMrKYzoREemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OMrKZDoREemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_OMrKZToREemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_OMrKZjoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_OMrKZzoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_OMrKaDoREemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OMrKaToREemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OMqjUToREemSPvPXzEQ11A" x="1240" width="161" height="81"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OM2wkzoREemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OM2wlDoREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OM2wljoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OM2wlToREemSPvPXzEQ11A" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TDS7EDoREemSPvPXzEQ11A" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_TDS7EjoREemSPvPXzEQ11A" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TDS7EzoREemSPvPXzEQ11A" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TDS7FDoREemSPvPXzEQ11A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TDS7FToREemSPvPXzEQ11A" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_V711gDoREemSPvPXzEQ11A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOdu.uml#_V1GUUDoREemSPvPXzEQ11A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_V711gToREemSPvPXzEQ11A"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TDS7FjoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TDS7FzoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TDS7GDoREemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TDS7GToREemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TDS7GjoREemSPvPXzEQ11A" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TDS7GzoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TDS7HDoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TDS7HToREemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TDS7HjoREemSPvPXzEQ11A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_TDS7HzoREemSPvPXzEQ11A" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_TDS7IDoREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_TDS7IToREemSPvPXzEQ11A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_TDS7IjoREemSPvPXzEQ11A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TDS7IzoREemSPvPXzEQ11A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOdu.uml#_TDP3wDoREemSPvPXzEQ11A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TDS7EToREemSPvPXzEQ11A" x="1240" y="160" width="166"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TDZoxzoREemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_TDZoyDoREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TDZoyjoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_TDP3wDoREemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TDZoyToREemSPvPXzEQ11A" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_eoL6kDoREemSPvPXzEQ11A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eoL6kToREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eoL6kzoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_arMgkDoREemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eoL6kjoREemSPvPXzEQ11A" x="1460" y="60"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_lW6NAZQPEeebLvYqX3NA2Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_lW6NApQPEeebLvYqX3NA2Q"/>
@@ -8058,6 +8178,7 @@
       <element xmi:type="uml:Association" href="TapiOdu.uml#_C8ff4JQSEeebLvYqX3NA2Q"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rV5TEouYEeiu6boZkiJHCA" points="[973, 274, -643984, -643984]$[962, 399, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sbHOsIuYEeiu6boZkiJHCA" id="(0.4453125,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5VdOcDoREemSPvPXzEQ11A" id="(0.5405405405405406,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_rWg-J4uYEeiu6boZkiJHCA" type="StereotypeCommentLink" source="_rV5TEIuYEeiu6boZkiJHCA" target="_rWg-I4uYEeiu6boZkiJHCA">
       <styles xmi:type="notation:FontStyle" xmi:id="_rWg-KIuYEeiu6boZkiJHCA"/>
@@ -8144,6 +8265,49 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_z5N_BouYEeiu6boZkiJHCA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z5N_B4uYEeiu6boZkiJHCA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z5N_CIuYEeiu6boZkiJHCA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OM3XoDoREemSPvPXzEQ11A" type="StereotypeCommentLink" source="_OMqjUDoREemSPvPXzEQ11A" target="_OM2wkzoREemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OM3XoToREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OM3XpToREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OM3XojoREemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM3XozoREemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM3XpDoREemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_TDZoyzoREemSPvPXzEQ11A" type="StereotypeCommentLink" source="_TDS7EDoREemSPvPXzEQ11A" target="_TDZoxzoREemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_TDZozDoREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TDZo0DoREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_TDP3wDoREemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TDZozToREemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TDZozjoREemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TDZozzoREemSPvPXzEQ11A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_arNusDoREemSPvPXzEQ11A" type="Abstraction_Edge" source="_TDS7EDoREemSPvPXzEQ11A" target="_OMqjUDoREemSPvPXzEQ11A" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_arOVwDoREemSPvPXzEQ11A" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_arOVwToREemSPvPXzEQ11A" x="13" y="3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_arOVwjoREemSPvPXzEQ11A" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_arOVwzoREemSPvPXzEQ11A" x="-7" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_arNusToREemSPvPXzEQ11A"/>
+      <element xmi:type="uml:Abstraction" href="TapiOdu.uml#_arMgkDoREemSPvPXzEQ11A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_arNusjoREemSPvPXzEQ11A" points="[1320, 160, -643984, -643984]$[1320, 81, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a6YMEDoREemSPvPXzEQ11A" id="(0.4819277108433735,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a6YMEToREemSPvPXzEQ11A" id="(0.4968944099378882,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eoL6lDoREemSPvPXzEQ11A" type="StereotypeCommentLink" source="_arNusDoREemSPvPXzEQ11A" target="_eoL6kDoREemSPvPXzEQ11A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eoL6lToREemSPvPXzEQ11A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eoL6mToREemSPvPXzEQ11A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_arMgkDoREemSPvPXzEQ11A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eoL6ljoREemSPvPXzEQ11A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eoL6lzoREemSPvPXzEQ11A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eoL6mDoREemSPvPXzEQ11A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_b2XPEKu6Eei1V6VHLzh4gA" type="PapyrusUMLClassDiagram" name="OduTypes" measurementUnit="Pixel">

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -123,7 +123,16 @@ License: This module is distributed under the Apache License 2.0</body>
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_sYw7vx3BEea2UIYIpgn3Zw" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_sYw7vx3BEea2UIYIpgn3Zw" name="Diagrams">
+      <packagedElement xmi:type="uml:Class" xmi:id="_TDP3wDoREemSPvPXzEQ11A" name="OduMegSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_V1GUUDoREemSPvPXzEQ11A" name="megLevel">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_arMgkDoREemSPvPXzEQ11A" name="OduMegAugmentsMeg" client="_TDP3wDoREemSPvPXzEQ11A">
+        <supplier xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_sYxiwB3BEea2UIYIpgn3Zw" name="ObjectClasses">
       <packagedElement xmi:type="uml:Class" xmi:id="_sYxiwR3BEea2UIYIpgn3Zw" name="OduTerminationAndClientAdaptationPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_TmyDEEeLEeetffGEmR5xrg" annotatedElement="_sYxiwR3BEea2UIYIpgn3Zw">
@@ -382,6 +391,12 @@ Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). No
             <body>This attribute indicates the tandem connection monitoring field of the ODU OH.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4Y11MDoREemSPvPXzEQ11A" name="codirectional" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4Y11MToREemSPvPXzEQ11A" annotatedElement="_4Y11MDoREemSPvPXzEQ11A">
+            <body>This attribute specifies the directionality of the ODU MIP with respect to the associated ODU CEP. The value of TRUE means that the (half MIP/sink part of the) ODU MIP receives the same signal direction as the sink part of the ODU CEP. The Source part behaves similarly. This attribute is meaningful only on objects instantiated under ODU CEP, and at least one among ODU CEP and the subordinate object is bidirectional.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_sGWmEJRHEee0N_ppE1lIiw" name="OduMepPac">
@@ -1116,4 +1131,13 @@ Optical transport network: Linear protection</body>
   <OpenModel_Profile:Specify xmi:id="_BaLIQARbEemABdf1yJ9dlA" base_Abstraction="_3XrIkARaEemABdf1yJ9dlA">
     <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
   </OpenModel_Profile:Specify>
+  <OpenModel_Profile:OpenModelClass xmi:id="_TDP3wToREemSPvPXzEQ11A" base_Class="_TDP3wDoREemSPvPXzEQ11A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_TDQe0DoREemSPvPXzEQ11A" base_Class="_TDP3wDoREemSPvPXzEQ11A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_V1GUUToREemSPvPXzEQ11A" base_Property="_V1GUUDoREemSPvPXzEQ11A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_V1GUUjoREemSPvPXzEQ11A" base_StructuralFeature="_V1GUUDoREemSPvPXzEQ11A"/>
+  <OpenModel_Profile:Specify xmi:id="_egwc4DoREemSPvPXzEQ11A" base_Abstraction="_arMgkDoREemSPvPXzEQ11A">
+    <target>/TapiCommon:Context:_context/TapiOam:OamContext:_meg</target>
+  </OpenModel_Profile:Specify>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_4Y11MjoREemSPvPXzEQ11A" base_Property="_4Y11MDoREemSPvPXzEQ11A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4Y11MzoREemSPvPXzEQ11A" base_StructuralFeature="_4Y11MDoREemSPvPXzEQ11A"/>
 </xmi:XMI>


### PR DESCRIPTION
TAPI Common, removed BandwidthProfile data type and removed the
reference to it from Capacity data type.
TAPI OAM, create/update/delete/get OamServiceEndPoint, removed the
“End”, reviewed all parameters of the operations.
TAPI OAM, moved granularityPeriod and suspectIntervalFlag from TAPI
CurrentData and HistoryData to a PM dedicated package (e.g. PmDataPac),
because these two attributes are meaningless e.g. in Link Trace job
case.
TAPI OAM, Removed PmDataBin class.
TAPI OAM, removed mepIdentifier and peerMepIdentifier parameters from
createOamServicePoint.
TAPI OAM, createOamJob, removed oamServicePoint input parameter,
replaced by oamServiceId and oamServicePointId string parameters.
TAPI OAM, moved layerProtocolName attribute from OamConstraint to
OamService class. Deleted direction attribute of OamConstraint class.
Moved megLevel attribute from OamConstraint to technology specific MEGs.
Removed OamConstraint class.
TAPI OAM, removed direction attribute from OamServicePoint, Meg and Mep
classes.
TAPI OAM, updated oamService and OamServicePoint operations according to
above modifications.