### PR TITLE
Non-configurable subscription filters in Data API objects

### DIFF
--- a/YANG/tapi-notification@2018-12-10.tree
+++ b/YANG/tapi-notification@2018-12-10.tree
@@ -47,11 +47,11 @@ module: tapi-notification
        |  |     +--rw value-name    string
        |  |     +--rw value?        string
        |  +--rw subscription-filter
-       |  |  +--ro requested-notification-types*   notification-type
-       |  |  +--ro requested-object-types*         object-type
-       |  |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-       |  |  +--ro requested-object-identifier*    tapi-common:uuid
-       |  |  +--ro include-content?                boolean
+       |  |  +--rw requested-notification-types*   notification-type
+       |  |  +--rw requested-object-types*         object-type
+       |  |  +--rw requested-layer-protocols*      tapi-common:layer-protocol-name
+       |  |  +--rw requested-object-identifier*    tapi-common:uuid
+       |  |  +--rw include-content?                boolean
        |  |  +--rw local-id?                       string
        |  |  +--rw name* [value-name]
        |  |     +--rw value-name    string

--- a/YANG/tapi-notification@2018-12-10.yang
+++ b/YANG/tapi-notification@2018-12-10.yang
@@ -108,27 +108,22 @@ module tapi-notification {
     grouping subscription-filter {
         leaf-list requested-notification-types {
             type notification-type;
-            config false;
             description "none";
         }
         leaf-list requested-object-types {
             type object-type;
-            config false;
             description "none";
         }
         leaf-list requested-layer-protocols {
             type tapi-common:layer-protocol-name;
-            config false;
             description "none";
         }
         leaf-list requested-object-identifier {
             type tapi-common:uuid;
-            config false;
             description "none";
         }
         leaf include-content {
             type boolean;
-            config false;
             description "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)";
         }
         uses tapi-common:local-class;
@@ -599,5 +594,5 @@ module tapi-notification {
                 description "none";
             }
         }
-    }    
+    }
 }


### PR DESCRIPTION
The following objects within:

tapi-notification:notification-context/tapi-notification:notif-subscription-filter

 - requested-notification-types
 - requested-object-types
 - requested-layer-protocols
 - requested-object-identifier
 - include-content

Has been modified to be configurable.