### PR TITLE
TapiEqpt YANG/TREE files & UML model updates to generate proper YANG

### DIFF
--- a/UML/TapiEquipment.notation
+++ b/UML/TapiEquipment.notation
@@ -28,7 +28,7 @@
     <children xmi:type="notation:Shape" xmi:id="_kfYgcDmuEem1ZNpCEF2XWQ" type="Comment_Shape" fillColor="8047085">
       <children xmi:type="notation:DecorationNode" xmi:id="_kfYgcjmuEem1ZNpCEF2XWQ" type="Comment_BodyLabel"/>
       <element xmi:type="uml:Comment" href="TapiEquipment.uml#_kfXSUDmuEem1ZNpCEF2XWQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kfYgcTmuEem1ZNpCEF2XWQ" x="1020" y="-220" width="281" height="21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kfYgcTmuEem1ZNpCEF2XWQ" x="-10" y="-243" width="281" height="21"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vjDakv0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="__vjDa0v0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -61,7 +61,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vjDsUv0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vjD5kv0EemT5f_Ewhfs6A" x="1360" y="220" width="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vjD5kv0EemT5f_Ewhfs6A" x="337" y="148" width="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vjqd0v0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="__vjqeEv0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -95,7 +95,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vjq70v0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vkRikv0EemT5f_Ewhfs6A" x="1560" y="-240"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vkRikv0EemT5f_Ewhfs6A" x="533" y="-258"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vk4gEv0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="__vk4gUv0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -132,7 +132,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vk4-kv0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vk5L0v0EemT5f_Ewhfs6A" x="1760" y="-80" width="150"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vk5L0v0EemT5f_Ewhfs6A" x="737" y="-152" width="150"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vmGoEv0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="__vmGoUv0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -166,7 +166,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vmHGEv0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vmHTUv0EemT5f_Ewhfs6A" x="1360" y="-80" width="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vmHTUv0EemT5f_Ewhfs6A" x="337" y="-152" width="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vmtsEv0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="8047085">
       <children xmi:type="notation:DecorationNode" xmi:id="__vmtsUv0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -207,7 +207,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vmuXUv0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vmukkv0EemT5f_Ewhfs6A" x="1020" y="220" width="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vmukkv0EemT5f_Ewhfs6A" x="-3" y="148" width="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vn76kv0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="__vn760v0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -249,7 +249,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vojUEv0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vojhUv0EemT5f_Ewhfs6A" x="1760" y="220" width="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vojhUv0EemT5f_Ewhfs6A" x="737" y="86" width="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__vpxNEv0EemT5f_Ewhfs6A" type="Class_Shape" fillColor="8047085">
       <children xmi:type="notation:DecorationNode" xmi:id="__vpxNUv0EemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -306,148 +306,148 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vpypkv0EemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vpy20v0EemT5f_Ewhfs6A" x="1020" width="160"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__v9TAEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__v9TAUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__v9TA0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__v9TAkv0EemT5f_Ewhfs6A" x="1410" y="570"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__wUfYEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__wUfYUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__wUfY0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__wUfYkv0EemT5f_Ewhfs6A" x="1790" y="-290"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__wcbMEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__wcbMUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__wcbM0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__wcbMkv0EemT5f_Ewhfs6A" x="1790" y="-390"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__wdCQEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__wdCQUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__wdCQ0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__wdCQkv0EemT5f_Ewhfs6A" x="1790" y="-390"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__w_00Ev0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__w_00Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__w_000v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__w_00kv0EemT5f_Ewhfs6A" x="1970" y="30"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__xIXsEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__xIXsUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__xIXs0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xIXskv0EemT5f_Ewhfs6A" x="1970" y="-70"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__xKz8Ev0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__xKz8Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__xKz80v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xKz8kv0EemT5f_Ewhfs6A" x="1970" y="-70"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__xtmgEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__xtmgUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__xtmg0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xtmgkv0EemT5f_Ewhfs6A" x="1590" y="-90"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__x2JYEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__x2JYUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__x2JY0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__x2JYkv0EemT5f_Ewhfs6A" x="1590" y="-190"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__x2wdUv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__x2wdkv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__x2weEv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__x2wd0v0EemT5f_Ewhfs6A" x="1590" y="-190"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__yOj4Ev0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__yOj4Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__yOj40v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__yOj4kv0EemT5f_Ewhfs6A" x="870" y="570"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__yaKEEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__yaKEUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__yaKE0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__yaKEkv0EemT5f_Ewhfs6A" x="870" y="470"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__zJJ4Ev0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__zJJ4Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__zJw8Ev0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__zJJ4kv0EemT5f_Ewhfs6A" x="1990" y="330"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__zZBgEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__zZBgUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__zZBg0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__zZBgkv0EemT5f_Ewhfs6A" x="1990" y="230"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__0X48Ev0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__0X48Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__0X480v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__0X48kv0EemT5f_Ewhfs6A" x="870" y="-10"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__0yIoEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__0yIoUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__0yIo0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__0yIokv0EemT5f_Ewhfs6A" x="870" y="-110"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__vpy20v0EemT5f_Ewhfs6A" x="-3" y="-72" width="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_FoNqYEv2EemT5f_Ewhfs6A" type="Comment_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_FoORcEv2EemT5f_Ewhfs6A" type="Comment_BodyLabel"/>
       <element xmi:type="uml:Comment" href="TapiEquipment.uml#_87bG8ElkEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FoORcUv2EemT5f_Ewhfs6A" x="1020" y="-180" width="281" height="8"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FoORcUv2EemT5f_Ewhfs6A" x="-4" y="-205" width="281" height="8"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_rMoG80v2EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_rMoG9Ev2EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rMoG9kv2EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_OczBUE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OczBUU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OczBU02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OczBUk2qEemQQPVBE79CWA" x="537" y="148"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Odou0E2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Odou0U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OdpV4E2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Odou0k2qEemQQPVBE79CWA" x="733" y="-258"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OeK6UE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OeK6UU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeK6U02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OeK6Uk2qEemQQPVBE79CWA" x="733" y="-358"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OeYVsE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OeYVsU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeYVs02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OeYVsk2qEemQQPVBE79CWA" x="733" y="-358"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OfKY0E2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OfKY0U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfKY002qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OfKY0k2qEemQQPVBE79CWA" x="937" y="-152"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OfiMQE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OfiMQU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfiMQ02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OfiMQk2qEemQQPVBE79CWA" x="937" y="-252"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ofr9QE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ofr9QU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ofr9Q02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ofr9Qk2qEemQQPVBE79CWA" x="937" y="-252"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OgVdgE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OgVdgU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgVdg02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OgVdgk2qEemQQPVBE79CWA" x="537" y="-152"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OgvGIE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OgvGIU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgvGI02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OgvGIk2qEemQQPVBE79CWA" x="537" y="-252"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Og43IE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Og43IU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Og43I02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Og43Ik2qEemQQPVBE79CWA" x="537" y="-252"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Oh91ME2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Oh91MU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oh91M02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Oh91Mk2qEemQQPVBE79CWA" x="197" y="148"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OicWUE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OicWUU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OicWU02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OicWUk2qEemQQPVBE79CWA" x="197" y="48"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OjPAgE2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OjPAgU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjPAg02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OjPAgk2qEemQQPVBE79CWA" x="937" y="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OjmM4E2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OjmM4U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjmM402qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OjmM4k2qEemQQPVBE79CWA" x="937" y="-14"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ojv94E2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ojv94U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ojv9402qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rMoG9Uv2EemT5f_Ewhfs6A" x="1960" y="120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ojv94k2qEemQQPVBE79CWA" x="937" y="-14"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OkXB4E2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OkXB4U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OkXB402qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OkXB4k2qEemQQPVBE79CWA" x="197" y="-72"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Okp80E2qEemQQPVBE79CWA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Okp80U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Okp8002qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Okp80k2qEemQQPVBE79CWA" x="197" y="-172"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_hb9t2i8LEeexxefg2F1i1Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_hb9t2y8LEeexxefg2F1i1Q"/>
@@ -506,7 +506,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vicU0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vicV0v0EemT5f_Ewhfs6A" points="[1760, 300, -643984, -643984]$[1680, 300, -643984, -643984]$[1680, 240, -643984, -643984]$[1760, 240, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vicV0v0EemT5f_Ewhfs6A" points="[737, 166, -643984, -643984]$[657, 166, -643984, -643984]$[657, 106, -643984, -643984]$[737, 106, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vicWEv0EemT5f_Ewhfs6A" id="(0.0,0.8)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vicWUv0EemT5f_Ewhfs6A" id="(0.0,0.2)"/>
     </edges>
@@ -537,7 +537,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vjDY0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vjDZ0v0EemT5f_Ewhfs6A" points="[1380, -40, -643984, -643984]$[1160, -40, -643984, -643984]$[1160, 0, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vjDZ0v0EemT5f_Ewhfs6A" points="[357, -112, -643984, -643984]$[137, -112, -643984, -643984]$[137, -72, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vjDaEv0EemT5f_Ewhfs6A" id="(0.0,0.4)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vjDaUv0EemT5f_Ewhfs6A" id="(0.625,0.0)"/>
     </edges>
@@ -568,18 +568,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vjqc0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vjqdEv0EemT5f_Ewhfs6A" points="[1900, 320, -643984, -643984]$[1900, 380, -643984, -643984]$[1780, 380, -643984, -643984]$[1780, 320, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vjqdEv0EemT5f_Ewhfs6A" points="[877, 186, -643984, -643984]$[877, 246, -643984, -643984]$[757, 246, -643984, -643984]$[757, 186, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vjqdUv0EemT5f_Ewhfs6A" id="(0.875,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vjqdkv0EemT5f_Ewhfs6A" id="(0.125,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__vlfkEv0EemT5f_Ewhfs6A" type="Association_Edge" source="__vk4gEv0EemT5f_Ewhfs6A" target="__vjDakv0EemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfkUv0EemT5f_Ewhfs6A" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfkkv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfk0v0EemT5f_Ewhfs6A" x="67"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfk0v0EemT5f_Ewhfs6A" x="32" y="-5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlflEv0EemT5f_Ewhfs6A" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlflUv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlflkv0EemT5f_Ewhfs6A" x="47" y="-19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlflkv0EemT5f_Ewhfs6A" x="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfl0v0EemT5f_Ewhfs6A" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfmEv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -591,7 +591,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfnUv0EemT5f_Ewhfs6A" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfnkv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfn0v0EemT5f_Ewhfs6A" x="29" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfn0v0EemT5f_Ewhfs6A" x="17" y="18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfoEv0EemT5f_Ewhfs6A" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfoUv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -599,7 +599,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vlfo0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vlfp0v0EemT5f_Ewhfs6A" points="[1780, -40, -643984, -643984]$[1600, -40, -643984, -643984]$[1600, 280, -643984, -643984]$[1480, 280, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vlfp0v0EemT5f_Ewhfs6A" points="[757, -112, -643984, -643984]$[577, -112, -643984, -643984]$[577, 208, -643984, -643984]$[457, 208, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlfqEv0EemT5f_Ewhfs6A" id="(0.0,0.4)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlfqUv0EemT5f_Ewhfs6A" id="(1.0,0.6)"/>
     </edges>
@@ -633,18 +633,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vlfv0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vlfw0v0EemT5f_Ewhfs6A" points="[1175, 280, -643984, -643984]$[1255, 280, -643984, -643984]$[1255, 40, -643984, -643984]$[1164, 40, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vlfw0v0EemT5f_Ewhfs6A" points="[152, 208, -643984, -643984]$[232, 208, -643984, -643984]$[232, -32, -643984, -643984]$[141, -32, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlfxEv0EemT5f_Ewhfs6A" id="(1.0,0.6)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlfxUv0EemT5f_Ewhfs6A" id="(1.0,0.4)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__vlfxkv0EemT5f_Ewhfs6A" type="Association_Edge" source="__vjqd0v0EemT5f_Ewhfs6A" target="__vmGoEv0EemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfx0v0EemT5f_Ewhfs6A" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfyEv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfyUv0EemT5f_Ewhfs6A" x="10" y="-87"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfyUv0EemT5f_Ewhfs6A" x="33" y="-25"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfykv0EemT5f_Ewhfs6A" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfy0v0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfzEv0EemT5f_Ewhfs6A" x="-1" y="-67"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlfzEv0EemT5f_Ewhfs6A" x="30" y="-12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlfzUv0EemT5f_Ewhfs6A" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlfzkv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -656,7 +656,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlf00v0EemT5f_Ewhfs6A" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlf1Ev0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlf1Uv0EemT5f_Ewhfs6A" x="36" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vlf1Uv0EemT5f_Ewhfs6A" x="20" y="16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vlf1kv0EemT5f_Ewhfs6A" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vlf10v0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -664,18 +664,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vlf2Uv0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vlf3Uv0EemT5f_Ewhfs6A" points="[1520, -200, -643984, -643984]$[1420, -200, -643984, -643984]$[1420, -80, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlf3kv0EemT5f_Ewhfs6A" id="(0.0,0.4)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlf30v0EemT5f_Ewhfs6A" id="(0.37344398340248963,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vlf3Uv0EemT5f_Ewhfs6A" points="[533, -227, -643984, -643984]$[398, -227, -643984, -643984]$[398, -152, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlf3kv0EemT5f_Ewhfs6A" id="(0.0,0.31)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vlf30v0EemT5f_Ewhfs6A" id="(0.375,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__vn70Ev0EemT5f_Ewhfs6A" type="Association_Edge" source="__vjqd0v0EemT5f_Ewhfs6A" target="__vk4gEv0EemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__vn70Uv0EemT5f_Ewhfs6A" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vn70kv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vn700v0EemT5f_Ewhfs6A" x="21" y="87"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vn700v0EemT5f_Ewhfs6A" x="29" y="29"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vn71Ev0EemT5f_Ewhfs6A" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vn71Uv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vn71kv0EemT5f_Ewhfs6A" x="9" y="67"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vn71kv0EemT5f_Ewhfs6A" x="21" y="12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vn710v0EemT5f_Ewhfs6A" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vn72Ev0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -695,9 +695,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vn740v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vn750v0EemT5f_Ewhfs6A" points="[1658, -200, -643984, -643984]$[1840, -200, -643984, -643984]$[1840, 29, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vn76Ev0EemT5f_Ewhfs6A" id="(1.0,0.4)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vn76Uv0EemT5f_Ewhfs6A" id="(0.5309734513274337,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vn750v0EemT5f_Ewhfs6A" points="[672, -227, -643984, -643984]$[818, -227, -643984, -643984]$[818, -152, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vn76Ev0EemT5f_Ewhfs6A" id="(1.0,0.31)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vn76Uv0EemT5f_Ewhfs6A" id="(0.5466666666666666,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__vpxAEv0EemT5f_Ewhfs6A" type="Association_Edge" source="__vpxNEv0EemT5f_Ewhfs6A" target="__vmtsEv0EemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__vpxAUv0EemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -726,18 +726,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vpxE0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vpxF0v0EemT5f_Ewhfs6A" points="[1100, 100, -643984, -643984]$[1100, 220, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vpxF0v0EemT5f_Ewhfs6A" points="[77, 28, -643984, -643984]$[77, 148, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vpxGEv0EemT5f_Ewhfs6A" id="(0.5,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vpxGUv0EemT5f_Ewhfs6A" id="(0.5,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__vpxGkv0EemT5f_Ewhfs6A" type="Association_Edge" source="__vk4gEv0EemT5f_Ewhfs6A" target="__vn76kv0EemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__vpxG0v0EemT5f_Ewhfs6A" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vpxHEv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vpxHUv0EemT5f_Ewhfs6A" x="27"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vpxHUv0EemT5f_Ewhfs6A" x="-3" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vpxHkv0EemT5f_Ewhfs6A" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vpxH0v0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__vpxIEv0EemT5f_Ewhfs6A" x="7" y="8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__vpxIEv0EemT5f_Ewhfs6A" x="-22" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__vpxIUv0EemT5f_Ewhfs6A" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__vpxIkv0EemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -757,9 +757,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vpxLUv0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vpxMUv0EemT5f_Ewhfs6A" points="[1810, 20, -643984, -643984]$[1810, 100, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vpxMkv0EemT5f_Ewhfs6A" id="(0.5309734513274337,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vpxM0v0EemT5f_Ewhfs6A" id="(0.4979253112033195,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vpxMUv0EemT5f_Ewhfs6A" points="[787, -52, -643984, -643984]$[787, 28, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vpxMkv0EemT5f_Ewhfs6A" id="(0.5266666666666666,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vpxM0v0EemT5f_Ewhfs6A" id="(0.49375,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__vrmMEv0EemT5f_Ewhfs6A" type="Association_Edge" source="__vmGoEv0EemT5f_Ewhfs6A" target="__vjDakv0EemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__vrmMUv0EemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -788,179 +788,179 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__vrmQ0v0EemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vrmR0v0EemT5f_Ewhfs6A" points="[1440, 20, -643984, -643984]$[1440, 220, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vrmR0v0EemT5f_Ewhfs6A" points="[417, -52, -643984, -643984]$[417, 148, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vrmSEv0EemT5f_Ewhfs6A" id="(0.5,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vrmSUv0EemT5f_Ewhfs6A" id="(0.5,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__v9TBEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vjDakv0EemT5f_Ewhfs6A" target="__v9TAEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__v9TBUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__v9TCUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OczoYE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjDakv0EemT5f_Ewhfs6A" target="_OczBUE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OczoYU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OczoZU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__v9TBkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__v9TB0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__v9TCEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OczoYk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OczoY02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OczoZE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__wUfZEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vjqd0v0EemT5f_Ewhfs6A" target="__wUfYEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__wUfZUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__wUfaUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OdpV4U2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjqd0v0EemT5f_Ewhfs6A" target="_Odou0E2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OdpV4k2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OdpV5k2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__wUfZkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wUfZ0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wUfaEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OdpV402qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OdpV5E2qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OdpV5U2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__wcbNEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vlfxkv0EemT5f_Ewhfs6A" target="__wcbMEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__wcbNUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__wcbOUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OeK6VE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vlfxkv0EemT5f_Ewhfs6A" target="_OeK6UE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OeK6VU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeK6WU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__wcbNkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wcbN0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wcbOEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OeK6Vk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeK6V02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeK6WE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__wdCREv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vn70Ev0EemT5f_Ewhfs6A" target="__wdCQEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__wdCRUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__wdCSUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OeYVtE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vn70Ev0EemT5f_Ewhfs6A" target="_OeYVsE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OeYVtU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeYVuU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__wdCRkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wdCR0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wdCSEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OeYVtk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeYVt02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeYVuE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__w_01Ev0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vk4gEv0EemT5f_Ewhfs6A" target="__w_00Ev0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__w_01Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__w_02Uv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OfK_4E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vk4gEv0EemT5f_Ewhfs6A" target="_OfKY0E2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OfK_4U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfK_5U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__w_01kv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__w_010v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__w_02Ev0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OfK_4k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfK_402qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfK_5E2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__xIXtEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vlfkEv0EemT5f_Ewhfs6A" target="__xIXsEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__xIXtUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__xI-wEv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OfiMRE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vlfkEv0EemT5f_Ewhfs6A" target="_OfiMQE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OfiMRU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfizUE2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__xIXtkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__xIXt0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__xIXuEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OfiMRk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfiMR02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfiMSE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__xKz9Ev0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vpxGkv0EemT5f_Ewhfs6A" target="__xKz8Ev0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__xKz9Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__xKz-Uv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ofr9RE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vpxGkv0EemT5f_Ewhfs6A" target="_Ofr9QE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ofr9RU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ofr9SU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__xKz9kv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__xKz90v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__xKz-Ev0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ofr9Rk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ofr9R02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ofr9SE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__xtmhEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vmGoEv0EemT5f_Ewhfs6A" target="__xtmgEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__xtmhUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__xtmiUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OgVdhE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vmGoEv0EemT5f_Ewhfs6A" target="_OgVdgE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OgVdhU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgVdiU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__xtmhkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__xtmh0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__xtmiEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OgVdhk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgVdh02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgVdiE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__x2JZEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vjDUEv0EemT5f_Ewhfs6A" target="__x2JYEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__x2JZUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__x2wcEv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OgvGJE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjDUEv0EemT5f_Ewhfs6A" target="_OgvGIE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OgvGJU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgvGKU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__x2JZkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__x2JZ0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__x2JaEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OgvGJk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgvGJ02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgvGKE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__x2weUv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vrmMEv0EemT5f_Ewhfs6A" target="__x2wdUv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__x2wekv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__x2wfkv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Og43JE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vrmMEv0EemT5f_Ewhfs6A" target="_Og43IE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Og43JU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Og43KU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__x2we0v0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__x2wfEv0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__x2wfUv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Og43Jk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Og43J02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Og43KE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__yOj5Ev0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vmtsEv0EemT5f_Ewhfs6A" target="__yOj4Ev0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__yOj5Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__yOj6Uv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Oh91NE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vmtsEv0EemT5f_Ewhfs6A" target="_Oh91ME2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Oh91NU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oh-cQE2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__yOj5kv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__yOj50v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__yOj6Ev0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Oh91Nk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oh91N02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oh91OE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__yaKFEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vlfqkv0EemT5f_Ewhfs6A" target="__yaKEEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__yaKFUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__yaKGUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OicWVE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vlfqkv0EemT5f_Ewhfs6A" target="_OicWUE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OicWVU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OicWWU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__yaKFkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__yaKF0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__yaKGEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OicWVk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OicWV02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OicWWE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__zJw8Uv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vn76kv0EemT5f_Ewhfs6A" target="__zJJ4Ev0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__zJw8kv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__zJw9kv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OjPAhE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vn76kv0EemT5f_Ewhfs6A" target="_OjPAgE2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OjPAhU2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjPnkE2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__zJw80v0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__zJw9Ev0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__zJw9Uv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OjPAhk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjPAh02qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjPAiE2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__zZBhEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vicQEv0EemT5f_Ewhfs6A" target="__zZBgEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__zZBhUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__zZBiUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_OjmM5E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vicQEv0EemT5f_Ewhfs6A" target="_OjmM4E2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OjmM5U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjmM6U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__zZBhkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__zZBh0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__zZBiEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OjmM5k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjmM502qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjmM6E2qEemQQPVBE79CWA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__0X49Ev0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vpxNEv0EemT5f_Ewhfs6A" target="__0X48Ev0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__0X49Uv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__0X4-Uv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__0X49kv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__0X490v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__0X4-Ev0EemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__0yIpEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vpxAEv0EemT5f_Ewhfs6A" target="__0yIoEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="__0yIpUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__0yIqUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__0yIpkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__0yIp0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__0yIqEv0EemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_rMoG90v2EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__vjqYEv0EemT5f_Ewhfs6A" target="_rMoG80v2EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_rMoG-Ev2EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rMoG_Ev2EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ojv95E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjqYEv0EemT5f_Ewhfs6A" target="_Ojv94E2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ojv95U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ojv96U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rMoG-Uv2EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rMoG-kv2EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rMoG-0v2EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ojv95k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ojv9502qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ojv96E2qEemQQPVBE79CWA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OkXB5E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vpxNEv0EemT5f_Ewhfs6A" target="_OkXB4E2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OkXB5U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OkXB6U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OkXB5k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OkXB502qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OkXB6E2qEemQQPVBE79CWA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Okp81E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vpxAEv0EemT5f_Ewhfs6A" target="_Okp80E2qEemQQPVBE79CWA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Okp81U2qEemQQPVBE79CWA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Okp82U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Okp81k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Okp8102qEemQQPVBE79CWA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Okp82E2qEemQQPVBE79CWA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_UDyhIES5Eem_eeeaz1ENMQ" type="PapyrusUMLClassDiagram" name="EquipmentModelDetail" measurementUnit="Pixel">
@@ -1101,6 +1101,14 @@
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_SWpBcEvNEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_TiAoYUvNEemT5f_Ewhfs6A"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_7GGYQFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7GGYQVFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7GG_UFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7GG_UVFgEemgMYGocegK5A"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_YvvTRES5Eem_eeeaz1ENMQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_YvvTRUS5Eem_eeeaz1ENMQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_YvvTRkS5Eem_eeeaz1ENMQ"/>
@@ -1119,7 +1127,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YvvTUUS5Eem_eeeaz1ENMQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YvvTc0S5Eem_eeeaz1ENMQ" x="660" y="-20" width="402" height="167"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YvvTc0S5Eem_eeeaz1ENMQ" x="660" y="-20" width="402" height="193"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Yvv6IUS5Eem_eeeaz1ENMQ" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_Yvv6IkS5Eem_eeeaz1ENMQ" type="Class_NameLabel"/>
@@ -1137,6 +1145,14 @@
         <children xmi:type="notation:Shape" xmi:id="_Wivp8ElmEemT5f_Ewhfs6A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_PshE4ElZEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Wivp8UlmEemT5f_Ewhfs6A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_xMlVcFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xMlVcVFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_xMmjkFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xMmjkVFgEemgMYGocegK5A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Yvv6KES5Eem_eeeaz1ENMQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Yvv6KUS5Eem_eeeaz1ENMQ"/>
@@ -1156,7 +1172,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvv6NUS5Eem_eeeaz1ENMQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvv6V0S5Eem_eeeaz1ENMQ" x="1760" y="20" width="281" height="81"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvv6V0S5Eem_eeeaz1ENMQ" x="1726" y="20" width="315" height="109"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_YvwhXUS5Eem_eeeaz1ENMQ" type="Comment_Shape" fillColor="13420443">
       <children xmi:type="notation:DecorationNode" xmi:id="_YvwhXkS5Eem_eeeaz1ENMQ" type="Comment_BodyLabel"/>
@@ -1189,6 +1205,14 @@
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_-LKxMEvNEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="__UZDEUvNEemT5f_Ewhfs6A"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_5NAIoFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5NAIoVFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_5NAIolFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5NAIo1FgEemgMYGocegK5A"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Yvy9R0S5Eem_eeeaz1ENMQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Yvy9SES5Eem_eeeaz1ENMQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_Yvy9SUS5Eem_eeeaz1ENMQ"/>
@@ -1207,12 +1231,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy9VES5Eem_eeeaz1ENMQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy9dkS5Eem_eeeaz1ENMQ" x="660" y="560" width="400" height="101"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Yvy9pUS5Eem_eeeaz1ENMQ" type="Comment_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Yvy9pkS5Eem_eeeaz1ENMQ" type="Comment_BodyLabel"/>
-      <element xmi:type="uml:Comment" href="TapiEquipment.uml#_ey96wDmvEem1ZNpCEF2XWQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy9p0S5Eem_eeeaz1ENMQ" x="2220" y="380" width="161"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy9dkS5Eem_eeeaz1ENMQ" x="660" y="560" width="400" height="120"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Yvy9qES5Eem_eeeaz1ENMQ" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_Yvy9qUS5Eem_eeeaz1ENMQ" type="Class_NameLabel"/>
@@ -1226,6 +1245,14 @@
         <children xmi:type="notation:Shape" xmi:id="_Yvy9r0S5Eem_eeeaz1ENMQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_LcVo0DmlEemDl_QGWIY6yg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Yvy9yUS5Eem_eeeaz1ENMQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_1rg-4FFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1rg-4VFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_1ri0EFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1ri0EVFgEemgMYGocegK5A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Yvy9ykS5Eem_eeeaz1ENMQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Yvy9y0S5Eem_eeeaz1ENMQ"/>
@@ -1245,79 +1272,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy910S5Eem_eeeaz1ENMQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy9-US5Eem_eeeaz1ENMQ" x="1200" y="560" width="381"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wIt5MElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wIt5MUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wIt5M0lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wIt5MklTEemT5f_Ewhfs6A" x="2140" y="500"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wKQxUElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wKQxUUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wKQxU0lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wKQxUklTEemT5f_Ewhfs6A" x="2140" y="220"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wK4cYElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wK4cYUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wK4cY0lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wK4cYklTEemT5f_Ewhfs6A" x="860" y="-20"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wLWWcElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wLWWcUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wLWWc0lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wLWWcklTEemT5f_Ewhfs6A" x="860" y="-120"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wLuJ4ElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wLuJ4UlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wLuJ40lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wLuJ4klTEemT5f_Ewhfs6A" x="1780" y="220"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wL2swElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wL2swUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wL2sw0lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wL2swklTEemT5f_Ewhfs6A" x="1780" y="120"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wOJy0ElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wOJy0UlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wOJy00lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wOJy0klTEemT5f_Ewhfs6A" x="860" y="460"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wOqwMElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wOqwMUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wOqwM0lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wOqwMklTEemT5f_Ewhfs6A" x="860" y="360"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_wPE_4ElTEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wPE_4UlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wPE_40lTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wPE_4klTEemT5f_Ewhfs6A" x="1460" y="500"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yvy9-US5Eem_eeeaz1ENMQ" x="1200" y="560" width="381" height="100"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ESGL0ElgEemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_ESGL0klgEemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -1341,6 +1296,14 @@
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_VSkDMElgEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_jbpHoUvaEemT5f_Ewhfs6A"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_zk1mQFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zk1mQVFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_zk2NUFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zk2NUVFgEemgMYGocegK5A"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_ESGL1klgEemT5f_Ewhfs6A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_ESGL10lgEemT5f_Ewhfs6A"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_ESGL2ElgEemT5f_Ewhfs6A"/>
@@ -1359,15 +1322,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ESGL40lgEemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ESGL0UlgEemT5f_Ewhfs6A" x="1780" y="320" width="401" height="121"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_ESRK-0lgEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ESRK_ElgEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ESRK_klgEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ESRK_UlgEemT5f_Ewhfs6A" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ESGL0UlgEemT5f_Ewhfs6A" x="1780" y="305" width="401" height="136"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_87cVEElkEemT5f_Ewhfs6A" type="Comment_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_87cVEklkEemT5f_Ewhfs6A" type="Comment_BodyLabel"/>
@@ -1462,22 +1417,6 @@
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-KwtEUvDEemT5f_Ewhfs6A" x="-360" y="380" width="341" height="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_y_VhBEvEEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_y_VhBUvEEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y_VhB0vEEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y_VhBkvEEemT5f_Ewhfs6A" x="-640" y="-160"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_1mty9EvEEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1mty9UvEEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1mty90vEEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1mty9kvEEemT5f_Ewhfs6A" x="-640" y="400"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_7n5SQEvEEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="10011046">
       <children xmi:type="notation:DecorationNode" xmi:id="_7n55UEvEEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_7n55UUvEEemT5f_Ewhfs6A" type="DataType_FloatingNameLabel">
@@ -1506,14 +1445,6 @@
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7n5SQUvEEemT5f_Ewhfs6A" x="-1220" y="420" width="481" height="101"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_A36aZEvFEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_A36aZUvFEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_A36aZ0vFEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A36aZkvFEemT5f_Ewhfs6A" x="-1080" y="400"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_MawgkEvHEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="10011046">
       <children xmi:type="notation:DecorationNode" xmi:id="_MawgkkvHEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_Mawgk0vHEemT5f_Ewhfs6A" type="DataType_FloatingNameLabel">
@@ -1537,14 +1468,6 @@
       </children>
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MawgkUvHEemT5f_Ewhfs6A" x="160" y="420" width="480"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ma8Gw0vHEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ma8GxEvHEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ma8GxkvHEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ma8GxUvHEemT5f_Ewhfs6A" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rjM_QEvHEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="10011046">
       <children xmi:type="notation:DecorationNode" xmi:id="_rjNmUEvHEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
@@ -1587,14 +1510,6 @@
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rjM_QUvHEemT5f_Ewhfs6A" x="-740" y="200" width="521" height="121"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_wzyIFEvHEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_wzyIFUvHEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wzyIF0vHEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wzyIFkvHEemT5f_Ewhfs6A" x="-860" y="320"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_6zavEEvJEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="10011046">
       <children xmi:type="notation:DecorationNode" xmi:id="_6zavEkvJEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_6zavE0vJEemT5f_Ewhfs6A" type="DataType_FloatingNameLabel">
@@ -1632,14 +1547,6 @@
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6zavEUvJEemT5f_Ewhfs6A" x="-200" y="200" width="541" height="121"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6zluMEvJEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6zluMUvJEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6zluM0vJEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6zluMkvJEemT5f_Ewhfs6A" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_9Zye8EvKEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="10011046">
       <children xmi:type="notation:DecorationNode" xmi:id="_9Zye8kvKEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_9ZzGAEvKEemT5f_Ewhfs6A" type="DataType_FloatingNameLabel">
@@ -1664,14 +1571,6 @@
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9Zye8UvKEemT5f_Ewhfs6A" x="-200" y="660" width="441"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ce0fFEvLEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ce0fFUvLEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ce0fF0vLEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ce0fFkvLEemT5f_Ewhfs6A" x="360" y="620"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_MSkREEvLEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="10011046">
       <children xmi:type="notation:DecorationNode" xmi:id="_MSkREkvLEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_MSkRE0vLEemT5f_Ewhfs6A" type="DataType_FloatingNameLabel">
@@ -1695,14 +1594,6 @@
       </children>
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MSkREUvLEemT5f_Ewhfs6A" x="-640" y="660"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_RDGA0EvLEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_RDGA0UvLEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RDGA00vLEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RDGA0kvLEemT5f_Ewhfs6A" x="-440" y="640"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_iYsasEvLEemT5f_Ewhfs6A" type="DataType_Shape" fillColor="13420443">
       <children xmi:type="notation:DecorationNode" xmi:id="_iYsaskvLEemT5f_Ewhfs6A" type="DataType_NameLabel"/>
@@ -1736,14 +1627,6 @@
       <element xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iYsasUvLEemT5f_Ewhfs6A" x="-340" y="840" width="321" height="121"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xhJnl0vLEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xhJnmEvLEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xhJnmkvLEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xhJnmUvLEemT5f_Ewhfs6A" x="-440" y="800"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_dOMqwEvWEemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_dOMqwkvWEemT5f_Ewhfs6A" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_dOMqw0vWEemT5f_Ewhfs6A" type="Class_FloatingNameLabel">
@@ -1757,6 +1640,14 @@
         <children xmi:type="notation:Shape" xmi:id="_Bhvf4EvYEemT5f_Ewhfs6A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_S0xjYEvXEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Bhvf4UvYEemT5f_Ewhfs6A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vGYd8FFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vGYd8VFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_vGYd8lFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_vGYd81FgEemgMYGocegK5A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_dOMqxkvWEemT5f_Ewhfs6A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_dOMqx0vWEemT5f_Ewhfs6A"/>
@@ -1776,39 +1667,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dONR2UvWEemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dOMqwUvWEemT5f_Ewhfs6A" x="1380" y="-100" width="281" height="81"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_dOUmk0vWEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_dOUmlEvWEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dOUmlkvWEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dOUmlUvWEemT5f_Ewhfs6A" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_2t7_E0vXEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2t7_FEvXEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2t8mIEvXEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2t7_FUvXEemT5f_Ewhfs6A" x="1480" y="-200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_9ZzaIEvXEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_9ZzaIUvXEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9ZzaI0vXEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9ZzaIkvXEemT5f_Ewhfs6A" x="1480" y="-200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_VZ5rN0vaEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_VZ5rOEvaEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VZ5rOkvaEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VZ5rOUvaEemT5f_Ewhfs6A" x="1360" y="320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dOMqwUvWEemT5f_Ewhfs6A" x="1380" y="-100" width="281" height="108"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_gPB_sEvwEemT5f_Ewhfs6A" type="Class_Shape" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_gPB_skvwEemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -1823,6 +1682,14 @@
         <children xmi:type="notation:Shape" xmi:id="_lZxUUEvyEemT5f_Ewhfs6A" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_DN0oYkvyEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_lZxUUUvyEemT5f_Ewhfs6A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_soYKcFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_soYKcVFgEemgMYGocegK5A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_soZYkFFgEemgMYGocegK5A" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_soZYkVFgEemgMYGocegK5A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_gPB_tkvwEemT5f_Ewhfs6A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_gPB_t0vwEemT5f_Ewhfs6A"/>
@@ -1842,15 +1709,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gPB_w0vwEemT5f_Ewhfs6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gPB_sUvwEemT5f_Ewhfs6A" x="1580" y="-300" width="301" height="101"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_gPMXwEvwEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_gPMXwUvwEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gPMXw0vwEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gPMXwkvwEemT5f_Ewhfs6A" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gPB_sUvwEemT5f_Ewhfs6A" x="1580" y="-300" width="301" height="113"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_7M57YEvwEemT5f_Ewhfs6A" type="Class_Shape" fillColor="12621752">
       <children xmi:type="notation:DecorationNode" xmi:id="_7M6icEvwEemT5f_Ewhfs6A" type="Class_NameLabel"/>
@@ -1878,61 +1737,345 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7M57YUvwEemT5f_Ewhfs6A" x="2380" y="-300" width="141"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7NJzA0vwEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7NJzBEvwEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7NJzBkvwEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+    <children xmi:type="notation:Shape" xmi:id="_4jT6oE2rEemQQPVBE79CWA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4jaBQE2rEemQQPVBE79CWA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4jaBQU2rEemQQPVBE79CWA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4jaBQk2rEemQQPVBE79CWA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4jaoUE2rEemQQPVBE79CWA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_ZEoQwE2sEemQQPVBE79CWA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEquipment.uml#_6B6BtS7BEemaZq0-6SfFXw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZEoQwU2sEemQQPVBE79CWA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4jaoUU2rEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4jaoUk2rEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4jaoU02rEemQQPVBE79CWA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4jaoVE2rEemQQPVBE79CWA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4jaoVU2rEemQQPVBE79CWA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4jaoVk2rEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4jaoV02rEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4jaoWE2rEemQQPVBE79CWA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4jaoWU2rEemQQPVBE79CWA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_4jbPYE2rEemQQPVBE79CWA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_4jbPYU2rEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_4jbPYk2rEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_4jbPY02rEemQQPVBE79CWA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4jbPZE2rEemQQPVBE79CWA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4jT6oU2rEemQQPVBE79CWA" x="2133" y="-84" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8PgDEE2sEemQQPVBE79CWA" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8PhRME2sEemQQPVBE79CWA" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8PhRMU2sEemQQPVBE79CWA" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8PhRMk2sEemQQPVBE79CWA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8PhRM02sEemQQPVBE79CWA" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Pai7oE2tEemQQPVBE79CWA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEquipment.uml#_Aw6nkTlbEemDl_QGWIY6yg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Pai7oU2tEemQQPVBE79CWA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8PhRNE2sEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8PhRNU2sEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8PhRNk2sEemQQPVBE79CWA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8PhRN02sEemQQPVBE79CWA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8Ph4QE2sEemQQPVBE79CWA" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8Ph4QU2sEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8Ph4Qk2sEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8Ph4Q02sEemQQPVBE79CWA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8Ph4RE2sEemQQPVBE79CWA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8Ph4RU2sEemQQPVBE79CWA" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8Ph4Rk2sEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8Ph4R02sEemQQPVBE79CWA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8Ph4SE2sEemQQPVBE79CWA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8Ph4SU2sEemQQPVBE79CWA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8PgDEU2sEemQQPVBE79CWA" x="1936" y="581" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tTijIFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tTijIVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTijI1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NJzBUvwEemT5f_Ewhfs6A" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTijIlFnEemgMYGocegK5A" x="2580" y="560"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QPbS8EvxEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QPbS8UvxEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPbS80vxEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
+    <children xmi:type="notation:Shape" xmi:id="_tTxzsFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tTxzsVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTxzs1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPbS8kvxEemT5f_Ewhfs6A" x="1920" y="-360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTxzslFnEemgMYGocegK5A" x="1340" y="320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Yp5vcEvyEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Yp5vcUvyEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yp5vc0vyEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
+    <children xmi:type="notation:Shape" xmi:id="_tUYQoFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tUYQoVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tUYQo1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yp5vckvyEemT5f_Ewhfs6A" x="1920" y="-360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tUYQolFnEemgMYGocegK5A" x="2580" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2a5TA0vyEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2a5TBEvyEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2a5TBkvyEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
+    <children xmi:type="notation:Shape" xmi:id="_tU-GgFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tU-GgVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tU-Gg1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2a5TBUvyEemT5f_Ewhfs6A" x="1780" y="-360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tU-GglFnEemgMYGocegK5A" x="860" y="-20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ImzCwEvzEemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ImzCwUvzEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ImzCw0vzEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
+    <children xmi:type="notation:Shape" xmi:id="_tWBPYFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tWBPYVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWBPY1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ImzCwkvzEemT5f_Ewhfs6A" x="1960" y="220"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tWBPYlFnEemgMYGocegK5A" x="860" y="-120"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_bp8uIEv0EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bp8uIUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bp8uI0v0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_tWiMwFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tWiMwVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWiMw1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tWiMwlFnEemgMYGocegK5A" x="1926" y="20"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tXKe4FFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tXKe4VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXKe41FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tXKe4lFnEemgMYGocegK5A" x="1926" y="-80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tXTo0FFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tXTo0VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXTo01FnEemgMYGocegK5A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bp8uIkv0EemT5f_Ewhfs6A" x="1960" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tXTo0lFnEemgMYGocegK5A" x="1926" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_rMnf4Ev2EemT5f_Ewhfs6A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_rMnf4Uv2EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rMnf40v2EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_tX0mMFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tX0mMVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tX0mM1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tX0mMlFnEemgMYGocegK5A" x="860" y="560"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tZYFYFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tZYFYVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZYFY1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tZYFYlFnEemgMYGocegK5A" x="860" y="460"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tZ6Q4FFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tZ6Q4VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZ6Q41FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tZ6Q4lFnEemgMYGocegK5A" x="1400" y="560"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ta36MFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ta36MVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ta36M1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ta36MlFnEemgMYGocegK5A" x="1980" y="305"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tbrLcFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tbrLcVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbrLc1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tbrLclFnEemgMYGocegK5A" x="1980" y="205"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tbwrAFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tbwrAVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbwrA1FnEemgMYGocegK5A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rMnf4kv2EemT5f_Ewhfs6A" x="1980" y="220"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tbwrAlFnEemgMYGocegK5A" x="1980" y="205"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tb7DEFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tb7DEVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tb7DE1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tb7DElFnEemgMYGocegK5A" x="-680" y="-40"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tcjVMFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tcjVMVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tcjVM1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tcjVMlFnEemgMYGocegK5A" x="-160" y="380"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tdXNgFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tdXNgVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdXNg1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tdXNglFnEemgMYGocegK5A" x="-1020" y="420"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tdwPEFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tdwPEVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdwPE1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tdwPElFnEemgMYGocegK5A" x="360" y="420"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_teBU0FFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_teBU0VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_teBU01FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_teBU0lFnEemgMYGocegK5A" x="-540" y="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_telVgFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_telVgVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_telVg1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_telVglFnEemgMYGocegK5A" y="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tfDPkFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tfDPkVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfDPk1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tfDPklFnEemgMYGocegK5A" y="660"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tfU8YFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tfU8YVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfU8Y1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tfU8YlFnEemgMYGocegK5A" x="-440" y="660"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tfmpMFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tfmpMVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfmpM1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tfmpMlFnEemgMYGocegK5A" x="-140" y="840"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tgZ6cFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tgZ6cVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tgZ6c1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tgZ6clFnEemgMYGocegK5A" x="1580" y="-100"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_th7kcFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_th7kcVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_th7kc1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_th7kclFnEemgMYGocegK5A" x="1580" y="-200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tiGjkFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tiGjkVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiGjk1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tiGjklFnEemgMYGocegK5A" x="1580" y="-200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tiu1sFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tiu1sVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiu1s1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tiu1slFnEemgMYGocegK5A" x="1780" y="-300"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tjj8IFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tjj8IVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjj8I1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tjj8IlFnEemgMYGocegK5A" x="1780" y="-400"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tjsfAFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tjsfAVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjsfA1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tjsfAlFnEemgMYGocegK5A" x="1780" y="-400"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tj3eIFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tj3eIVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tj3eI1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tj3eIlFnEemgMYGocegK5A" x="1780" y="-400"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tkmd8FFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tkmd8VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tkmd81FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tkmd8lFnEemgMYGocegK5A" x="2580" y="-300"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tlZIIFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tlZIIVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlZII1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tlZIIlFnEemgMYGocegK5A" x="2333" y="-84"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tlxioFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tlxioVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlyJsFFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tlxiolFnEemgMYGocegK5A" x="2333" y="-184"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tmMZYFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tmMZYVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmMZY1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tmMZYlFnEemgMYGocegK5A" x="2136" y="581"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tmiXoFFnEemgMYGocegK5A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tmiXoVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmiXo1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tmiXolFnEemgMYGocegK5A" x="2136" y="481"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_UDyhIUS5Eem_eeeaz1ENMQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_UDyhIkS5Eem_eeeaz1ENMQ"/>
@@ -1940,7 +2083,7 @@
       <owner xmi:type="uml:Package" href="TapiEquipment.uml#_NcVIoEdWEeasL6dcjI1vEA"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiEquipment.uml#_NcVIoEdWEeasL6dcjI1vEA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_YvsPkES5Eem_eeeaz1ENMQ" type="Association_Edge" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_Yvs210S5Eem_eeeaz1ENMQ" routing="Rectilinear" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_YvsPkES5Eem_eeeaz1ENMQ" type="Association_Edge" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_8PgDEE2sEemQQPVBE79CWA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_YvsPkUS5Eem_eeeaz1ENMQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YvsPkkS5Eem_eeeaz1ENMQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YvsPk0S5Eem_eeeaz1ENMQ" y="-20"/>
@@ -1967,9 +2110,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_YvsPo0S5Eem_eeeaz1ENMQ"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_Aw5ZcDlbEemDl_QGWIY6yg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YvsPpES5Eem_eeeaz1ENMQ" points="[1561, 560, -643984, -643984]$[1979, 560, -643984, -643984]$[1979, 580, -643984, -643984]$[2380, 580, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvsPpUS5Eem_eeeaz1ENMQ" id="(1.0,0.6)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvsPpkS5Eem_eeeaz1ENMQ" id="(0.0,0.6)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YvsPpES5Eem_eeeaz1ENMQ" points="[1581, 619, -643984, -643984]$[1936, 619, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvsPpUS5Eem_eeeaz1ENMQ" id="(1.0,0.59)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvsPpkS5Eem_eeeaz1ENMQ" id="(0.0,0.6229508196721312)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Yvs2o0S5Eem_eeeaz1ENMQ" type="Association_Edge" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_Yvy9QES5Eem_eeeaz1ENMQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Yvs2pES5Eem_eeeaz1ENMQ" type="Association_StereotypeLabel">
@@ -2030,8 +2173,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Yvtdw0S5Eem_eeeaz1ENMQ"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Yvtdx0S5Eem_eeeaz1ENMQ" points="[1685, 250, -643984, -643984]$[1625, 250, -643984, -643984]$[1625, 470, -643984, -643984]$[1506, 470, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvtdyES5Eem_eeeaz1ENMQ" id="(0.0,0.49382716049382713)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvtdyUS5Eem_eeeaz1ENMQ" id="(1.0,0.2)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvtdyES5Eem_eeeaz1ENMQ" id="(0.0,0.3669724770642202)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvtdyUS5Eem_eeeaz1ENMQ" id="(1.0,0.25)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YvteBES5Eem_eeeaz1ENMQ" type="Association_Edge" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_YvvTPUS5Eem_eeeaz1ENMQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_YvteBUS5Eem_eeeaz1ENMQ" type="Association_StereotypeLabel">
@@ -2064,15 +2207,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_YvteGUS5Eem_eeeaz1ENMQ"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YvteHUS5Eem_eeeaz1ENMQ" points="[1060, 520, -643984, -643984]$[1120, 520, -643984, -643984]$[1120, 60, -643984, -643984]$[1062, 60, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvteHkS5Eem_eeeaz1ENMQ" id="(1.0,0.594059405940594)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvteH0S5Eem_eeeaz1ENMQ" id="(1.0,0.47904191616766467)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Yvur0ES5Eem_eeeaz1ENMQ" type="Comment_AnnotatedElementEdge" source="_Yvy9pUS5Eem_eeeaz1ENMQ" target="_YvsPkES5Eem_eeeaz1ENMQ" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Yvur0US5Eem_eeeaz1ENMQ"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Yvur0kS5Eem_eeeaz1ENMQ" points="[2260, 440, -643984, -643984]$[2260, 500, -643984, -643984]$[2240, 500, -643984, -643984]$[2240, 560, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yvur00S5Eem_eeeaz1ENMQ" id="(0.4968944099378882,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yvur1ES5Eem_eeeaz1ENMQ" id="(0.8057553956834532,0.45454545454545453)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvteHkS5Eem_eeeaz1ENMQ" id="(1.0,0.5)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvteH0S5Eem_eeeaz1ENMQ" id="(1.0,0.41450777202072536)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Yvv6dUS5Eem_eeeaz1ENMQ" type="Association_Edge" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_Yvs210S5Eem_eeeaz1ENMQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Yvv6dkS5Eem_eeeaz1ENMQ" type="Association_StereotypeLabel">
@@ -2105,14 +2241,14 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvwhDUS5Eem_eeeaz1ENMQ" id="(0.425531914893617,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvwhDkS5Eem_eeeaz1ENMQ" id="(0.425531914893617,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_YvxvOkS5Eem_eeeaz1ENMQ" type="Association_Edge" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_Yvur1US5Eem_eeeaz1ENMQ" routing="Rectilinear" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_YvxvOkS5Eem_eeeaz1ENMQ" type="Association_Edge" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_4jT6oE2rEemQQPVBE79CWA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_YvxvO0S5Eem_eeeaz1ENMQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YvxvPES5Eem_eeeaz1ENMQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YvxvPUS5Eem_eeeaz1ENMQ" x="-1" y="-18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YvxvPkS5Eem_eeeaz1ENMQ" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YvxvP0S5Eem_eeeaz1ENMQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YvxvQES5Eem_eeeaz1ENMQ" x="9" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YvxvQES5Eem_eeeaz1ENMQ" x="-2" y="-52"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YvxvQUS5Eem_eeeaz1ENMQ" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YvxvQkS5Eem_eeeaz1ENMQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2124,7 +2260,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YvxvR0S5Eem_eeeaz1ENMQ" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YvxvSES5Eem_eeeaz1ENMQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YvxvSUS5Eem_eeeaz1ENMQ" x="30" y="7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YvxvSUS5Eem_eeeaz1ENMQ" x="24" y="-13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_YvxvSkS5Eem_eeeaz1ENMQ" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YvxvS0S5Eem_eeeaz1ENMQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2132,106 +2268,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_YvxvTUS5Eem_eeeaz1ENMQ"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_6B5aoC7BEemaZq0-6SfFXw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YvxvTkS5Eem_eeeaz1ENMQ" points="[2001, 80, -643984, -643984]$[2199, 80, -643984, -643984]$[2199, 100, -643984, -643984]$[2380, 100, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvxvT0S5Eem_eeeaz1ENMQ" id="(1.0,0.7407407407407407)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvxvUES5Eem_eeeaz1ENMQ" id="(0.0,0.6)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_YvxvUUS5Eem_eeeaz1ENMQ" type="Comment_AnnotatedElementEdge" source="_Yvy9pUS5Eem_eeeaz1ENMQ" target="_YvxvOkS5Eem_eeeaz1ENMQ" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_YvxvUkS5Eem_eeeaz1ENMQ"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YvxvU0S5Eem_eeeaz1ENMQ" points="[2300, 380, -643984, -643984]$[2300, 200, -643984, -643984]$[2266, 200, -643984, -643984]$[2266, 80, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvxvVES5Eem_eeeaz1ENMQ" id="(0.4968944099378882,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvxvVUS5Eem_eeeaz1ENMQ" id="(0.677570093457944,0.48717948717948717)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wIt5NElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_Yvs210S5Eem_eeeaz1ENMQ" target="_wIt5MElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wIt5NUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wIt5OUlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wIt5NklTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wIt5N0lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wIt5OElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wKQxVElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_wKQxUElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wKQxVUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wKQxWUlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wKQxVklTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wKQxV0lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wKQxWElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wK4cZElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_wK4cYElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wK4cZUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wK4caUlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wK4cZklTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wK4cZ0lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wK4caElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wLW9gElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_Yvs2o0S5Eem_eeeaz1ENMQ" target="_wLWWcElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wLW9gUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wLW9hUlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wLW9gklTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wLW9g0lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wLW9hElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wLuJ5ElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_wLuJ4ElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wLuJ5UlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wLuJ6UlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wLuJ5klTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wLuJ50lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wLuJ6ElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wL2sxElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_YvtdsES5Eem_eeeaz1ENMQ" target="_wL2swElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wL2sxUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wL2syUlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wL2sxklTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wL2sx0lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wL2syElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wOJy1ElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_wOJy0ElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wOJy1UlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wOJy2UlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wOJy1klTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wOJy10lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wOJy2ElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wOrXQElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_YvteBES5Eem_eeeaz1ENMQ" target="_wOqwMElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wOrXQUlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wOrXRUlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wOrXQklTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wOrXQ0lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wOrXRElTEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wPE_5ElTEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_wPE_4ElTEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wPE_5UlTEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wPE_6UlTEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wPE_5klTEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wPE_50lTEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wPE_6ElTEemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YvxvTkS5Eem_eeeaz1ENMQ" points="[2041, 66, -643984, -643984]$[2171, 66, -643984, -643984]$[2171, 1, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvxvT0S5Eem_eeeaz1ENMQ" id="(1.0,0.42201834862385323)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YvxvUES5Eem_eeeaz1ENMQ" id="(0.3145539906103286,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QbC-0ElZEemT5f_Ewhfs6A" type="Association_Edge" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_ESGL0ElgEemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_QbC-00lZEemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -2261,18 +2300,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_QbC-0UlZEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QbC-0klZEemT5f_Ewhfs6A" points="[1920, 101, -643984, -643984]$[1920, 320, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RwuYUElZEemT5f_Ewhfs6A" id="(0.5693950177935944,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RwuYUElZEemT5f_Ewhfs6A" id="(0.6158730158730159,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RwuYUUlZEemT5f_Ewhfs6A" id="(0.3491271820448878,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ESRK_0lgEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_ESRK-0lgEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ESRLAElgEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ESRyAklgEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ESRLAUlgEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ESRyAElgEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ESRyAUlgEemT5f_Ewhfs6A"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MMsq4ElgEemT5f_Ewhfs6A" type="Association_Edge" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_ESGL0ElgEemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_MMsq40lgEemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -2302,8 +2331,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_MMsq4UlgEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MMsq4klgEemT5f_Ewhfs6A" points="[1780, 420, -643984, -643984]$[1720, 420, -643984, -643984]$[1720, 360, -643984, -643984]$[1780, 360, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NkQ6wElgEemT5f_Ewhfs6A" id="(0.0,0.8264462809917356)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NkQ6wUlgEemT5f_Ewhfs6A" id="(0.0,0.3305785123966942)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NkQ6wElgEemT5f_Ewhfs6A" id="(0.0,0.8455882352941176)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NkQ6wUlgEemT5f_Ewhfs6A" id="(0.0,0.40441176470588236)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_V8cGoElgEemT5f_Ewhfs6A" type="Association_Edge" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_ESGL0ElgEemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_V8cGo0lgEemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -2335,96 +2364,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_V8cGoklgEemT5f_Ewhfs6A" points="[2060, 440, -643984, -643984]$[2060, 500, -643984, -643984]$[1860, 500, -643984, -643984]$[1860, 440, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XQGG4ElgEemT5f_Ewhfs6A" id="(0.6982543640897756,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XQGG4UlgEemT5f_Ewhfs6A" id="(0.19950124688279303,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_y_VhCEvEEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_jqTmgEqtEemT5f_Ewhfs6A" target="_y_VhBEvEEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_y_VhCUvEEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y_VhDUvEEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_y_VhCkvEEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y_VhC0vEEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y_VhDEvEEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1mty-EvEEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_-KwtEEvDEemT5f_Ewhfs6A" target="_1mty9EvEEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1mty-UvEEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1mty_UvEEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1mty-kvEEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1mty-0vEEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1mty_EvEEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_A36aaEvFEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_7n5SQEvEEemT5f_Ewhfs6A" target="_A36aZEvFEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_A36aaUvFEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_A36abUvFEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_A36aakvFEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A36aa0vFEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A36abEvFEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ma8Gx0vHEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_MawgkEvHEemT5f_Ewhfs6A" target="_Ma8Gw0vHEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ma8GyEvHEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ma8t0kvHEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ma8GyUvHEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ma8t0EvHEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ma8t0UvHEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wzyIGEvHEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_rjM_QEvHEemT5f_Ewhfs6A" target="_wzyIFEvHEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_wzyIGUvHEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wzyIHUvHEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wzyIGkvHEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wzyIG0vHEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wzyIHEvHEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6zluNEvJEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_6zavEEvJEemT5f_Ewhfs6A" target="_6zluMEvJEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6zluNUvJEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6zluOUvJEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6zluNkvJEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zluN0vJEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zluOEvJEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ce0fGEvLEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_9Zye8EvKEemT5f_Ewhfs6A" target="_Ce0fFEvLEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ce0fGUvLEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ce1GIUvLEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ce0fGkvLEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ce0fG0vLEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ce1GIEvLEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_RDGA1EvLEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_MSkREEvLEemT5f_Ewhfs6A" target="_RDGA0EvLEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_RDGA1UvLEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RDGA2UvLEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RDGA1kvLEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RDGA10vLEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RDGA2EvLEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xhJnm0vLEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_iYsasEvLEemT5f_Ewhfs6A" target="_xhJnl0vLEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xhJnnEvLEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xhKOokvLEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xhJnnUvLEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xhKOoEvLEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xhKOoUvLEemT5f_Ewhfs6A"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_kADSsEvOEemT5f_Ewhfs6A" type="Usage_Edge" source="_7n5SQEvEEemT5f_Ewhfs6A" target="_jqTmgEqtEemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_kADSs0vOEemT5f_Ewhfs6A" type="Usage_NameLabel">
@@ -2558,7 +2497,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Ae0j8UvQEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Usage" href="TapiEquipment.uml#_Aez84EvQEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ae0j8kvQEemT5f_Ewhfs6A" points="[660, 120, -643984, -643984]$[80, 120, -643984, -643984]$[80, 200, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B5o8IEvQEemT5f_Ewhfs6A" id="(0.0,0.8383233532934131)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B5o8IEvQEemT5f_Ewhfs6A" id="(0.0,0.7253886010362695)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B5o8IUvQEemT5f_Ewhfs6A" id="(0.5175600739371534,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DjwUkEvQEemT5f_Ewhfs6A" type="Usage_Edge" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_rjM_QEvHEemT5f_Ewhfs6A" routing="Rectilinear">
@@ -2573,7 +2512,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_DjwUkUvQEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Usage" href="TapiEquipment.uml#_DjvGcEvQEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DjwUkkvQEemT5f_Ewhfs6A" points="[660, 40, -643984, -643984]$[-340, 40, -643984, -643984]$[-340, 200, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9wNYEvQEemT5f_Ewhfs6A" id="(0.0,0.3592814371257485)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9wNYEvQEemT5f_Ewhfs6A" id="(0.0,0.31088082901554404)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9wNYUvQEemT5f_Ewhfs6A" id="(0.7677543186180422,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_GUR7cEvQEemT5f_Ewhfs6A" type="Usage_Edge" source="_9Zye8EvKEemT5f_Ewhfs6A" target="_iYsasEvLEemT5f_Ewhfs6A" routing="Rectilinear">
@@ -2618,7 +2557,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_XJBjoUvTEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Usage" href="TapiEquipment.uml#_XJAVgEvTEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XJBjokvTEemT5f_Ewhfs6A" points="[660, 580, -643984, -643984]$[-460, 580, -643984, -643984]$[-460, 660, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yd66AEvTEemT5f_Ewhfs6A" id="(0.0,0.19801980198019803)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yd66AEvTEemT5f_Ewhfs6A" id="(0.0,0.16666666666666666)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yd66AUvTEemT5f_Ewhfs6A" id="(0.4295942720763723,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ZkjK4EvTEemT5f_Ewhfs6A" type="Usage_Edge" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_9Zye8EvKEemT5f_Ewhfs6A" routing="Rectilinear">
@@ -2633,7 +2572,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_ZkjK4UvTEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Usage" href="TapiEquipment.uml#_Zkij0EvTEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZkjK4kvTEemT5f_Ewhfs6A" points="[660, 620, -643984, -643984]$[80, 620, -643984, -643984]$[80, 660, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a-TMEEvTEemT5f_Ewhfs6A" id="(0.0,0.594059405940594)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a-TMEEvTEemT5f_Ewhfs6A" id="(0.0,0.5)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a-TMEUvTEemT5f_Ewhfs6A" id="(0.6349206349206349,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7qq7oEvTEemT5f_Ewhfs6A" type="Usage_Edge" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_YvuFIkS5Eem_eeeaz1ENMQ" routing="Rectilinear">
@@ -2664,17 +2603,7 @@
       <element xmi:type="uml:Usage" href="TapiEquipment.uml#_U8ovIEvUEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U8p9QkvUEemT5f_Ewhfs6A" points="[1340, 320, -643984, -643984]$[1340, 20, -643984, -643984]$[1062, 20, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WbM-4EvUEemT5f_Ewhfs6A" id="(0.5278592375366569,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WbM-4UvUEemT5f_Ewhfs6A" id="(1.0,0.23952095808383234)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dOUml0vWEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_dOUmk0vWEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_dOUmmEvWEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dOUmnEvWEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dOUmmUvWEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dOUmmkvWEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dOUmm0vWEemT5f_Ewhfs6A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WbM-4UvUEemT5f_Ewhfs6A" id="(1.0,0.20725388601036268)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_TTeRkEvXEemT5f_Ewhfs6A" type="Association_Edge" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_YvvTPUS5Eem_eeeaz1ENMQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_TTeRk0vXEemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -2704,7 +2633,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_TTeRkUvXEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TTeRkkvXEemT5f_Ewhfs6A" points="[1280, -60, -643984, -643984]$[840, -60, -643984, -643984]$[840, -20, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URfZAEvXEemT5f_Ewhfs6A" id="(0.0,0.49382716049382713)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URfZAEvXEemT5f_Ewhfs6A" id="(0.0,0.37037037037037035)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URfZAUvXEemT5f_Ewhfs6A" id="(0.44776119402985076,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WUpjkEvXEemT5f_Ewhfs6A" type="Association_Edge" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_Yvy9qES5Eem_eeeaz1ENMQ" routing="Rectilinear">
@@ -2738,56 +2667,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XWKD4EvXEemT5f_Ewhfs6A" id="(0.42704626334519574,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XWKD4UvXEemT5f_Ewhfs6A" id="(0.7874015748031497,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2t8mIUvXEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_WUpjkEvXEemT5f_Ewhfs6A" target="_2t7_E0vXEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2t8mIkvXEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2t8mJkvXEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2t8mI0vXEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2t8mJEvXEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2t8mJUvXEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9ZzaJEvXEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_TTeRkEvXEemT5f_Ewhfs6A" target="_9ZzaIEvXEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_9ZzaJUvXEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9ZzaKUvXEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9ZzaJkvXEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ZzaJ0vXEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ZzaKEvXEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_VZ5rO0vaEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_YvuFIkS5Eem_eeeaz1ENMQ" target="_VZ5rN0vaEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_VZ5rPEvaEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VZ5rQEvaEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZ5rPUvaEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VZ5rPkvaEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VZ5rP0vaEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_gPMXxEvwEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_gPMXwEvwEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_gPMXxUvwEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gPMXyUvwEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gPMXxkvwEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gPMXx0vwEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gPMXyEvwEemT5f_Ewhfs6A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7NJzB0vwEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_7M57YEvwEemT5f_Ewhfs6A" target="_7NJzA0vwEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7NJzCEvwEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7NJzDEvwEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7NJzCUvwEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7NJzCkvwEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7NJzC0vwEemT5f_Ewhfs6A"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_I4JjYEvxEemT5f_Ewhfs6A" type="Abstraction_Edge" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_7M57YEvwEemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_I4JjY0vxEemT5f_Ewhfs6A" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ZnfZEEvyEemT5f_Ewhfs6A" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -2803,18 +2682,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_I4JjYUvxEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_I4JjYkvxEemT5f_Ewhfs6A" points="[1859, -260, -643984, -643984]$[2080, -260, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JsCecEvxEemT5f_Ewhfs6A" id="(1.0,0.39603960396039606)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JsCecEvxEemT5f_Ewhfs6A" id="(1.0,0.35398230088495575)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JsCecUvxEemT5f_Ewhfs6A" id="(0.0,0.4)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QPbS9EvxEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_I4JjYEvxEemT5f_Ewhfs6A" target="_QPbS8EvxEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QPbS9UvxEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPbS-UvxEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPbS9kvxEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPbS90vxEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPbS-EvxEemT5f_Ewhfs6A"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__DqVEEvxEemT5f_Ewhfs6A" type="Association_Edge" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_dOMqwEvWEemT5f_Ewhfs6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__DqVE0vxEemT5f_Ewhfs6A" type="Association_StereotypeLabel">
@@ -2844,7 +2713,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="__DqVEUvxEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__DqVEkvxEemT5f_Ewhfs6A" points="[1720, -200, -643984, -643984]$[1500, -200, -643984, -643984]$[1500, -100, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6M7gEvxEemT5f_Ewhfs6A" id="(0.0,0.594059405940594)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6M7gEvxEemT5f_Ewhfs6A" id="(0.0,0.5309734513274337)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6M7gUvxEemT5f_Ewhfs6A" id="(0.42704626334519574,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_DpB9sEvyEemT5f_Ewhfs6A" type="Association_Edge" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_Yvv6IUS5Eem_eeeaz1ENMQ" routing="Rectilinear">
@@ -2875,58 +2744,386 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_DpB9sUvyEemT5f_Ewhfs6A"/>
       <element xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DpB9skvyEemT5f_Ewhfs6A" points="[1799, -180, -643984, -643984]$[1940, -180, -643984, -643984]$[1940, 20, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgApAEvyEemT5f_Ewhfs6A" id="(1.0,0.7920792079207921)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgApAUvyEemT5f_Ewhfs6A" id="(0.6405693950177936,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgApAEvyEemT5f_Ewhfs6A" id="(1.0,0.7079646017699115)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgApAUvyEemT5f_Ewhfs6A" id="(0.6793650793650794,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Yp5vdEvyEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="__DqVEEvxEemT5f_Ewhfs6A" target="_Yp5vcEvyEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Yp5vdUvyEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yp5veUvyEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
+    <edges xmi:type="notation:Connector" xmi:id="_MccoQE2sEemQQPVBE79CWA" type="Abstraction_Edge" source="_4jT6oE2rEemQQPVBE79CWA" target="_Yvur1US5Eem_eeeaz1ENMQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MccoQ02sEemQQPVBE79CWA" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_QmiqIE2sEemQQPVBE79CWA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MccoRE2sEemQQPVBE79CWA" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_McdPUE2sEemQQPVBE79CWA" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Q55rAE2sEemQQPVBE79CWA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_McdPUU2sEemQQPVBE79CWA" x="21" y="-11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_MccoQU2sEemQQPVBE79CWA"/>
+      <element xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MccoQk2sEemQQPVBE79CWA" points="[2271, 1, -643984, -643984]$[2271, 65, -643984, -643984]$[2380, 65, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NDINwE2sEemQQPVBE79CWA" id="(0.6431924882629108,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NDINwU2sEemQQPVBE79CWA" id="(0.0,0.45)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Tt3yAE2tEemQQPVBE79CWA" type="Abstraction_Edge" source="_8PgDEE2sEemQQPVBE79CWA" target="_Yvs210S5Eem_eeeaz1ENMQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Tt3yA02tEemQQPVBE79CWA" type="Abstraction_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Tt3yBE2tEemQQPVBE79CWA" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Tt4ZEE2tEemQQPVBE79CWA" type="Abstraction_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Tt4ZEU2tEemQQPVBE79CWA" x="-36" y="-5"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Tt3yAU2tEemQQPVBE79CWA"/>
+      <element xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tt3yAk2tEemQQPVBE79CWA" points="[2125, 606, -643984, -643984]$[2380, 606, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVCfsE2tEemQQPVBE79CWA" id="(1.0,0.4098360655737705)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVCfsU2tEemQQPVBE79CWA" id="(0.0,0.46)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tTijJFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvs210S5Eem_eeeaz1ENMQ" target="_tTijIFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tTijJVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTijKVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Yp5vdkvyEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yp5vd0vyEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yp5veEvyEemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tTijJlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTijJ1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTijKFFnEemgMYGocegK5A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2a5TB0vyEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_DpB9sEvyEemT5f_Ewhfs6A" target="_2a5TA0vyEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2a5TCEvyEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2a56EEvyEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
+    <edges xmi:type="notation:Connector" xmi:id="_tTxztFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvuFIkS5Eem_eeeaz1ENMQ" target="_tTxzsFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tTxztVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTyawlFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2a5TCUvyEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2a5TCkvyEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2a5TC0vyEemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tTxztlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTyawFFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTyawVFnEemgMYGocegK5A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ImzCxEvzEemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_MMsq4ElgEemT5f_Ewhfs6A" target="_ImzCwEvzEemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ImzCxUvzEemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ImzCyUvzEemT5f_Ewhfs6A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
+    <edges xmi:type="notation:Connector" xmi:id="_tUYQpFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_tUYQoFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tUYQpVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tUYQqVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ImzCxkvzEemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ImzCx0vzEemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ImzCyEvzEemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tUYQplFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tUYQp1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tUYQqFFnEemgMYGocegK5A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bp8uJEv0EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_QbC-0ElZEemT5f_Ewhfs6A" target="_bp8uIEv0EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bp8uJUv0EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bp8uKUv0EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_tU-GhFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_tU-GgFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tU-GhVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tU-GiVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tU-GhlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tU-Gh1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tU-GiFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tWB2cFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvs2o0S5Eem_eeeaz1ENMQ" target="_tWBPYFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tWB2cVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWB2dVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tWB2clFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWB2c1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWB2dFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tWiMxFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_tWiMwFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tWiMxVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWiMyVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tWiMxlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWiMx1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWiMyFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tXKe5FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvtdsES5Eem_eeeaz1ENMQ" target="_tXKe4FFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tXKe5VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXKe6VFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tXKe5lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXKe51FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXKe6FFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tXTo1FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_QbC-0ElZEemT5f_Ewhfs6A" target="_tXTo0FFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tXTo1VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXUP4lFnEemgMYGocegK5A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bp8uJkv0EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bp8uJ0v0EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bp8uKEv0EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tXTo1lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXUP4FFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXUP4VFnEemgMYGocegK5A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_rMnf5Ev2EemT5f_Ewhfs6A" type="StereotypeCommentLink" source="_V8cGoElgEemT5f_Ewhfs6A" target="_rMnf4Ev2EemT5f_Ewhfs6A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_rMnf5Uv2EemT5f_Ewhfs6A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rMnf6Uv2EemT5f_Ewhfs6A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_tX0mNFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_tX0mMFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tX0mNVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tX0mOVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tX0mNlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tX0mN1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tX0mOFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tZYFZFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvteBES5Eem_eeeaz1ENMQ" target="_tZYFYFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tZYFZVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZYFaVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tZYFZlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZYFZ1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZYFaFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tZ6Q5FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_tZ6Q4FFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tZ6Q5VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZ638lFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tZ6Q5lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZ638FFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZ638VFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ta36NFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_ta36MFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ta36NVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ta36OVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ta36NlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ta36N1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ta36OFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tbrLdFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MMsq4ElgEemT5f_Ewhfs6A" target="_tbrLcFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tbrLdVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbrLeVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tbrLdlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbrLd1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbrLeFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tbwrBFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_V8cGoElgEemT5f_Ewhfs6A" target="_tbwrAFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tbwrBVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbwrCVFnEemgMYGocegK5A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rMnf5kv2EemT5f_Ewhfs6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rMnf50v2EemT5f_Ewhfs6A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rMnf6Ev2EemT5f_Ewhfs6A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tbwrBlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbwrB1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbwrCFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tb7DFFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_jqTmgEqtEemT5f_Ewhfs6A" target="_tb7DEFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tb7DFVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tb7DGVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tb7DFlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tb7DF1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tb7DGFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tcjVNFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_-KwtEEvDEemT5f_Ewhfs6A" target="_tcjVMFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tcjVNVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tcjVOVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tcjVNlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tcjVN1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tcjVOFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tdXNhFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_7n5SQEvEEemT5f_Ewhfs6A" target="_tdXNgFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tdXNhVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdXNiVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tdXNhlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdXNh1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdXNiFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tdwPFFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MawgkEvHEemT5f_Ewhfs6A" target="_tdwPEFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tdwPFVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdwPGVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tdwPFlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdwPF1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdwPGFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_teBU1FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_rjM_QEvHEemT5f_Ewhfs6A" target="_teBU0FFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_teBU1VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_teB74lFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_teBU1lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_teB74FFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_teB74VFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_telVhFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_6zavEEvJEemT5f_Ewhfs6A" target="_telVgFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_telVhVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tel8klFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_telVhlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tel8kFFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tel8kVFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tfD2oFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_9Zye8EvKEemT5f_Ewhfs6A" target="_tfDPkFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tfD2oVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfD2pVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tfD2olFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfD2o1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfD2pFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tfU8ZFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MSkREEvLEemT5f_Ewhfs6A" target="_tfU8YFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tfU8ZVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfU8aVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tfU8ZlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfU8Z1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfU8aFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tfmpNFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_iYsasEvLEemT5f_Ewhfs6A" target="_tfmpMFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tfmpNVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfmpOVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tfmpNlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfmpN1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfmpOFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tgZ6dFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_tgZ6cFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tgZ6dVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tgZ6eVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tgZ6dlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tgZ6d1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tgZ6eFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_th7kdFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_TTeRkEvXEemT5f_Ewhfs6A" target="_th7kcFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_th7kdVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_th7keVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_th7kdlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_th7kd1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_th7keFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tiGjlFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_WUpjkEvXEemT5f_Ewhfs6A" target="_tiGjkFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tiGjlVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiHKolFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tiGjllFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiHKoFFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiHKoVFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tiu1tFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_tiu1sFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tiu1tVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiu1uVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tiu1tlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiu1t1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiu1uFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tjj8JFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_I4JjYEvxEemT5f_Ewhfs6A" target="_tjj8IFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tjj8JVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjj8KVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tjj8JlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjj8J1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjj8KFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tjtGEFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="__DqVEEvxEemT5f_Ewhfs6A" target="_tjsfAFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tjtGEVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjtGFVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tjtGElFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjtGE1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjtGFFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tj3eJFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_DpB9sEvyEemT5f_Ewhfs6A" target="_tj3eIFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tj3eJVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tj3eKVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tj3eJlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tj3eJ1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tj3eKFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tkmd9FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_7M57YEvwEemT5f_Ewhfs6A" target="_tkmd8FFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tkmd9VFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tkmd-VFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tkmd9lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tkmd91FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tkmd-FFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tlZIJFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_4jT6oE2rEemQQPVBE79CWA" target="_tlZIIFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tlZIJVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlZIKVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tlZIJlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlZIJ1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlZIKFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tlyJsVFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MccoQE2sEemQQPVBE79CWA" target="_tlxioFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tlyJslFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlyJtlFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tlyJs1FnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlyJtFFnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlyJtVFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tmMZZFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_8PgDEE2sEemQQPVBE79CWA" target="_tmMZYFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tmMZZVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmMZaVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tmMZZlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmMZZ1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmMZaFFnEemgMYGocegK5A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tmiXpFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Tt3yAE2tEemQQPVBE79CWA" target="_tmiXoFFnEemgMYGocegK5A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tmiXpVFnEemgMYGocegK5A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmiXqVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tmiXplFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmiXp1FnEemgMYGocegK5A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmiXqFFnEemgMYGocegK5A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEquipment.uml
+++ b/UML/TapiEquipment.uml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenInterfaceModel_Profile="http:///schemas/OpenInterfaceModel_Profile/_3NKYsD78EeiIisB6uOvKFA/8" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_S30WUD8HEeiIisB6uOvKFA/26" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenInterfaceModel_Profile/_3NKYsD78EeiIisB6uOvKFA/8 UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_3NPRMD78EeiIisB6uOvKFA http:///schemas/OpenModel_Profile/_S30WUD8HEeiIisB6uOvKFA/26 UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_S32LgD8HEeiIisB6uOvKFA">
   <uml:Model xmi:id="_oGqilVLNEeO75dO39GbF8Q" name="TapiEquipment">
-    <packageImport xmi:type="uml:PackageImport" xmi:id="_8Q4ecKxrEeS5HuAudtqItw">
-      <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
-    </packageImport>
     <packagedElement xmi:type="uml:Package" xmi:id="_-M-CgEdVEeasL6dcjI1vEA" name="Associations">
       <packagedElement xmi:type="uml:Association" xmi:id="_ayCpID-NEeaRI-H69PghuA" name="EquipmentHasHolder" memberEnd="_ayDQMj-NEeaRI-H69PghuA _ayD3QD-NEeaRI-H69PghuA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ayDQMD-NEeaRI-H69PghuA" source="org.eclipse.papyrus">
@@ -20,16 +17,11 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oEvt8D-QEeaRI-H69PghuA" value="*"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_6B5aoC7BEemaZq0-6SfFXw" name="LinkSupportedByPhysicalSpan" memberEnd="_6B6BsS7BEemaZq0-6SfFXw _6B6BtS7BEemaZq0-6SfFXw" navigableOwnedEnd="_6B6BtS7BEemaZq0-6SfFXw">
+      <packagedElement xmi:type="uml:Association" xmi:id="_6B5aoC7BEemaZq0-6SfFXw" name="LinkSupportedByPhysicalSpan" memberEnd="_6B6BsS7BEemaZq0-6SfFXw _6B6BtS7BEemaZq0-6SfFXw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6B5aoS7BEemaZq0-6SfFXw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6B6BsC7BEemaZq0-6SfFXw" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_6B6BtS7BEemaZq0-6SfFXw" name="multiplestrandspan" type="_qCBY4FRMEeiyzdV8zVsJ_w" association="_6B5aoC7BEemaZq0-6SfFXw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9ONloC7BEemaZq0-6SfFXw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9OTFMC7BEemaZq0-6SfFXw" value="1"/>
-        </ownedEnd>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_6B6BsS7BEemaZq0-6SfFXw" name="link" association="_6B5aoC7BEemaZq0-6SfFXw">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_6B6BsS7BEemaZq0-6SfFXw" name="_link" type="_4jJikE2rEemQQPVBE79CWA" association="_6B5aoC7BEemaZq0-6SfFXw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6B6Bsy7BEemaZq0-6SfFXw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6B6BtC7BEemaZq0-6SfFXw" value="*"/>
         </ownedEnd>
@@ -43,16 +35,11 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xqRm4FRQEeiyzdV8zVsJ_w" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_Aw5ZcDlbEemDl_QGWIY6yg" name="NodeEdgepointAccessedViaAccessPort" memberEnd="_Aw5ZczlbEemDl_QGWIY6yg _Aw6nkTlbEemDl_QGWIY6yg" navigableOwnedEnd="_Aw6nkTlbEemDl_QGWIY6yg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_Aw5ZcDlbEemDl_QGWIY6yg" name="NodeEdgePointSupportedByAccessPort" memberEnd="_Aw5ZczlbEemDl_QGWIY6yg _Aw6nkTlbEemDl_QGWIY6yg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Aw5ZcTlbEemDl_QGWIY6yg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Aw5ZcjlbEemDl_QGWIY6yg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_Aw6nkTlbEemDl_QGWIY6yg" name="accessport" type="_8SXNpD-HEeaRI-H69PghuA" association="_Aw5ZcDlbEemDl_QGWIY6yg">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aYpaQDlcEemDl_QGWIY6yg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aYu50DlcEemDl_QGWIY6yg" value="1"/>
-        </ownedEnd>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_Aw5ZczlbEemDl_QGWIY6yg" name="nodeedgepoint" association="_Aw5ZcDlbEemDl_QGWIY6yg">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Aw5ZczlbEemDl_QGWIY6yg" name="_nodeEdgePoint" type="_8PYHQE2sEemQQPVBE79CWA" association="_Aw5ZcDlbEemDl_QGWIY6yg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Aw6AgTlbEemDl_QGWIY6yg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Aw6nkDlbEemDl_QGWIY6yg" value="*"/>
         </ownedEnd>
@@ -124,8 +111,14 @@
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_I4IVQEvxEemT5f_Ewhfs6A" name="AugmentsRootContext" client="_gO_jcEvwEemT5f_Ewhfs6A">
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_McPz8E2sEemQQPVBE79CWA" client="_4jJikE2rEemQQPVBE79CWA">
+        <supplier xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Tt0usE2tEemQQPVBE79CWA" client="_8PYHQE2sEemQQPVBE79CWA">
+        <supplier xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_mlzoUEdzEeasL6dcjI1vEA" name="DataTypes">
+    <packagedElement xmi:type="uml:Package" xmi:id="_mlzoUEdzEeasL6dcjI1vEA" name="TypeDefinitions">
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_y2WM8EQ-EeasL6dcjI1vEA" name="ConnectorAndPinOrientation">
         <ownedComment xmi:type="uml:Comment" xmi:id="_XtPSIGoQEeaBUOurxzA2sw" annotatedElement="_y2WM8EQ-EeasL6dcjI1vEA">
           <body>Most connector schemes are asymmetric such that there are two orientations of the connector where a mating is only possible between two connectors of different orientations. &#xD;
@@ -227,22 +220,22 @@ Where the whole connector is used, then individual Pins need not be identified.<
           <body>The equipment that is actually present in the physical network.&#xD;
 It will expose all dynamic properties and some critical static properties.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_1yD_8EvHEemT5f_Ewhfs6A" name="actualNonFieldReplaceableModule" type="_7n4rMEvEEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1yD_8EvHEemT5f_Ewhfs6A" name="actualNonFieldReplaceableModule" type="_7n4rMEvEEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cneKUEvIEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cnoiYEvIEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_5h3SgEvHEemT5f_Ewhfs6A" name="actualHolder" type="_MSjC8EvLEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5h3SgEvHEemT5f_Ewhfs6A" name="actualHolder" type="_MSjC8EvLEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6ZPJ8EvIEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6ZXs0EvIEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_8L2MgEvHEemT5f_Ewhfs6A" name="commonActualProperties" type="_jqSYYEqtEemT5f_Ewhfs6A"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AOW_sEvIEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8L2MgEvHEemT5f_Ewhfs6A" name="commonActualProperties" type="_jqSYYEqtEemT5f_Ewhfs6A" isReadOnly="true"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AOW_sEvIEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_MSjC8EvLEemT5f_Ewhfs6A" name="ActualHolder">
         <ownedComment xmi:type="uml:Comment" xmi:id="_WMSvQEvLEemT5f_Ewhfs6A" annotatedElement="_MSjC8EvLEemT5f_Ewhfs6A">
           <body>A holder in the ActualEquipment.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PY9k0EvMEemT5f_Ewhfs6A" name="commonHolderProperties" type="_iYrMkEvLEemT5f_Ewhfs6A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PY9k0EvMEemT5f_Ewhfs6A" name="commonHolderProperties" type="_iYrMkEvLEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_7n4rMEvEEemT5f_Ewhfs6A" name="ActualNonFieldReplaceableModule">
         <ownedComment xmi:type="uml:Comment" xmi:id="_FIoWwEvHEemT5f_Ewhfs6A" annotatedElement="_7n4rMEvEEemT5f_Ewhfs6A">
@@ -252,8 +245,8 @@ Does not have any exposed holders (any associated holders are assumed to belong 
 Does not have any connectors (any associated connectors are assumed to belong to the containing FRU).&#xD;
 </body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Jl-hQEvGEemT5f_Ewhfs6A" name="commonActualProperties" type="_jqSYYEqtEemT5f_Ewhfs6A"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_djFI4EvGEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Jl-hQEvGEemT5f_Ewhfs6A" name="commonActualProperties" type="_jqSYYEqtEemT5f_Ewhfs6A" isReadOnly="true"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_djFI4EvGEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_jqSYYEqtEemT5f_Ewhfs6A" name="CommonActualProperties">
         <ownedComment xmi:type="uml:Comment" xmi:id="_vaYMgEvEEemT5f_Ewhfs6A" annotatedElement="_jqSYYEqtEemT5f_Ewhfs6A">
@@ -385,21 +378,21 @@ Full details on the actual power system would be provided from a number of PC in
 The expected equipment will state the type and may constrain any other invariant properties. &#xD;
 It may also provide desired ranges for dynamic properties.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_5CPsYkvJEemT5f_Ewhfs6A" name="expectedNonFieldReplaceableModule" visibility="public" type="_LUh4UEvHEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5CPsYkvJEemT5f_Ewhfs6A" name="expectedNonFieldReplaceableModule" visibility="public" type="_LUh4UEvHEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CPsY0vJEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5CPsZEvJEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_5CPsZUvJEemT5f_Ewhfs6A" name="expectedHolder" type="_9Zx34EvKEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5CPsZUvJEemT5f_Ewhfs6A" name="expectedHolder" type="_9Zx34EvKEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CPsZkvJEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5CPsZ0vJEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_5CPsaUvJEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5CPsaUvJEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_9Zx34EvKEemT5f_Ewhfs6A" name="ExpectedHolder">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KoNBAEvLEemT5f_Ewhfs6A" annotatedElement="_9Zx34EvKEemT5f_Ewhfs6A">
           <body>A definition of a holder expected in the ActualEquipment (i.e. an ActualHolder) as part of the constraints provided by the ExpectedEquipment.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_h6N5gEvMEemT5f_Ewhfs6A" name="commonHolderProperties" type="_iYrMkEvLEemT5f_Ewhfs6A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_h6N5gEvMEemT5f_Ewhfs6A" name="commonHolderProperties" type="_iYrMkEvLEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_LUh4UEvHEemT5f_Ewhfs6A" name="ExpectedNonFieldReplaceableModule">
         <ownedComment xmi:type="uml:Comment" xmi:id="_LUifYEvHEemT5f_Ewhfs6A" annotatedElement="_LUh4UEvHEemT5f_Ewhfs6A">
@@ -409,7 +402,7 @@ Does not have any exposed holders (any associated holders are assumed to belong 
 Does not have any connectors (any associated connectors are assumed to belong to the containing FRU).&#xD;
 </body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_LUifYkvHEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LUifYkvHEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_NcVIoEdWEeasL6dcjI1vEA" name="Diagrams">
@@ -421,9 +414,6 @@ Does not have any connectors (any associated connectors are assumed to belong to
       </ownedComment>
       <ownedComment xmi:type="uml:Comment" xmi:id="_xtfggDmuEem1ZNpCEF2XWQ">
         <body>TAPI classes from other models</body>
-      </ownedComment>
-      <ownedComment xmi:type="uml:Comment" xmi:id="_ey96wDmvEem1ZNpCEF2XWQ" annotatedElement="_Aw5ZcDlbEemDl_QGWIY6yg _6B5aoC7BEemaZq0-6SfFXw">
-        <body>Red associations to be made navigable</body>
       </ownedComment>
       <ownedComment xmi:type="uml:Comment" xmi:id="_qAD58DneEem1ZNpCEF2XWQ">
         <body>Detailed Properties.</body>
@@ -439,7 +429,10 @@ Does not have any connectors (any associated connectors are assumed to belong to
 Can be either field replaceable or not field replaceable.&#xD;
 Note: The model is currently constrained to inside plant.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ayDQMj-NEeaRI-H69PghuA" name="_containedHolder" type="_8SXNjj-HEeaRI-H69PghuA" aggregation="composite" association="_ayCpID-NEeaRI-H69PghuA">
+        <generalization xmi:type="uml:Generalization" xmi:id="_1KFCkFFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ayDQMj-NEeaRI-H69PghuA" name="_containedHolder" type="_8SXNjj-HEeaRI-H69PghuA" isReadOnly="true" aggregation="composite" association="_ayCpID-NEeaRI-H69PghuA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_UJERkC7xEeexxefg2F1i1Q" annotatedElement="_ayDQMj-NEeaRI-H69PghuA">
             <body>References the Holder in an Equipment that is available to take other Equipments.&#xD;
 For example:&#xD;
@@ -449,25 +442,25 @@ For example:&#xD;
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_g2SqkD-NEeaRI-H69PghuA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_g2T4sD-NEeaRI-H69PghuA" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_gLJ28EQvEeasL6dcjI1vEA" name="category" type="_mMOBgEQvEeasL6dcjI1vEA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gLJ28EQvEeasL6dcjI1vEA" name="category" type="_mMOBgEQvEeasL6dcjI1vEA" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_m5rxEIMpEeePYJZQb-Dcag" annotatedElement="_gLJ28EQvEeasL6dcjI1vEA">
             <body>This attribute provides the identifier for the form of equipments regarded as having particular shared characteristics.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_RUXMYEQwEeasL6dcjI1vEA" name="equipmentLocation">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RUXMYEQwEeasL6dcjI1vEA" name="equipmentLocation" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_XOQ_AEQwEeasL6dcjI1vEA" name="geographicalLocation">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XOQ_AEQwEeasL6dcjI1vEA" name="geographicalLocation" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_D3ArkD9KEemsT7Uwjmld0w" name="isExpectedActualMismatch" visibility="public">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_D3ArkD9KEemsT7Uwjmld0w" name="isExpectedActualMismatch" visibility="public" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_EZB3EEvNEemT5f_Ewhfs6A" name="expectedEquipment" type="_5CPsYEvJEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EZB3EEvNEemT5f_Ewhfs6A" name="expectedEquipment" type="_5CPsYEvJEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fVNJoEvNEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fVW6oEvNEemT5f_Ewhfs6A" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_SWpBcEvNEemT5f_Ewhfs6A" name="actualEquipment" type="_rjMYMEvHEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_SWpBcEvNEemT5f_Ewhfs6A" name="actualEquipment" type="_rjMYMEvHEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d2S7oEvNEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d2cFkEvNEemT5f_Ewhfs6A" value="1"/>
         </ownedAttribute>
@@ -476,7 +469,10 @@ For example:&#xD;
         <ownedComment xmi:type="uml:Comment" xmi:id="_p_ujAFMPEeaDuo8VlVeg_g" annotatedElement="_8SXNjj-HEeaRI-H69PghuA">
           <body>Represents a space in an equipment in which another equipment can be fitted in the field.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_X1q3Qj-QEeaRI-H69PghuA" name="_occupyingFru" type="_8SXNej-HEeaRI-H69PghuA" aggregation="shared" association="_X1qQMD-QEeaRI-H69PghuA">
+        <generalization xmi:type="uml:Generalization" xmi:id="_60_-AFFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_X1q3Qj-QEeaRI-H69PghuA" name="_occupyingFru" type="_8SXNej-HEeaRI-H69PghuA" isReadOnly="true" aggregation="shared" association="_X1qQMD-QEeaRI-H69PghuA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_rR5jEFfREearRtXLY7gquw" annotatedElement="_X1q3Qj-QEeaRI-H69PghuA">
             <body>The FRU that is occupying the holder. &#xD;
 A holder may be unoccupied. &#xD;
@@ -485,11 +481,11 @@ An FRU may occupy more hat one holder (using or blocking are intentionally not d
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qmEbMD-QEeaRI-H69PghuA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qmFpUD-QEeaRI-H69PghuA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_vtnigEvNEemT5f_Ewhfs6A" name="expectedHolder" type="_9Zx34EvKEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vtnigEvNEemT5f_Ewhfs6A" name="expectedHolder" type="_9Zx34EvKEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4WD_AEvNEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4WOXEEvNEemT5f_Ewhfs6A" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-LKxMEvNEemT5f_Ewhfs6A" name="actualHolder" type="_MSjC8EvLEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-LKxMEvNEemT5f_Ewhfs6A" name="actualHolder" type="_MSjC8EvLEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ErbZMEvOEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Erit8EvOEemT5f_Ewhfs6A" value="1"/>
         </ownedAttribute>
@@ -499,7 +495,10 @@ An FRU may occupy more hat one holder (using or blocking are intentionally not d
           <body>A group of pins that together support a signal group where any one pin removed from the group will prevent all signals of the signal group from flowing successfully.&#xD;
 In some cases the AccessPort may simply reference a single connector (e.g., where the pin-connector association is simpe such that the AccessPort references all pinsof one connector).</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_LcVo0DmlEemDl_QGWIY6yg" name="connectorPin" type="_BB_mUDmkEemDl_QGWIY6yg">
+        <generalization xmi:type="uml:Generalization" xmi:id="__wF_AFFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LcVo0DmlEemDl_QGWIY6yg" name="connectorPin" type="_BB_mUDmkEemDl_QGWIY6yg" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Pe5nAElWEemT5f_Ewhfs6A" annotatedElement="_LcVo0DmlEemDl_QGWIY6yg">
             <body>The list of Pins that support the AccessPort.</body>
           </ownedComment>
@@ -513,11 +512,14 @@ In some cases the AccessPort may simply reference a single connector (e.g., wher
 The adjacency is supported by a group of strands between pins of the AccessPorts.&#xD;
 This is a physical abstraction.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_xJV5gVRPEeiyzdV8zVsJ_w" name="_accessPort" type="_8SXNpD-HEeaRI-H69PghuA" association="_xJVScFRPEeiyzdV8zVsJ_w">
+        <generalization xmi:type="uml:Generalization" xmi:id="_nlAUAFFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xJV5gVRPEeiyzdV8zVsJ_w" name="_accessPort" type="_8SXNpD-HEeaRI-H69PghuA" isReadOnly="true" association="_xJVScFRPEeiyzdV8zVsJ_w">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wFFKsFRQEeiyzdV8zVsJ_w" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wFGY0FRQEeiyzdV8zVsJ_w" value="2"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PshE4ElZEemT5f_Ewhfs6A" name="_strand" type="_ESEWoElgEemT5f_Ewhfs6A" aggregation="composite" association="_PsaXMElZEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PshE4ElZEemT5f_Ewhfs6A" name="_abstractStrand" type="_ESEWoElgEemT5f_Ewhfs6A" isReadOnly="true" aggregation="composite" association="_PsaXMElZEemT5f_Ewhfs6A">
           <ownedComment xmi:type="uml:Comment" xmi:id="_uuDXYElmEemT5f_Ewhfs6A" annotatedElement="_PshE4ElZEemT5f_Ewhfs6A">
             <body>Both the serial segments that form an end-end strand and the parallel end-end strands.</body>
           </ownedComment>
@@ -539,15 +541,18 @@ In this model a Strand:&#xD;
 - where a cable has more than two end each strand only goes between two of the ends&#xD;
 This model does NOT account for multiple copper strands being spliced.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ljmqk0lgEemT5f_Ewhfs6A" name="_adjacentStrand" type="_ESEWoElgEemT5f_Ewhfs6A" aggregation="shared" association="_LjmqkElgEemT5f_Ewhfs6A">
+        <generalization xmi:type="uml:Generalization" xmi:id="_pPrtIFFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ljmqk0lgEemT5f_Ewhfs6A" name="_adjacentStrand" type="_ESEWoElgEemT5f_Ewhfs6A" isReadOnly="true" aggregation="shared" association="_LjmqkElgEemT5f_Ewhfs6A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LjnRoElgEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LjnRoUlgEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_VSkDMElgEemT5f_Ewhfs6A" name="_splicedStrand" type="_ESEWoElgEemT5f_Ewhfs6A" association="_VSjcIElgEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VSkDMElgEemT5f_Ewhfs6A" name="_splicedStrand" type="_ESEWoElgEemT5f_Ewhfs6A" isReadOnly="true" association="_VSjcIElgEemT5f_Ewhfs6A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VSkDMklgEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VSkqQElgEemT5f_Ewhfs6A" value="2"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3a-T8ElVEemT5f_Ewhfs6A" name="connectorPin" visibility="public" type="_BB_mUDmkEemDl_QGWIY6yg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3a-T8ElVEemT5f_Ewhfs6A" name="connectorPin" visibility="public" type="_BB_mUDmkEemDl_QGWIY6yg" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Hu-RcElXEemT5f_Ewhfs6A" annotatedElement="_3a-T8ElVEemT5f_Ewhfs6A">
             <body>A strand can end on two or more Pins (usually 2 pins, but a strand my be spliced to split a signal). This model supports only 2 ended strands.&#xD;
 A abstract strand may be spliced at both ends and hence have no direct relationship to pins or may be connected to pins at one or both ends.&#xD;
@@ -558,7 +563,7 @@ In some cases it may not be relevant to represent the pin detail and hence the r
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3a-T8UlVEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3a-T8klVEemT5f_Ewhfs6A" value="2"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Z2xRYElkEemT5f_Ewhfs6A" name="strandMediaCharacteristics">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Z2xRYElkEemT5f_Ewhfs6A" name="strandMediaCharacteristics" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_nuf5YEvZEemT5f_Ewhfs6A" annotatedElement="_Z2xRYElkEemT5f_Ewhfs6A">
             <body>Relevant physical properties of the abstract strand.</body>
           </ownedComment>
@@ -571,25 +576,51 @@ In some cases it may not be relevant to represent the pin detail and hence the r
         <ownedComment xmi:type="uml:Comment" xmi:id="_mWrAQEvYEemT5f_Ewhfs6A" annotatedElement="_dOLcoEvWEemT5f_Ewhfs6A">
           <body>A logical grouping of Equipments and AccessPorts that are closely located and form a support a coherent system of related functions.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_S0xjYEvXEemT5f_Ewhfs6A" name="_equipment" type="_8SXNej-HEeaRI-H69PghuA" aggregation="composite" association="_S0vuMEvXEemT5f_Ewhfs6A">
+        <generalization xmi:type="uml:Generalization" xmi:id="_wvS5UFFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_S0xjYEvXEemT5f_Ewhfs6A" name="_equipment" type="_8SXNej-HEeaRI-H69PghuA" isReadOnly="true" aggregation="composite" association="_S0vuMEvXEemT5f_Ewhfs6A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_S0yKcEvXEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_S0yKcUvXEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_V19cckvXEemT5f_Ewhfs6A" name="_accessPort" type="_8SXNpD-HEeaRI-H69PghuA" aggregation="composite" association="_V181YEvXEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_V19cckvXEemT5f_Ewhfs6A" name="_accessPort" type="_8SXNpD-HEeaRI-H69PghuA" isReadOnly="true" aggregation="composite" association="_V181YEvXEemT5f_Ewhfs6A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_V1-DgEvXEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_V1-DgUvXEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_gO_jcEvwEemT5f_Ewhfs6A" name="TapiPhysicalContext">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-o7g4kvxEemT5f_Ewhfs6A" name="device" type="_dOLcoEvWEemT5f_Ewhfs6A" aggregation="composite" association="_-o6SwEvxEemT5f_Ewhfs6A">
+      <packagedElement xmi:type="uml:Class" xmi:id="_gO_jcEvwEemT5f_Ewhfs6A" name="PhysicalContext">
+        <generalization xmi:type="uml:Generalization" xmi:id="_x29E8FFcEemgMYGocegK5A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-o7g4kvxEemT5f_Ewhfs6A" name="_device" type="_dOLcoEvWEemT5f_Ewhfs6A" isReadOnly="true" aggregation="composite" association="_-o6SwEvxEemT5f_Ewhfs6A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-o8H8UvxEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-o8vAEvxEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_DN0oYkvyEemT5f_Ewhfs6A" name="physicalspan" type="_qCBY4FRMEeiyzdV8zVsJ_w" aggregation="composite" association="_DN0BUEvyEemT5f_Ewhfs6A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_DN0oYkvyEemT5f_Ewhfs6A" name="_physicalSpan" type="_qCBY4FRMEeiyzdV8zVsJ_w" isReadOnly="true" aggregation="composite" association="_DN0BUEvyEemT5f_Ewhfs6A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DN1PcUvyEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DN12gEvyEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_4jJikE2rEemQQPVBE79CWA" name="SupportingPhysicalSpan">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6B6BtS7BEemaZq0-6SfFXw" name="_physicalSpan" type="_qCBY4FRMEeiyzdV8zVsJ_w" association="_6B5aoC7BEemaZq0-6SfFXw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9ONloC7BEemaZq0-6SfFXw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9OTFMC7BEemaZq0-6SfFXw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_8PYHQE2sEemQQPVBE79CWA" name="SupportingAccessPort">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Aw6nkTlbEemDl_QGWIY6yg" name="_accessPort" type="_8SXNpD-HEeaRI-H69PghuA" association="_Aw5ZcDlbEemDl_QGWIY6yg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aYpaQDlcEemDl_QGWIY6yg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aYu50DlcEemDl_QGWIY6yg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_E6MfIE2pEemQQPVBE79CWA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_LnxxcE2pEemQQPVBE79CWA">
+        <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_LnyYgE2pEemQQPVBE79CWA">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_wICQ8B5XEem_sucP_HGUpA">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_wIEtMB5XEem_sucP_HGUpA" source="http://www.eclipse.org/uml2/2.0.0/UML">
@@ -671,7 +702,6 @@ In some cases it may not be relevant to represent the pin detail and hence the r
   <OpenModel_Profile:Mature xmi:id="_wyQm8C7uEeexxefg2F1i1Q" base_Element="_8SXNjj-HEeaRI-H69PghuA"/>
   <OpenModel_Profile:Mature xmi:id="_jxitMC7vEeexxefg2F1i1Q" base_Element="_X1qQMD-QEeaRI-H69PghuA"/>
   <OpenModel_Profile:Mature xmi:id="_puDu8C7vEeexxefg2F1i1Q" base_Element="_X1q3Qj-QEeaRI-H69PghuA"/>
-  <OpenModel_Profile:Mature xmi:id="_vLdLwC7vEeexxefg2F1i1Q" base_Element="_ayCpID-NEeaRI-H69PghuA"/>
   <OpenModel_Profile:Mature xmi:id="_xf8W4C7vEeexxefg2F1i1Q" base_Element="_ayDQMj-NEeaRI-H69PghuA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_qCBY4VRMEeiyzdV8zVsJ_w" base_Class="_qCBY4FRMEeiyzdV8zVsJ_w"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_xJV5glRPEeiyzdV8zVsJ_w" base_StructuralFeature="_xJV5gVRPEeiyzdV8zVsJ_w"/>
@@ -680,15 +710,14 @@ In some cases it may not be relevant to represent the pin detail and hence the r
   <OpenModel_Profile:Experimental xmi:id="_4R1wwFRQEeiyzdV8zVsJ_w" base_Element="_xJVScFRPEeiyzdV8zVsJ_w"/>
   <OpenModel_Profile:Experimental xmi:id="_0xh2QFRREeiyzdV8zVsJ_w" base_Element="_xJV5gVRPEeiyzdV8zVsJ_w"/>
   <OpenModel_Profile:OpenModelStatement xmi:id="_jMYQ4C7AEemaZq0-6SfFXw" base_Model="_oGqilVLNEeO75dO39GbF8Q"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_6B6Bsi7BEemaZq0-6SfFXw" base_StructuralFeature="_6B6BsS7BEemaZq0-6SfFXw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6B6owC7BEemaZq0-6SfFXw" base_StructuralFeature="_6B6BtS7BEemaZq0-6SfFXw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Aw6AgDlbEemDl_QGWIY6yg" base_StructuralFeature="_Aw5ZczlbEemDl_QGWIY6yg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Aw6nkjlbEemDl_QGWIY6yg" base_StructuralFeature="_Aw6nkTlbEemDl_QGWIY6yg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_D-nvgTmkEemDl_QGWIY6yg" base_StructuralFeature="_D-nvgDmkEemDl_QGWIY6yg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_VlGeATmkEemDl_QGWIY6yg" base_StructuralFeature="_VlGeADmkEemDl_QGWIY6yg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_D-nvgTmkEemDl_QGWIY6yg" base_StructuralFeature="_D-nvgDmkEemDl_QGWIY6yg" partOfObjectKey="2"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VlGeATmkEemDl_QGWIY6yg" base_StructuralFeature="_VlGeADmkEemDl_QGWIY6yg" partOfObjectKey="3"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_LcVo0TmlEemDl_QGWIY6yg" base_StructuralFeature="_LcVo0DmlEemDl_QGWIY6yg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_D3EV8D9KEemsT7Uwjmld0w" base_StructuralFeature="_D3ArkD9KEemsT7Uwjmld0w"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_y1arcT9MEemsT7Uwjmld0w" base_StructuralFeature="_y1arcD9MEemsT7Uwjmld0w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_y1arcT9MEemsT7Uwjmld0w" base_StructuralFeature="_y1arcD9MEemsT7Uwjmld0w" partOfObjectKey="1"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_3a-7AElVEemT5f_Ewhfs6A" base_StructuralFeature="_3a-T8ElVEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_CDDs8ElWEemT5f_Ewhfs6A" base_Element="_3a-T8ElVEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_PshE4UlZEemT5f_Ewhfs6A" base_StructuralFeature="_PshE4ElZEemT5f_Ewhfs6A"/>
@@ -759,11 +788,12 @@ In some cases it may not be relevant to represent the pin detail and hence the r
   <OpenModel_Profile:Experimental xmi:id="_KfPUcEvaEemT5f_Ewhfs6A" base_Element="_VlGeADmkEemDl_QGWIY6yg"/>
   <OpenModel_Profile:Experimental xmi:id="_UnWM4EvaEemT5f_Ewhfs6A" base_Element="_BB_mUDmkEemDl_QGWIY6yg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_gO_jcUvwEemT5f_Ewhfs6A" base_Class="_gO_jcEvwEemT5f_Ewhfs6A"/>
-  <OpenModel_Profile:Specify xmi:id="_P2AGUEvxEemT5f_Ewhfs6A" base_Abstraction="_I4IVQEvxEemT5f_Ewhfs6A"/>
+  <OpenModel_Profile:Specify xmi:id="_P2AGUEvxEemT5f_Ewhfs6A" base_Abstraction="_I4IVQEvxEemT5f_Ewhfs6A">
+    <target>/TapiCommon:TapiContext:_context</target>
+  </OpenModel_Profile:Specify>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fetgEvxEemT5f_Ewhfs6A" base_Property="_ayD3QD-NEeaRI-H69PghuA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fetgUvxEemT5f_Ewhfs6A" base_Property="_X1reUD-QEeaRI-H69PghuA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fetgkvxEemT5f_Ewhfs6A" base_Property="_6B6BtS7BEemaZq0-6SfFXw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fetg0vxEemT5f_Ewhfs6A" base_Property="_6B6BsS7BEemaZq0-6SfFXw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fethEvxEemT5f_Ewhfs6A" base_Property="_xJXHoFRPEeiyzdV8zVsJ_w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fethUvxEemT5f_Ewhfs6A" base_Property="_Aw6nkTlbEemDl_QGWIY6yg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2fethkvxEemT5f_Ewhfs6A" base_Property="_Aw5ZczlbEemDl_QGWIY6yg"/>
@@ -846,4 +876,22 @@ In some cases it may not be relevant to represent the pin detail and hence the r
   <OpenModel_Profile:Experimental xmi:id="_PLmMgEvzEemT5f_Ewhfs6A" base_Element="_VSkDMElgEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_bOJi8Ev0EemT5f_Ewhfs6A" base_Element="_PsaXMElZEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_qo_OYEv2EemT5f_Ewhfs6A" base_Element="_VSjcIElgEemT5f_Ewhfs6A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_wWu6wE2rEemQQPVBE79CWA" base_Property="_6B6BtS7BEemaZq0-6SfFXw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wWvh0E2rEemQQPVBE79CWA" base_StructuralFeature="_6B6BtS7BEemaZq0-6SfFXw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_4jLXwE2rEemQQPVBE79CWA" base_Class="_4jJikE2rEemQQPVBE79CWA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_4jL-0E2rEemQQPVBE79CWA" base_Class="_4jJikE2rEemQQPVBE79CWA"/>
+  <OpenModel_Profile:Specify xmi:id="_e_Om8E2sEemQQPVBE79CWA" base_Abstraction="_McPz8E2sEemQQPVBE79CWA">
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node</target>
+  </OpenModel_Profile:Specify>
+  <OpenModel_Profile:OpenModelClass xmi:id="_8PZVYE2sEemQQPVBE79CWA" base_Class="_8PYHQE2sEemQQPVBE79CWA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_8PZ8cE2sEemQQPVBE79CWA" base_Class="_8PYHQE2sEemQQPVBE79CWA"/>
+  <OpenModel_Profile:Specify xmi:id="_Xno44E2tEemQQPVBE79CWA" base_Abstraction="_Tt0usE2tEemQQPVBE79CWA">
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint</target>
+  </OpenModel_Profile:Specify>
+  <OpenModel_Profile:StrictComposite xmi:id="_WgS5AFFgEemgMYGocegK5A" base_Association="_DN0BUEvyEemT5f_Ewhfs6A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_YHrGgFFgEemgMYGocegK5A" base_Association="_-o6SwEvxEemT5f_Ewhfs6A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_aB9o8FFgEemgMYGocegK5A" base_Association="_PsaXMElZEemT5f_Ewhfs6A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_iNKv0FFgEemgMYGocegK5A" base_Association="_ayCpID-NEeaRI-H69PghuA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_-UAXUFFjEemgMYGocegK5A" base_Association="_S0vuMEvXEemT5f_Ewhfs6A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Auv7cFFkEemgMYGocegK5A" base_Association="_V181YEvXEemT5f_Ewhfs6A"/>
 </xmi:XMI>

--- a/YANG/tapi-equipment@2019-03-31.tree
+++ b/YANG/tapi-equipment@2019-03-31.tree
@@ -1,0 +1,142 @@
+
+module: tapi-equipment
+  augment /tapi-common:context:
+    +--rw physical-context
+       +--ro device* [uuid]
+       |  +--ro equipment* [uuid]
+       |  |  +--ro contained-holder* [uuid]
+       |  |  |  +--ro occupying-fru
+       |  |  |  |  +--ro device-uuid?      -> /tapi-common:context/tapi-equipment:physical-context/device/uuid
+       |  |  |  |  +--ro equipment-uuid?   -> /tapi-common:context/tapi-equipment:physical-context/device/equipment/uuid
+       |  |  |  +--ro expected-holder
+       |  |  |  |  +--ro common-holder-properties
+       |  |  |  |     +--ro holder-category?   holder-category
+       |  |  |  |     +--ro is-guided?         boolean
+       |  |  |  |     +--ro holder-location?   string
+       |  |  |  +--ro actual-holder
+       |  |  |  |  +--ro common-holder-properties
+       |  |  |  |     +--ro holder-category?   holder-category
+       |  |  |  |     +--ro is-guided?         boolean
+       |  |  |  |     +--ro holder-location?   string
+       |  |  |  +--ro uuid               uuid
+       |  |  |  +--ro name* [value-name]
+       |  |  |     +--ro value-name    string
+       |  |  |     +--ro value?        string
+       |  |  +--ro category?                      equipment-category
+       |  |  +--ro equipment-location?            string
+       |  |  +--ro geographical-location?         string
+       |  |  +--ro is-expected-actual-mismatch?   boolean
+       |  |  +--ro expected-equipment
+       |  |  |  +--ro expected-non-field-replaceable-module* []
+       |  |  |  |  +--ro common-equipment-properties
+       |  |  |  |     +--ro asset-type-identifier?        string
+       |  |  |  |     +--ro equipment-type-description?   string
+       |  |  |  |     +--ro equipment-type-identifier?    string
+       |  |  |  |     +--ro equipment-type-name?          string
+       |  |  |  |     +--ro equipment-type-version?       string
+       |  |  |  |     +--ro manufacturer-identifier?      string
+       |  |  |  |     +--ro manufacturer-name?            string
+       |  |  |  +--ro expected-holder* []
+       |  |  |  |  +--ro common-holder-properties
+       |  |  |  |     +--ro holder-category?   holder-category
+       |  |  |  |     +--ro is-guided?         boolean
+       |  |  |  |     +--ro holder-location?   string
+       |  |  |  +--ro common-equipment-properties
+       |  |  |     +--ro asset-type-identifier?        string
+       |  |  |     +--ro equipment-type-description?   string
+       |  |  |     +--ro equipment-type-identifier?    string
+       |  |  |     +--ro equipment-type-name?          string
+       |  |  |     +--ro equipment-type-version?       string
+       |  |  |     +--ro manufacturer-identifier?      string
+       |  |  |     +--ro manufacturer-name?            string
+       |  |  +--ro actual-equipment
+       |  |  |  +--ro actual-non-field-replaceable-module* []
+       |  |  |  |  +--ro common-actual-properties
+       |  |  |  |  |  +--ro asset-instance-identifier?   string
+       |  |  |  |  |  +--ro is-powered?                  boolean
+       |  |  |  |  |  +--ro manufacture-date?            tapi-common:date-and-time
+       |  |  |  |  |  +--ro serial-number?               string
+       |  |  |  |  |  +--ro temperature?                 decimal64
+       |  |  |  |  +--ro common-equipment-properties
+       |  |  |  |     +--ro asset-type-identifier?        string
+       |  |  |  |     +--ro equipment-type-description?   string
+       |  |  |  |     +--ro equipment-type-identifier?    string
+       |  |  |  |     +--ro equipment-type-name?          string
+       |  |  |  |     +--ro equipment-type-version?       string
+       |  |  |  |     +--ro manufacturer-identifier?      string
+       |  |  |  |     +--ro manufacturer-name?            string
+       |  |  |  +--ro actual-holder* []
+       |  |  |  |  +--ro common-holder-properties
+       |  |  |  |     +--ro holder-category?   holder-category
+       |  |  |  |     +--ro is-guided?         boolean
+       |  |  |  |     +--ro holder-location?   string
+       |  |  |  +--ro common-actual-properties
+       |  |  |  |  +--ro asset-instance-identifier?   string
+       |  |  |  |  +--ro is-powered?                  boolean
+       |  |  |  |  +--ro manufacture-date?            tapi-common:date-and-time
+       |  |  |  |  +--ro serial-number?               string
+       |  |  |  |  +--ro temperature?                 decimal64
+       |  |  |  +--ro common-equipment-properties
+       |  |  |     +--ro asset-type-identifier?        string
+       |  |  |     +--ro equipment-type-description?   string
+       |  |  |     +--ro equipment-type-identifier?    string
+       |  |  |     +--ro equipment-type-name?          string
+       |  |  |     +--ro equipment-type-version?       string
+       |  |  |     +--ro manufacturer-identifier?      string
+       |  |  |     +--ro manufacturer-name?            string
+       |  |  +--ro uuid                           uuid
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--ro access-port* [uuid]
+       |  |  +--ro connector-pin* [connector-identification pin-identification equipment-uuid]
+       |  |  |  +--ro connector-identification    string
+       |  |  |  +--ro pin-identification          string
+       |  |  |  +--ro equipment-uuid              tapi-common:uuid
+       |  |  +--ro uuid             uuid
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--ro uuid           uuid
+       |  +--ro name* [value-name]
+       |     +--ro value-name    string
+       |     +--ro value?        string
+       +--ro physical-span* [uuid]
+       |  +--ro access-port* [device-uuid access-port-uuid]
+       |  |  +--ro device-uuid         -> /tapi-common:context/tapi-equipment:physical-context/device/uuid
+       |  |  +--ro access-port-uuid    -> /tapi-common:context/tapi-equipment:physical-context/device/access-port/uuid
+       |  +--ro abstract-strand* [local-id]
+       |  |  +--ro adjacent-strand* [physical-span-uuid abstract-strand-local-id]
+       |  |  |  +--ro physical-span-uuid          -> /tapi-common:context/tapi-equipment:physical-context/physical-span/uuid
+       |  |  |  +--ro abstract-strand-local-id    -> /tapi-common:context/tapi-equipment:physical-context/physical-span/abstract-strand/local-id
+       |  |  +--ro spliced-strand* [physical-span-uuid abstract-strand-local-id]
+       |  |  |  +--ro physical-span-uuid          -> /tapi-common:context/tapi-equipment:physical-context/physical-span/uuid
+       |  |  |  +--ro abstract-strand-local-id    -> /tapi-common:context/tapi-equipment:physical-context/physical-span/abstract-strand/local-id
+       |  |  +--ro connector-pin* [connector-identification pin-identification equipment-uuid]
+       |  |  |  +--ro connector-identification    string
+       |  |  |  +--ro pin-identification          string
+       |  |  |  +--ro equipment-uuid              tapi-common:uuid
+       |  |  +--ro strand-media-characteristics* [value-name]
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro value?        string
+       |  |  +--ro local-id                        string
+       |  |  +--ro name* [value-name]
+       |  |     +--ro value-name    string
+       |  |     +--ro value?        string
+       |  +--ro uuid               uuid
+       |  +--ro name* [value-name]
+       |     +--ro value-name    string
+       |     +--ro value?        string
+       +--rw uuid?            uuid
+       +--rw name* [value-name]
+          +--rw value-name    string
+          +--rw value?        string
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node:
+    +--ro supporting-physical-span
+       +--ro physical-span
+          +--ro physical-span-uuid?   -> /tapi-common:context/tapi-equipment:physical-context/physical-span/uuid
+  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point:
+    +--ro supporting-access-port
+       +--ro access-port
+          +--ro device-uuid?        -> /tapi-common:context/tapi-equipment:physical-context/device/uuid
+          +--ro access-port-uuid?   -> /tapi-common:context/tapi-equipment:physical-context/device/access-port/uuid

--- a/YANG/tapi-equipment@2019-03-31.yang
+++ b/YANG/tapi-equipment@2019-03-31.yang
@@ -1,0 +1,593 @@
+module tapi-equipment {
+    namespace "urn:onf:otcc:yang:tapi-equipment";
+    prefix tapi-equipment;
+    import tapi-common {
+        prefix tapi-common;
+    }
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    organization "ONF OTCC (Open Transport Configuration & Control) Project";
+    contact "
+         Project Web: <https://wiki.opennetworking.org/display/OTCC/TAPI>
+         Project List: <mailto:transport-api@opennetworking.org>
+         Editor: Karthik Sethuraman
+                 <mailto:karthik.sethuraman@necam.com>";
+    description "
+        - The TAPI YANG models included in this TAPI release are a *normative* part of the TAPI SDK.
+        - The YANG specifications have been generated from the corresponding UML model using the [ONF EAGLE UML2YANG mapping tool]
+        <https://github.com/OpenNetworkingFoundation/EagleUmlYang>
+        and further edited manually to comply with the [ONF IISOMI UML2YANG mapping guidelines]
+        <https://wiki.opennetworking.org/display/OIMT/UML+-+YANG+Guidelines>
+        - Status of YANG model artifacts can be determined by referring to the corresponding UML artifacts.
+        As described in the UML models, some artifacts are considered *experimental*, and thus the corresponding YANG artifacts.
+        - The ONF TAPI release process does not guarantee backward compatibility of YANG models across major versions of TAPI releases.
+        The YANG model backward compatibility criteria are outlined in section 11 of <https://tools.ietf.org/html/rfc7950>.
+        YANG models included in this release may not be backward compatible with previous TAPI releases.";
+    revision 2019-03-31 {
+        description "ONF Transport API version 2.2-RC1.
+                   Changes included in this TAPI release (v2.2) are listed in
+                  <https://github.com/OpenNetworkingFoundation/TAPI/blob/develop/CHANGE_LOG/change-log.2.2.md>";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 7950, RFC 6087 and ONF TAPI UML model
+                  <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.2.0/UML>";
+    }
+    revision 2018-12-10 {
+        description "ONF Transport API version 2.1.1.
+                   Changes included in this TAPI release (v2.1.1) are listed in
+                  <https://github.com/OpenNetworkingFoundation/TAPI/blob/develop/CHANGE_LOG/change-log.2.1.1.md>";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 7950, RFC 6087 and ONF TAPI UML model
+                  <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.1.1/UML>";
+    }
+    revision 2018-10-16 {
+        description "ONF Transport API version 2.1.0.
+                   Changes included in this TAPI release (v2.1.0) are listed in
+                  <https://github.com/OpenNetworkingFoundation/TAPI/blob/develop/CHANGE_LOG/change-log.2.1.0.md>";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 7950, RFC 6087 and ONF TAPI UML model
+                  <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.1.0/UML>";
+    }
+    revision 2018-03-07 {
+        description "ONF Transport API version 2.0.2
+        This YANG module has been generated from the TAPI UML Model using the IISOMI-Eagle xmi2yang mapping tool.
+        Changes in this revision: <https://github.com/OpenNetworkingFoundation/TAPI/blob/develop/CHANGE_LOG/change-log.2.0.2.md>";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
+                  <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.2/UML>";
+    }
+    revision 2018-02-16 {
+        description "ONF Transport API version 2.0.1
+        This YANG module has been generated from the TAPI UML Model using the IISOMI-Eagle xmi2yang mapping tool.
+        Changes in this revision: <https://github.com/OpenNetworkingFoundation/TAPI/blob/develop/CHANGE_LOG/change-log.2.0.1.md>";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
+                  <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.1/UML>";
+    }
+    revision 2018-01-02 {
+        description "ONF Transport API version 2.0.0
+        This YANG module has been generated from the TAPI UML Model using the IISOMI-Eagle xmi2yang mapping tool.
+        Changes in this revision: <https://github.com/OpenNetworkingFoundation/TAPI/blob/develop/CHANGE_LOG/change-log.2.0.0.md>";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
+                  <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
+    }
+    augment "/tapi-common:context" {
+        container physical-context {
+            uses physical-context;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node" {
+        container supporting-physical-span {
+            uses supporting-physical-span;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point" {
+        container supporting-access-port {
+            uses supporting-access-port;
+            description "none";
+        }
+        description "none";
+    }
+    /**************************
+    * definitions of references
+    **************************/
+    grouping device-ref {
+        leaf device-uuid {
+        	type leafref {
+                path '/tapi-common:context/tapi-equipment:physical-context/tapi-equipment:device/tapi-equipment:uuid';
+            }
+            description "none";
+        }
+        description "none";
+    }
+    grouping equipment-ref {
+    	uses device-ref;
+        leaf equipment-uuid {
+        	type leafref {
+                path '/tapi-common:context/tapi-equipment:physical-context/tapi-equipment:device/tapi-equipment:equipment/tapi-equipment:uuid';
+            }
+            description "none";
+        }
+        description "none";
+    }
+    grouping equipment-holder-ref {
+    	uses equipment-ref;
+        leaf equipment-holder-uuid {
+        	type leafref {
+                path '/tapi-common:context/tapi-equipment:physical-context/tapi-equipment:device/tapi-equipment:equipment/tapi-equipment:contained-holder/tapi-equipment:uuid';
+            }
+            description "none";
+        }
+        description "none";
+    }
+    grouping access-port-ref {
+    	uses device-ref;
+        leaf access-port-uuid {
+        	type leafref {
+                path '/tapi-common:context/tapi-equipment:physical-context/tapi-equipment:device/tapi-equipment:access-port/tapi-equipment:uuid';
+            }
+            description "none";
+        }
+        description "none";
+    }
+    grouping physical-span-ref {
+        leaf physical-span-uuid {
+        	type leafref {
+                path '/tapi-common:context/tapi-equipment:physical-context/tapi-equipment:physical-span/tapi-equipment:uuid';
+            }
+            description "none";
+        }
+        description "none";
+    }
+    grouping abstract-strand-ref {
+    	uses physical-span-ref;
+        leaf abstract-strand-local-id {
+        	type leafref {
+                path '/tapi-common:context/tapi-equipment:physical-context/tapi-equipment:physical-span/tapi-equipment:abstract-strand/tapi-equipment:local-id';
+            }
+            description "none";
+        }
+        description "none";
+    }
+    /**************************
+    * package type-definitions
+    **************************/ 
+    identity CONNECTOR_AND_PIN_ORIENTATION {
+        description "none";
+    }
+    identity CONNECTOR_AND_PIN_ORIENTATION_MALE {
+        base CONNECTOR_AND_PIN_ORIENTATION;
+        description "The connecting elements are dominantly protrusions.";
+    }
+    identity CONNECTOR_AND_PIN_ORIENTATION_FEMALE {
+        base CONNECTOR_AND_PIN_ORIENTATION;
+        description "The connecting elements are dominantly indentations.";
+    }
+    identity CONNECTOR_AND_PIN_ORIENTATION_SYMMETRIC_NEUTRAL {
+        base CONNECTOR_AND_PIN_ORIENTATION;
+        description "The pin (and housing) orientation combination is such that it is symmetric so a connector is compatible with itself.
+            The connecting element may be a surface rather than protrusions or indentations.";
+    }
+    identity EQUIPMENT_CATEGORY {
+        description "none";
+    }
+    identity EQUIPMENT_CATEGORY_SUBRACK {
+        base EQUIPMENT_CATEGORY;
+        description "An assembly with holders designed to accommodate CIRCUIT_PACKs. 
+            The assembly is designed to be mounted in a RACK.";
+    }
+    identity EQUIPMENT_CATEGORY_CIRCUIT_PACK {
+        base EQUIPMENT_CATEGORY;
+        description "An assembly with connectors compatible with those in a holder.
+            The assembly is designed to be mounted in a holder (SLOT) of a SUBRACK.
+            May also support holders (SLOTs) for SMALL_FORMFACTOR_PLUGGABLEs.";
+    }
+    identity EQUIPMENT_CATEGORY_SMALL_FORMFACTOR_PLUGGABLE {
+        base EQUIPMENT_CATEGORY;
+        description "A small assembly (compared to a CIRCUIT_PACK) with connectors compatible with those in a holder.
+            The assembly is designed to be mounted in a holder (SLOT) of a CIRCUIT_PACK or STAND_ALONE_UNIT.";
+    }
+    identity EQUIPMENT_CATEGORY_STAND_ALONE_UNIT {
+        base EQUIPMENT_CATEGORY;
+        description "An assembly with connectors for cabling and potentially with holders.
+            The assembly is designed to be mounted in a freeform environment (on a table or simple mechanical cabinet).
+            May support holders (SLOTs) for CIRCUIT_PACKs or for SMALL_FORMFACTOR_PLUGGABLEs.";
+    }
+    identity EQUIPMENT_CATEGORY_RACK {
+        base EQUIPMENT_CATEGORY;
+        description "A mechanical assembly with cabling and predefined mounting points for particular SUBRACK types.
+            The assembly is designed to be mounted on the floor in a row with other RACKs.";
+    }
+    identity HOLDER_CATEGORY {
+        description "none";
+    }
+    identity HOLDER_CATEGORY_SLOT {
+        base HOLDER_CATEGORY;
+        description "A guided holder with fixed connectors.
+            The guided holder is designed to take a particular form of CIRCUIT_PACK or SMALL_FORMFACTOR_PLUGGABLE";
+    }
+    typedef connector-and-pin-orientation {
+        type identityref {
+            base CONNECTOR_AND_PIN_ORIENTATION;
+        }
+        description "Most connector schemes are asymmetric such that there are two orientations of the connector where a mating is only possible between two connectors of different orientations. 
+            A multi-pin connector may have a mix of pin orientations. In this case, it is expected that the dominant orientation of pin is chosen for the connector orientation.";
+    }
+    typedef equipment-category {
+        type identityref {
+            base EQUIPMENT_CATEGORY;
+        }
+        description "The form of equipment.";
+    }
+    typedef holder-category {
+        type identityref {
+            base HOLDER_CATEGORY;
+        }
+        description "The form of holder.";
+    }
+    grouping connector-pin-address {
+        leaf connector-identification {
+            type string;
+            description "Identification of the Connector in the conetxt of the referenced Equipment.";
+        }
+        leaf pin-identification {
+            type string;
+            description "Where relevant, identification of the Pin in the contect of the connector.
+                Where the whole connector is used, then individual Pins need not be identified.";
+        }
+        leaf equipment-uuid {
+            type tapi-common:uuid;
+            description "Reference to the Equipment that is fitted with the Connector/Pin.";
+        }
+        description "The identification of the location of the Connector and/or Pin.";
+    }
+    grouping actual-equipment {
+        list actual-non-field-replaceable-module {
+            config false;
+            uses actual-non-field-replaceable-module;
+            description "none";
+        }
+        list actual-holder {
+            config false;
+            uses actual-holder;
+            description "none";
+        }
+        container common-actual-properties {
+            config false;
+            uses common-actual-properties;
+            description "none";
+        }
+        container common-equipment-properties {
+            config false;
+            uses common-equipment-properties;
+            description "none";
+        }
+        description "The equipment that is actually present in the physical network.
+            It will expose all dynamic properties and some critical static properties.";
+    }
+    grouping actual-holder {
+        container common-holder-properties {
+            config false;
+            uses common-holder-properties;
+            description "none";
+        }
+        description "A holder in the ActualEquipment.";
+    }
+    grouping actual-non-field-replaceable-module {
+        container common-actual-properties {
+            config false;
+            uses common-actual-properties;
+            description "none";
+        }
+        container common-equipment-properties {
+            config false;
+            uses common-equipment-properties;
+            description "none";
+        }
+        description "A structure that represents an actual equipment that cannot be replaced in the field.
+            Is simply a subordinate part of an ActualEquipment (FRU). 
+            Does not have any exposed holders (any associated holders are assumed to belong to the containing FRU).
+            Does not have any connectors (any associated connectors are assumed to belong to the containing FRU).
+            ";
+    }
+    grouping common-actual-properties {
+        leaf asset-instance-identifier {
+            type string;
+            description "This attribute represents the asset identifier of this instance from the manufacturer's perspective.";
+        }
+        leaf is-powered {
+            type boolean;
+            description "The state of the power being supplied to the equipment.
+                Note that this attribute summarizes the power state. 
+                Full details on the actual power system would be provided from a number of PC instances representing the relevant parts of the Power function (e.g. different voltage supplies).";
+        }
+        leaf manufacture-date {
+            type tapi-common:date-and-time;
+            description "This attribute represents the date on which this instance is manufactured.";
+        }
+        leaf serial-number {
+            type string;
+            description "This attribute represents the serial number of this instance.";
+        }
+        leaf temperature {
+            type decimal64 {
+                fraction-digits 7;
+            }
+            description "The measured temperature of the Equipment.";
+        }
+        description "Properties common to actual Equipment.";
+    }
+    grouping common-equipment-properties {
+        leaf asset-type-identifier {
+            type string;
+            description "Represents the invariant properties of the equipment asset allocated by the operator that define and characterize the type.";
+        }
+        leaf equipment-type-description {
+            type string;
+            description "Text describing the type of Equipment.";
+        }
+        leaf equipment-type-identifier {
+            type string;
+            description "This attribute identifies the part type of the equipment.";
+        }
+        leaf equipment-type-name {
+            type string;
+            description "This attribute identifies the type of the equipment.";
+        }
+        leaf equipment-type-version {
+            type string;
+            description "This attribute identifies the version of the equipment.";
+        }
+        leaf manufacturer-identifier {
+            type string;
+            description "The formal unique identifier of the manufacturer.";
+        }
+        leaf manufacturer-name {
+            type string;
+            description "The formal name of the manufacturer of the Equipment.";
+        }
+        description "Properties common to all aspects of Equipment.";
+    }
+    grouping common-holder-properties {
+        leaf holder-category {
+            type holder-category;
+            description "The type of holder.";
+        }
+        leaf is-guided {
+            type boolean;
+            description "This attribute indicates whether the holder has guides that constrain the position of the equipment in the holder or not.";
+        }
+        leaf holder-location {
+            type string;
+            description "The relative position of the holder in the context of its containing equipment along with the position of that containing Equipment (and further recursion).";
+        }
+        description "Properties common to all aspects of Holder.";
+    }
+    grouping expected-equipment {
+        list expected-non-field-replaceable-module {
+            config false;
+            uses expected-non-field-replaceable-module;
+            description "none";
+        }
+        list expected-holder {
+            config false;
+            uses expected-holder;
+            description "none";
+        }
+        container common-equipment-properties {
+            config false;
+            uses common-equipment-properties;
+            description "none";
+        }
+        description "A definition of the restrictions on the equipment that is expected to be present in the physical network at a particular 'place'.
+            The expected equipment will state the type and may constrain any other invariant properties. 
+            It may also provide desired ranges for dynamic properties.";
+    }
+    grouping expected-holder {
+        container common-holder-properties {
+            config false;
+            uses common-holder-properties;
+            description "none";
+        }
+        description "A definition of a holder expected in the ActualEquipment (i.e. an ActualHolder) as part of the constraints provided by the ExpectedEquipment.";
+    }
+    grouping expected-non-field-replaceable-module {
+        container common-equipment-properties {
+            config false;
+            uses common-equipment-properties;
+            description "none";
+        }
+        description "A structure that represents an expected equipment that cannot be replaced in the field.
+            Is simply a subordinate part of an ExpectedEquipment (FRU). 
+            Does not have any exposed holders (any associated holders are assumed to belong to the containing FRU).
+            Does not have any connectors (any associated connectors are assumed to belong to the containing FRU).
+            ";
+    }
+
+    /**************************
+    * package object-classes
+    **************************/ 
+    grouping equipment {
+        list contained-holder {
+            key 'uuid';
+            config false;
+            uses holder;
+            description "References the Holder in an Equipment that is available to take other Equipments.
+                For example:
+                - Slot in a sub-rack
+                - Slot in a Field Replaceable Unit that can take a small form-factor pluggable.";
+        }
+        leaf category {
+            type equipment-category;
+            config false;
+            description "This attribute provides the identifier for the form of equipments regarded as having particular shared characteristics.";
+        }
+        leaf equipment-location {
+            type string;
+            config false;
+            description "none";
+        }
+        leaf geographical-location {
+            type string;
+            config false;
+            description "none";
+        }
+        leaf is-expected-actual-mismatch {
+            type boolean;
+            config false;
+            description "none";
+        }
+        container expected-equipment {
+            config false;
+            uses expected-equipment;
+            description "none";
+        }
+        container actual-equipment {
+            config false;
+            uses actual-equipment;
+            description "none";
+        }
+        uses tapi-common:global-class;
+        description "Represents any relevant physical thing. 
+            Can be either field replaceable or not field replaceable.
+            Note: The model is currently constrained to inside plant.";
+    }
+    grouping holder {
+        container occupying-fru {
+            uses equipment-ref;
+            description "The FRU that is occupying the holder. 
+                A holder may be unoccupied. 
+                An FRU may occupy more hat one holder (using or blocking are intentionally not distinguished here).";
+        }
+        container expected-holder {
+            config false;
+            uses expected-holder;
+            description "none";
+        }
+        container actual-holder {
+            config false;
+            uses actual-holder;
+            description "none";
+        }
+        uses tapi-common:global-class;
+        description "Represents a space in an equipment in which another equipment can be fitted in the field.";
+    }
+    grouping access-port {
+        list connector-pin {
+            key 'connector-identification pin-identification equipment-uuid';
+            config false;
+            min-elements 1;
+            uses connector-pin-address;
+            description "The list of Pins that support the AccessPort.";
+        }
+        uses tapi-common:global-class;
+        description "A group of pins that together support a signal group where any one pin removed from the group will prevent all signals of the signal group from flowing successfully.
+            In some cases the AccessPort may simply reference a single connector (e.g., where the pin-connector association is simpe such that the AccessPort references all pinsof one connector).";
+    }
+    grouping physical-span {
+        list access-port {
+            uses access-port-ref;
+            key "device-uuid access-port-uuid";
+            min-elements 2;
+            max-elements 2;
+            description "none";
+        }
+        list abstract-strand {
+            key 'local-id';
+            config false;
+            min-elements 1;
+            uses abstract-strand;
+            description "Both the serial segments that form an end-end strand and the parallel end-end strands.";
+        }
+        uses tapi-common:global-class;
+        description "An adjacency between AccessPorts. 
+            The adjacency is supported by a group of strands between pins of the AccessPorts.
+            This is a physical abstraction.";
+    }
+    grouping abstract-strand {
+        list adjacent-strand {
+        	uses abstract-strand-ref;
+        	key "physical-span-uuid abstract-strand-local-id";
+            description "none";
+        }
+        list spliced-strand {
+        	uses abstract-strand-ref;
+        	key "physical-span-uuid abstract-strand-local-id";
+            max-elements 2;
+            description "none";
+        }
+        list connector-pin {
+            key 'connector-identification pin-identification equipment-uuid';
+            config false;
+            max-elements 2;
+            uses connector-pin-address;
+            description "A strand can end on two or more Pins (usually 2 pins, but a strand my be spliced to split a signal). This model supports only 2 ended strands.
+                A abstract strand may be spliced at both ends and hence have no direct relationship to pins or may be connected to pins at one or both ends.
+                In the essential model these Pins would be on connectors that plug in to connectors on Equipments.
+                The AbstractStrand is extended to the pins of the AccessPort which are the Pins on the Connectors of the Equipment.
+                In some cases it may not be relevant to represent the pin detail and hence the reference is to a connector alone.";
+        }
+        list strand-media-characteristics {
+            key 'value-name';
+            config false;
+            uses tapi-common:name-and-value;
+            description "Relevant physical properties of the abstract strand.";
+        }
+        uses tapi-common:local-class;
+        description "This object represents an abstraction of one or more strands in series that provides sufficient detail to enable appropriate engineering.
+            A strand represents a continuous long, thin piece of a medium such as glass fiber or copper wire.
+            In this model a Strand:
+            - a strand has two ends
+            - a splice can only be between 2 strands.
+            - the end of a strand may have a splice, a connector or be hidden
+            - only one end can be hidden in an equipment
+            - where a cable has more than two end each strand only goes between two of the ends
+            This model does NOT account for multiple copper strands being spliced.";
+    }
+    grouping device {
+        list equipment {
+            key 'uuid';
+            config false;
+            uses equipment;
+            description "none";
+        }
+        list access-port {
+            key 'uuid';
+            config false;
+            uses access-port;
+            description "none";
+        }
+        uses tapi-common:global-class;
+        description "A logical grouping of Equipments and AccessPorts that are closely located and form a support a coherent system of related functions.";
+    }
+    grouping physical-context {
+        list device {
+            key 'uuid';
+            config false;
+            uses device;
+            description "none";
+        }
+        list physical-span {
+            key 'uuid';
+            config false;
+            uses physical-span;
+            description "none";
+        }
+        uses tapi-common:global-class;
+        description "none";
+    }
+    grouping supporting-physical-span {
+        container physical-span {
+            uses physical-span-ref;
+            description "none";
+        }
+        description "none";
+    }
+    grouping supporting-access-port {
+        container access-port {
+            uses access-port-ref;
+            description "none";
+        }
+        description "none";
+    }
+
+}


### PR DESCRIPTION
Main Changes to UML include
- adding Global/Local class as parent to all TapiEqpt classes
- specifying partOfObjectKey values
- specifying <StrictComposite> stereotypes
- specifying isReadOnly=true
- adding Augment classes for supporting PysicalSpan & AccessPort