### PR TITLE
Photonic Power Model: Uml updates to align with committed Yang

### DIFF
--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -497,125 +497,125 @@
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCyqQcG-EeiAg83ctgK3eQ" x="279" y="145"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J0CREPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J0CREfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0CRE_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PwXacFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PwXacVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PwYBgFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J0CREvKSEeiTnqcAgKK24Q" x="422" y="25"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PwXaclJqEemV99d_1db7sQ" x="422" y="25"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J0VzEPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J0VzEfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0VzE_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Pwv08FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Pwv08VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pwv081JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J0VzEvKSEeiTnqcAgKK24Q" x="517" y="291"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pwv08lJqEemV99d_1db7sQ" x="517" y="291"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J0gLIPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J0gLIfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0gLI_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Pw8CMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Pw8CMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pw8CM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J0gLIvKSEeiTnqcAgKK24Q" x="664" y="279"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pw8CMlJqEemV99d_1db7sQ" x="664" y="279"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J0qjMPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J0qjMfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0qjM_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PxIPcFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PxIPcVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxIPc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J0qjMvKSEeiTnqcAgKK24Q" x="941" y="159"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxIPclJqEemV99d_1db7sQ" x="941" y="159"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J007QPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J007QfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J007Q_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PxT1oFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PxT1oVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxT1o1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J007QvKSEeiTnqcAgKK24Q" x="1017" y="19"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxT1olJqEemV99d_1db7sQ" x="1017" y="19"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J1H2MPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J1H2MfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1H2M_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PxnXoFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PxnXoVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxnXo1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J1H2MvKSEeiTnqcAgKK24Q" x="257" y="485"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxnXolJqEemV99d_1db7sQ" x="257" y="485"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J1SOQPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J1SOQfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1SOQ_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PxxvsFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PxxvsVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pxxvs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J1SOQvKSEeiTnqcAgKK24Q" x="707" y="21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxxvslJqEemV99d_1db7sQ" x="707" y="21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J1paoPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J1paofKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1pao_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PyN0kFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PyN0kVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyN0k1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J1paovKSEeiTnqcAgKK24Q" x="1156" y="163"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PyN0klJqEemV99d_1db7sQ" x="1156" y="163"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J10ZwPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J10ZwfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J10Zw_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PydsMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PydsMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PydsM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J10ZwvKSEeiTnqcAgKK24Q" x="601" y="494"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PydsMlJqEemV99d_1db7sQ" x="601" y="494"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J1-x0PKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J1-x0fKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1-x0_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PyoEQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PyoEQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyorUFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J1-x0vKSEeiTnqcAgKK24Q" x="252" y="34"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PyoEQlJqEemV99d_1db7sQ" x="252" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J2JJ4PKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J2JJ4fKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2JJ4_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PyzDYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PyzDYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyzDY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J2JJ4vKSEeiTnqcAgKK24Q" x="249" y="214"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PyzDYlJqEemV99d_1db7sQ" x="249" y="214"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J2P3kPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J2P3kfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2P3k_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Py5xEFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Py5xEVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Py5xE1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J2P3kvKSEeiTnqcAgKK24Q" x="249" y="114"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Py5xElJqEemV99d_1db7sQ" x="249" y="114"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J2YacPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J2YacfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2Yac_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PzCT8FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PzCT8VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzCT81JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J2YacvKSEeiTnqcAgKK24Q" x="727" y="494"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzCT8lJqEemV99d_1db7sQ" x="727" y="494"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J2iygPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J2iygfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2iyg_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PzNTEFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PzNTEVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzNTE1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J2iygvKSEeiTnqcAgKK24Q" x="968" y="492"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzNTElJqEemV99d_1db7sQ" x="968" y="492"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_J2tKkPKSEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_J2tKkfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2tKk_KSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_PzXrIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_PzXrIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzXrI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J2tKkvKSEeiTnqcAgKK24Q" x="479" y="145"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzXrIlJqEemV99d_1db7sQ" x="479" y="145"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_w3tFAY6QEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_w3tFAo6QEeeyZasfnNSonw"/>
@@ -646,155 +646,155 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMIoJEeivCevppATXng" id="(0.5294117647058824,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMYoJEeivCevppATXng" id="(0.4866666666666667,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J0CRFPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_J0CREPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J0CRFfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0CRGfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PwYBgVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_PwXacFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PwYBglJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PwYBhlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J0CRFvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0CRF_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0CRGPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PwYBg1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PwYBhFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PwYBhVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J0VzFPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_BsudMI6YEeeyZasfnNSonw" target="_J0VzEPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J0VzFfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0VzGfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Pwv09FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_BsudMI6YEeeyZasfnNSonw" target="_Pwv08FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Pwv09VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pwv0-VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J0VzFvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0VzF_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0VzGPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pwv09lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pwv091JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pwv0-FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J0gLJPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_GaDH8I6YEeeyZasfnNSonw" target="_J0gLIPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J0gLJfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0gLKfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Pw8CNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_GaDH8I6YEeeyZasfnNSonw" target="_Pw8CMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Pw8CNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pw8COVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J0gLJvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0gLJ_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0gLKPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pw8CNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pw8CN1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pw8COFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J0qjNPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_I9O2YI6YEeeyZasfnNSonw" target="_J0qjMPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J0qjNfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J0qjOfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PxIPdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_I9O2YI6YEeeyZasfnNSonw" target="_PxIPcFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PxIPdVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxIPeVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J0qjNvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0qjN_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J0qjOPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxIPdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxIPd1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxIPeFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J007RPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_Lm61cI6YEeeyZasfnNSonw" target="_J007QPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J007RfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J007SfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PxT1pFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Lm61cI6YEeeyZasfnNSonw" target="_PxT1oFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PxT1pVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxT1qVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J007RvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J007R_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J007SPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxT1plJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxT1p1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxT1qFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J1H2NPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_xu7CoI8ZEeedErNofqJXiw" target="_J1H2MPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J1H2NfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1H2OfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PxnXpFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xu7CoI8ZEeedErNofqJXiw" target="_PxnXoFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PxnXpVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxnXqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J1H2NvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1H2N_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1H2OPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxnXplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxnXp1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxnXqFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J1SORPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_wB7jIXPYEeiPPoPDo3q5jA" target="_J1SOQPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J1SORfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1SOSfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PxxvtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_wB7jIXPYEeiPPoPDo3q5jA" target="_PxxvsFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PxxvtVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxxvuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J1SORvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1SOR_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1SOSPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxxvtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pxxvt1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxxvuFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J1papPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="__ZU_8XkzEeiO-c_khjKlFQ" target="_J1paoPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J1papfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1qBsvKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PyN0lFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="__ZU_8XkzEeiO-c_khjKlFQ" target="_PyN0kFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PyN0lVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyN0mVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J1papvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1qBsPKSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1qBsfKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PyN0llJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyN0l1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyN0mFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J10ZxPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_J10ZwPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J10ZxfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J10ZyfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PydsNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_PydsMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PydsNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PydsOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J10ZxvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J10Zx_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J10ZyPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PydsNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PydsN1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PydsOFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J1-x1PKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_DY-LUIoJEeivCevppATXng" target="_J1-x0PKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J1-x1fKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1_Y4PKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PyorUVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_DY-LUIoJEeivCevppATXng" target="_PyoEQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PyorUlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyorVlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J1-x1vKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1-x1_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1-x2PKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PyorU1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyorVFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyorVVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J2JJ5PKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_Er39oIoJEeivCevppATXng" target="_J2JJ4PKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J2JJ5fKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2JJ6fKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PyzDZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Er39oIoJEeivCevppATXng" target="_PyzDYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PyzDZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyzDaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J2JJ5vKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2JJ5_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2JJ6PKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PyzDZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyzDZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyzDaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J2P3lPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_J2P3kPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J2P3lfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2P3mfKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Py5xFFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_Py5xEFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Py5xFVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Py5xGVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J2P3lvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2P3l_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2P3mPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Py5xFlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Py5xF1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Py5xGFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J2YadPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_EMsiYLqdEeimKvjOEffRIA" target="_J2YacPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J2YadfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2YaefKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PzC7AFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_EMsiYLqdEeimKvjOEffRIA" target="_PzCT8FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PzC7AVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzC7BVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J2YadvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2Yad_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2YaePKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PzC7AlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzC7A1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzC7BFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J2iyhPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_lnxLALqdEeimKvjOEffRIA" target="_J2iygPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J2iyhfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2iyifKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PzNTFFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_lnxLALqdEeimKvjOEffRIA" target="_PzNTEFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PzNTFVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzNTGVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J2iyhvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2iyh_KSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2iyiPKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PzNTFlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzNTF1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzNTGFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_J2tKlPKSEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_J2tKkPKSEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_J2tKlfKSEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J2txovKSEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_PzXrJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_PzXrIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PzXrJVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzYSMFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J2tKlvKSEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2txoPKSEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J2txofKSEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PzXrJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzXrJ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzXrKFJqEemV99d_1db7sQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_gKM6AI6dEeeyZasfnNSonw" type="layersTree" name="Layers Tree Editor"/>
@@ -900,16 +900,16 @@
         </children>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4rH_DHjAEeixydPRZ8lIKA" x="-259" y="-447" width="159" height="62"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_lhOqs_KvEeiTnqcAgKK24Q" type="StereotypeComment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_lhOqtPKvEeiTnqcAgKK24Q"/>
-        <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lhOqtvKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+      <children xmi:type="notation:Shape" xmi:id="_QTyQkFJqEemV99d_1db7sQ" type="StereotypeComment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QTyQkVJqEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTyQk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
           <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
         </styles>
         <element xsi:nil="true"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lhOqtfKvEeiTnqcAgKK24Q" x="-59" y="-447"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QTyQklJqEemV99d_1db7sQ" x="-59" y="-447"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8QyEXiGEeiPPoPDo3q5jA" x="-210" y="-456" width="351" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8QyEXiGEeiPPoPDo3q5jA" x="-210" y="-456" width="575" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EqrGYHiHEeiPPoPDo3q5jA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_EqrtcHiHEeiPPoPDo3q5jA" type="Class_NameLabel"/>
@@ -920,6 +920,10 @@
         <children xmi:type="notation:Shape" xmi:id="_EFhiMHiYEeixydPRZ8lIKA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_fhbGYHiHEeiPPoPDo3q5jA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_EFhiMXiYEeixydPRZ8lIKA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_rL1f0FJkEemV99d_1db7sQ" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_IGOA8FJkEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_rL1f0VJkEemV99d_1db7sQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_EqrtdHiHEeiPPoPDo3q5jA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_EqrtdXiHEeiPPoPDo3q5jA"/>
@@ -939,7 +943,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EqrtgXiHEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EqrGYXiHEeiPPoPDo3q5jA" x="-296" y="-306" height="71"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EqrGYXiHEeiPPoPDo3q5jA" x="-316" y="-308" height="79"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_NhvNsHiHEeiPPoPDo3q5jA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_NhvNsniHEeiPPoPDo3q5jA" type="Class_NameLabel"/>
@@ -963,13 +967,6 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_l6_TYJmrEeiOmuqNbykpsw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_nIXsgZmrEeiOmuqNbykpsw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_7ZKFYLs6Eeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jg6iAMDZEeiXyMZOD9tv6w" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jg6iAcDZEeiXyMZOD9tv6w" key="fontColor" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_eIOh8rs6Eeiljfl0umr-iQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7ZKFYbs6Eeiljfl0umr-iQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_NhvNtniHEeiPPoPDo3q5jA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_NhvNt3iHEeiPPoPDo3q5jA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_NhvNuHiHEeiPPoPDo3q5jA"/>
@@ -988,7 +985,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nhv0yXiHEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-315" y="-39" height="134"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-312" y="-117" height="112"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_aIaS8HiKEeixydPRZ8lIKA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_aIaS8XiKEeixydPRZ8lIKA" showTitle="true"/>
@@ -1028,7 +1025,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7No-8HjAEeixydPRZ8lIKA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NoX0XjAEeixydPRZ8lIKA" x="430" y="-457" width="427" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NoX0XjAEeixydPRZ8lIKA" x="674" y="-459" width="427" height="67"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BMxTIHjqEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BMxTIXjqEeiO-c_khjKlFQ" showTitle="true"/>
@@ -1072,7 +1069,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0bY4XkwEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0VSMXkwEeiO-c_khjKlFQ" x="323" y="-297" height="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0VSMXkwEeiO-c_khjKlFQ" x="567" y="-299" height="80"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_-Be4sHkyEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_-Be4snkyEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1110,7 +1107,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Be4w3kyEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Be4sXkyEeiO-c_khjKlFQ" x="-52" y="-146" width="300" height="95"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Be4sXkyEeiO-c_khjKlFQ" x="223" y="-100" width="259" height="95"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_XVnyQHk6EeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_XVoZUHk6EeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -1168,7 +1165,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVoZYXk6EeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVnyQXk6EeiO-c_khjKlFQ" x="300" y="-129" width="304" height="176"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XVnyQXk6EeiO-c_khjKlFQ" x="544" y="-131" width="304" height="176"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_s3mNEJmTEeiOmuqNbykpsw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_s3sTsJmTEeiOmuqNbykpsw" type="Class_NameLabel"/>
@@ -1179,6 +1176,10 @@
         <children xmi:type="notation:Shape" xmi:id="_FbD70JmUEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_8Tky45mTEeiOmuqNbykpsw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_FbD70ZmUEeiOmuqNbykpsw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_si7OkFJkEemV99d_1db7sQ" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_UStL8lJkEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_si7OkVJkEemV99d_1db7sQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_s3sTtJmTEeiOmuqNbykpsw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_s3sTtZmTEeiOmuqNbykpsw"/>
@@ -1198,7 +1199,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3sTwZmTEeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3mNEZmTEeiOmuqNbykpsw" x="-45" y="-303" height="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s3mNEZmTEeiOmuqNbykpsw" x="107" y="-306" height="77"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EtIM4JmWEeiOmuqNbykpsw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_EtIM4pmWEeiOmuqNbykpsw" type="Class_NameLabel"/>
@@ -1209,6 +1210,10 @@
         <children xmi:type="notation:Shape" xmi:id="_zAoOkJmYEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_nWzrw5mYEeiOmuqNbykpsw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_zAoOkZmYEeiOmuqNbykpsw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RUwXoFJlEemV99d_1db7sQ" type="Property_ClassAttributeLabel" fontColor="255">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_HbzVgFJlEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RUwXoVJlEemV99d_1db7sQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_EtIM5pmWEeiOmuqNbykpsw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_EtIM55mWEeiOmuqNbykpsw"/>
@@ -1228,7 +1233,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM85mWEeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM4ZmWEeiOmuqNbykpsw" x="661" y="-293" width="280" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtIM4ZmWEeiOmuqNbykpsw" x="844" y="-295" width="375" height="74"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_aw4GAJmYEeiOmuqNbykpsw" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_aw4GApmYEeiOmuqNbykpsw" type="Class_NameLabel"/>
@@ -1258,41 +1263,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GE5mYEeiOmuqNbykpsw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GAZmYEeiOmuqNbykpsw" x="665" y="-144" width="262" height="78"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_MlzdkJs8EeikSLSDi2qpXA" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mlzdkps8EeikSLSDi2qpXA" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mlzdk5s8EeikSLSDi2qpXA" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MlzdlJs8EeikSLSDi2qpXA" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_MlzdlZs8EeikSLSDi2qpXA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_f8xSQJs8EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vzXWsHk-EeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_f8xSQZs8EeikSLSDi2qpXA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_f8xSQps8EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vzXWsXk-EeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_f8xSQ5s8EeikSLSDi2qpXA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Mlzdlps8EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Mlzdl5s8EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_MlzdmJs8EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MlzdmZs8EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Mlzdmps8EeikSLSDi2qpXA" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Mlzdm5s8EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_MlzdnJs8EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_MlzdnZs8EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mlzdnps8EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Mlzdn5s8EeikSLSDi2qpXA" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_MlzdoJs8EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_MlzdoZs8EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Mlzdops8EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mlzdo5s8EeikSLSDi2qpXA"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MlzdkZs8EeikSLSDi2qpXA" x="335" y="138" height="83"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aw4GAZmYEeiOmuqNbykpsw" x="1003" y="-149" width="198" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_gP2P0Lq4EeimKvjOEffRIA" type="Class_Shape">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_it2GUMDZEeiXyMZOD9tv6w" source="PapyrusCSSForceValue">
@@ -1354,221 +1325,291 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P47q4EeimKvjOEffRIA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P0bq4EeimKvjOEffRIA" x="-310" y="177" height="142"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P0bq4EeimKvjOEffRIA" x="-320" y="67" height="142"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_NzUVwLtKEeiljfl0umr-iQ" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_NzU80LtKEeiljfl0umr-iQ" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NzU80btKEeiljfl0umr-iQ" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NzU80rtKEeiljfl0umr-iQ" y="15"/>
+    <children xmi:type="notation:Shape" xmi:id="_KblyUFJjEemV99d_1db7sQ" type="Class_Shape" fontColor="255" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_KblyUlJjEemV99d_1db7sQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_KblyU1JjEemV99d_1db7sQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_KblyVFJjEemV99d_1db7sQ" y="15"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_NzU807tKEeiljfl0umr-iQ" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_OvmX0LtKEeiljfl0umr-iQ" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_75ksULKeEei69qzpcujF2A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OvmX0btKEeiljfl0umr-iQ"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KblyVVJjEemV99d_1db7sQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="__CzYUFJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_zsrDAFJlEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__CzYUVJmEemV99d_1db7sQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OvmX0rtKEeiljfl0umr-iQ" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_8j738LKeEei69qzpcujF2A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OvmX07tKEeiljfl0umr-iQ"/>
+        <children xmi:type="notation:Shape" xmi:id="__Cz_YFJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_9JQSMFJlEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__Cz_YVJmEemV99d_1db7sQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Ovm-4LtKEeiljfl0umr-iQ" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_-E0b4LKeEei69qzpcujF2A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ovm-4btKEeiljfl0umr-iQ"/>
+        <children xmi:type="notation:Shape" xmi:id="__Cz_YlJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_E5FEoFJmEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__Cz_Y1JmEemV99d_1db7sQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Ovm-4rtKEeiljfl0umr-iQ" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#__ErWYLKeEei69qzpcujF2A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ovm-47tKEeiljfl0umr-iQ"/>
+        <children xmi:type="notation:Shape" xmi:id="__Cz_ZFJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_L_1E4FJmEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__Cz_ZVJmEemV99d_1db7sQ"/>
         </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_NzU81LtKEeiljfl0umr-iQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_NzU81btKEeiljfl0umr-iQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_NzU81rtKEeiljfl0umr-iQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NzU817tKEeiljfl0umr-iQ"/>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KblyVlJjEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KblyV1JjEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KblyWFJjEemV99d_1db7sQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KblyWVJjEemV99d_1db7sQ"/>
       </children>
-      <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NzUVwbtKEeiljfl0umr-iQ" x="663" y="-40"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KbmZYFJjEemV99d_1db7sQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KbmZYVJjEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KbmZYlJjEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KbmZY1JjEemV99d_1db7sQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KbmZZFJjEemV99d_1db7sQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_KbmZZVJjEemV99d_1db7sQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_KbmZZlJjEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_KbmZZ1JjEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_KbmZaFJjEemV99d_1db7sQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KbmZaVJjEemV99d_1db7sQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KblyUVJjEemV99d_1db7sQ" x="6" y="48" width="342" height="112"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lg4FYPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lg4FYfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lg4FY_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_BnMvEFJkEemV99d_1db7sQ" type="Class_Shape" fontColor="255" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BnNWIFJkEemV99d_1db7sQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BnNWIVJkEemV99d_1db7sQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BnNWIlJkEemV99d_1db7sQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BnNWI1JkEemV99d_1db7sQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_7ogbsFJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_aiF0cFJmEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7ogbsVJmEemV99d_1db7sQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7ohCwFJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_g5liAFJmEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7ohCwVJmEemV99d_1db7sQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7ohCwlJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_oFiyYFJmEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7ohCw1JmEemV99d_1db7sQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7ohp0FJmEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vVoU0FJmEemV99d_1db7sQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7ohp0VJmEemV99d_1db7sQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BnNWJFJkEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BnNWJVJkEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BnNWJlJkEemV99d_1db7sQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BnNWJ1JkEemV99d_1db7sQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BnNWKFJkEemV99d_1db7sQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BnNWKVJkEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BnNWKlJkEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BnNWK1JkEemV99d_1db7sQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BnNWLFJkEemV99d_1db7sQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BnNWLVJkEemV99d_1db7sQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BnNWLlJkEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BnNWL1JkEemV99d_1db7sQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BnNWMFJkEemV99d_1db7sQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BnNWMVJkEemV99d_1db7sQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BnMvEVJkEemV99d_1db7sQ" x="884" y="-62" width="324" height="116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QTmqYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QTmqYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTmqY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lg4FYvKvEeiTnqcAgKK24Q" x="-10" y="-456"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QTmqYlJqEemV99d_1db7sQ" x="-10" y="-456"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_liP-YPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_liP-YfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_liP-Y_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QUXfYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QUXfYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QUXfY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_liP-YvKvEeiTnqcAgKK24Q" x="-96" y="-306"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QUXfYlJqEemV99d_1db7sQ" x="-116" y="-308"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ljNAoPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ljNAofKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ljNAo_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QU6R8FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QU6R8VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU6R81JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ljNAovKvEeiTnqcAgKK24Q" x="-96" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU6R8lJqEemV99d_1db7sQ" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ljWxoPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ljWxofKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ljWxo_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QU_KcFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QU_KcVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU_Kc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ljWxovKvEeiTnqcAgKK24Q" x="-96" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU_KclJqEemV99d_1db7sQ" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lkSlwPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lkSlwfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lkSlw_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QVHGQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QVHGQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVHGQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVHGQlJqEemV99d_1db7sQ" x="-116" y="-408"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QVoDoFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QVoDoVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVoDo1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lkSlwvKvEeiTnqcAgKK24Q" x="-115" y="-39"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVoDolJqEemV99d_1db7sQ" x="-112" y="-117"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lm_UcPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lm_UcfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lm_7gPKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QWOgkFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QWOgkVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWOgk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lm_UcvKvEeiTnqcAgKK24Q" x="-115" y="-139"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWOgklJqEemV99d_1db7sQ" x="-112" y="-217"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ln4sUPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ln4sUfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ln4sU_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QWjQsFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QWjQsVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWjQs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ln4sUvKvEeiTnqcAgKK24Q" x="630" y="-457"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWjQslJqEemV99d_1db7sQ" x="874" y="-459"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lpPXMPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lpPXMfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lpPXM_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QXHRYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QXHRYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QXHRY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lpPXMvKvEeiTnqcAgKK24Q" x="523" y="-297"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QXHRYlJqEemV99d_1db7sQ" x="767" y="-299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lqCocPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lqCocfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lqCoc_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QYdVMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QYdVMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYd8QFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lqCocvKvEeiTnqcAgKK24Q" x="523" y="-397"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QYdVMlJqEemV99d_1db7sQ" x="767" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lqIvEPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lqIvEfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lqIvE_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QYiNsFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QYiNsVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYiNs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lqIvEvKvEeiTnqcAgKK24Q" x="523" y="-397"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QYiNslJqEemV99d_1db7sQ" x="767" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lq15sPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lq15sfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lq15s_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QZB88FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QZB88VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZCkAFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lq15svKvEeiTnqcAgKK24Q" x="148" y="-146"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QZB88lJqEemV99d_1db7sQ" x="423" y="-100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lsNLoPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lsNLofKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lsNLo_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QZ-_MFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QZ-_MVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZ-_M1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lsNLovKvEeiTnqcAgKK24Q" x="500" y="-129"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QZ-_MlJqEemV99d_1db7sQ" x="744" y="-131"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ltaFgPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ltaFgfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ltaskPKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_N9lv4Js8EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ltaFgvKvEeiTnqcAgKK24Q" x="500" y="-229"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_luV5oPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_luV5ofKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_luV5o_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QbNHMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QbNHMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbNHM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luV5ovKvEeiTnqcAgKK24Q" x="155" y="-303"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QbNHMlJqEemV99d_1db7sQ" x="307" y="-306"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lu6hYPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lu6hYfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lu7IcPKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QbpzIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QbpzIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbqaMFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lu6hYvKvEeiTnqcAgKK24Q" x="155" y="-403"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QbpzIlJqEemV99d_1db7sQ" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lvCdMPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lvCdMfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lvCdM_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Qbv5wFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qbv5wVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qbv5w1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvCdMvKvEeiTnqcAgKK24Q" x="155" y="-403"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qbv5wlJqEemV99d_1db7sQ" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lvtyoPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lvtyofKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lvtyo_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Qb0yQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qb0yQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qb0yQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qb0yQlJqEemV99d_1db7sQ" x="307" y="-406"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QcTTYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QcTTYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QcTTY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvtyovKvEeiTnqcAgKK24Q" x="861" y="-293"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QcTTYlJqEemV99d_1db7sQ" x="1044" y="-295"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lwU2oPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lwU2ofKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lwU2o_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Qcv_UFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qcv_UVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qcv_U1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lwU2ovKvEeiTnqcAgKK24Q" x="861" y="-393"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qcv_UlJqEemV99d_1db7sQ" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lwcLYPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lwcLYfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lwcLY_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Qc1e4FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qc1e4VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc1e41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lwcLYvKvEeiTnqcAgKK24Q" x="861" y="-393"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qc1e4lJqEemV99d_1db7sQ" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lxTHAPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lxTHAfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lxTHA_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Qc6-cFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qc6-cVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc6-c1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qc6-clJqEemV99d_1db7sQ" x="1044" y="-395"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QdYRcFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QdYRcVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QdYRc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lxTHAvKvEeiTnqcAgKK24Q" x="865" y="-144"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QdYRclJqEemV99d_1db7sQ" x="1203" y="-149"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_lykSUPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lykSUfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lykSU_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykSUvKvEeiTnqcAgKK24Q" x="535" y="138"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_lzv-EPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_lzv-EfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lzv-E_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QeGqMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QeGqMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QeGqM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lzv-EvKvEeiTnqcAgKK24Q" x="-110" y="177"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QeGqMlJqEemV99d_1db7sQ" x="-120" y="67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_l11BsPKvEeiTnqcAgKK24Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_l11BsfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l11Bs_KvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
+    <children xmi:type="notation:Shape" xmi:id="_QfMPUFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QfMPUVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QfMPU1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l11BsvKvEeiTnqcAgKK24Q" x="863" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QfMPUlJqEemV99d_1db7sQ" x="206" y="48"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QgJRkFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QgJRkVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QgJRk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QgJRklJqEemV99d_1db7sQ" x="1084" y="-62"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
@@ -1587,9 +1628,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Y9rskXiHEeiPPoPDo3q5jA"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y9rskniHEeiPPoPDo3q5jA" points="[-160, -319, -643984, -643984]$[-160, -394, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4HiHEeiPPoPDo3q5jA" id="(0.5964912280701754,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4XiHEeiPPoPDo3q5jA" id="(0.14245014245014245,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y9rskniHEeiPPoPDo3q5jA" points="[-74, -300, -643984, -643984]$[-74, -394, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4HiHEeiPPoPDo3q5jA" id="(0.5955882352941176,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y_aK4XiHEeiPPoPDo3q5jA" id="(0.2382608695652174,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Xq0xwHkwEeiO-c_khjKlFQ" type="Abstraction_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_7NoX0HjAEeixydPRZ8lIKA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Xq0xw3kwEeiO-c_khjKlFQ" type="Abstraction_NameLabel">
@@ -1602,18 +1643,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Xq0xwXkwEeiO-c_khjKlFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xq0xwnkwEeiO-c_khjKlFQ" points="[483, -297, -643984, -643984]$[483, -390, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xq0xwnkwEeiO-c_khjKlFQ" points="[727, -299, -643984, -643984]$[727, -392, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrlmwHkwEeiO-c_khjKlFQ" id="(0.6177606177606177,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XrlmwXkwEeiO-c_khjKlFQ" id="(0.12412177985948478,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7cWEIIuWEeiu6boZkiJHCA" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_NhvNsHiHEeiPPoPDo3q5jA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWEI4uWEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eCQMoJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWEJIuWEeiu6boZkiJHCA" x="-8" y="8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWEJIuWEeiu6boZkiJHCA" x="12" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrMIuWEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eEiroJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrMYuWEeiu6boZkiJHCA" x="-30" y="-2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7cWrMYuWEeiu6boZkiJHCA" x="-6" y="-11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7cWrMouWEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eGvEAJmXEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1633,9 +1674,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7cWEIYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-180, -235, -643984, -643984]$[-180, -39, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.5043859649122807,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.39644970414201186,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-164, -229, -643984, -643984]$[-164, -117, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.37254901960784315,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.4378698224852071,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BDZzQIuXEeiu6boZkiJHCA" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_XVnyQHk6EeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzQ4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1664,18 +1705,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BDZzQYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDZzQouXEeiu6boZkiJHCA" points="[445, -217, -643984, -643984]$[445, -142, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDZzQouXEeiu6boZkiJHCA" points="[689, -219, -643984, -643984]$[689, -144, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_541CMJmoEeiOmuqNbykpsw" id="(0.4671814671814672,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbbsIuXEeiu6boZkiJHCA" id="(0.47368421052631576,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_8V3R4JmTEeiOmuqNbykpsw" type="Association_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_-Be4sHkyEeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_8V3R45mTEeiOmuqNbykpsw" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GJu_sJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R5JmTEeiOmuqNbykpsw" x="11" y="1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R5JmTEeiOmuqNbykpsw" x="3" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8V3R5ZmTEeiOmuqNbykpsw" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GMOTAJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R5pmTEeiOmuqNbykpsw" x="-3" y="-2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8V3R5pmTEeiOmuqNbykpsw" x="-10" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_8V3R55mTEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_GOs_QJmUEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1695,9 +1736,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_8V3R4ZmTEeiOmuqNbykpsw"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8V3R4pmTEeiOmuqNbykpsw" points="[93, -237, -643984, -643984]$[93, -146, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8acP4JmTEeiOmuqNbykpsw" id="(0.49458483754512633,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8acP4ZmTEeiOmuqNbykpsw" id="(0.48,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8V3R4pmTEeiOmuqNbykpsw" points="[385, -229, -643984, -643984]$[385, -100, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8acP4JmTEeiOmuqNbykpsw" id="(0.6813725490196079,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8acP4ZmTEeiOmuqNbykpsw" id="(0.6254826254826255,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VE_BkJmVEeiOmuqNbykpsw" type="Abstraction_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_-8QyEHiGEeiPPoPDo3q5jA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_VE_Bk5mVEeiOmuqNbykpsw" type="Abstraction_NameLabel">
@@ -1710,9 +1751,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_VE_BkZmVEeiOmuqNbykpsw"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VE_BkpmVEeiOmuqNbykpsw" points="[64, -303, -643984, -643984]$[64, -352, -643984, -643984]$[68, -352, -643984, -643984]$[68, -394, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VKa7MJmVEeiOmuqNbykpsw" id="(0.40794223826714804,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VKa7MZmVEeiOmuqNbykpsw" id="(0.792022792022792,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VE_BkpmVEeiOmuqNbykpsw" points="[286, -306, -643984, -643984]$[286, -394, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VKa7MJmVEeiOmuqNbykpsw" id="(0.4387254901960784,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VKa7MZmVEeiOmuqNbykpsw" id="(0.8626086956521739,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_nZkr4JmYEeiOmuqNbykpsw" type="Association_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_aw4GAJmYEeiOmuqNbykpsw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_nZqygJmYEeiOmuqNbykpsw" type="Association_StereotypeLabel">
@@ -1741,9 +1782,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_nZkr4ZmYEeiOmuqNbykpsw"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nZkr4pmYEeiOmuqNbykpsw" points="[797, -226, -643984, -643984]$[797, -144, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoJmYEeiOmuqNbykpsw" id="(0.48214285714285715,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoZmYEeiOmuqNbykpsw" id="(0.5,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nZkr4pmYEeiOmuqNbykpsw" points="[1134, -228, -643984, -643984]$[1134, -149, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoJmYEeiOmuqNbykpsw" id="(0.7733333333333333,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nffGoZmYEeiOmuqNbykpsw" id="(0.6616161616161617,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ObaTQJmaEeiOmuqNbykpsw" type="Abstraction_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_7NoX0HjAEeixydPRZ8lIKA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_ObaTQ5maEeiOmuqNbykpsw" type="Abstraction_NameLabel">
@@ -1756,49 +1797,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ObaTQZmaEeiOmuqNbykpsw"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ObaTQpmaEeiOmuqNbykpsw" points="[798, -293, -643984, -643984]$[798, -343, -643984, -643984]$[794, -343, -643984, -643984]$[794, -390, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgJmaEeiOmuqNbykpsw" id="(0.48214285714285715,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ObaTQpmaEeiOmuqNbykpsw" points="[1040, -295, -643984, -643984]$[1040, -345, -643984, -643984]$[1040, -392, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgJmaEeiOmuqNbykpsw" id="(0.5226666666666666,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OixfgZmaEeiOmuqNbykpsw" id="(0.8571428571428571,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OBTyQJs8EeikSLSDi2qpXA" type="Association_Edge" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_MlzdkJs8EeikSLSDi2qpXA" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_OBTyQ5s8EeikSLSDi2qpXA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VVFh4Js8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyRJs8EeikSLSDi2qpXA" x="4" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_OBTyRZs8EeikSLSDi2qpXA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VYVDIJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyRps8EeikSLSDi2qpXA" x="-15" y="-17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_OBTyR5s8EeikSLSDi2qpXA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Va8SQJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTySJs8EeikSLSDi2qpXA" x="10" y="-19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_OBTySZs8EeikSLSDi2qpXA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vd5foJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTySps8EeikSLSDi2qpXA" x="-11" y="18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_OBTyS5s8EeikSLSDi2qpXA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vg-BwJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyTJs8EeikSLSDi2qpXA" x="10" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_OBTyTZs8EeikSLSDi2qpXA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VjWnYJs8EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OBTyTps8EeikSLSDi2qpXA" x="-18" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_OBTyQZs8EeikSLSDi2qpXA"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_N9lv4Js8EeikSLSDi2qpXA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OBTyQps8EeikSLSDi2qpXA" points="[450, 34, -643984, -643984]$[450, 138, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OIv3AJs8EeikSLSDi2qpXA" id="(0.4934210526315789,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OIv3AZs8EeikSLSDi2qpXA" id="(0.558252427184466,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_eVdssLs6Eeiljfl0umr-iQ" type="Association_Edge" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_gP2P0Lq4EeimKvjOEffRIA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_eVjzULs6Eeiljfl0umr-iQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mtZA8Ls6Eeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eVjzUbs6Eeiljfl0umr-iQ" x="3" y="8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eVjzUbs6Eeiljfl0umr-iQ" x="4" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_eVjzUrs6Eeiljfl0umr-iQ" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_myuz8Ls6Eeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eVjzU7s6Eeiljfl0umr-iQ" x="-14" y="-17"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eVjzU7s6Eeiljfl0umr-iQ" x="-10" y="-9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_eVjzVLs6Eeiljfl0umr-iQ" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_m47ikLs6Eeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1814,13 +1824,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_eVjzWrs6Eeiljfl0umr-iQ" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_nLxmELs6Eeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eVjzW7s6Eeiljfl0umr-iQ" x="-19" y="14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eVjzW7s6Eeiljfl0umr-iQ" x="-11" y="16"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_eVdssbs6Eeiljfl0umr-iQ"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVdssrs6Eeiljfl0umr-iQ" points="[-163, 95, -643984, -643984]$[-163, 177, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQLs6Eeiljfl0umr-iQ" id="(0.4494047619047619,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQbs6Eeiljfl0umr-iQ" id="(0.5069444444444444,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVdssrs6Eeiljfl0umr-iQ" points="[-166, -5, -643984, -643984]$[-166, 67, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQLs6Eeiljfl0umr-iQ" id="(0.4289940828402367,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQbs6Eeiljfl0umr-iQ" id="(0.53125,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_zY6jAMMqEei3gLXE4_XcoA" type="Association_Edge" source="_7NoX0HjAEeixydPRZ8lIKA" target="_-8QyEHiGEeiPPoPDo3q5jA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_zY6jA8MqEei3gLXE4_XcoA" type="Association_StereotypeLabel">
@@ -1849,249 +1859,362 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_zY6jAcMqEei3gLXE4_XcoA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zY6jAsMqEei3gLXE4_XcoA" points="[430, -420, -643984, -643984]$[141, -420, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a32gwDRkEemXiOBFvSRVzQ" id="(0.0,0.5522388059701493)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_07ESQMMqEei3gLXE4_XcoA" id="(1.0,0.5806451612903226)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zY6jAsMqEei3gLXE4_XcoA" points="[674, -422, -643984, -643984]$[407, -422, -643984, -643984]$[407, -428, -643984, -643984]$[141, -428, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a32gwDRkEemXiOBFvSRVzQ" id="(0.0,0.5373134328358209)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_07ESQMMqEei3gLXE4_XcoA" id="(1.0,0.532258064516129)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lg4FZPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_-8QyEHiGEeiPPoPDo3q5jA" target="_lg4FYPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lg4FZfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lg4FafKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_IKgrEFJkEemV99d_1db7sQ" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_KblyUFJjEemV99d_1db7sQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_IKhSIFJkEemV99d_1db7sQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Jbz64FJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSIVJkEemV99d_1db7sQ" x="-82" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IKhSIlJkEemV99d_1db7sQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Jfe58FJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSI1JkEemV99d_1db7sQ" x="-100" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IKhSJFJkEemV99d_1db7sQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JiubMFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSJVJkEemV99d_1db7sQ" x="65" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IKhSJlJkEemV99d_1db7sQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Jl8uUFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSJ1JkEemV99d_1db7sQ" x="-65" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IKhSKFJkEemV99d_1db7sQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JpOEwFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSKVJkEemV99d_1db7sQ" x="12" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IKhSKlJkEemV99d_1db7sQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JsaisFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSK1JkEemV99d_1db7sQ" x="-11" y="20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_IKgrEVJkEemV99d_1db7sQ"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IKgrElJkEemV99d_1db7sQ" points="[49, -229, -643984, -643984]$[49, 48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IRA7sFJkEemV99d_1db7sQ" id="(0.8921568627450981,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IRA7sVJkEemV99d_1db7sQ" id="(0.12280701754385964,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UYJsoFJkEemV99d_1db7sQ" type="Association_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_KblyUFJjEemV99d_1db7sQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UYKTsFJkEemV99d_1db7sQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5AN1sFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTsVJkEemV99d_1db7sQ" x="-36" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UYKTslJkEemV99d_1db7sQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5DwR4FJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTs1JkEemV99d_1db7sQ" x="-54" y="-4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UYKTtFJkEemV99d_1db7sQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5HEroFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTtVJkEemV99d_1db7sQ" x="42" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UYKTtlJkEemV99d_1db7sQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5KYeUFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTt1JkEemV99d_1db7sQ" x="-42" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UYKTuFJkEemV99d_1db7sQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5NpNsFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTuVJkEemV99d_1db7sQ" x="9" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UYKTulJkEemV99d_1db7sQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5Q7LMFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTu1JkEemV99d_1db7sQ" x="-12" y="15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_UYJsoVJkEemV99d_1db7sQ"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYJsolJkEemV99d_1db7sQ" points="[206, -229, -643984, -643984]$[206, 48, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeV0MFJkEemV99d_1db7sQ" id="(0.24509803921568626,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeV0MVJkEemV99d_1db7sQ" id="(0.5877192982456141,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HfzEsFJlEemV99d_1db7sQ" type="Association_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_BnMvEFJkEemV99d_1db7sQ" routing="Rectilinear" lineColor="255">
+      <children xmi:type="notation:DecorationNode" xmi:id="_HfzrwFJlEemV99d_1db7sQ" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WhOcgFJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HfzrwVJlEemV99d_1db7sQ" x="-24" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HfzrwlJlEemV99d_1db7sQ" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WkbhgFJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Hfzrw1JlEemV99d_1db7sQ" x="-43" y="3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HfzrxFJlEemV99d_1db7sQ" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Wn1a0FJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HfzrxVJlEemV99d_1db7sQ" x="27" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HfzrxlJlEemV99d_1db7sQ" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WrSXcFJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Hfzrx1JlEemV99d_1db7sQ" x="-27" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HfzryFJlEemV99d_1db7sQ" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WueOUFJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HfzryVJlEemV99d_1db7sQ" x="8" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HfzrylJlEemV99d_1db7sQ" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WxxZ8FJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Hfzry1JlEemV99d_1db7sQ" x="-11" y="17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_HfzEsVJlEemV99d_1db7sQ"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HfzEslJlEemV99d_1db7sQ" points="[935, -221, -643984, -643984]$[935, -62, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmBogFJlEemV99d_1db7sQ" id="(0.24,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmBogVJlEemV99d_1db7sQ" id="(0.15432098765432098,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QTmqZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_-8QyEHiGEeiPPoPDo3q5jA" target="_QTmqYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QTmqZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTmqaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lg4FZvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lg4FZ_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lg4FaPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QTmqZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTmqZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTmqaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lhOqt_KvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_4rH-0HjAEeixydPRZ8lIKA" target="_lhOqs_KvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lhOquPKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lhOqvPKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QTyQlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_4rH-0HjAEeixydPRZ8lIKA" target="_QTyQkFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QTyQlVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTyQmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lhOqufKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lhOquvKvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lhOqu_KvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QTyQllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTyQl1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTyQmFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_liP-ZPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_liP-YPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_liP-ZfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_liP-afKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QUXfZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_QUXfYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QUXfZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QUYGcFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_liP-ZvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_liP-Z_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_liP-aPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QUXfZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QUXfZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QUXfaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ljNApPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_ljNAoPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ljNApfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ljNAqfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QU6R9FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_QU6R8FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QU6R9VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU6R-VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ljNApvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ljNAp_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ljNAqPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QU6R9lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU6R91JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU6R-FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ljWxpPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_ljWxoPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ljWxpfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ljWxqfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QU_KdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_QU_KcFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QU_KdVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU_xglJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ljWxpvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ljWxp_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ljWxqPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QU_KdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU_xgFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU_xgVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lkSlxPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_lkSlwPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lkSlxfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lkSlyfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QVHGRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_IKgrEFJkEemV99d_1db7sQ" target="_QVHGQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QVHGRVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVHGSVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QVHGRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVHGR1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVHGSFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QVoDpFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_QVoDoFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QVoDpVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVoDqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lkSlxvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lkSlx_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lkSlyPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QVoDplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVoDp1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVoDqFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lm_7gfKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_eVdssLs6Eeiljfl0umr-iQ" target="_lm_UcPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lm_7gvKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lm_7hvKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QWOglFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_eVdssLs6Eeiljfl0umr-iQ" target="_QWOgkFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QWOglVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWOgmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lm_7g_KvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lm_7hPKvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lm_7hfKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QWOgllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWOgl1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWOgmFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ln4sVPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_7NoX0HjAEeixydPRZ8lIKA" target="_ln4sUPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ln4sVfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ln4sWfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QWjQtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_7NoX0HjAEeixydPRZ8lIKA" target="_QWjQsFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QWjQtVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWjQuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ln4sVvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ln4sV_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ln4sWPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QWjQtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWjQt1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWjQuFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lpPXNPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_lpPXMPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lpPXNfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lpP-QvKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QXHRZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_QXHRYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QXHRZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QXH4cFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lpPXNvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lpP-QPKvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lpP-QfKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QXHRZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QXHRZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QXHRaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lqCodPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_lqCocPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lqCodfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lqCoefKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QYd8QVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_QYdVMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QYd8QlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYd8RlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lqCodvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lqCod_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lqCoePKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QYd8Q1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYd8RFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYd8RVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lqIvFPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_lqIvEPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lqIvFfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lqIvGfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QYiNtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_QYiNsFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QYiNtVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYiNuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lqIvFvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lqIvF_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lqIvGPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QYiNtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYiNt1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYiNuFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lq15tPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_-Be4sHkyEeiO-c_khjKlFQ" target="_lq15sPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lq15tfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lq15ufKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QZCkAVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_-Be4sHkyEeiO-c_khjKlFQ" target="_QZB88FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QZCkAlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZCkBlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lq15tvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lq15t_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lq15uPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QZCkA1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZCkBFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZCkBVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lsNLpPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_lsNLoPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lsNLpfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lsNLqfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QZ-_NFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_QZ-_MFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QZ-_NVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZ-_OVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lsNLpvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lsNLp_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lsNLqPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QZ-_NlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZ-_N1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZ-_OFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ltaskfKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_OBTyQJs8EeikSLSDi2qpXA" target="_ltaFgPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ltaskvKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ltaslvKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_N9lv4Js8EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ltask_KvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ltaslPKvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ltaslfKvEeiTnqcAgKK24Q"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_luV5pPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_luV5oPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_luV5pfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_luWgsvKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QbNHNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_QbNHMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QbNHNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbNHOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_luV5pvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_luWgsPKvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_luWgsfKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QbNHNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbNHN1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbNHOFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lu7IcfKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_lu6hYPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lu7IcvKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lu7IdvKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QbqaMVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_QbpzIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QbqaMlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbqaNlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu7Ic_KvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu7IdPKvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu7IdfKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QbqaM1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbqaNFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbqaNVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lvCdNPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_lvCdMPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lvCdNfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lvCdOfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Qbv5xFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_Qbv5wFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qbv5xVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qbv5yVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lvCdNvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lvCdN_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lvCdOPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qbv5xlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qbv5x1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qbv5yFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lvtypPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_lvtyoPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lvtypfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lvtyqfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Qb0yRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_UYJsoFJkEemV99d_1db7sQ" target="_Qb0yQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qb0yRVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qb0ySVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qb0yRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qb0yR1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qb0ySFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QcTTZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_QcTTYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QcTTZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QcTTaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lvtypvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lvtyp_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lvtyqPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QcTTZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QcTTZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QcTTaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lwU2pPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_lwU2oPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lwU2pfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lwU2qfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Qcv_VFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_Qcv_UFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qcv_VVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qcv_WVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lwU2pvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwU2p_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwU2qPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qcv_VlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qcv_V1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qcv_WFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lwcLZPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_lwcLYPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lwcLZfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lwcLafKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Qc1e5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_Qc1e4FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qc1e5VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc1e6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lwcLZvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwcLZ_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwcLaPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qc1e5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc1e51JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc1e6FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lxTHBPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_lxTHAPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lxTHBfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lxTHCfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Qc6-dFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_HfzEsFJlEemV99d_1db7sQ" target="_Qc6-cFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qc6-dVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc6-eVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qc6-dlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc6-d1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc6-eFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QdYRdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_QdYRcFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QdYRdVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QdYReVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lxTHBvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lxTHB_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lxTHCPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QdYRdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QdYRd1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QdYReFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lykSVPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_MlzdkJs8EeikSLSDi2qpXA" target="_lykSUPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lykSVfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lykSWfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lykSVvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykSV_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykSWPKvEeiTnqcAgKK24Q"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lzv-FPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_lzv-EPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_lzv-FfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lzv-GfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QeGqNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_QeGqMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QeGqNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QeHRQFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lzv-FvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lzv-F_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lzv-GPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QeGqNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QeGqN1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QeGqOFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_l11owPKvEeiTnqcAgKK24Q" type="StereotypeCommentLink" source="_NzUVwLtKEeiljfl0umr-iQ" target="_l11BsPKvEeiTnqcAgKK24Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_l11owfKvEeiTnqcAgKK24Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l11oxfKvEeiTnqcAgKK24Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
+    <edges xmi:type="notation:Connector" xmi:id="_QfMPVFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_KblyUFJjEemV99d_1db7sQ" target="_QfMPUFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QfMPVVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QfM2YVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l11owvKvEeiTnqcAgKK24Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l11ow_KvEeiTnqcAgKK24Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l11oxPKvEeiTnqcAgKK24Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QfMPVlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QfMPV1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QfM2YFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QgJRlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_BnMvEFJkEemV99d_1db7sQ" target="_QgJRkFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QgJRlVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QgJRmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QgJRllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QgJRl1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QgJRmFJqEemV99d_1db7sQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="OtsiResourceSpec" measurementUnit="Pixel">
@@ -2104,6 +2227,10 @@
         <children xmi:type="notation:Shape" xmi:id="_xbRtw3kvEeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_lIJUIHZfEeiPPoPDo3q5jA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRt7nkvEeiO-c_khjKlFQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_zCMuMFJbEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_AMLfknk8EeiO-c_khjKlFQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zCMuMVJbEemV99d_1db7sQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_xbRt73kvEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_xbRt8HkvEeiO-c_khjKlFQ"/>
@@ -2123,7 +2250,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRt_HkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuMXkvEeiO-c_khjKlFQ" x="243" y="-134" width="213" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuMXkvEeiO-c_khjKlFQ" x="121" y="-135" width="213" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRupnkvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRup3kvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -2251,10 +2378,6 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_KjQ3rhKOEeajhbtskMXJfw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_xbRyo3kvEeiO-c_khjKlFQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_MJpXIHk8EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_AMLfknk8EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_MJpXIXk8EeiO-c_khjKlFQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_xbRypHkvEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_xbRypXkvEeiO-c_khjKlFQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_xbRypnkvEeiO-c_khjKlFQ"/>
@@ -2376,56 +2499,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U2bL8nk6EeiO-c_khjKlFQ" x="1158" y="-140"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_sregEHk7EeiO-c_khjKlFQ" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_srfHIHk7EeiO-c_khjKlFQ" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_srfHIXk7EeiO-c_khjKlFQ" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_srfHInk7EeiO-c_khjKlFQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_srfHI3k7EeiO-c_khjKlFQ" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_9yYWoHk7EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qzTdgXk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9yYWoXk7EeiO-c_khjKlFQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9yY9sHk7EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qzTdgnk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9yY9sXk7EeiO-c_khjKlFQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9yY9snk7EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qzTdhHk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9yY9s3k7EeiO-c_khjKlFQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9yY9tHk7EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qzTdhXk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9yY9tXk7EeiO-c_khjKlFQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9yY9tnk7EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qzTdg3k7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9yY9t3k7EeiO-c_khjKlFQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9yZkwHk7EeiO-c_khjKlFQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_65vVkHk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9yZkwXk7EeiO-c_khjKlFQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_srfHJHk7EeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_srfHJXk7EeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_srfHJnk7EeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_srfHJ3k7EeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_srfuMHk7EeiO-c_khjKlFQ" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_srfuMXk7EeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_srfuMnk7EeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_srfuM3k7EeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_srfuNHk7EeiO-c_khjKlFQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_srfuNXk7EeiO-c_khjKlFQ" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_srfuNnk7EeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_srfuN3k7EeiO-c_khjKlFQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_srfuOHk7EeiO-c_khjKlFQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_srfuOXk7EeiO-c_khjKlFQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_qzTdgHk7EeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sregEXk7EeiO-c_khjKlFQ" x="19" y="-129" width="215" height="156"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DQVXo3k9EeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DQVXpHk9EeiO-c_khjKlFQ" showTitle="true"/>
@@ -2661,85 +2734,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2NF3gpstEeikSLSDi2qpXA" x="783" y="-132"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_wHswIJs5EeikSLSDi2qpXA" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_wHswIps5EeikSLSDi2qpXA" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_wHswI5s5EeikSLSDi2qpXA" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_wHswJJs5EeikSLSDi2qpXA" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_wHswJZs5EeikSLSDi2qpXA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_w9RBwLucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PBP80MG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PBP80cG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_UecwQLq2EeimKvjOEffRIA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_w9RBwbucEeiljfl0umr-iQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_w9Ro0LucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_jwVxEXk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_w9Ro0bucEeiljfl0umr-iQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_w9SP4LucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_jwVxEnk7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_w9SP4bucEeiljfl0umr-iQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_w9SP4rucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_jwVxE3k7EeiO-c_khjKlFQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_w9SP47ucEeiljfl0umr-iQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_wHswJps5EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_wHswJ5s5EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_wHswKJs5EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wHswKZs5EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_wHswKps5EeikSLSDi2qpXA" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_wHswK5s5EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_wHswLJs5EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_wHswLZs5EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wHswLps5EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_wHswL5s5EeikSLSDi2qpXA" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_wHswMJs5EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_wHswMZs5EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_wHswMps5EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wHswM5s5EeikSLSDi2qpXA"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_wHacQJs5EeikSLSDi2qpXA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wHswIZs5EeikSLSDi2qpXA" x="377" y="143" height="123"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_-2iRMJs7EeikSLSDi2qpXA" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_-2iRMps7EeikSLSDi2qpXA" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_-2iRM5s7EeikSLSDi2qpXA" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-2iRNJs7EeikSLSDi2qpXA" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_-2iRNZs7EeikSLSDi2qpXA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_tSQFoJs8EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vzXWsHk-EeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_tSQFoZs8EeikSLSDi2qpXA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_tSQFops8EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vzXWsXk-EeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_tSQFo5s8EeikSLSDi2qpXA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_-2iRNps7EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_-2iRN5s7EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_-2iROJs7EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2iROZs7EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_-2iROps7EeikSLSDi2qpXA" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_-2iRO5s7EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_-2iRPJs7EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_-2iRPZs7EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2iRPps7EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_-2oX0Js7EeikSLSDi2qpXA" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_-2oX0Zs7EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_-2oX0ps7EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_-2oX05s7EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2oX1Js7EeikSLSDi2qpXA"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-2iRMZs7EeikSLSDi2qpXA" x="634" y="159" width="254" height="105"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_SfGPYJtAEeikSLSDi2qpXA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_SfGPYZtAEeikSLSDi2qpXA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SfGPY5tAEeikSLSDi2qpXA" name="BASE_ELEMENT">
@@ -2860,133 +2854,77 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z_3Rsrs8Eeiljfl0umr-iQ" x="781" y="-133"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jM04QPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jM04QfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jM04Q_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P2DLsFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P2DLsVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2DywFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jM04QvPlEeinaYo1FpF9OA" x="443" y="-134"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P2DLslJqEemV99d_1db7sQ" x="321" y="-135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jNZgAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jNZgAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jNZgA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P2mlUFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P2mlUVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2mlU1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jNZgAvPlEeinaYo1FpF9OA" x="443" y="-234"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P2mlUlJqEemV99d_1db7sQ" x="321" y="-235"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jNx6gPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jNx6gfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jNx6g_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P278gFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P278gVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P278g1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jNx6gvPlEeinaYo1FpF9OA" x="409" y="-443"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P278glJqEemV99d_1db7sQ" x="409" y="-443"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jOWiQPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jOWiQfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jOWiQ_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P3fWIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P3fWIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P3fWI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jOWiQvPlEeinaYo1FpF9OA" x="672" y="-133"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P3fWIlJqEemV99d_1db7sQ" x="672" y="-133"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jPZrI_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jPZrJPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPZrJvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P4oloFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P4oloVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P4pMsFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jPZrJfPlEeinaYo1FpF9OA" x="672" y="-233"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P4ololJqEemV99d_1db7sQ" x="672" y="-233"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jPl4YPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jPl4YfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPl4Y_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_zJXKUJs5EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jPl4YvPlEeinaYo1FpF9OA" x="672" y="-233"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jPr_APPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jPr_AfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPr_A_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_2EwdEJs8EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jPr_AvPlEeinaYo1FpF9OA" x="672" y="-233"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jPyFo_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jPyFpPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPyFpvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_Y0iHMLucEeiljfl0umr-iQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jPyFpfPlEeinaYo1FpF9OA" x="672" y="-233"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jQWtYPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jQWtYfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jQWtY_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P5Ht0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P5Ht0VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P5Ht01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jQWtYvPlEeinaYo1FpF9OA" x="688" y="-299"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P5Ht0lJqEemV99d_1db7sQ" x="688" y="-299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jQpoU_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jQpoVPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jQpoVvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P6K2sFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P6K2sVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6K2s1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jQpoVfPlEeinaYo1FpF9OA" x="688" y="-399"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P6K2slJqEemV99d_1db7sQ" x="688" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jRXaAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jRXaAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jRXaA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P6p-4FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P6p-4VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6p-41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jRXaAvPlEeinaYo1FpF9OA" x="303" y="-298"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P6p-4lJqEemV99d_1db7sQ" x="303" y="-298"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_jR8Bw_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jR8BxPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jR8BxvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P7Gq0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P7Gq0VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P7Gq01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jR8BxfPlEeinaYo1FpF9OA" x="303" y="-398"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jSIPAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jSIPAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jSIPA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_AMK4gHk8EeiO-c_khjKlFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jSIPAvPlEeinaYo1FpF9OA" x="303" y="-398"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jSmwIPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jSmwIfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jSmwI_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_qzTdgHk7EeiO-c_khjKlFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jSmwIvPlEeinaYo1FpF9OA" x="219" y="-129"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jUVOcPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jUVOcfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jUVOc_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_wHacQJs5EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jUVOcvPlEeinaYo1FpF9OA" x="577" y="143"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_jVSQs_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_jVSQtPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jVSQtvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jVSQtfPlEeinaYo1FpF9OA" x="834" y="159"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P7Gq0lJqEemV99d_1db7sQ" x="303" y="-398"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_xbR3JHkvEeiO-c_khjKlFQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_xbR3JXkvEeiO-c_khjKlFQ"/>
@@ -3060,36 +2998,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LOdamok9Eeil5oKL3Vgl-g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LOdam4k9Eeil5oKL3Vgl-g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KmsHYIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_sregEHk7EeiO-c_khjKlFQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_KmsHY4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2ivDIJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHZIuXEeiu6boZkiJHCA" x="5" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_KmsHZYuXEeiu6boZkiJHCA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2lZ8oJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHZouXEeiu6boZkiJHCA" x="-10" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_KmsHZ4uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2pDGgJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHaIuXEeiu6boZkiJHCA" x="14" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_KmsHaYuXEeiu6boZkiJHCA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2rPe4Jo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHaouXEeiu6boZkiJHCA" x="-13" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_KmsHa4uXEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2tVwoJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHbIuXEeiu6boZkiJHCA" x="14" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_KmsHbYuXEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2v6jgJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_KmsHbouXEeiu6boZkiJHCA" x="-13" y="-20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_KmsHYYuXEeiu6boZkiJHCA"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_AMK4gHk8EeiO-c_khjKlFQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KmsHYouXEeiu6boZkiJHCA" points="[232, -219, -643984, -643984]$[175, -129, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LmPf4IuXEeiu6boZkiJHCA" id="(0.09385113268608414,1.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MtNH8IuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_xbRyc3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH84uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2yA1QJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -3118,7 +3026,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_MtNH8YuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MtNH8ouXEeiu6boZkiJHCA" points="[331, -134, -643984, -643984]$[280, -219, -643984, -643984]"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYw8IuXEeiu6boZkiJHCA" id="(0.7864077669902912,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zac2IFJbEemV99d_1db7sQ" id="(0.4647887323943662,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYw8IuXEeiu6boZkiJHCA" id="(0.3818770226537217,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QoX9AIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRu43kvEeiO-c_khjKlFQ" target="_xbRvg3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_QoX9A4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -3151,258 +3060,95 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SIuVcIuXEeiu6boZkiJHCA" id="(0.4447058823529412,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RzyAMIuXEeiu6boZkiJHCA" id="(0.5389408099688473,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zM5mgJs5EeikSLSDi2qpXA" type="Association_Edge" source="_xbRu43kvEeiO-c_khjKlFQ" target="_wHswIJs5EeikSLSDi2qpXA" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_zM5mg5s5EeikSLSDi2qpXA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zqL_cJs5EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zM5mhJs5EeikSLSDi2qpXA" x="6" y="3"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zM5mhZs5EeikSLSDi2qpXA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zsklEJs5EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zM5mhps5EeikSLSDi2qpXA" x="-7"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zM5mh5s5EeikSLSDi2qpXA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zuq20Js5EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zM5miJs5EeikSLSDi2qpXA" x="15" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zM5miZs5EeikSLSDi2qpXA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zxKxMJs5EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zM5mips5EeikSLSDi2qpXA" x="-15" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zM5mi5s5EeikSLSDi2qpXA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zzvkEJs5EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zM5mjJs5EeikSLSDi2qpXA" x="8" y="16"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zM5mjZs5EeikSLSDi2qpXA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_z178cJs5EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zM5mjps5EeikSLSDi2qpXA" x="-14" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_zM5mgZs5EeikSLSDi2qpXA"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_zJXKUJs5EeikSLSDi2qpXA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zM5mgps5EeikSLSDi2qpXA" points="[523, 31, -643984, -643984]$[523, 143, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRw4YJs5EeikSLSDi2qpXA" id="(0.1223529411764706,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRw4YZs5EeikSLSDi2qpXA" id="(0.6150627615062761,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2HPJUJs8EeikSLSDi2qpXA" type="Association_Edge" source="_xbRu43kvEeiO-c_khjKlFQ" target="_-2iRMJs7EeikSLSDi2qpXA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_2HPJU5s8EeikSLSDi2qpXA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_d6dGwLqtEeimKvjOEffRIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2HPJVJs8EeikSLSDi2qpXA" x="7" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_2HPJVZs8EeikSLSDi2qpXA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_d9jeELqtEeimKvjOEffRIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2HPJVps8EeikSLSDi2qpXA" x="-5"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_2HPJV5s8EeikSLSDi2qpXA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eAy_ULqtEeimKvjOEffRIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2HPJWJs8EeikSLSDi2qpXA" x="9" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_2HPJWZs8EeikSLSDi2qpXA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eDr7QLqtEeimKvjOEffRIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2HPJWps8EeikSLSDi2qpXA" x="-9" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_2HPJW5s8EeikSLSDi2qpXA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eG61cLqtEeimKvjOEffRIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2HPJXJs8EeikSLSDi2qpXA" x="9" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_2HPJXZs8EeikSLSDi2qpXA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_eK9A4LqtEeimKvjOEffRIA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_2HPJXps8EeikSLSDi2qpXA" x="-10" y="23"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_2HPJUZs8EeikSLSDi2qpXA"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_2EwdEJs8EeikSLSDi2qpXA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2HPJUps8EeikSLSDi2qpXA" points="[599, 73, -643984, -643984]$[600, 151, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Mk8UJs8EeikSLSDi2qpXA" id="(0.5058823529411764,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Mk8UZs8EeikSLSDi2qpXA" id="(0.20866141732283464,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Y349MLucEeiljfl0umr-iQ" type="Association_Edge" source="_xbRu43kvEeiO-c_khjKlFQ" target="_-2iRMJs7EeikSLSDi2qpXA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y349M7ucEeiljfl0umr-iQ" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_b7FocLucEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y349NLucEeiljfl0umr-iQ" x="5" y="5"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y349NbucEeiljfl0umr-iQ" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_b_K3MLucEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y349NrucEeiljfl0umr-iQ" x="-9"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y349N7ucEeiljfl0umr-iQ" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cC7V0LucEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y349OLucEeiljfl0umr-iQ" x="12" y="18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y349ObucEeiljfl0umr-iQ" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cG2MgLucEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y349OrucEeiljfl0umr-iQ" x="-12" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y349O7ucEeiljfl0umr-iQ" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cK4X8LucEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y349PLucEeiljfl0umr-iQ" x="12" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y349PbucEeiljfl0umr-iQ" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_cOZmALucEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y349PrucEeiljfl0umr-iQ" x="-12" y="20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Y349MbucEeiljfl0umr-iQ"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_Y0iHMLucEeiljfl0umr-iQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y349MrucEeiljfl0umr-iQ" points="[621, 103, -643984, -643984]$[623, 183, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y-49ELucEeiljfl0umr-iQ" id="(0.8729411764705882,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y-49EbucEeiljfl0umr-iQ" id="(0.8228346456692913,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jM04RPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_jM04QPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jM04RfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jM04SfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P2DywVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_P2DLsFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P2DywlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2DyxlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jM04RvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jM04R_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jM04SPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P2Dyw1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2DyxFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2DyxVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jNZgBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="_jNZgAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jNZgBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jNZgCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P2mlVFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="_P2mlUFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P2mlVVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2nMYlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jNZgBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jNZgB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jNZgCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P2mlVlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2nMYFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2nMYVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jNx6hPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="_jNx6gPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jNx6hfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jNx6ifPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P278hFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="_P278gFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P278hVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P278iVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jNx6hvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jNx6h_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jNx6iPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P278hlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P278h1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P278iFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jOWiRPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbRu43kvEeiO-c_khjKlFQ" target="_jOWiQPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jOWiRfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jOWiSfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P3fWJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRu43kvEeiO-c_khjKlFQ" target="_P3fWIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P3fWJVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P3fWKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jOWiRvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jOWiR_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jOWiSPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P3fWJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P3fWJ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P3fWKFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jPZrJ_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_QoX9AIuXEeiu6boZkiJHCA" target="_jPZrI_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jPZrKPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPZrLPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P4pMsVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_QoX9AIuXEeiu6boZkiJHCA" target="_P4oloFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P4pMslJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P4pMtlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jPZrKfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPZrKvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPZrK_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P4pMs1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P4pMtFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P4pMtVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jPl4ZPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_zM5mgJs5EeikSLSDi2qpXA" target="_jPl4YPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jPl4ZfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPl4afPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_zJXKUJs5EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jPl4ZvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPl4Z_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPl4aPPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jPr_BPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_2HPJUJs8EeikSLSDi2qpXA" target="_jPr_APPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jPr_BfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPr_CfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_2EwdEJs8EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jPr_BvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPr_B_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPr_CPPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jPyFp_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_Y349MLucEeiljfl0umr-iQ" target="_jPyFo_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jPyFqPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jPyFrPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_Y0iHMLucEeiljfl0umr-iQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jPyFqfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPyFqvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jPyFq_PlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jQWtZPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_jQWtYPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jQWtZfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jQWtafPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P5Ht1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_P5Ht0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P5Ht1VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P5Ht2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jQWtZvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jQWtZ_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jQWtaPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P5Ht1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P5Ht11JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P5Ht2FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jQpoV_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="_jQpoU_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jQpoWPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jQpoXPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P6K2tFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="_P6K2sFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P6K2tVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6K2uVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jQpoWfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jQpoWvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jQpoW_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P6K2tlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6K2t1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6K2uFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jRXaBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_jRXaAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jRXaBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jRXaCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P6p-5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_P6p-4FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P6p-5VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6p-6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jRXaBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jRXaB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jRXaCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P6p-5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6p-51JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6p-6FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jR8Bx_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_xbR393kvEeiO-c_khjKlFQ" target="_jR8Bw_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jR8ByPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jR8BzPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P7Gq1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbR393kvEeiO-c_khjKlFQ" target="_P7Gq0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P7Gq1VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P7Gq2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jR8ByfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jR8ByvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jR8By_PlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jSIPBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_KmsHYIuXEeiu6boZkiJHCA" target="_jSIPAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jSIPBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jSIPCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_AMK4gHk8EeiO-c_khjKlFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jSIPBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jSIPB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jSIPCPPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jSmwJPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_sregEHk7EeiO-c_khjKlFQ" target="_jSmwIPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jSmwJfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jSmwKfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_qzTdgHk7EeiO-c_khjKlFQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jSmwJvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jSmwJ_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jSmwKPPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jUVOdPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_wHswIJs5EeikSLSDi2qpXA" target="_jUVOcPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jUVOdfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jUVOefPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_wHacQJs5EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jUVOdvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jUVOd_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jUVOePPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jVSQt_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_-2iRMJs7EeikSLSDi2qpXA" target="_jVSQs_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jVSQuPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jVSQvPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jVSQufPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jVSQuvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jVSQu_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P7Gq1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P7Gq11JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P7Gq2FJqEemV99d_1db7sQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_3bpg4IoMEeivCevppATXng" type="PapyrusUMLClassDiagram" name="McResourceSpec" measurementUnit="Pixel">
@@ -3656,183 +3402,125 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_WCN9oJqMEeid4dfn4JFJZg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WDKY0ZqMEeid4dfn4JFJZg" x="341" y="-291" height="62"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_asvRIJs-EeikSLSDi2qpXA" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_asvRIps-EeikSLSDi2qpXA" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_asvRI5s-EeikSLSDi2qpXA" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_asvRJJs-EeikSLSDi2qpXA" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_asvRJZs-EeikSLSDi2qpXA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_cPhSgJs-EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vzXWsHk-EeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cPhSgZs-EeikSLSDi2qpXA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_cPhSgps-EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_vzXWsXk-EeiW-bN1POS5zg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_cPhSg5s-EeikSLSDi2qpXA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_asvRJps-EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_asvRJ5s-EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_asvRKJs-EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_asvRKZs-EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_asvRKps-EeikSLSDi2qpXA" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_asvRK5s-EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_asvRLJs-EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_asvRLZs-EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_asvRLps-EeikSLSDi2qpXA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_asvRL5s-EeikSLSDi2qpXA" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_asvRMJs-EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_asvRMZs-EeikSLSDi2qpXA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_asvRMps-EeikSLSDi2qpXA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_asvRM5s-EeikSLSDi2qpXA"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_asvRIZs-EeikSLSDi2qpXA" x="540" y="42" width="303" height="83"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_kLsUQ_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kLsURPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kLsURvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P9P_4FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P9P_4VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P9P_41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kLsURfPlEeinaYo1FpF9OA" x="582" y="-442"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P9P_4lJqEemV99d_1db7sQ" x="582" y="-442"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kMdJQ_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kMdJRPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kMdJRvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P90noFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P90noVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P90no1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kMdJRfPlEeinaYo1FpF9OA" x="753" y="-295"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P90nolJqEemV99d_1db7sQ" x="753" y="-295"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kM1jw_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kM1jxPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kM1jxvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P-L0AFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P-L0AVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-MbEFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kM1jxfPlEeinaYo1FpF9OA" x="753" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-L0AlJqEemV99d_1db7sQ" x="753" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kM7qYPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kM7qYfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kM7qY_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P-QsgFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P-QsgVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-Qsg1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kM7qYvPlEeinaYo1FpF9OA" x="753" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-QsglJqEemV99d_1db7sQ" x="753" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kNaLgPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kNaLgfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kNaLg_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P-wbwFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P-wbwVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-wbw1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kNaLgvPlEeinaYo1FpF9OA" x="1047" y="-292"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-wbwlJqEemV99d_1db7sQ" x="1047" y="-292"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kNymAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kNymAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kNymA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P_KEYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P_KEYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_KEY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kNymAvPlEeinaYo1FpF9OA" x="1047" y="-392"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_KEYlJqEemV99d_1db7sQ" x="1047" y="-392"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kNymE_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kNymFPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kNymFvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P_OV0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P_OV0VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_O84FJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kNymFfPlEeinaYo1FpF9OA" x="1047" y="-392"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_OV0lJqEemV99d_1db7sQ" x="1047" y="-392"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kORHI_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kORHJPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kORHJvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_P_rBwFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_P_rBwVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_rBw1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kORHJfPlEeinaYo1FpF9OA" x="736" y="-125"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_rBwlJqEemV99d_1db7sQ" x="736" y="-125"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kO1u4PPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kO1u4fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kO1u4_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_GXqq4Js9EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kO1u4vPlEeinaYo1FpF9OA" x="736" y="-225"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_kO71gPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kO71gfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kO71g_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_tRVGELudEeiljfl0umr-iQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kO71gvPlEeinaYo1FpF9OA" x="736" y="-225"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_kPOJY_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kPOJZPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kPOJZvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QAaBkFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QAaBkVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QAaBk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kPOJZfPlEeinaYo1FpF9OA" x="117" y="-448"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QAaBklJqEemV99d_1db7sQ" x="117" y="-448"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kP43wPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kP43wfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kP43w_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QA_QYFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QA_QYVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QA_QY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kP43wvPlEeinaYo1FpF9OA" x="109" y="-294"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QA_QYlJqEemV99d_1db7sQ" x="109" y="-294"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kQRSQPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kQRSQfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kQRSQ_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QBXD0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QBXq4FJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBXq4lJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kQRSQvPlEeinaYo1FpF9OA" x="109" y="-394"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBXq4VJqEemV99d_1db7sQ" x="109" y="-394"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kQRSU_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kQRSVPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kQRSVvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QBdKcFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QBdKcVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBdKc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kQRSVfPlEeinaYo1FpF9OA" x="109" y="-394"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBdKclJqEemV99d_1db7sQ" x="109" y="-394"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kQ8AoPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kQ8AofPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kQ8Ao_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QB_V8FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QB_V8VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QB_9AFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kQ8AovPlEeinaYo1FpF9OA" x="104" y="-146"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QB_V8lJqEemV99d_1db7sQ" x="104" y="-146"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kRy8Q_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kRy8RPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kRy8RvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QDGJMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QDGJMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDGJM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_WCN9oJqMEeid4dfn4JFJZg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kRy8RfPlEeinaYo1FpF9OA" x="541" y="-291"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QDGJMlJqEemV99d_1db7sQ" x="541" y="-291"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_kSLWw_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kSLWxPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kSLWxvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QDZrMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QDZrMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDZrM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dkJeAJqMEeid4dfn4JFJZg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kSLWxfPlEeinaYo1FpF9OA" x="541" y="-391"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_kSv-gPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_kSv-gfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kSv-g_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kSv-gvPlEeinaYo1FpF9OA" x="740" y="42"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QDZrMlJqEemV99d_1db7sQ" x="541" y="-391"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_3bpg4YoMEeivCevppATXng" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_3bpg4ooMEeivCevppATXng"/>
@@ -3911,7 +3599,7 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_quGURZozEeiOmuqNbykpsw" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__P49UJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGURpozEeiOmuqNbykpsw" x="-70" y="33"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGURpozEeiOmuqNbykpsw" x="-89" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_quGUR5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="__QpyUJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -3996,37 +3684,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dpnM0JqMEeid4dfn4JFJZg" id="(0.4673913043478261,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dpnM0ZqMEeid4dfn4JFJZg" id="(0.08050089445438283,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_avUEAJs-EeikSLSDi2qpXA" type="Association_Edge" source="_lvNYYJozEeiOmuqNbykpsw" target="_asvRIJs-EeikSLSDi2qpXA" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_avUEA5s-EeikSLSDi2qpXA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bKoHAJs-EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_avUEBJs-EeikSLSDi2qpXA" x="5" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_avUEBZs-EeikSLSDi2qpXA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bMcE4Js-EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_avUEBps-EeikSLSDi2qpXA" x="-8" y="-5"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_avUEB5s-EeikSLSDi2qpXA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bOJ8IJs-EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_avUECJs-EeikSLSDi2qpXA" x="12" y="-18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_avUECZs-EeikSLSDi2qpXA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bP3zYJs-EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_avUECps-EeikSLSDi2qpXA" x="-11" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_avUEC5s-EeikSLSDi2qpXA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bR3-gJs-EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_avUEDJs-EeikSLSDi2qpXA" x="13" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_avUEDZs-EeikSLSDi2qpXA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bUvFQJs-EeikSLSDi2qpXA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_avUEDps-EeikSLSDi2qpXA" x="-11" y="18"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_avUEAZs-EeikSLSDi2qpXA"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_GXqq4Js9EeikSLSDi2qpXA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_avUEAps-EeikSLSDi2qpXA" points="[595, -36, -643984, -643984]$[595, 42, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXhTgJs-EeikSLSDi2qpXA" id="(0.18354430379746836,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXhTgZs-EeikSLSDi2qpXA" id="(0.1782178217821782,0.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_PPGIgLtQEeiljfl0umr-iQ" type="Association_Edge" source="_SvF9cJozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_PPH9sLtQEeiljfl0umr-iQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_QkOIYLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -4092,31 +3749,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c0YScLtQEeiljfl0umr-iQ" id="(0.42934782608695654,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c0YScbtQEeiljfl0umr-iQ" id="(0.10726643598615918,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tTykMLudEeiljfl0umr-iQ" type="Association_Edge" source="_lvNYYJozEeiOmuqNbykpsw" target="_asvRIJs-EeikSLSDi2qpXA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_tTykM7udEeiljfl0umr-iQ" type="Association_StereotypeLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTykNLudEeiljfl0umr-iQ" x="7" y="4"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_tTykNbudEeiljfl0umr-iQ" type="Association_NameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTykNrudEeiljfl0umr-iQ" x="-7" y="4"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_tTzLQLudEeiljfl0umr-iQ" type="Association_TargetRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTzLQbudEeiljfl0umr-iQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_tTzLQrudEeiljfl0umr-iQ" type="Association_SourceRoleLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTzLQ7udEeiljfl0umr-iQ" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_tTzLRLudEeiljfl0umr-iQ" type="Association_SourceMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTzLRbudEeiljfl0umr-iQ" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_tTzLRrudEeiljfl0umr-iQ" type="Association_TargetMultiplicityLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tTzLR7udEeiljfl0umr-iQ" x="3" y="24"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_tTykMbudEeiljfl0umr-iQ"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_tRVGELudEeiljfl0umr-iQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tTykMrudEeiljfl0umr-iQ" points="[767, -36, -643984, -643984]$[767, 42, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZRhILudEeiljfl0umr-iQ" id="(0.7310126582278481,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZRhIbudEeiljfl0umr-iQ" id="(0.7491749174917491,0.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_NDF3oMMqEei3gLXE4_XcoA" type="Association_Edge" source="_F5DNQpo1EeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw">
       <children xmi:type="notation:DecorationNode" xmi:id="_NDF3o8MqEei3gLXE4_XcoA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PJ82cMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -4148,185 +3780,155 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PbcPEMMqEei3gLXE4_XcoA" id="(1.0,0.5846153846153846)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PbcPEcMqEei3gLXE4_XcoA" id="(0.0,0.49230769230769234)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kLsUR_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_SvF9cJozEeiOmuqNbykpsw" target="_kLsUQ_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kLsUSPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kLsUTPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P9P_5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_SvF9cJozEeiOmuqNbykpsw" target="_P9P_4FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P9P_5VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P9P_6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kLsUSfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kLsUSvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kLsUS_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P9P_5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P9P_51JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P9P_6FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kMdJR_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_aiK4MJozEeiOmuqNbykpsw" target="_kMdJQ_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kMdJSPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kMdJTPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P90npFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_aiK4MJozEeiOmuqNbykpsw" target="_P90noFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P90npVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P90nqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kMdJSfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kMdJSvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kMdJS_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P90nplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P90np1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P90nqFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kM1jx_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_c-z5wZozEeiOmuqNbykpsw" target="_kM1jw_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kM1jyPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kM1jzPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P-MbEVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_c-z5wZozEeiOmuqNbykpsw" target="_P-L0AFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P-MbElJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-MbFlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kM1jyfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kM1jyvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kM1jy_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P-MbE1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-MbFFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-MbFVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kM7qZPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_qPcpYJozEeiOmuqNbykpsw" target="_kM7qYPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kM7qZfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kM7qafPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P-QshFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_qPcpYJozEeiOmuqNbykpsw" target="_P-QsgFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P-QshVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-QsiVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kM7qZvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kM7qZ_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kM7qaPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P-QshlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-Qsh1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-QsiFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kNaLhPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_a2-DgpozEeiOmuqNbykpsw" target="_kNaLgPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kNaLhfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kNaLifPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P-wbxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_a2-DgpozEeiOmuqNbykpsw" target="_P-wbwFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P-wbxVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-wbyVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kNaLhvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kNaLh_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kNaLiPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P-wbxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-wbx1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-wbyFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kNymBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_dbbkUJozEeiOmuqNbykpsw" target="_kNymAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kNymBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kNymCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P_KEZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_dbbkUJozEeiOmuqNbykpsw" target="_P_KEYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P_KEZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_KEaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kNymBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kNymB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kNymCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_KEZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_KEZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_KEaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kNymF_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_quGUQJozEeiOmuqNbykpsw" target="_kNymE_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kNymGPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kNymHPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P_O84VJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_quGUQJozEeiOmuqNbykpsw" target="_P_OV0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P_O84lJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_O85lJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kNymGfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kNymGvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kNymG_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_O841JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_O85FJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_O85VJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kORHJ_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_lvNYYJozEeiOmuqNbykpsw" target="_kORHI_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kORHKPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kORHLPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_P_rBxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_lvNYYJozEeiOmuqNbykpsw" target="_P_rBwFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P_rBxVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_rByVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kORHKfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kORHKvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kORHK_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_rBxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_rBx1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_rByFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kO1u5PPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_avUEAJs-EeikSLSDi2qpXA" target="_kO1u4PPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kO1u5fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kO1u6fPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_GXqq4Js9EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kO1u5vPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kO1u5_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kO1u6PPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kO71hPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_tTykMLudEeiljfl0umr-iQ" target="_kO71gPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kO71hfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kO71ifPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_tRVGELudEeiljfl0umr-iQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kO71hvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kO71h_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kO71iPPlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kPOJZ_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_F5DNQpo1EeiOmuqNbykpsw" target="_kPOJY_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kPOJaPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kPOJbPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QAaBlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5DNQpo1EeiOmuqNbykpsw" target="_QAaBkFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QAaBlVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QAaBmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kPOJafPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kPOJavPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kPOJa_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QAaBllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QAaBl1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QAaBmFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kP43xPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_kP43wPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kP43xfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kP43yfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QA_QZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_QA_QYFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QA_QZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QA_3cFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kP43xvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kP43x_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kP43yPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QA_QZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QA_QZ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QA_QaFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kQRSRPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_F5DNMJo1EeiOmuqNbykpsw" target="_kQRSQPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kQRSRfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kQRSSfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QBXq41JqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5DNMJo1EeiOmuqNbykpsw" target="_QBXD0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QBXq5FJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBXq6FJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kQRSRvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kQRSR_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kQRSSPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QBXq5VJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBXq5lJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBXq51JqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kQRSV_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_F5JURJo1EeiOmuqNbykpsw" target="_kQRSU_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kQRSWPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kQRSXPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QBdKdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5JURJo1EeiOmuqNbykpsw" target="_QBdKcFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QBdKdVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBdKeVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kQRSWfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kQRSWvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kQRSW_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QBdKdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBdKd1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBdKeFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kQ8ApPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_F5JUXpo1EeiOmuqNbykpsw" target="_kQ8AoPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kQ8ApfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kQ8AqfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QB_9AVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5JUXpo1EeiOmuqNbykpsw" target="_QB_V8FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QB_9AlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QCAkEFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kQ8ApvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kQ8Ap_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kQ8AqPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QB_9A1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QB_9BFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QB_9BVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kRy8R_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_WDKY0JqMEeid4dfn4JFJZg" target="_kRy8Q_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kRy8SPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kRy8TPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QDGJNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_WDKY0JqMEeid4dfn4JFJZg" target="_QDGJMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QDGJNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDGJOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_WCN9oJqMEeid4dfn4JFJZg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kRy8SfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kRy8SvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kRy8S_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QDGJNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDGJN1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDGJOFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kSLWx_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_dkQywJqMEeid4dfn4JFJZg" target="_kSLWw_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kSLWyPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kSLWzPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QDZrNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_dkQywJqMEeid4dfn4JFJZg" target="_QDZrMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QDZrNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDaSQlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dkJeAJqMEeid4dfn4JFJZg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kSLWyfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kSLWyvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kSLWy_PlEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_kSv-hPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_asvRIJs-EeikSLSDi2qpXA" target="_kSv-gPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_kSv-hfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kSv-ifPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_-2cKkJs7EeikSLSDi2qpXA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kSv-hvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kSv-h_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kSv-iPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QDZrNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDaSQFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDaSQVJqEemV99d_1db7sQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_47kdwPJSEeiTnqcAgKK24Q" type="PapyrusUMLClassDiagram" name="ServiceInterfaceSpec" measurementUnit="Pixel">
@@ -4464,213 +4066,213 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_byzeEfPiEeinaYo1FpF9OA" x="31" y="8" width="299" height="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PD40E_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PD40FPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PD40FvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QGL5cFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QGL5cVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGL5c1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PD40FfPlEeinaYo1FpF9OA" x="374" y="118"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGL5clJqEemV99d_1db7sQ" x="380" y="154"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PELvAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PELvAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PELvA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QGYGsFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QGYGsVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGYGs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PELvAvPlEeinaYo1FpF9OA" x="189" y="115"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGYGslJqEemV99d_1db7sQ" x="195" y="151"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PE8kAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PE8kAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PE8kA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QGjF0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QGjF0VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGjF01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PE8kAvPlEeinaYo1FpF9OA" x="1173" y="-32"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGjF0lJqEemV99d_1db7sQ" x="1173" y="-32"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PFO34_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PFO35PPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PFO35vPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QGusAFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QGusAVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGusA1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PFO35fPlEeinaYo1FpF9OA" x="683" y="-21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGusAlJqEemV99d_1db7sQ" x="683" y="-21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PFnSYPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PFnSYfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PFnSY_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QG5rIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QG5rIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QG5rI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PFnSYvPlEeinaYo1FpF9OA" x="662" y="391"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QG5rIlJqEemV99d_1db7sQ" x="662" y="391"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PF_s4PPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PF_s4fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PF_s4_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QHEqQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QHEqQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHEqQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PF_s4vPlEeinaYo1FpF9OA" x="1166" y="389"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QHEqQlJqEemV99d_1db7sQ" x="1166" y="389"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PGwh4PPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PGwh4fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PGwh4_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QHgvIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QHgvIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHgvI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGwh4vPlEeinaYo1FpF9OA" x="219" y="245"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QHgvIlJqEemV99d_1db7sQ" x="225" y="281"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PHC1w_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PHC1xPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PHC1xvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QHzDAFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QHzDAVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHzDA1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z05pcPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PHC1xfPlEeinaYo1FpF9OA" x="219" y="145"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QHzDAlJqEemV99d_1db7sQ" x="225" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PHI8afPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PHI8avPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PHI8bPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QH3UcFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QH3UcVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QH3Uc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0gaEkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PHI8a_PlEeinaYo1FpF9OA" x="219" y="145"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QH3UclJqEemV99d_1db7sQ" x="225" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PIYSg_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PIYShPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PIYShvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QISyQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QISyQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QITZUFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PIYShfPlEeinaYo1FpF9OA" x="668" y="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QISyQlJqEemV99d_1db7sQ" x="668" y="135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PKADIPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PKADIfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKADI_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QJTe4FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJTe4VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJTe41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_2olSAPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PKADIvPlEeinaYo1FpF9OA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJTe4lJqEemV99d_1db7sQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PKAqM_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PKAqNPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKAqNvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QJXJQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJXJQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJXwUFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_3PqgIPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PKAqNfPlEeinaYo1FpF9OA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJXJQlJqEemV99d_1db7sQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PKH-8PPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PKH-8fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKH-8_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QJbasFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJbasVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJbas1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_8ryxoPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PKH-8vPlEeinaYo1FpF9OA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJbaslJqEemV99d_1db7sQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PKZEsPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PKZEsfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKZEs_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QJfsIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJfsIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJfsI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_-HZ0APJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PKZEsvPlEeinaYo1FpF9OA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJfsIlJqEemV99d_1db7sQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PKfLU_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PKfLVPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKfLVvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QJj9kFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJj9kVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJj9k1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_OuQmoPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PKfLVfPlEeinaYo1FpF9OA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJj9klJqEemV99d_1db7sQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PKl5APPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PKl5AfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKl5A_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QJo2EFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QJo2EVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJo2E1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Qv8xkPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PKl5AvPlEeinaYo1FpF9OA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJo2ElJqEemV99d_1db7sQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PLcNkPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PLcNkfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PLcNk_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKE68FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKE68VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKFiAFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PLcNkvPlEeinaYo1FpF9OA" x="1157" y="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKE68lJqEemV99d_1db7sQ" x="1157" y="135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PMHjAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PMHjAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMHjA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKX14FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKX14VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKX141JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_32fPkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMHjAvPlEeinaYo1FpF9OA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKX14lJqEemV99d_1db7sQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PMNpo_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PMNppPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMTwQPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKcHUFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKcHUVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKcHU1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_4V4hUPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMNppfPlEeinaYo1FpF9OA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKcHUlJqEemV99d_1db7sQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PMZ24PPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PMZ24fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMZ24_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKgYwFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKgYwVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKgYw1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_5DM6UPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMZ24vPlEeinaYo1FpF9OA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKgYwlJqEemV99d_1db7sQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PMf9gPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PMf9gfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMf9g_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKkqMFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKkqMVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKkqM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_56YZ8PJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMf9gvPlEeinaYo1FpF9OA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKkqMlJqEemV99d_1db7sQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PMmEI_PlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PMmEJPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMmEJvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKo7oFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKo7oVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKo7o1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_GZ48sPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PMmEJfPlEeinaYo1FpF9OA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKo7olJqEemV99d_1db7sQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PM4YAPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PM4YAfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PM4YA_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QKtNEFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QKtNEVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKtNE1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_P7X6APJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PM4YAvPlEeinaYo1FpF9OA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKtNElJqEemV99d_1db7sQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PNjtcPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PNjtcfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PNjtc_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QLMVQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QLMVQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLMVQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PNjtcvPlEeinaYo1FpF9OA" x="225" y="-28"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLMVQlJqEemV99d_1db7sQ" x="231" y="8"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_POCOkPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_POCOkfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_POCOk_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QLmk8FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QLmk8VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLmk81JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_gfAHcPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_POCOkvPlEeinaYo1FpF9OA" x="225" y="-128"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLmk8lJqEemV99d_1db7sQ" x="231" y="-92"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_POIVMPPlEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_POIVMfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_POIVM_PlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QLsrkFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QLsrkVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLsrk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_hQjgMPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_POIVMvPlEeinaYo1FpF9OA" x="225" y="-128"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLsrklJqEemV99d_1db7sQ" x="231" y="-92"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_47kdwfJSEeiTnqcAgKK24Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_47kdwvJSEeiTnqcAgKK24Q"/>
@@ -4918,265 +4520,265 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hUMqEPPiEeinaYo1FpF9OA" id="(0.842809364548495,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hUMqEfPiEeinaYo1FpF9OA" id="(0.5282051282051282,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PD40F_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_76u9kPJSEeiTnqcAgKK24Q" target="_PD40E_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PD40GPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PD40HPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QGL5dFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_76u9kPJSEeiTnqcAgKK24Q" target="_QGL5cFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QGL5dVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGMgglJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PD40GfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PD40GvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PD40G_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGL5dlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGMggFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGMggVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PELvBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_8W-NoPJSEeiTnqcAgKK24Q" target="_PELvAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PELvBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PELvCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QGYGtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_8W-NoPJSEeiTnqcAgKK24Q" target="_QGYGsFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QGYGtVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGYGuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PELvBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PELvB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PELvCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGYGtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGYGt1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGYGuFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PE8kBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_RmCMYPJTEeiTnqcAgKK24Q" target="_PE8kAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PE8kBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PE8kCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QGjF1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_RmCMYPJTEeiTnqcAgKK24Q" target="_QGjF0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QGjF1VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGjF2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PE8kBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PE8kB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PE8kCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGjF1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGjF11JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGjF2FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PFO35_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_R6EisPJTEeiTnqcAgKK24Q" target="_PFO34_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PFO36PPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PFO37PPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QGusBFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_R6EisPJTEeiTnqcAgKK24Q" target="_QGusAFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QGusBVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGusCVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PFO36fPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PFO36vPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PFO36_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGusBlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGusB1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGusCFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PFnSZPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_TEZn0PJTEeiTnqcAgKK24Q" target="_PFnSYPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PFnSZfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PFnSafPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QG5rJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_TEZn0PJTEeiTnqcAgKK24Q" target="_QG5rIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QG5rJVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QG5rKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PFnSZvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PFnSZ_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PFnSaPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QG5rJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QG5rJ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QG5rKFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PF_s5PPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_UOifsPJTEeiTnqcAgKK24Q" target="_PF_s4PPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PF_s5fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PF_s6fPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QHEqRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_UOifsPJTEeiTnqcAgKK24Q" target="_QHEqQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QHEqRVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHEqSVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PF_s5vPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PF_s5_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PF_s6PPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QHEqRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHEqR1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHEqSFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PGwh5PPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_aYe5cPJTEeiTnqcAgKK24Q" target="_PGwh4PPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PGwh5fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PGwh6fPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QHgvJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_aYe5cPJTEeiTnqcAgKK24Q" target="_QHgvIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QHgvJVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHgvKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PGwh5vPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PGwh5_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PGwh6PPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QHgvJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHgvJ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHgvKFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PHC1x_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_z0_wEPJTEeiTnqcAgKK24Q" target="_PHC1w_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PHC1yPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PHC1zPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QHzDBFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_z0_wEPJTEeiTnqcAgKK24Q" target="_QHzDAFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QHzDBVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHzDCVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z05pcPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PHC1yfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PHC1yvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PHC1y_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QHzDBlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHzDB1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHzDCFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PHI8bfPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_0ggLMPJTEeiTnqcAgKK24Q" target="_PHI8afPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PHI8bvPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PHI8cvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QH3UdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_0ggLMPJTEeiTnqcAgKK24Q" target="_QH3UcFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QH3UdVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QH3UeVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0gaEkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PHI8b_PlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PHI8cPPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PHI8cfPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QH3UdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QH3Ud1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QH3UeFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PIYSh_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_lm3dcPJTEeiTnqcAgKK24Q" target="_PIYSg_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PIYSiPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PIYSjPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QITZUVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_lm3dcPJTEeiTnqcAgKK24Q" target="_QISyQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QITZUlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QITZVlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PIYSifPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYSivPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYSi_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QITZU1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QITZVFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QITZVVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PKADJPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_2olSAfJTEeiTnqcAgKK24Q" target="_PKADIPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PKADJfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKADKfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QJTe5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_2olSAfJTEeiTnqcAgKK24Q" target="_QJTe4FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJTe5VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJTe6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_2olSAPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKADJvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKADJ_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKADKPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJTe5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJTe51JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJTe6FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PKAqN_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_3PqgIfJTEeiTnqcAgKK24Q" target="_PKAqM_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PKAqOPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKAqPPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QJXwUVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_3PqgIfJTEeiTnqcAgKK24Q" target="_QJXJQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJXwUlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJXwVlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_3PqgIPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKAqOfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKAqOvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKAqO_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJXwU1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJXwVFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJXwVVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PKH-9PPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_8ryxofJTEeiTnqcAgKK24Q" target="_PKH-8PPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PKH-9fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKH--fPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QJcBwFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_8ryxofJTEeiTnqcAgKK24Q" target="_QJbasFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJcBwVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJcBxVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_8ryxoPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKH-9vPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKH-9_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKH--PPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJcBwlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJcBw1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJcBxFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PKZEtPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_-HZ0AfJTEeiTnqcAgKK24Q" target="_PKZEsPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PKZEtfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKZEufPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QJfsJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_-HZ0AfJTEeiTnqcAgKK24Q" target="_QJfsIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJfsJVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJfsKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_-HZ0APJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKZEtvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKZEt_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKZEuPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJfsJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJfsJ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJfsKFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PKfLV_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_OuQmofJWEeiTnqcAgKK24Q" target="_PKfLU_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PKfLWPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKfLXPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QJj9lFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_OuQmofJWEeiTnqcAgKK24Q" target="_QJj9kFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJj9lVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJkkoFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_OuQmoPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKfLWfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKfLWvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKfLW_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJj9llJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJj9l1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJj9mFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PKl5BPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_Qv8xkfJWEeiTnqcAgKK24Q" target="_PKl5APPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PKl5BfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PKl5CfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QJo2FFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Qv8xkfJWEeiTnqcAgKK24Q" target="_QJo2EFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QJo2FVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJo2GVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Qv8xkPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PKl5BvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKl5B_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PKl5CPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJo2FlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJo2F1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJo2GFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PLcNlPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_tNB9kPJTEeiTnqcAgKK24Q" target="_PLcNkPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PLcNlfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PLcNmfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKFiAVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_tNB9kPJTEeiTnqcAgKK24Q" target="_QKE68FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKFiAlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKFiBlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PLcNlvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PLcNl_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PLcNmPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKFiA1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKFiBFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKFiBVJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PMHjBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_32fPkfJTEeiTnqcAgKK24Q" target="_PMHjAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PMHjBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMHjCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKX15FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_32fPkfJTEeiTnqcAgKK24Q" target="_QKX14FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKX15VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKX16VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_32fPkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PMHjBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMHjB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMHjCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKX15lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKX151JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKX16FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PMTwQfPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_4V-n8PJTEeiTnqcAgKK24Q" target="_PMNpo_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PMTwQvPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMTwRvPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKcHVFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_4V-n8PJTEeiTnqcAgKK24Q" target="_QKcHUFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKcHVVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKcHWVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_4V4hUPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PMTwQ_PlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMTwRPPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMTwRfPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKcHVlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKcHV1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKcHWFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PMZ25PPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_5DM6UfJTEeiTnqcAgKK24Q" target="_PMZ24PPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PMZ25fPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMZ26fPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKgYxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_5DM6UfJTEeiTnqcAgKK24Q" target="_QKgYwFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKgYxVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKgYyVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_5DM6UPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PMZ25vPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMZ25_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMZ26PPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKgYxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKgYx1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKgYyFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PMf9hPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_56YZ8fJTEeiTnqcAgKK24Q" target="_PMf9gPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PMf9hfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMf9ifPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKkqNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_56YZ8fJTEeiTnqcAgKK24Q" target="_QKkqMFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKkqNVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKkqOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_56YZ8PJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PMf9hvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMf9h_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMf9iPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKkqNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKkqN1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKkqOFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PMmEJ_PlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_GZ_DUPJWEeiTnqcAgKK24Q" target="_PMmEI_PlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PMmEKPPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PMmELPPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKo7pFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_GZ_DUPJWEeiTnqcAgKK24Q" target="_QKo7oFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKo7pVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKo7qVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_GZ48sPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PMmEKfPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMmEKvPlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PMmEK_PlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKo7plJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKo7p1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKo7qFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PM4YBPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_P7X6AfJWEeiTnqcAgKK24Q" target="_PM4YAPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PM4YBfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PM4YCfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QKtNFFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_P7X6AfJWEeiTnqcAgKK24Q" target="_QKtNEFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QKtNFVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKtNGVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_P7X6APJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PM4YBvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PM4YB_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PM4YCPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKtNFlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKtNF1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKtNGFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PNjtdPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_byzeEPPiEeinaYo1FpF9OA" target="_PNjtcPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PNjtdfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PNjtefPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QLMVRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_byzeEPPiEeinaYo1FpF9OA" target="_QLMVQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QLMVRVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLMVSVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PNjtdvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PNjtd_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PNjtePPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QLMVRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLMVR1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLMVSFJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_POCOlPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_gfM7wPPiEeinaYo1FpF9OA" target="_POCOkPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_POCOlfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_POCOmfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QLmk9FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_gfM7wPPiEeinaYo1FpF9OA" target="_QLmk8FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QLmk9VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLmk-VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_gfAHcPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_POCOlvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_POCOl_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_POCOmPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QLmk9lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLmk91JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLmk-FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_POIVNPPlEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_hQmjgPPiEeinaYo1FpF9OA" target="_POIVMPPlEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_POIVNfPlEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_POIVOfPlEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QLsrlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_hQmjgPPiEeinaYo1FpF9OA" target="_QLsrkFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QLsrlVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLsrmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_hQjgMPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_POIVNvPlEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_POIVN_PlEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_POIVOPPlEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QLsrllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLsrl1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLsrmFJqEemV99d_1db7sQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_1hK84PPmEeinaYo1FpF9OA" type="PapyrusUMLClassDiagram" name="ResourceInterfaceSpec" measurementUnit="Pixel">
@@ -5211,42 +4813,10 @@
       <element xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_82BrB_PmEeinaYo1FpF9OA" x="40" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_824mMPPmEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_824mMfPmEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_824mM_PmEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_824mMvPmEeinaYo1FpF9OA" x="285" y="446"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_82-s0PPmEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_82-s0fPmEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_82-s0_PmEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_82-s0vPmEeinaYo1FpF9OA" x="285" y="346"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_83K6EPPmEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_83K6EfPmEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_83K6E_PmEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_83K6EvPmEeinaYo1FpF9OA" x="303" y="327"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_ccsWUPPnEeinaYo1FpF9OA" type="NamedElement_DefaultShape">
       <children xmi:type="notation:DecorationNode" xmi:id="_ccsWUvPnEeinaYo1FpF9OA" type="NamedElement_NameLabel"/>
       <element xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ccsWUfPnEeinaYo1FpF9OA" x="402" y="142" width="371" height="70"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_cc4jk_PnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cc4jlPPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cc4jlvPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cc4jlfPnEeinaYo1FpF9OA" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_fxd5wPPnEeinaYo1FpF9OA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_fxd5wvPnEeinaYo1FpF9OA" type="Class_NameLabel"/>
@@ -5274,14 +4844,6 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fxd5wfPnEeinaYo1FpF9OA" x="416" y="-2" width="325" height="74"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_fxwNoPPnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_fxwNofPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fxwNo_PnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fxwNovPnEeinaYo1FpF9OA" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_qeHpsPPnEeinaYo1FpF9OA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_qeHpsvPnEeinaYo1FpF9OA" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_qeHps_PnEeinaYo1FpF9OA" type="Class_FloatingNameLabel">
@@ -5307,14 +4869,6 @@
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qeHpsfPnEeinaYo1FpF9OA" x="305" y="299" width="272" height="68"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_qeT28_PnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_qeT29PPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qeT29vPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qeT29fPnEeinaYo1FpF9OA" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_s45qEPPnEeinaYo1FpF9OA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_s45qEvPnEeinaYo1FpF9OA" type="Class_NameLabel"/>
@@ -5342,37 +4896,85 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s45qEfPnEeinaYo1FpF9OA" x="590" y="298" width="253" height="70"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_s5L98_PnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_s5L99PPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s5L99vPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
+    <children xmi:type="notation:Shape" xmi:id="_QNur4FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QNur4VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QNur41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s5L99fPnEeinaYo1FpF9OA" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QNur4lJqEemV99d_1db7sQ" x="222" y="153"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6gm14_PnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6gm15PPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6gm15vPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
+    <children xmi:type="notation:Shape" xmi:id="_QOBm0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QOBm0VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOBm01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6gm15fPnEeinaYo1FpF9OA" x="790" y="198"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOBm0lJqEemV99d_1db7sQ" x="222" y="53"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7jeoI_PnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7jeoJPPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7jeoJvPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
+    <children xmi:type="notation:Shape" xmi:id="_QOKwwFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QOKwwVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOKww1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7jeoJfPnEeinaYo1FpF9OA" x="505" y="199"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOKwwlJqEemV99d_1db7sQ" x="240" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_81VRk_PnEeinaYo1FpF9OA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_81VRlPPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_81bYMPPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_QOVI0FJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QOVI0VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOVI01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOVI0lJqEemV99d_1db7sQ" x="602" y="142"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QOx0wFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QOx0wVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOx0w1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOx0wlJqEemV99d_1db7sQ" x="616" y="-2"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QPEIoFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QPEIoVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPEIo1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_yw4xIPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_81VRlfPnEeinaYo1FpF9OA" x="616" y="-102"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPEIolJqEemV99d_1db7sQ" x="616" y="-102"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QPe_YFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QPe_YVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPe_Y1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPe_YlJqEemV99d_1db7sQ" x="505" y="299"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QPxTQFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QPxTQVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPx6UFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPxTQlJqEemV99d_1db7sQ" x="505" y="199"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QQNYIFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QQNYIVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQNYI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QQNYIlJqEemV99d_1db7sQ" x="790" y="298"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QQfsAFJqEemV99d_1db7sQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_QQfsAVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQgTEFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QQfsAlJqEemV99d_1db7sQ" x="790" y="198"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_1hK84fPmEeinaYo1FpF9OA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_1hK84vPmEeinaYo1FpF9OA"/>
@@ -5394,76 +4996,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_82BqnPPmEeinaYo1FpF9OA" points="[100, 153, -643984, -643984]$[100, 84, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_82BqnfPmEeinaYo1FpF9OA" id="(0.3611111111111111,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_82BqnvPmEeinaYo1FpF9OA" id="(0.3592814371257485,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_824mNPPmEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_82Bqn_PmEeinaYo1FpF9OA" target="_824mMPPmEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_824mNfPmEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_824mOfPmEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_824mNvPmEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_824mN_PmEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_824mOPPmEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_82-s1PPmEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_82BqkfPmEeinaYo1FpF9OA" target="_82-s0PPmEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_82-s1fPmEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_82-s2fPmEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_82-s1vPmEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_82-s1_PmEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_82-s2PPmEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_83K6FPPmEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_82Bq5_PmEeinaYo1FpF9OA" target="_83K6EPPmEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_83K6FfPmEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_83K6GfPmEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_83K6FvPmEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_83K6F_PmEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_83K6GPPmEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cc4jl_PnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_ccsWUPPnEeinaYo1FpF9OA" target="_cc4jk_PnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cc4jmPPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cc4jnPPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cc4jmfPnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cc4jmvPnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cc4jm_PnEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_fxwNpPPnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_fxd5wPPnEeinaYo1FpF9OA" target="_fxwNoPPnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_fxwNpfPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fxwNqfPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fxwNpvPnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fxwNp_PnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fxwNqPPnEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qeT29_PnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_qeHpsPPnEeinaYo1FpF9OA" target="_qeT28_PnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_qeT2-PPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qeT2_PPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qeT2-fPnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qeT2-vPnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qeT2-_PnEeinaYo1FpF9OA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_s5L99_PnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_s45qEPPnEeinaYo1FpF9OA" target="_s5L98_PnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_s5L9-PPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s5L9_PPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_s5L9-fPnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s5L9-vPnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s5L9-_PnEeinaYo1FpF9OA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_yw4xIfPnEeinaYo1FpF9OA" type="Abstraction_Edge" source="_fxd5wPPnEeinaYo1FpF9OA" target="_ccsWUPPnEeinaYo1FpF9OA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_yw4xJPPnEeinaYo1FpF9OA" type="Abstraction_NameLabel">
@@ -5510,35 +5042,105 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z82N8PPnEeinaYo1FpF9OA" id="(0.43478260869565216,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z82N8fPnEeinaYo1FpF9OA" id="(0.8032345013477089,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6gm15_PnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_z7yeAPPnEeinaYo1FpF9OA" target="_6gm14_PnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6gm16PPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6gm17PPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_QNur5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_82Bqn_PmEeinaYo1FpF9OA" target="_QNur4FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QNur5VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QNur6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6gm16fPnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6gm16vPnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6gm16_PnEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QNur5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QNur51JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QNur6FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7jeoJ_PnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_zUAsUfPnEeinaYo1FpF9OA" target="_7jeoI_PnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7jeoKPPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7jeoLPPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_QOBm1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_82BqkfPmEeinaYo1FpF9OA" target="_QOBm0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QOBm1VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOBm2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7jeoKfPnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7jeoKvPnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7jeoK_PnEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOBm1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOBm11JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOBm2FJqEemV99d_1db7sQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_81bYMfPnEeinaYo1FpF9OA" type="StereotypeCommentLink" source="_yw4xIfPnEeinaYo1FpF9OA" target="_81VRk_PnEeinaYo1FpF9OA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_81bYMvPnEeinaYo1FpF9OA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_81bYNvPnEeinaYo1FpF9OA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_QOKwxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_82Bq5_PmEeinaYo1FpF9OA" target="_QOKwwFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QOKwxVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOKwyVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOKwxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOKwx1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOKwyFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QOVI1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_ccsWUPPnEeinaYo1FpF9OA" target="_QOVI0FJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QOVI1VJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOVI2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOVI1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOVI11JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOVI2FJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QOx0xFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_fxd5wPPnEeinaYo1FpF9OA" target="_QOx0wFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QOx0xVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOx0yVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOx0xlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOx0x1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOx0yFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QPEIpFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_yw4xIfPnEeinaYo1FpF9OA" target="_QPEIoFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QPEIpVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPEIqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_yw4xIPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_81bYM_PnEeinaYo1FpF9OA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_81bYNPPnEeinaYo1FpF9OA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_81bYNfPnEeinaYo1FpF9OA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPEIplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPEIp1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPEIqFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QPe_ZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_qeHpsPPnEeinaYo1FpF9OA" target="_QPe_YFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QPe_ZVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPe_aVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPe_ZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPe_Z1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPe_aFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QPx6UVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_zUAsUfPnEeinaYo1FpF9OA" target="_QPxTQFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QPx6UlJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPx6VlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPx6U1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPx6VFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPx6VVJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QQNYJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_s45qEPPnEeinaYo1FpF9OA" target="_QQNYIFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QQNYJVJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQNYKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QQNYJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQNYJ1JqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQNYKFJqEemV99d_1db7sQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QQgTEVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_z7yeAPPnEeinaYo1FpF9OA" target="_QQfsAFJqEemV99d_1db7sQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_QQgTElJqEemV99d_1db7sQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQgTFlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QQgTE1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQgTFFJqEemV99d_1db7sQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQgTFVJqEemV99d_1db7sQ"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -64,7 +64,7 @@ License: This module is distributed under the Apache License 2.0</body>
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AMLfkHk8EeiO-c_khjKlFQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AMLfkXk8EeiO-c_khjKlFQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_AMMGonk8EeiO-c_khjKlFQ" name="otsiaconnectionendpointspec" type="_mXvsEHZlEeiPPoPDo3q5jA" association="_AMK4gHk8EeiO-c_khjKlFQ"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_AMMGonk8EeiO-c_khjKlFQ" name="otsiaconnectionendpointspec" type="_KjQ3qhKOEeajhbtskMXJfw" association="_AMK4gHk8EeiO-c_khjKlFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_LhPS8IoJEeivCevppATXng" name="PhotonicAugmentsLayerProtocolQualifer" client="_ErlpwIoJEeivCevppATXng">
         <supplier xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
@@ -90,7 +90,7 @@ License: This module is distributed under the Apache License 2.0</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uzBycJmoEeiOmuqNbykpsw" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ObUMoJmaEeiOmuqNbykpsw" name="McCsepSpecAugmentsCsep" client="_UyBxsBKOEeajhbtskMXJfw">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ObUMoJmaEeiOmuqNbykpsw" name="McCsepSpecAugmentsCsep" client="_Es15AJmWEeiOmuqNbykpsw">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_c-z5wJozEeiOmuqNbykpsw" name="McCepSpecAugmentsCep" client="_aiExkJozEeiOmuqNbykpsw">
@@ -235,6 +235,24 @@ License: This module is distributed under the Apache License 2.0</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_z7sXYPPnEeinaYo1FpF9OA" name="OtsiCepSpecAugmentsCepDetailsOutput" client="_KjQ3rRKOEeajhbtskMXJfw">
         <supplier xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_USr90FJkEemV99d_1db7sQ" name="McSipHasPowerCapabilityPac" memberEnd="_UStL8lJkEemV99d_1db7sQ _USuaEVJkEemV99d_1db7sQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_UStL8FJkEemV99d_1db7sQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_UStL8VJkEemV99d_1db7sQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_USuaEVJkEemV99d_1db7sQ" name="mediachannelpoolcapabilitypac" type="_syPL8JmTEeiOmuqNbykpsw" association="_USr90FJkEemV99d_1db7sQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_IGJvgFJkEemV99d_1db7sQ" name="OtsiSipHasPowerCapabilityPac" memberEnd="_IGOA8FJkEemV99d_1db7sQ _IGPPEVJkEemV99d_1db7sQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IGMLwFJkEemV99d_1db7sQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IGMLwVJkEemV99d_1db7sQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_IGPPEVJkEemV99d_1db7sQ" name="otsiserviceinterfacepointspec" type="_EqncAHiHEeiPPoPDo3q5jA" association="_IGJvgFJkEemV99d_1db7sQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_HbvrIFJlEemV99d_1db7sQ" name="SmcCsepHasPowerConfigPac" memberEnd="_HbzVgFJlEemV99d_1db7sQ _Hbz8klJlEemV99d_1db7sQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_HbyucFJlEemV99d_1db7sQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_HbyucVJlEemV99d_1db7sQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Hbz8klJlEemV99d_1db7sQ" name="mediachannelconnectivityserviceendpointspec" type="_Es15AJmWEeiOmuqNbykpsw" association="_HbvrIFJlEemV99d_1db7sQ"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_bTHgIBKOEeajhbtskMXJfw" name="ObjectClasses">
@@ -242,6 +260,7 @@ License: This module is distributed under the Apache License 2.0</body>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lIJUIHZfEeiPPoPDo3q5jA" name="numberOfOtsi" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AMLfknk8EeiO-c_khjKlFQ" name="fecParameters" type="_U2XowFJbEemV99d_1db7sQ" isReadOnly="true" aggregation="composite" association="_AMK4gHk8EeiO-c_khjKlFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3rRKOEeajhbtskMXJfw" name="OtsiConnectionEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3sRKOEeajhbtskMXJfw" name="_otsiTermination" type="_KjQ3tBKOEeajhbtskMXJfw" isReadOnly="true" aggregation="composite" association="_KjQ3phKOEeajhbtskMXJfw">
@@ -271,18 +290,18 @@ License: This module is distributed under the Apache License 2.0</body>
           <defaultValue xmi:type="uml:LiteralString" xmi:id="_yxi8ULDnEeiUZaG2JnNtGQ" value="UNDEFINED"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_QkC-sLtPEeiljfl0umr-iQ" name="selectedSpectrum" type="_wB7jIHPYEeiPPoPDo3q5jA" isReadOnly="true"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_2EwdE5s8EeikSLSDi2qpXA" name="_transmitedPower" type="_-2cKkJs7EeikSLSDi2qpXA" isReadOnly="true" aggregation="composite" association="_2EwdEJs8EeikSLSDi2qpXA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2EwdE5s8EeikSLSDi2qpXA" name="transmitedPower" type="_4sZ_UFJYEemV99d_1db7sQ" isReadOnly="true" aggregation="composite" association="_2EwdEJs8EeikSLSDi2qpXA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Qoxu0LTaEeiF8sBzK2t1Sw" annotatedElement="_2EwdE5s8EeikSLSDi2qpXA">
             <body>Measured power at the Transmitter.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2EwdFps8EeikSLSDi2qpXA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2EwdF5s8EeikSLSDi2qpXA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Y0j8YrucEeiljfl0umr-iQ" name="_receivedPower" type="_-2cKkJs7EeikSLSDi2qpXA" aggregation="composite" association="_Y0iHMLucEeiljfl0umr-iQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Y0j8YrucEeiljfl0umr-iQ" name="receivedPower" type="_4sZ_UFJYEemV99d_1db7sQ" aggregation="composite" association="_Y0iHMLucEeiljfl0umr-iQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Y0lxkLucEeiljfl0umr-iQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Y0lxkbucEeiljfl0umr-iQ" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_zJdQ8ps5EeikSLSDi2qpXA" name="_laserProperties" type="_wHacQJs5EeikSLSDi2qpXA" isReadOnly="true" aggregation="composite" association="_zJXKUJs5EeikSLSDi2qpXA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zJdQ8ps5EeikSLSDi2qpXA" name="laserProperties" type="_TmiYkFJbEemV99d_1db7sQ" isReadOnly="true" aggregation="composite" association="_zJXKUJs5EeikSLSDi2qpXA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_5EaLILKgEei69qzpcujF2A" annotatedElement="_zJdQ8ps5EeikSLSDi2qpXA">
             <body>Laser properties.</body>
           </ownedComment>
@@ -318,11 +337,11 @@ License: This module is distributed under the Apache License 2.0</body>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_nBhMkI6cEeeyZasfnNSonw" name="MediaChannelPropertiesPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_J3v2UHZlEeiPPoPDo3q5jA" name="occupiedSpectrum" type="_wB7jIHPYEeiPPoPDo3q5jA" isReadOnly="true"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GXqq45s9EeikSLSDi2qpXA" name="_measuredPowerIngress" type="_-2cKkJs7EeikSLSDi2qpXA" isReadOnly="true" aggregation="composite" association="_GXqq4Js9EeikSLSDi2qpXA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GXqq45s9EeikSLSDi2qpXA" name="measuredPowerIngress" type="_4sZ_UFJYEemV99d_1db7sQ" isReadOnly="true" aggregation="composite" association="_GXqq4Js9EeikSLSDi2qpXA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GXqq5ps9EeikSLSDi2qpXA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GXqq55s9EeikSLSDi2qpXA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_tRWUMrudEeiljfl0umr-iQ" name="_measuredPowerEgress" type="_-2cKkJs7EeikSLSDi2qpXA" aggregation="composite" association="_tRVGELudEeiljfl0umr-iQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tRWUMrudEeiljfl0umr-iQ" name="measuredPowerEgress" type="_4sZ_UFJYEemV99d_1db7sQ" aggregation="composite" association="_tRVGELudEeiljfl0umr-iQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tRYJYLudEeiljfl0umr-iQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tRYwcLudEeiljfl0umr-iQ" value="1"/>
         </ownedAttribute>
@@ -332,7 +351,6 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3rxKOEeajhbtskMXJfw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sBKOEeajhbtskMXJfw" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AMLfknk8EeiO-c_khjKlFQ" name="_fecParameters" type="_qzTdgHk7EeiO-c_khjKlFQ" isReadOnly="true" aggregation="composite" association="_AMK4gHk8EeiO-c_khjKlFQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_NhrjUHiHEeiPPoPDo3q5jA" name="OtsiCapabilityPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_CosS4LKjEei69qzpcujF2A" annotatedElement="_NhrjUHiHEeiPPoPDo3q5jA">
@@ -373,6 +391,10 @@ License: This module is distributed under the Apache License 2.0</body>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_EqncAHiHEeiPPoPDo3q5jA" name="OtsiServiceInterfacePointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_fhbGYHiHEeiPPoPDo3q5jA" name="_otsiCapability" type="_NhrjUHiHEeiPPoPDo3q5jA" isReadOnly="true" aggregation="composite" association="_fhWN4HiHEeiPPoPDo3q5jA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IGOA8FJkEemV99d_1db7sQ" name="_powerManagementCapability" type="_KbiH8FJjEemV99d_1db7sQ" aggregation="composite" association="_IGJvgFJkEemV99d_1db7sQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IGOoAVJkEemV99d_1db7sQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IGPPEFJkEemV99d_1db7sQ" value="1"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_O0PLkHkwEeiO-c_khjKlFQ" name="OtsiConnectivityServiceEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aZkrcnk6EeiO-c_khjKlFQ" name="_otsiConfig" type="_XVi5wHk6EeiO-c_khjKlFQ" aggregation="composite" association="_aZjdUHk6EeiO-c_khjKlFQ">
@@ -404,7 +426,7 @@ License: This module is distributed under the Apache License 2.0</body>
             <body>Laser control can be FORCED-ON, FORCED-OFF or LASER-SHUTDOWN</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_N9lv45s8EeikSLSDi2qpXA" name="_transmitPower" type="_-2cKkJs7EeikSLSDi2qpXA" aggregation="composite" association="_N9lv4Js8EeikSLSDi2qpXA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_N9lv45s8EeikSLSDi2qpXA" name="transmitPower" type="_4sZ_UFJYEemV99d_1db7sQ" aggregation="composite" association="_N9lv4Js8EeikSLSDi2qpXA">
           <ownedComment xmi:type="uml:Comment" xmi:id="_8K--oLDsEeiUZaG2JnNtGQ" annotatedElement="_N9lv45s8EeikSLSDi2qpXA">
             <body>Transmit power as requested.</body>
           </ownedComment>
@@ -424,60 +446,30 @@ License: This module is distributed under the Apache License 2.0</body>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_qzTdgHk7EeiO-c_khjKlFQ" name="FecPropertiesPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgXk7EeiO-c_khjKlFQ" name="preFecBer" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_EFRWAKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdgXk7EeiO-c_khjKlFQ">
-            <body>counter: bit error rate before correction by FEC</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_1KmGcKnYEeiJ3vVqCdpzlA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgnk7EeiO-c_khjKlFQ" name="postFecBer" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_AqG2sKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdgnk7EeiO-c_khjKlFQ">
-            <body>counter: bit error rate after correction by FEC</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_2HRKEKnYEeiJ3vVqCdpzlA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhHk7EeiO-c_khjKlFQ" name="correctedBytes" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_88brEKnYEeiJ3vVqCdpzlA" annotatedElement="_qzTdhHk7EeiO-c_khjKlFQ">
-            <body>Bytes corrected between those that were received corrupted</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_r6GygKnYEeiJ3vVqCdpzlA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhXk7EeiO-c_khjKlFQ" name="correctedBits" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_7RtOoKnYEeiJ3vVqCdpzlA" annotatedElement="_qzTdhXk7EeiO-c_khjKlFQ">
-            <body>Bits corrected between those that were received corrupted</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3RzqkKnYEeiJ3vVqCdpzlA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdg3k7EeiO-c_khjKlFQ" name="uncorrectableBytes" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_e8-_UKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdg3k7EeiO-c_khjKlFQ">
-            <body>Bytes that could not be corrected by FEC</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_W2PhsKnZEeiJ3vVqCdpzlA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_65vVkHk7EeiO-c_khjKlFQ" name="uncorrectableBits" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_eSBWwKnZEeiJ3vVqCdpzlA" annotatedElement="_65vVkHk7EeiO-c_khjKlFQ">
-            <body>Bits that could not be corrected by FEC</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_YHDCQKnZEeiJ3vVqCdpzlA"/>
-        </ownedAttribute>
-      </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_syPL8JmTEeiOmuqNbykpsw" name="MediaChannelServiceInterfacePointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_8Tky45mTEeiOmuqNbykpsw" name="_mcPool" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_8Tky4JmTEeiOmuqNbykpsw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Tky5pmTEeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Tq5gJmTEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UStL8lJkEemV99d_1db7sQ" name="_powerManagementCapability" type="_KbiH8FJjEemV99d_1db7sQ" aggregation="composite" association="_USr90FJkEemV99d_1db7sQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UStzAVJkEemV99d_1db7sQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_USuaEFJkEemV99d_1db7sQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_Es15AJmWEeiOmuqNbykpsw" name="MediaChannelConnectivityServiceEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nWzrw5mYEeiOmuqNbykpsw" name="_mcConfig" type="_awx_YJmYEeiOmuqNbykpsw" aggregation="composite" association="_nWzrwJmYEeiOmuqNbykpsw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nWzrxpmYEeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nWzrx5mYEeiOmuqNbykpsw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_HbzVgFJlEemV99d_1db7sQ" name="_powerManagementConfig" type="_BnH2kFJkEemV99d_1db7sQ" aggregation="composite" association="_HbvrIFJlEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_NrBCEFJrEemV99d_1db7sQ" annotatedElement="_HbzVgFJlEemV99d_1db7sQ">
+            <body>This parameters shall be used to configure the expected&#xD;
+and intended (desired) power levels at the endpoints of the media&#xD;
+Channel connectivity service. These parameters are dependent of the&#xD;
+related OTSi power-management capabilities exposed at the SIPs</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Hbz8kFJlEemV99d_1db7sQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Hbz8kVJlEemV99d_1db7sQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_awx_YJmYEeiOmuqNbykpsw" name="MediaChannelConfigPac">
@@ -499,45 +491,10 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_WCN9oJqMEeid4dfn4JFJZg" name="MediaChannelAssemblySpec"/>
-      <packagedElement xmi:type="uml:Class" xmi:id="_wHacQJs5EeikSLSDi2qpXA" name="LaserPropertiesPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_UecwQLq2EeimKvjOEffRIA" name="laserStatus" type="_lnk9wLqdEeimKvjOEffRIA" isReadOnly="true"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEXk7EeiO-c_khjKlFQ" name="laserApplicationType" visibility="public" type="_01yZ8HpKEei5LIrjJTgegQ" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Gpgv0LDpEeiUZaG2JnNtGQ" annotatedElement="_jwVxEXk7EeiO-c_khjKlFQ">
-            <body>The type of laser, its operational wavelengths, and its applications. String size 255.</body>
-          </ownedComment>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEnk7EeiO-c_khjKlFQ" name="laserBiasCurrent" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_d-ddALDpEeiUZaG2JnNtGQ" annotatedElement="_jwVxEnk7EeiO-c_khjKlFQ">
-            <body>The Bias current of the laser that is the medium polarization current of the laser.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxE3k7EeiO-c_khjKlFQ" name="laserTemperature" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_7LkTkLDtEeiUZaG2JnNtGQ" annotatedElement="_jwVxE3k7EeiO-c_khjKlFQ">
-            <body>The temperature of the laser</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_-2cKkJs7EeikSLSDi2qpXA" name="PowerPropertiesPac">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_Of5m4LKiEei69qzpcujF2A" annotatedElement="_-2cKkJs7EeikSLSDi2qpXA">
+      <packagedElement xmi:type="uml:Class" xmi:id="_sPmrcLTbEeiF8sBzK2t1Sw" name="TotalPowerThresholdPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Of5m4LKiEei69qzpcujF2A">
           <body>Indication with severity warning raised when a total power value measured is above the threshold.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsHk-EeiW-bN1POS5zg" name="totalPower">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_NX2skLDoEeiUZaG2JnNtGQ" annotatedElement="_vzXWsHk-EeiW-bN1POS5zg">
-            <body>The total power at any point in a channel specified in dBm.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsXk-EeiW-bN1POS5zg" name="powerSpectralDensity" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_srl1QLDoEeiUZaG2JnNtGQ" annotatedElement="_vzXWsXk-EeiW-bN1POS5zg">
-            <body>This describes how power of a signal  is distributed over frequency specified in nW/MHz</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vzXWsnk-EeiW-bN1POS5zg"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_sPmrcLTbEeiF8sBzK2t1Sw" name="TotalPowerThresholdPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_11FX8LTbEeiF8sBzK2t1Sw" name="totalPowerUpperWarnThresholdDefault">
           <ownedComment xmi:type="uml:Comment" xmi:id="_11FX8bTbEeiF8sBzK2t1Sw" annotatedElement="_11FX8LTbEeiF8sBzK2t1Sw">
             <body>Can read the value of the default  threshold that was set</body>
@@ -573,6 +530,68 @@ License: This module is distributed under the Apache License 2.0</body>
             <body>Can read the value of the lower threshold that was set</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KbiH8FJjEemV99d_1db7sQ" name="PowerManagementCapabilityPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_rm4noFJlEemV99d_1db7sQ" annotatedElement="_KbiH8FJjEemV99d_1db7sQ">
+          <body>This pac includes power management capabilities which can be&#xD;
+exposed as part of the characterization of the different LTPs&#xD;
+at the PHOTONIC_MEDIA layer.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zsrDAFJlEemV99d_1db7sQ" name="supportableMaximumOutputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4k9noFJlEemV99d_1db7sQ" annotatedElement="_zsrDAFJlEemV99d_1db7sQ">
+            <body>This parameter exposes the maximum output power supported&#xD;
+at the Logical-Termination-Point (LTP) associated to the SIP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9JQSMFJlEemV99d_1db7sQ" name="supportableMinimumOutputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AXskIFJmEemV99d_1db7sQ" annotatedElement="_9JQSMFJlEemV99d_1db7sQ">
+            <body>This parameter exposes the minimum output power supported&#xD;
+at the Logical-Termination-Point (LTP) associated to the SIP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_E5FEoFJmEemV99d_1db7sQ" name="tolerableMaximumInputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_IKDtMFJmEemV99d_1db7sQ" annotatedElement="_E5FEoFJmEemV99d_1db7sQ">
+            <body>This parameter exposes the maximum input power tolerated&#xD;
+at the Logical-Termination-Point (LTP) associated to the SIP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_L_1E4FJmEemV99d_1db7sQ" name="tolerableMinimumInputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_T4cm8FJmEemV99d_1db7sQ" annotatedElement="_L_1E4FJmEemV99d_1db7sQ">
+            <body>This parameter exposes the minimum input power tolerated&#xD;
+at the Logical-Termination-Point (LTP) associated to the SIP.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_BnH2kFJkEemV99d_1db7sQ" name="PowerManagementConfigPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_57x0IFJmEemV99d_1db7sQ" annotatedElement="_BnH2kFJkEemV99d_1db7sQ">
+          <body>This pac includes power management constrains which can be included&#xD;
+as part of the characterization of the Connectivity-Service-End-Points&#xD;
+associated to Logical-Termination-Points (LTPs) at the PHOTONIC_MEDIA layer.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_aiF0cFJmEemV99d_1db7sQ" name="intendedMaximumOutputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_dMPtkFJmEemV99d_1db7sQ" annotatedElement="_aiF0cFJmEemV99d_1db7sQ">
+            <body>This parameter shall be used to specify the maximum output power&#xD;
+desired at the Logical-Termination-Point (LTP) associated to the CSEP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_g5liAFJmEemV99d_1db7sQ" name="intendedMinimumOutputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jwOX8FJmEemV99d_1db7sQ" annotatedElement="_g5liAFJmEemV99d_1db7sQ">
+            <body>This parameter shall be used to specify the minimum output power&#xD;
+desired at the Logical-Termination-Point (LTP) associated to the CSEP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oFiyYFJmEemV99d_1db7sQ" name="expectedMaximumInputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rRrXMFJmEemV99d_1db7sQ" annotatedElement="_oFiyYFJmEemV99d_1db7sQ">
+            <body>This parameter shall be used to specify the maximum input power&#xD;
+being received at the Logical-Termination-Point (LTP) associated to the CSEP.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vVoU0FJmEemV99d_1db7sQ" name="expectedMinimumInputPower" type="_4sZ_UFJYEemV99d_1db7sQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ybMXkFJmEemV99d_1db7sQ" annotatedElement="_vVoU0FJmEemV99d_1db7sQ">
+            <body>This parameter shall be used to specify the minimum input power&#xD;
+being received at the Logical-Termination-Point (LTP) associated to the CSEP.</body>
+          </ownedComment>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
@@ -761,6 +780,85 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
           <defaultValue xmi:type="uml:InstanceValue" xmi:id="_nJd3wHk1EeiO-c_khjKlFQ" type="_iHIbYI6KEeeyZasfnNSonw" instance="_G--TMHPEEeiPPoPDo3q5jA"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_4sZ_UFJYEemV99d_1db7sQ" name="PowerProperties">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsHk-EeiW-bN1POS5zg" name="totalPower">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_NX2skLDoEeiUZaG2JnNtGQ" annotatedElement="_vzXWsHk-EeiW-bN1POS5zg">
+            <body>The total power at any point in a channel specified in dBm.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vzXWsXk-EeiW-bN1POS5zg" name="powerSpectralDensity" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_srl1QLDoEeiUZaG2JnNtGQ" annotatedElement="_vzXWsXk-EeiW-bN1POS5zg">
+            <body>This describes how power of a signal  is distributed over frequency specified in nW/MHz</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vzXWsnk-EeiW-bN1POS5zg"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_U2XowFJbEemV99d_1db7sQ" name="FecProperties">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgXk7EeiO-c_khjKlFQ" name="preFecBer" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EFRWAKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdgXk7EeiO-c_khjKlFQ">
+            <body>counter: bit error rate before correction by FEC</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_1KmGcKnYEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdgnk7EeiO-c_khjKlFQ" name="postFecBer" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AqG2sKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdgnk7EeiO-c_khjKlFQ">
+            <body>counter: bit error rate after correction by FEC</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_2HRKEKnYEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhHk7EeiO-c_khjKlFQ" name="correctedBytes" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_88brEKnYEeiJ3vVqCdpzlA" annotatedElement="_qzTdhHk7EeiO-c_khjKlFQ">
+            <body>Bytes corrected between those that were received corrupted</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_r6GygKnYEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdhXk7EeiO-c_khjKlFQ" name="correctedBits" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7RtOoKnYEeiJ3vVqCdpzlA" annotatedElement="_qzTdhXk7EeiO-c_khjKlFQ">
+            <body>Bits corrected between those that were received corrupted</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3RzqkKnYEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qzTdg3k7EeiO-c_khjKlFQ" name="uncorrectableBytes" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_e8-_UKnZEeiJ3vVqCdpzlA" annotatedElement="_qzTdg3k7EeiO-c_khjKlFQ">
+            <body>Bytes that could not be corrected by FEC</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_W2PhsKnZEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_65vVkHk7EeiO-c_khjKlFQ" name="uncorrectableBits" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_eSBWwKnZEeiJ3vVqCdpzlA" annotatedElement="_65vVkHk7EeiO-c_khjKlFQ">
+            <body>Bits that could not be corrected by FEC</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_YHDCQKnZEeiJ3vVqCdpzlA"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_TmiYkFJbEemV99d_1db7sQ" name="LaserProperties">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UecwQLq2EeimKvjOEffRIA" name="laserStatus" type="_lnk9wLqdEeimKvjOEffRIA" isReadOnly="true"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEXk7EeiO-c_khjKlFQ" name="laserApplicationType" visibility="public" type="_01yZ8HpKEei5LIrjJTgegQ" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Gpgv0LDpEeiUZaG2JnNtGQ" annotatedElement="_jwVxEXk7EeiO-c_khjKlFQ">
+            <body>The type of laser, its operational wavelengths, and its applications. String size 255.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxEnk7EeiO-c_khjKlFQ" name="laserBiasCurrent" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_d-ddALDpEeiUZaG2JnNtGQ" annotatedElement="_jwVxEnk7EeiO-c_khjKlFQ">
+            <body>The Bias current of the laser that is the medium polarization current of the laser.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jwVxE3k7EeiO-c_khjKlFQ" name="laserTemperature" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7LkTkLDtEeiUZaG2JnNtGQ" annotatedElement="_jwVxE3k7EeiO-c_khjKlFQ">
+            <body>The temperature of the laser</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+        </ownedAttribute>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_MSvNkBMEEeaOevPmmmHXcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_eTzcwDK1Eeau3Z0jZdArnw">
@@ -813,10 +911,10 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ouzcsdK-Eeau-fGWj88_Vg" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wucSQBM0Eee0L_IMWjydgQ" base_StructuralFeature="_hv9NtdnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:Specify xmi:id="_lHWc4BNAEeeQQtMBY9ly8w" base_Abstraction="_Z6tlUBNAEeeQQtMBY9ly8w">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint</target>
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:Specify xmi:id="_1DcbQBNCEeeQQtMBY9ly8w" base_Abstraction="_wY7M4BNCEeeQQtMBY9ly8w">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:CepList:_connectionEndPoint</target>
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
   </OpenModel_Profile:Specify>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncURhsEeewCs0lkpWskw" base_Property="_KjQ3oxKOEeajhbtskMXJfw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IyncUhhsEeewCs0lkpWskw" base_Property="_KjQ3pxKOEeajhbtskMXJfw"/>
@@ -866,10 +964,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_Lv2GAHNoEeiPPoPDo3q5jA" base_Element="_KjQ3rRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_NG-4EHNoEeiPPoPDo3q5jA" base_Element="_YS8DkIfeEeet-8tHdGGp_w"/>
   <OpenModel_Profile:Experimental xmi:id="_OQvVcHNoEeiPPoPDo3q5jA" base_Element="_VvSIYEUIEead1bezhJG4aw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_16WvEXPYEeiPPoPDo3q5jA" base_Property="_16WvEHPYEeiPPoPDo3q5jA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_16WvEnPYEeiPPoPDo3q5jA" base_StructuralFeature="_16WvEHPYEeiPPoPDo3q5jA" partOfObjectKey="1" unit="MHz"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_53PbYXPYEeiPPoPDo3q5jA" base_Property="_53PbYHPYEeiPPoPDo3q5jA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_53PbYnPYEeiPPoPDo3q5jA" base_StructuralFeature="_53PbYHPYEeiPPoPDo3q5jA" partOfObjectKey="2" unit="MHz"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_lIJUIXZfEeiPPoPDo3q5jA" base_Property="_lIJUIHZfEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_lIJUInZfEeiPPoPDo3q5jA" base_StructuralFeature="_lIJUIHZfEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:Experimental xmi:id="_vgaIcHZfEeiPPoPDo3q5jA" base_Element="_wB7jIHPYEeiPPoPDo3q5jA"/>
@@ -879,7 +973,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_mXvsEnZlEeiPPoPDo3q5jA" base_Class="_mXvsEHZlEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:Experimental xmi:id="_uas14HZlEeiPPoPDo3q5jA" base_Element="_mXvsEHZlEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:Specify xmi:id="_f3w0EHZpEeiPPoPDo3q5jA" base_Abstraction="_XCHpEHZpEeiPPoPDo3q5jA">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:CepList:_connectionEndPoint</target>
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:OpenModelClass xmi:id="_EqoDEHiHEeiPPoPDo3q5jA" base_Class="_EqncAHiHEeiPPoPDo3q5jA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_EqoDEXiHEeiPPoPDo3q5jA" base_Class="_EqncAHiHEeiPPoPDo3q5jA"/>
@@ -896,7 +990,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_fhbtcniHEeiPPoPDo3q5jA" base_StructuralFeature="_fhbtcHiHEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:StrictComposite xmi:id="_kKOdgHiHEeiPPoPDo3q5jA" base_Association="_fhWN4HiHEeiPPoPDo3q5jA"/>
   <OpenModel_Profile:Specify xmi:id="_cPkIQHkwEeiO-c_khjKlFQ" base_Abstraction="_XqurIHkwEeiO-c_khjKlFQ">
-    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
+    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityContext/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:Experimental xmi:id="_fYXvcHk0EeiO-c_khjKlFQ" base_Element="__ZU_8HkzEeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_O0PLknkwEeiO-c_khjKlFQ" base_Class="_O0PLkHkwEeiO-c_khjKlFQ"/>
@@ -919,12 +1013,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelClass xmi:id="_XVkH4Hk6EeiO-c_khjKlFQ" base_Class="_XVi5wHk6EeiO-c_khjKlFQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_XVjg0Hk6EeiO-c_khjKlFQ" base_Class="_XVi5wHk6EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:Experimental xmi:id="_qXjyIHk6EeiO-c_khjKlFQ" base_Element="_XVi5wHk6EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYInk7EeiO-c_khjKlFQ" base_Property="_jwVxEXk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYI3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEXk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJHk7EeiO-c_khjKlFQ" base_Property="_jwVxEnk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJXk7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEnk7EeiO-c_khjKlFQ" valueRange="" unit="mA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJnk7EeiO-c_khjKlFQ" base_Property="_jwVxE3k7EeiO-c_khjKlFQ" attributeValueChangeNotification="NO" bitLength="LENGTH_8_BIT"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJ3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxE3k7EeiO-c_khjKlFQ" unit="Celsius"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzUroXk7EeiO-c_khjKlFQ" base_Property="_qzTdgXk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_16_BIT"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_qzUronk7EeiO-c_khjKlFQ" base_StructuralFeature="_qzTdgXk7EeiO-c_khjKlFQ" counter="ZERO_COUNTER" unit="ms"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qzVSsHk7EeiO-c_khjKlFQ" base_Property="_qzTdgnk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES" bitLength="LENGTH_16_BIT"/>
@@ -942,14 +1030,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AMMtsHk8EeiO-c_khjKlFQ" base_Property="_AMMGonk8EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_AMMtsXk8EeiO-c_khjKlFQ" base_StructuralFeature="_AMMGonk8EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_IwNWIHk8EeiO-c_khjKlFQ" base_Association="_AMK4gHk8EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzXWs3k-EeiW-bN1POS5zg" base_Property="_vzXWsHk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzX9wHk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsHk-EeiW-bN1POS5zg" valueRange="" unit="dBm"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzYk0Hk-EeiW-bN1POS5zg" base_Property="_vzXWsXk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_32_BIT"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzYk0Xk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsXk-EeiW-bN1POS5zg" valueRange="" unit="nW/MHz"/>
   <OpenModel_Profile:Experimental xmi:id="_2KBpAHpKEei5LIrjJTgegQ" base_Element="_01yZ8HpKEei5LIrjJTgegQ"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_qzUroHk7EeiO-c_khjKlFQ" base_Class="_qzTdgHk7EeiO-c_khjKlFQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_qzUEkHk7EeiO-c_khjKlFQ" base_Class="_qzTdgHk7EeiO-c_khjKlFQ"/>
-  <OpenModel_Profile:Experimental xmi:id="_FzBzUHk8EeiO-c_khjKlFQ" base_Element="_qzTdgHk7EeiO-c_khjKlFQ"/>
   <OpenModel_Profile:Specify xmi:id="_V_v5MIoJEeivCevppATXng" base_Abstraction="_LhPS8IoJEeivCevppATXng"/>
   <OpenModel_Profile:Experimental xmi:id="_i4NZYIoJEeivCevppATXng" base_Element="_ErlpwIoJEeivCevppATXng"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_8Tky5JmTEeiOmuqNbykpsw" base_StructuralFeature="_8Tky45mTEeiOmuqNbykpsw"/>
@@ -970,7 +1051,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nWzrypmYEeiOmuqNbykpsw" base_Property="_nWzryJmYEeiOmuqNbykpsw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_85XbAJmoEeiOmuqNbykpsw" base_Association="_nWzrwJmYEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Specify xmi:id="_6wAP4JmqEeiOmuqNbykpsw" base_Abstraction="_ObUMoJmaEeiOmuqNbykpsw">
-    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
+    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connectivityContext/TapiConnectivity:ConnectivityContext:_connectivityService/TapiConnectivity:ConnectivityService:_endPoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_l6_TYZmrEeiOmuqNbykpsw" base_StructuralFeature="_l6_TYJmrEeiOmuqNbykpsw" valueRange=""/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_l6_TYpmrEeiOmuqNbykpsw" base_Property="_l6_TYJmrEeiOmuqNbykpsw" attributeValueChangeNotification="YES"/>
@@ -989,15 +1070,15 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_VbmVEJo1EeiOmuqNbykpsw" base_Element="_aiExkJozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Experimental xmi:id="_WIP_sJo1EeiOmuqNbykpsw" base_Element="_a2384JozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Specify xmi:id="_-QGz8Jo2EeiOmuqNbykpsw" base_Abstraction="_c-z5wJozEeiOmuqNbykpsw">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:CepList:_connectionEndPoint</target>
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:Specify xmi:id="__ffYMJo2EeiOmuqNbykpsw" base_Abstraction="_dbVdsJozEeiOmuqNbykpsw">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:CepList:_connectionEndPoint</target>
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:StrictComposite xmi:id="_DOQI8Jo3EeiOmuqNbykpsw" base_Association="_qOr0YJozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_EKZBEJo3EeiOmuqNbykpsw" base_Association="_qtbl4JozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Specify xmi:id="_gYYgMJqMEeid4dfn4JFJZg" base_Abstraction="_dkJeAJqMEeid4dfn4JFJZg">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:CepList:_connectionEndPoint</target>
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_cRshMZqYEeid4dfn4JFJZg" base_StructuralFeature="_cRshMJqYEeid4dfn4JFJZg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cRtIQJqYEeid4dfn4JFJZg" base_Property="_cRshMJqYEeid4dfn4JFJZg"/>
@@ -1013,16 +1094,10 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_Es15AZmWEeiOmuqNbykpsw" base_Class="_Es15AJmWEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Experimental xmi:id="_rS7w0JmdEeiOmuqNbykpsw" base_Element="_Es15AJmWEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Experimental xmi:id="_ScZwcJsvEeikSLSDi2qpXA" base_Element="_WCN9oJqMEeid4dfn4JFJZg"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_wHacQZs5EeikSLSDi2qpXA" base_Class="_wHacQJs5EeikSLSDi2qpXA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_wHacQps5EeikSLSDi2qpXA" base_Class="_wHacQJs5EeikSLSDi2qpXA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zJdQ85s5EeikSLSDi2qpXA" base_StructuralFeature="_zJdQ8ps5EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zJdQ9Js5EeikSLSDi2qpXA" base_Property="_zJdQ8ps5EeikSLSDi2qpXA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zJdQ-Js5EeikSLSDi2qpXA" base_StructuralFeature="_zJdQ95s5EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zJdQ-Zs5EeikSLSDi2qpXA" base_Property="_zJdQ95s5EeikSLSDi2qpXA"/>
-  <OpenModel_Profile:Experimental xmi:id="_DrTSoJs6EeikSLSDi2qpXA" base_Element="_wHacQJs5EeikSLSDi2qpXA"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_-2cKkZs7EeikSLSDi2qpXA" base_Class="_-2cKkJs7EeikSLSDi2qpXA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_-2cKkps7EeikSLSDi2qpXA" base_Class="_-2cKkJs7EeikSLSDi2qpXA"/>
-  <OpenModel_Profile:Experimental xmi:id="_C2W8wJs8EeikSLSDi2qpXA" base_Element="_-2cKkJs7EeikSLSDi2qpXA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_N9lv5Js8EeikSLSDi2qpXA" base_StructuralFeature="_N9lv45s8EeikSLSDi2qpXA" unit=""/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_N9lv5Zs8EeikSLSDi2qpXA" base_Property="_N9lv45s8EeikSLSDi2qpXA" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_N9lv6Zs8EeikSLSDi2qpXA" base_StructuralFeature="_N9lv6Js8EeikSLSDi2qpXA"/>
@@ -1159,4 +1234,58 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Specify xmi:id="_80eV8PPnEeinaYo1FpF9OA" base_Abstraction="_yw4xIPPnEeinaYo1FpF9OA">
     <target>/TapiConnectivity:ConnectivityService:getConnectionEndPointDetails/TapiConnectivity::output/TapiConnectivity::connectionEndPoint</target>
   </OpenModel_Profile:Specify>
+  <OpenModel_Profile:Experimental xmi:id="_8WfEYFJYEemV99d_1db7sQ" base_Element="_4sZ_UFJYEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_16WvEnPYEeiPPoPDo3q5jA" base_StructuralFeature="_16WvEHPYEeiPPoPDo3q5jA" partOfObjectKey="1" unit="MHz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_16WvEXPYEeiPPoPDo3q5jA" base_Property="_16WvEHPYEeiPPoPDo3q5jA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_53PbYnPYEeiPPoPDo3q5jA" base_StructuralFeature="_53PbYHPYEeiPPoPDo3q5jA" partOfObjectKey="2" unit="MHz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_53PbYXPYEeiPPoPDo3q5jA" base_Property="_53PbYHPYEeiPPoPDo3q5jA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzX9wHk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsHk-EeiW-bN1POS5zg" valueRange="" unit="dBm"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzXWs3k-EeiW-bN1POS5zg" base_Property="_vzXWsHk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vzYk0Xk-EeiW-bN1POS5zg" base_StructuralFeature="_vzXWsXk-EeiW-bN1POS5zg" valueRange="" unit="nW/MHz"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vzYk0Hk-EeiW-bN1POS5zg" base_Property="_vzXWsXk-EeiW-bN1POS5zg" attributeValueChangeNotification="YES" bitLength="LENGTH_32_BIT"/>
+  <OpenModel_Profile:Experimental xmi:id="_aMR9gFJbEemV99d_1db7sQ" base_Element="_U2XowFJbEemV99d_1db7sQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_bIGFgFJbEemV99d_1db7sQ" base_Element="_TmiYkFJbEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJ3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxE3k7EeiO-c_khjKlFQ" unit="Celsius"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJnk7EeiO-c_khjKlFQ" base_Property="_jwVxE3k7EeiO-c_khjKlFQ" attributeValueChangeNotification="NO" bitLength="LENGTH_8_BIT"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYJXk7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEnk7EeiO-c_khjKlFQ" valueRange="" unit="mA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYJHk7EeiO-c_khjKlFQ" base_Property="_jwVxEnk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jwWYI3k7EeiO-c_khjKlFQ" base_StructuralFeature="_jwVxEXk7EeiO-c_khjKlFQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jwWYInk7EeiO-c_khjKlFQ" base_Property="_jwVxEXk7EeiO-c_khjKlFQ" attributeValueChangeNotification="YES"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_KbivAFJjEemV99d_1db7sQ" base_Class="_KbiH8FJjEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KbjWEFJjEemV99d_1db7sQ" base_Class="_KbiH8FJjEemV99d_1db7sQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_OcteYFJjEemV99d_1db7sQ" base_Element="_KbiH8FJjEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_BnIdoFJkEemV99d_1db7sQ" base_Class="_BnH2kFJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_BnJEsFJkEemV99d_1db7sQ" base_Class="_BnH2kFJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_Eb65cFJkEemV99d_1db7sQ" base_Element="_BnH2kFJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IGOA8VJkEemV99d_1db7sQ" base_StructuralFeature="_IGOA8FJkEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IGOoAFJkEemV99d_1db7sQ" base_Property="_IGOA8FJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IGPPElJkEemV99d_1db7sQ" base_StructuralFeature="_IGPPEVJkEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IGP2IFJkEemV99d_1db7sQ" base_Property="_IGPPEVJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Od-0QFJkEemV99d_1db7sQ" base_Association="_IGJvgFJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UStL81JkEemV99d_1db7sQ" base_StructuralFeature="_UStL8lJkEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UStzAFJkEemV99d_1db7sQ" base_Property="_UStL8lJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_USuaElJkEemV99d_1db7sQ" base_StructuralFeature="_USuaEVJkEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_USvBIFJkEemV99d_1db7sQ" base_Property="_USuaEVJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_iTJn4FJkEemV99d_1db7sQ" base_Association="_USr90FJkEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HbzVgVJlEemV99d_1db7sQ" base_StructuralFeature="_HbzVgFJlEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HbzVglJlEemV99d_1db7sQ" base_Property="_HbzVgFJlEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Hbz8k1JlEemV99d_1db7sQ" base_StructuralFeature="_Hbz8klJlEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Hbz8lFJlEemV99d_1db7sQ" base_Property="_Hbz8klJlEemV99d_1db7sQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_IxFGYFJlEemV99d_1db7sQ" base_Association="_HbvrIFJlEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zsrDAVJlEemV99d_1db7sQ" base_StructuralFeature="_zsrDAFJlEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zsrqEFJlEemV99d_1db7sQ" base_Property="_zsrDAFJlEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9JQSMVJlEemV99d_1db7sQ" base_StructuralFeature="_9JQSMFJlEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_9JQ5QFJlEemV99d_1db7sQ" base_Property="_9JQSMFJlEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_E5FEoVJmEemV99d_1db7sQ" base_StructuralFeature="_E5FEoFJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_E5FrsFJmEemV99d_1db7sQ" base_Property="_E5FEoFJmEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_L_1E4VJmEemV99d_1db7sQ" base_StructuralFeature="_L_1E4FJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_L_1E4lJmEemV99d_1db7sQ" base_Property="_L_1E4FJmEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aiF0cVJmEemV99d_1db7sQ" base_StructuralFeature="_aiF0cFJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_aiGbgFJmEemV99d_1db7sQ" base_Property="_aiF0cFJmEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_g5liAVJmEemV99d_1db7sQ" base_StructuralFeature="_g5liAFJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_g5mJEFJmEemV99d_1db7sQ" base_Property="_g5liAFJmEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oFiyYVJmEemV99d_1db7sQ" base_StructuralFeature="_oFiyYFJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_oFiyYlJmEemV99d_1db7sQ" base_Property="_oFiyYFJmEemV99d_1db7sQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vVoU0VJmEemV99d_1db7sQ" base_StructuralFeature="_vVoU0FJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vVo74FJmEemV99d_1db7sQ" base_Property="_vVoU0FJmEemV99d_1db7sQ"/>
 </xmi:XMI>

--- a/YANG/tapi-photonic-media@2019-03-31.tree
+++ b/YANG/tapi-photonic-media@2019-03-31.tree
@@ -53,50 +53,51 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
     +--ro otsi-assembly-connection-end-point-spec
        +--ro otsi-adapter
-       |  +--ro number-of-otsi?   uint64
-       +--ro fec-parameters
-          +--ro pre-fec-ber?           uint64
-          +--ro post-fec-ber?          uint64
-          +--ro corrected-bytes?       uint64
-          +--ro corrected-bits?        uint64
-          +--ro uncorrectable-bytes?   uint64
-          +--ro uncorrectable-bits?    uint64
+          +--ro number-of-otsi?   uint64
+          +--ro fec-parameters
+             +--ro pre-fec-ber?           uint64
+             +--ro post-fec-ber?          uint64
+             +--ro corrected-bytes?       uint64
+             +--ro corrected-bits?        uint64
+             +--ro uncorrectable-bytes?   uint64
+             +--ro uncorrectable-bits?    uint64
   augment /tapi-common:context/tapi-common:service-interface-point:
     +--rw otsi-service-interface-point-spec
        +--ro otsi-capability
-          +--ro supportable-lower-central-frequency* [central-frequency]
-          |  +--ro frequency-constraint
-          |  |  +--ro adjustment-granularity?   adjustment-granularity
-          |  |  +--ro grid-type?                grid-type
-          |  +--ro central-frequency       uint64
-          +--ro supportable-upper-central-frequency* [central-frequency]
-          |  +--ro frequency-constraint
-          |  |  +--ro adjustment-granularity?   adjustment-granularity
-          |  |  +--ro grid-type?                grid-type
-          |  +--ro central-frequency       uint64
-          +--ro supportable-application-identifier* [application-code]
-          |  +--ro application-identifier-type?   application-identifier-type
-          |  +--ro application-code               string
-          +--ro supportable-modulation*                modulation-technique
-          +--ro total-power-warn-threshold
-          |  +--ro total-power-upper-warn-threshold-default?   decimal64
-          |  +--ro total-power-upper-warn-threshold-min?       decimal64
-          |  +--ro total-power-upper-warn-threshold-max?       decimal64
-          |  +--ro total-power-lower-warn-threshold-default?   decimal64
-          |  +--ro total-power-lower-warn-threshold-max?       decimal64
-          |  +--ro total-power-lower-warn-threshold-min?       decimal64
-          +--ro supportable-maximum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro supportable-minimum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-maximum-input-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-minimum-input-power
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
+       |  +--ro supportable-lower-central-frequency* [central-frequency]
+       |  |  +--ro frequency-constraint
+       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  |  +--ro grid-type?                grid-type
+       |  |  +--ro central-frequency       uint64
+       |  +--ro supportable-upper-central-frequency* [central-frequency]
+       |  |  +--ro frequency-constraint
+       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  |  +--ro grid-type?                grid-type
+       |  |  +--ro central-frequency       uint64
+       |  +--ro supportable-application-identifier* [application-code]
+       |  |  +--ro application-identifier-type?   application-identifier-type
+       |  |  +--ro application-code               string
+       |  +--ro supportable-modulation*                modulation-technique
+       |  +--ro total-power-warn-threshold
+       |     +--ro total-power-upper-warn-threshold-default?   decimal64
+       |     +--ro total-power-upper-warn-threshold-min?       decimal64
+       |     +--ro total-power-upper-warn-threshold-max?       decimal64
+       |     +--ro total-power-lower-warn-threshold-default?   decimal64
+       |     +--ro total-power-lower-warn-threshold-max?       decimal64
+       |     +--ro total-power-lower-warn-threshold-min?       decimal64
+       +--rw power-management-capability
+          +--rw supportable-maximum-output-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw supportable-minimum-output-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw tolerable-maximum-input-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw tolerable-minimum-input-power
+             +--rw total-power?              decimal64
+             +--rw power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
     +--rw otsi-connectivity-service-end-point-spec
        +--rw otsi-config
@@ -142,41 +143,41 @@ module: tapi-photonic-media
        |     +--ro frequency-constraint
        |        +--ro adjustment-granularity?   adjustment-granularity
        |        +--ro grid-type?                grid-type
-       +--ro mc-capability
-          +--ro supportable-maximum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro supportable-minimum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-maximum-input-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-minimum-input-power
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
+       +--rw power-management-capability
+          +--rw supportable-maximum-output-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw supportable-minimum-output-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw tolerable-maximum-input-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw tolerable-minimum-input-power
+             +--rw total-power?              decimal64
+             +--rw power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-connectivity:connectivity-context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point:
     +--rw media-channel-connectivity-service-end-point-spec
        +--rw mc-config
-          +--rw spectrum
-          |  +--rw upper-frequency?        uint64
-          |  +--rw lower-frequency?        uint64
-          |  +--rw frequency-constraint
-          |     +--rw adjustment-granularity?   adjustment-granularity
-          |     +--rw grid-type?                grid-type
-          +--rw power-constraints
-             +--rw intended-maximum-output-power
-             |  +--rw total-power?              decimal64
-             |  +--rw power-spectral-density?   decimal64
-             +--rw intended-minimum-output-power
-             |  +--rw total-power?              decimal64
-             |  +--rw power-spectral-density?   decimal64
-             +--rw expected-maximum-input-power
-             |  +--rw total-power?              decimal64
-             |  +--rw power-spectral-density?   decimal64
-             +--rw expected-minimum-input-power
-                +--rw total-power?              decimal64
-                +--rw power-spectral-density?   decimal64
+       |  +--rw spectrum
+       |     +--rw upper-frequency?        uint64
+       |     +--rw lower-frequency?        uint64
+       |     +--rw frequency-constraint
+       |        +--rw adjustment-granularity?   adjustment-granularity
+       |        +--rw grid-type?                grid-type
+       +--rw power-management-config
+          +--rw intended-maximum-output-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw intended-minimum-output-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw expected-maximum-input-power
+          |  +--rw total-power?              decimal64
+          |  +--rw power-spectral-density?   decimal64
+          +--rw expected-minimum-input-power
+             +--rw total-power?              decimal64
+             +--rw power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
     +--ro media-channel-connection-end-point-spec
        +--ro media-channel
@@ -209,78 +210,138 @@ module: tapi-photonic-media
              +--ro power-spectral-density?   decimal64
   augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
     +--ro media-channel-assembly-spec
-  augment /tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip:
-    +-- otsi-service-interface-point-spec
-       +--ro otsi-capability
-          +--ro supportable-lower-central-frequency* [central-frequency]
-          |  +--ro frequency-constraint
-          |  |  +--ro adjustment-granularity?   adjustment-granularity
-          |  |  +--ro grid-type?                grid-type
-          |  +--ro central-frequency       uint64
-          +--ro supportable-upper-central-frequency* [central-frequency]
-          |  +--ro frequency-constraint
-          |  |  +--ro adjustment-granularity?   adjustment-granularity
-          |  |  +--ro grid-type?                grid-type
-          |  +--ro central-frequency       uint64
-          +--ro supportable-application-identifier* [application-code]
-          |  +--ro application-identifier-type?   application-identifier-type
-          |  +--ro application-code               string
-          +--ro supportable-modulation*                modulation-technique
-          +--ro total-power-warn-threshold
-          |  +--ro total-power-upper-warn-threshold-default?   decimal64
-          |  +--ro total-power-upper-warn-threshold-min?       decimal64
-          |  +--ro total-power-upper-warn-threshold-max?       decimal64
-          |  +--ro total-power-lower-warn-threshold-default?   decimal64
-          |  +--ro total-power-lower-warn-threshold-max?       decimal64
-          |  +--ro total-power-lower-warn-threshold-min?       decimal64
-          +--ro supportable-maximum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro supportable-minimum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-maximum-input-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-minimum-input-power
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
-  augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
-    +-- otsi-service-interface-point-spec
-       +--ro otsi-capability
-          +--ro supportable-lower-central-frequency* [central-frequency]
-          |  +--ro frequency-constraint
-          |  |  +--ro adjustment-granularity?   adjustment-granularity
-          |  |  +--ro grid-type?                grid-type
-          |  +--ro central-frequency       uint64
-          +--ro supportable-upper-central-frequency* [central-frequency]
-          |  +--ro frequency-constraint
-          |  |  +--ro adjustment-granularity?   adjustment-granularity
-          |  |  +--ro grid-type?                grid-type
-          |  +--ro central-frequency       uint64
-          +--ro supportable-application-identifier* [application-code]
-          |  +--ro application-identifier-type?   application-identifier-type
-          |  +--ro application-code               string
-          +--ro supportable-modulation*                modulation-technique
-          +--ro total-power-warn-threshold
-          |  +--ro total-power-upper-warn-threshold-default?   decimal64
-          |  +--ro total-power-upper-warn-threshold-min?       decimal64
-          |  +--ro total-power-upper-warn-threshold-max?       decimal64
-          |  +--ro total-power-lower-warn-threshold-default?   decimal64
-          |  +--ro total-power-lower-warn-threshold-max?       decimal64
-          |  +--ro total-power-lower-warn-threshold-min?       decimal64
-          +--ro supportable-maximum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro supportable-minimum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-maximum-input-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-minimum-input-power
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
+  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
+    +-- media-channel-connectivity-service-end-point-spec
+       +-- mc-config
+       |  +-- spectrum
+       |     +-- upper-frequency?        uint64
+       |     +-- lower-frequency?        uint64
+       |     +-- frequency-constraint
+       |        +-- adjustment-granularity?   adjustment-granularity
+       |        +-- grid-type?                grid-type
+       +-- power-management-config
+          +-- intended-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- intended-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
+    +-- media-channel-connectivity-service-end-point-spec
+       +-- mc-config
+       |  +-- spectrum
+       |     +-- upper-frequency?        uint64
+       |     +-- lower-frequency?        uint64
+       |     +-- frequency-constraint
+       |        +-- adjustment-granularity?   adjustment-granularity
+       |        +-- grid-type?                grid-type
+       +-- power-management-config
+          +-- intended-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- intended-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
+    +-- media-channel-connectivity-service-end-point-spec
+       +-- mc-config
+       |  +-- spectrum
+       |     +-- upper-frequency?        uint64
+       |     +-- lower-frequency?        uint64
+       |     +-- frequency-constraint
+       |        +-- adjustment-granularity?   adjustment-granularity
+       |        +-- grid-type?                grid-type
+       +-- power-management-config
+          +-- intended-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- intended-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
+    +-- media-channel-connectivity-service-end-point-spec
+       +-- mc-config
+       |  +-- spectrum
+       |     +-- upper-frequency?        uint64
+       |     +-- lower-frequency?        uint64
+       |     +-- frequency-constraint
+       |        +-- adjustment-granularity?   adjustment-granularity
+       |        +-- grid-type?                grid-type
+       +-- power-management-config
+          +-- intended-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- intended-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
+    +-- media-channel-connectivity-service-end-point-spec
+       +-- mc-config
+       |  +-- spectrum
+       |     +-- upper-frequency?        uint64
+       |     +-- lower-frequency?        uint64
+       |     +-- frequency-constraint
+       |        +-- adjustment-granularity?   adjustment-granularity
+       |        +-- grid-type?                grid-type
+       +-- power-management-config
+          +-- intended-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- intended-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
+    +-- media-channel-connectivity-service-end-point-spec
+       +-- mc-config
+       |  +-- spectrum
+       |     +-- upper-frequency?        uint64
+       |     +-- lower-frequency?        uint64
+       |     +-- frequency-constraint
+       |        +-- adjustment-granularity?   adjustment-granularity
+       |        +-- grid-type?                grid-type
+       +-- power-management-config
+          +-- intended-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- intended-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- expected-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
   augment /tapi-topology:get-node-edge-point-details/tapi-topology:output/tapi-topology:node-edge-point:
     +-- media-channel-node-edge-point-spec
        +--ro mc-pool
@@ -302,7 +363,99 @@ module: tapi-photonic-media
              +--ro frequency-constraint
                 +--ro adjustment-granularity?   adjustment-granularity
                 +--ro grid-type?                grid-type
-  augment /tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
+  augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
+    +-- media-channel-service-interface-point-spec
+       +--ro mc-pool
+       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro available-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
+       |     +--ro upper-frequency         uint64
+       |     +--ro lower-frequency         uint64
+       |     +--ro frequency-constraint
+       |        +--ro adjustment-granularity?   adjustment-granularity
+       |        +--ro grid-type?                grid-type
+       +-- power-management-capability
+          +-- supportable-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- supportable-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip:
+    +-- media-channel-service-interface-point-spec
+       +--ro mc-pool
+       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro available-spectrum* [upper-frequency lower-frequency]
+       |  |  +--ro upper-frequency         uint64
+       |  |  +--ro lower-frequency         uint64
+       |  |  +--ro frequency-constraint
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
+       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
+       |     +--ro upper-frequency         uint64
+       |     +--ro lower-frequency         uint64
+       |     +--ro frequency-constraint
+       |        +--ro adjustment-granularity?   adjustment-granularity
+       |        +--ro grid-type?                grid-type
+       +-- power-management-capability
+          +-- supportable-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- supportable-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
+  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
+    +-- otsi-connectivity-service-end-point-spec
+       +-- otsi-config
+          +-- central-frequency
+          |  +-- frequency-constraint
+          |  |  +-- adjustment-granularity?   adjustment-granularity
+          |  |  +-- grid-type?                grid-type
+          |  +-- central-frequency?      uint64
+          +-- spectrum
+          |  +-- upper-frequency?        uint64
+          |  +-- lower-frequency?        uint64
+          |  +-- frequency-constraint
+          |     +-- adjustment-granularity?   adjustment-granularity
+          |     +-- grid-type?                grid-type
+          +-- application-identifier
+          |  +-- application-identifier-type?   application-identifier-type
+          |  +-- application-code?              string
+          +-- modulation?                         modulation-technique
+          +-- laser-control?                      laser-control-type
+          +-- transmit-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- total-power-warn-threshold-upper?   decimal64
+          +-- total-power-warn-threshold-lower?   decimal64
+  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
           +-- central-frequency
@@ -350,95 +503,7 @@ module: tapi-photonic-media
           |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
-  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
-    +-- media-channel-connectivity-service-end-point-spec
-       +-- mc-config
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- power-constraints
-             +-- intended-maximum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- intended-minimum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-maximum-input-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-minimum-input-power
-                +-- total-power?              decimal64
-                +-- power-spectral-density?   decimal64
-  augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
-    +-- media-channel-connectivity-service-end-point-spec
-       +-- mc-config
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- power-constraints
-             +-- intended-maximum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- intended-minimum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-maximum-input-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-minimum-input-power
-                +-- total-power?              decimal64
-                +-- power-spectral-density?   decimal64
-  augment /tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
-    +-- media-channel-connectivity-service-end-point-spec
-       +-- mc-config
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- power-constraints
-             +-- intended-maximum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- intended-minimum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-maximum-input-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-minimum-input-power
-                +-- total-power?              decimal64
-                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
-    +-- media-channel-connectivity-service-end-point-spec
-       +-- mc-config
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- power-constraints
-             +-- intended-maximum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- intended-minimum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-maximum-input-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-minimum-input-power
-                +-- total-power?              decimal64
-                +-- power-spectral-density?   decimal64
-  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
           +-- central-frequency
@@ -486,74 +551,6 @@ module: tapi-photonic-media
           |  +-- power-spectral-density?   decimal64
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
-  augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
-    +-- media-channel-connectivity-service-end-point-spec
-       +-- mc-config
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- power-constraints
-             +-- intended-maximum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- intended-minimum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-maximum-input-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-minimum-input-power
-                +-- total-power?              decimal64
-                +-- power-spectral-density?   decimal64
-  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
-    +-- otsi-connectivity-service-end-point-spec
-       +-- otsi-config
-          +-- central-frequency
-          |  +-- frequency-constraint
-          |  |  +-- adjustment-granularity?   adjustment-granularity
-          |  |  +-- grid-type?                grid-type
-          |  +-- central-frequency?      uint64
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- application-identifier
-          |  +-- application-identifier-type?   application-identifier-type
-          |  +-- application-code?              string
-          +-- modulation?                         modulation-technique
-          +-- laser-control?                      laser-control-type
-          +-- transmit-power
-          |  +-- total-power?              decimal64
-          |  +-- power-spectral-density?   decimal64
-          +-- total-power-warn-threshold-upper?   decimal64
-          +-- total-power-warn-threshold-lower?   decimal64
-  augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
-    +-- media-channel-connectivity-service-end-point-spec
-       +-- mc-config
-          +-- spectrum
-          |  +-- upper-frequency?        uint64
-          |  +-- lower-frequency?        uint64
-          |  +-- frequency-constraint
-          |     +-- adjustment-granularity?   adjustment-granularity
-          |     +-- grid-type?                grid-type
-          +-- power-constraints
-             +-- intended-maximum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- intended-minimum-output-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-maximum-input-power
-             |  +-- total-power?              decimal64
-             |  +-- power-spectral-density?   decimal64
-             +-- expected-minimum-input-power
-                +-- total-power?              decimal64
-                +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point:
     +-- otsi-connectivity-service-end-point-spec
        +-- otsi-config
@@ -579,73 +576,79 @@ module: tapi-photonic-media
           +-- total-power-warn-threshold-upper?   decimal64
           +-- total-power-warn-threshold-lower?   decimal64
   augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
-    +-- media-channel-service-interface-point-spec
-       +--ro mc-pool
-       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
-       |  |  +--ro upper-frequency         uint64
-       |  |  +--ro lower-frequency         uint64
+    +-- otsi-service-interface-point-spec
+       +--ro otsi-capability
+       |  +--ro supportable-lower-central-frequency* [central-frequency]
        |  |  +--ro frequency-constraint
-       |  |     +--ro adjustment-granularity?   adjustment-granularity
-       |  |     +--ro grid-type?                grid-type
-       |  +--ro available-spectrum* [upper-frequency lower-frequency]
-       |  |  +--ro upper-frequency         uint64
-       |  |  +--ro lower-frequency         uint64
+       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  |  +--ro grid-type?                grid-type
+       |  |  +--ro central-frequency       uint64
+       |  +--ro supportable-upper-central-frequency* [central-frequency]
        |  |  +--ro frequency-constraint
-       |  |     +--ro adjustment-granularity?   adjustment-granularity
-       |  |     +--ro grid-type?                grid-type
-       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
-       |     +--ro upper-frequency         uint64
-       |     +--ro lower-frequency         uint64
-       |     +--ro frequency-constraint
-       |        +--ro adjustment-granularity?   adjustment-granularity
-       |        +--ro grid-type?                grid-type
-       +--ro mc-capability
-          +--ro supportable-maximum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro supportable-minimum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-maximum-input-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-minimum-input-power
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
+       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  |  +--ro grid-type?                grid-type
+       |  |  +--ro central-frequency       uint64
+       |  +--ro supportable-application-identifier* [application-code]
+       |  |  +--ro application-identifier-type?   application-identifier-type
+       |  |  +--ro application-code               string
+       |  +--ro supportable-modulation*                modulation-technique
+       |  +--ro total-power-warn-threshold
+       |     +--ro total-power-upper-warn-threshold-default?   decimal64
+       |     +--ro total-power-upper-warn-threshold-min?       decimal64
+       |     +--ro total-power-upper-warn-threshold-max?       decimal64
+       |     +--ro total-power-lower-warn-threshold-default?   decimal64
+       |     +--ro total-power-lower-warn-threshold-max?       decimal64
+       |     +--ro total-power-lower-warn-threshold-min?       decimal64
+       +-- power-management-capability
+          +-- supportable-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- supportable-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
   augment /tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip:
-    +-- media-channel-service-interface-point-spec
-       +--ro mc-pool
-       |  +--ro supportable-spectrum* [upper-frequency lower-frequency]
-       |  |  +--ro upper-frequency         uint64
-       |  |  +--ro lower-frequency         uint64
+    +-- otsi-service-interface-point-spec
+       +--ro otsi-capability
+       |  +--ro supportable-lower-central-frequency* [central-frequency]
        |  |  +--ro frequency-constraint
-       |  |     +--ro adjustment-granularity?   adjustment-granularity
-       |  |     +--ro grid-type?                grid-type
-       |  +--ro available-spectrum* [upper-frequency lower-frequency]
-       |  |  +--ro upper-frequency         uint64
-       |  |  +--ro lower-frequency         uint64
+       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  |  +--ro grid-type?                grid-type
+       |  |  +--ro central-frequency       uint64
+       |  +--ro supportable-upper-central-frequency* [central-frequency]
        |  |  +--ro frequency-constraint
-       |  |     +--ro adjustment-granularity?   adjustment-granularity
-       |  |     +--ro grid-type?                grid-type
-       |  +--ro occupied-spectrum* [upper-frequency lower-frequency]
-       |     +--ro upper-frequency         uint64
-       |     +--ro lower-frequency         uint64
-       |     +--ro frequency-constraint
-       |        +--ro adjustment-granularity?   adjustment-granularity
-       |        +--ro grid-type?                grid-type
-       +--ro mc-capability
-          +--ro supportable-maximum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro supportable-minimum-output-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-maximum-input-power
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro tolerable-minimum-input-power
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
+       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  |  +--ro grid-type?                grid-type
+       |  |  +--ro central-frequency       uint64
+       |  +--ro supportable-application-identifier* [application-code]
+       |  |  +--ro application-identifier-type?   application-identifier-type
+       |  |  +--ro application-code               string
+       |  +--ro supportable-modulation*                modulation-technique
+       |  +--ro total-power-warn-threshold
+       |     +--ro total-power-upper-warn-threshold-default?   decimal64
+       |     +--ro total-power-upper-warn-threshold-min?       decimal64
+       |     +--ro total-power-upper-warn-threshold-max?       decimal64
+       |     +--ro total-power-lower-warn-threshold-default?   decimal64
+       |     +--ro total-power-lower-warn-threshold-max?       decimal64
+       |     +--ro total-power-lower-warn-threshold-min?       decimal64
+       +-- power-management-capability
+          +-- supportable-maximum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- supportable-minimum-output-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-maximum-input-power
+          |  +-- total-power?              decimal64
+          |  +-- power-spectral-density?   decimal64
+          +-- tolerable-minimum-input-power
+             +-- total-power?              decimal64
+             +-- power-spectral-density?   decimal64
   augment /tapi-connectivity:get-connection-end-point-details/tapi-connectivity:output/tapi-connectivity:connection-end-point:
     +-- media-channel-connection-end-point-spec
        +--ro media-channel
@@ -664,14 +667,14 @@ module: tapi-photonic-media
   augment /tapi-connectivity:get-connection-end-point-details/tapi-connectivity:output/tapi-connectivity:connection-end-point:
     +-- otsi-assembly-connection-end-point-spec
        +--ro otsi-adapter
-       |  +--ro number-of-otsi?   uint64
-       +--ro fec-parameters
-          +--ro pre-fec-ber?           uint64
-          +--ro post-fec-ber?          uint64
-          +--ro corrected-bytes?       uint64
-          +--ro corrected-bits?        uint64
-          +--ro uncorrectable-bytes?   uint64
-          +--ro uncorrectable-bits?    uint64
+          +--ro number-of-otsi?   uint64
+          +--ro fec-parameters
+             +--ro pre-fec-ber?           uint64
+             +--ro post-fec-ber?          uint64
+             +--ro corrected-bytes?       uint64
+             +--ro corrected-bits?        uint64
+             +--ro uncorrectable-bytes?   uint64
+             +--ro uncorrectable-bits?    uint64
   augment /tapi-connectivity:get-connection-end-point-details/tapi-connectivity:output/tapi-connectivity:connection-end-point:
     +-- otsi-connection-end-point-spec
        +--ro otsi-termination
@@ -701,6 +704,3 @@ module: tapi-photonic-media
              +--ro laser-application-type?   laser-type
              +--ro laser-bias-current?       decimal64
              +--ro laser-temperature?        decimal64
-  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link:
-    +--ro power-loss-characteristic
-       +--ro expected-loss?   decimal64

--- a/YANG/tapi-photonic-media@2019-03-31.yang
+++ b/YANG/tapi-photonic-media@2019-03-31.yang
@@ -21,7 +21,7 @@ module tapi-photonic-media {
         Source: TapiPhotonicMedia.uml
         Copyright (c) 2018 Open Networking Foundation (ONF). All rights reserved.
         License: This module is distributed under the Apache License 2.0
-    	- The TAPI YANG models included in this TAPI release are a *normative* part of the TAPI SDK.
+        - The TAPI YANG models included in this TAPI release are a *normative* part of the TAPI SDK.
         - The YANG specifications have been generated from the corresponding UML model using the [ONF EAGLE UML2YANG mapping tool]
         <https://github.com/OpenNetworkingFoundation/EagleUmlYang>
         and further edited manually to comply with the [ONF IISOMI UML2YANG mapping guidelines]
@@ -73,7 +73,6 @@ module tapi-photonic-media {
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
-    
     augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
         container otsi-connection-end-point-spec {
             uses otsi-connection-end-point-spec;
@@ -144,16 +143,44 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    augment "/tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip" {
-        container otsi-service-interface-point-spec {
-            uses otsi-service-interface-point-spec;
+    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
             description "none";
         }
         description "none";
     }
-    augment "/tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip" {
-        container otsi-service-interface-point-spec {
-            uses otsi-service-interface-point-spec;
+    augment "/tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
+        container media-channel-connectivity-service-end-point-spec {
+            uses media-channel-connectivity-service-end-point-spec;
             description "none";
         }
         description "none";
@@ -165,7 +192,28 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    augment "/tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
+    augment "/tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip" {
+        container media-channel-service-interface-point-spec {
+            uses media-channel-service-interface-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip" {
+        container media-channel-service-interface-point-spec {
+            uses media-channel-service-interface-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
+        container otsi-connectivity-service-end-point-spec {
+            uses otsi-connectivity-service-end-point-spec;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
         container otsi-connectivity-service-end-point-spec {
             uses otsi-connectivity-service-end-point-spec;
             description "none";
@@ -179,35 +227,7 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
-        container media-channel-connectivity-service-end-point-spec {
-            uses media-channel-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-connectivity:update-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
-        container media-channel-connectivity-service-end-point-spec {
-            uses media-channel-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-connectivity:get-connectivity-service-details/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
-        container media-channel-connectivity-service-end-point-spec {
-            uses media-channel-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
     augment "/tapi-connectivity:get-connectivity-service-list/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
-        container media-channel-connectivity-service-end-point-spec {
-            uses media-channel-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
         container otsi-connectivity-service-end-point-spec {
             uses otsi-connectivity-service-end-point-spec;
             description "none";
@@ -217,27 +237,6 @@ module tapi-photonic-media {
     augment "/tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
         container otsi-connectivity-service-end-point-spec {
             uses otsi-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-connectivity:update-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
-        container media-channel-connectivity-service-end-point-spec {
-            uses media-channel-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:output/tapi-connectivity:service/tapi-connectivity:end-point" {
-        container otsi-connectivity-service-end-point-spec {
-            uses otsi-connectivity-service-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
-        container media-channel-connectivity-service-end-point-spec {
-            uses media-channel-connectivity-service-end-point-spec;
             description "none";
         }
         description "none";
@@ -250,15 +249,15 @@ module tapi-photonic-media {
         description "none";
     }
     augment "/tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip" {
-        container media-channel-service-interface-point-spec {
-            uses media-channel-service-interface-point-spec;
+        container otsi-service-interface-point-spec {
+            uses otsi-service-interface-point-spec;
             description "none";
         }
         description "none";
     }
     augment "/tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip" {
-        container media-channel-service-interface-point-spec {
-            uses media-channel-service-interface-point-spec;
+        container otsi-service-interface-point-spec {
+            uses otsi-service-interface-point-spec;
             description "none";
         }
         description "none";
@@ -284,14 +283,6 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:link" {
-        container power-loss-characteristic {
-            uses power-loss-pac;
-            description "none";
-        }
-        description "none";
-    }
-    
     /**************************
     * package object-classes
     **************************/ 
@@ -299,6 +290,11 @@ module tapi-photonic-media {
         leaf number-of-otsi {
             type uint64;
             config false;
+            description "none";
+        }
+        container fec-parameters {
+            config false;
+            uses fec-properties;
             description "none";
         }
         description "none";
@@ -335,16 +331,16 @@ module tapi-photonic-media {
         }
         container transmited-power {
             config false;
-            uses power-properties-pac;
+            uses power-properties;
             description "Measured power at the Transmitter.";
         }
         container received-power {
-            uses power-properties-pac;
+            uses power-properties;
             description "none";
         }
         container laser-properties {
             config false;
-            uses laser-properties-pac;
+            uses laser-properties;
             description "Laser properties.";
         }
         description "Provides status information only.";
@@ -393,11 +389,11 @@ module tapi-photonic-media {
         }
         container measured-power-ingress {
             config false;
-            uses power-properties-pac;
+            uses power-properties;
             description "none";
         }
         container measured-power-egress {
-            uses power-properties-pac;
+            uses power-properties;
             description "none";
         }
         description "none";
@@ -406,11 +402,6 @@ module tapi-photonic-media {
         container otsi-adapter {
             config false;
             uses otsi-gserver-adaptation-pac;
-            description "none";
-        }
-        container fec-parameters {
-            config false;
-            uses fec-properties-pac;
             description "none";
         }
         description "none";
@@ -444,13 +435,16 @@ module tapi-photonic-media {
             uses total-power-threshold-pac;
             description "none";
         }
-        uses power-management-capability-pac;
         description "Can read the status of the warning for the upper value that the power can reach.";
     }
     grouping otsi-service-interface-point-spec {
         container otsi-capability {
             config false;
             uses otsi-capability-pac;
+            description "none";
+        }
+        container power-management-capability {
+            uses power-management-capability-pac;
             description "none";
         }
         description "none";
@@ -462,56 +456,6 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    grouping power-management-capability-pac{
-      container supportable-maximum-output-power {
-          uses power-properties-pac;
-          description "This parameter exposes the maximum output power
-            supported at the Logical-Termination-Point (LTP) associated to the SIP.";
-      }
-      container supportable-minimum-output-power {
-          uses power-properties-pac;
-          description "This parameter exposes the minimum output power
-            supported at the Logical-Termination-Point (LTP) associated to the SIP.";
-      }
-      container tolerable-maximum-input-power {
-          uses power-properties-pac;
-          description "This parameter exposes the maximum input power
-            tolerated at the Logical-Termination-Point (LTP) associated to the SIP.";
-      }
-      container tolerable-minimum-input-power {
-          uses power-properties-pac;
-          description "This parameter exposes the minimum input power
-            tolerated at the Logical-Termination-Point (LTP) associated to the SIP.";
-      }
-      description "This pac includes power management capabilities which can
-        be exposed as part of the characterization of the different LTPs at the PHOTONIC_MEDIA layer.";
-    }
-    grouping power-management-config-pac{
-      container intended-maximum-output-power {
-          uses power-properties-pac;
-          description "This parameter shall be used to specify the maximum output power
-            desired at the Logical-Termination-Point (LTP) associated to the CSEP.";
-      }
-      container intended-minimum-output-power {
-          uses power-properties-pac;
-          description "This parameter shall be used to specify the minimum output power
-            desired at the Logical-Termination-Point (LTP) associated to the CSEP.";
-      }
-      container expected-maximum-input-power {
-          uses power-properties-pac;
-          description "This parameter shall be used to specify the maximum input power
-            being received at the Logical-Termination-Point (LTP) associated to the CSEP.";
-      }
-      container expected-minimum-input-power {
-          uses power-properties-pac;
-          description "This parameter shall be used to specify the minimum input power
-            being received at the Logical-Termination-Point (LTP) associated to the CSEP.";
-      }
-      description "This pac includes power management constrains which can
-        be included as part of the characterization of the Connectivity-Service-End-Points
-        associated to Logical-Termination-Points (LTPs) at the PHOTONIC_MEDIA layer.";
-    }
-
     grouping otsi-termination-config-pac {
         container central-frequency {
             uses central-frequency;
@@ -534,7 +478,7 @@ module tapi-photonic-media {
             description "Laser control can be FORCED-ON, FORCED-OFF or LASER-SHUTDOWN";
         }
         container transmit-power {
-            uses power-properties-pac;
+            uses power-properties;
             description "Transmit power as requested.";
         }
         leaf total-power-warn-threshold-upper {
@@ -551,47 +495,13 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    grouping fec-properties-pac {
-        leaf pre-fec-ber {
-            type uint64;
-            config false;
-            description "counter: bit error rate before correction by FEC";
-        }
-        leaf post-fec-ber {
-            type uint64;
-            config false;
-            description "counter: bit error rate after correction by FEC";
-        }
-        leaf corrected-bytes {
-            type uint64;
-            config false;
-            description "Bytes corrected between those that were received corrupted";
-        }
-        leaf corrected-bits {
-            type uint64;
-            config false;
-            description "Bits corrected between those that were received corrupted";
-        }
-        leaf uncorrectable-bytes {
-            type uint64;
-            config false;
-            description "Bytes that could not be corrected by FEC";
-        }
-        leaf uncorrectable-bits {
-            type uint64;
-            config false;
-            description "Bits that could not be corrected by FEC";
-        }
-        description "none";
-    }
     grouping media-channel-service-interface-point-spec {
         container mc-pool {
             config false;
             uses media-channel-pool-capability-pac;
             description "none";
         }
-        container mc-capability{
-            config false;
+        container power-management-capability {
             uses power-management-capability-pac;
             description "none";
         }
@@ -602,19 +512,19 @@ module tapi-photonic-media {
             uses media-channel-config-pac;
             description "none";
         }
+        container power-management-config {
+            uses power-management-config-pac;
+            description "This parameters shall be used to configure the expected
+                and intended (desired) power levels at the endpoints of the media
+                Channel connectivity service. These parameters are dependent of the
+                related OTSi power-management capabilities exposed at the SIPs";
+        }
         description "none";
     }
     grouping media-channel-config-pac {
         container spectrum {
             uses spectrum-band;
             description "none";
-        }
-        container power-constraints{
-            uses power-management-config-pac;
-            description "This parameters shall be used to configure the expected
-              and intended (desired) power levels at the endpoints of the media
-              Channel connectivity service. These parameters are dependent of the
-              related OTSi power-management capabilities exposed at the SIPs";
         }
         description "none";
     }
@@ -636,57 +546,6 @@ module tapi-photonic-media {
     }
     grouping media-channel-assembly-spec {
         description "none";
-    }
-    grouping laser-properties-pac {
-        leaf laser-status {
-            type laser-control-status-type;
-            config false;
-            description "none";
-        }
-        leaf laser-application-type {
-            type laser-type;
-            config false;
-            description "The type of laser, its operational wavelengths, and its applications. String size 255.";
-        }
-        leaf laser-bias-current {
-            type decimal64 {
-                fraction-digits 7;
-            }
-            config false;
-            description "The Bias current of the laser that is the medium polarization current of the laser.";
-        }
-        leaf laser-temperature {
-            type decimal64 {
-                fraction-digits 7;
-            }
-            config false;
-            description "The temperature of the laser";
-        }
-        description "none";
-    }
-    grouping power-loss-pac {
-        leaf expected-loss {
-            type decimal64 {
-                fraction-digits 7;
-            }
-            description "The total power loss in a photonic link specified in dB.";
-        }
-        description "none";
-    }
-    grouping power-properties-pac {
-        leaf total-power {
-            type decimal64 {
-                fraction-digits 7;
-            }
-            description "The total power at any point in a channel specified in dBm.";
-        }
-        leaf power-spectral-density {
-            type decimal64 {
-                fraction-digits 7;
-            }
-            description "This describes how power of a signal  is distributed over frequency specified in nW/MHz";
-        }
-        description "Indication with severity warning raised when a total power value measured is above the threshold.";
     }
     grouping total-power-threshold-pac {
         leaf total-power-upper-warn-threshold-default {
@@ -725,7 +584,57 @@ module tapi-photonic-media {
             }
             description "Can read the value of the lower threshold that was set";
         }
-        description "none";
+        description "Indication with severity warning raised when a total power value measured is above the threshold.";
+    }
+    grouping power-management-capability-pac {
+        container supportable-maximum-output-power {
+            uses power-properties;
+            description "This parameter exposes the maximum output power supported
+                at the Logical-Termination-Point (LTP) associated to the SIP.";
+        }
+        container supportable-minimum-output-power {
+            uses power-properties;
+            description "This parameter exposes the minimum output power supported
+                at the Logical-Termination-Point (LTP) associated to the SIP.";
+        }
+        container tolerable-maximum-input-power {
+            uses power-properties;
+            description "This parameter exposes the maximum input power tolerated
+                at the Logical-Termination-Point (LTP) associated to the SIP.";
+        }
+        container tolerable-minimum-input-power {
+            uses power-properties;
+            description "This parameter exposes the minimum input power tolerated
+                at the Logical-Termination-Point (LTP) associated to the SIP.";
+        }
+        description "This pac includes power management capabilities which can be
+            exposed as part of the characterization of the different LTPs
+            at the PHOTONIC_MEDIA layer.";
+    }
+    grouping power-management-config-pac {
+        container intended-maximum-output-power {
+            uses power-properties;
+            description "This parameter shall be used to specify the maximum output power
+                desired at the Logical-Termination-Point (LTP) associated to the CSEP.";
+        }
+        container intended-minimum-output-power {
+            uses power-properties;
+            description "This parameter shall be used to specify the minimum output power
+                desired at the Logical-Termination-Point (LTP) associated to the CSEP.";
+        }
+        container expected-maximum-input-power {
+            uses power-properties;
+            description "This parameter shall be used to specify the maximum input power
+                being received at the Logical-Termination-Point (LTP) associated to the CSEP.";
+        }
+        container expected-minimum-input-power {
+            uses power-properties;
+            description "This parameter shall be used to specify the minimum input power
+                being received at the Logical-Termination-Point (LTP) associated to the CSEP.";
+        }
+        description "This pac includes power management constrains which can be included
+            as part of the characterization of the Connectivity-Service-End-Points
+            associated to Logical-Termination-Points (LTPs) at the PHOTONIC_MEDIA layer.";
     }
 
     /**************************
@@ -1006,6 +915,81 @@ module tapi-photonic-media {
             description "Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width";
         }
         description "This data-type holds the frequency constraint information in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.";
+    }
+    grouping power-properties {
+        leaf total-power {
+            type decimal64 {
+                fraction-digits 7;
+            }
+            description "The total power at any point in a channel specified in dBm.";
+        }
+        leaf power-spectral-density {
+            type decimal64 {
+                fraction-digits 7;
+            }
+            description "This describes how power of a signal  is distributed over frequency specified in nW/MHz";
+        }
+        description "none";
+    }
+    grouping fec-properties {
+        leaf pre-fec-ber {
+            type uint64;
+            config false;
+            description "counter: bit error rate before correction by FEC";
+        }
+        leaf post-fec-ber {
+            type uint64;
+            config false;
+            description "counter: bit error rate after correction by FEC";
+        }
+        leaf corrected-bytes {
+            type uint64;
+            config false;
+            description "Bytes corrected between those that were received corrupted";
+        }
+        leaf corrected-bits {
+            type uint64;
+            config false;
+            description "Bits corrected between those that were received corrupted";
+        }
+        leaf uncorrectable-bytes {
+            type uint64;
+            config false;
+            description "Bytes that could not be corrected by FEC";
+        }
+        leaf uncorrectable-bits {
+            type uint64;
+            config false;
+            description "Bits that could not be corrected by FEC";
+        }
+        description "none";
+    }
+    grouping laser-properties {
+        leaf laser-status {
+            type laser-control-status-type;
+            config false;
+            description "none";
+        }
+        leaf laser-application-type {
+            type laser-type;
+            config false;
+            description "The type of laser, its operational wavelengths, and its applications. String size 255.";
+        }
+        leaf laser-bias-current {
+            type decimal64 {
+                fraction-digits 7;
+            }
+            config false;
+            description "The Bias current of the laser that is the medium polarization current of the laser.";
+        }
+        leaf laser-temperature {
+            type decimal64 {
+                fraction-digits 7;
+            }
+            config false;
+            description "The temperature of the laser";
+        }
+        description "none";
     }
 
 }


### PR DESCRIPTION
- Refactored PowerPropertiesPac, LaserPropertiesPac & FecPropertiesPac
classes to complex data-type
- Added PowerManagementCapabilityPac and PowerManagementConfigPac
classes
- Added powerManagementCapability attribute to the OtsiSIPSpec and
MediaChannelSIPSpec
- Added powerManagementConfig attribute to the MediaChannelCSEPSpec
- Minor re-ordering of few Yang RPC augment statements due to tool
generation
- removed Link augment statement for power-loss-characteristic as
TransferTimingPac in Topology has lossCharactersistic which can be used
for now. The TopologyPacs are expected to be enhanced soon