### PR TITLE
Photonic and Eqpt model changes as per TAPI call on April 2, 2019

### DIFF
--- a/UML/TapiEquipment.notation
+++ b/UML/TapiEquipment.notation
@@ -313,141 +313,141 @@
       <element xmi:type="uml:Comment" href="TapiEquipment.uml#_87bG8ElkEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FoORcUv2EemT5f_Ewhfs6A" x="-4" y="-205" width="281" height="8"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OczBUE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OczBUU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OczBU02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_afBLgFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_afBLgVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_afBLg1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OczBUk2qEemQQPVBE79CWA" x="537" y="148"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_afBLglVJEemD67R2QwZykA" x="537" y="148"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Odou0E2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Odou0U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OdpV4E2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_agbgwFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_agbgwVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_agcH0FVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Odou0k2qEemQQPVBE79CWA" x="733" y="-258"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_agbgwlVJEemD67R2QwZykA" x="733" y="-258"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OeK6UE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OeK6UU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeK6U02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ahHdQFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ahHdQVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ahIEUFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OeK6Uk2qEemQQPVBE79CWA" x="733" y="-358"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ahHdQlVJEemD67R2QwZykA" x="733" y="-358"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OeYVsE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OeYVsU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeYVs02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ahZxIFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ahZxIVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ahZxI1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OeYVsk2qEemQQPVBE79CWA" x="733" y="-358"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ahZxIlVJEemD67R2QwZykA" x="733" y="-358"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OfKY0E2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OfKY0U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfKY002qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ait_wFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ait_wVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ait_w1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OfKY0k2qEemQQPVBE79CWA" x="937" y="-152"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ait_wlVJEemD67R2QwZykA" x="937" y="-152"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OfiMQE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OfiMQU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfiMQ02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ajZVMFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ajZ8QFVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ajZ8QlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OfiMQk2qEemQQPVBE79CWA" x="937" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ajZ8QVVJEemD67R2QwZykA" x="937" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ofr9QE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ofr9QU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ofr9Q02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ajvTcFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ajvTcVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ajvTc1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ofr9Qk2qEemQQPVBE79CWA" x="937" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ajvTclVJEemD67R2QwZykA" x="937" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OgVdgE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OgVdgU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgVdg02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_akux8FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_akux8VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_akux81VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OgVdgk2qEemQQPVBE79CWA" x="537" y="-152"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_akux8lVJEemD67R2QwZykA" x="537" y="-152"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OgvGIE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OgvGIU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgvGI02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_alXEEFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_alXEEVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_alXEE1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OgvGIk2qEemQQPVBE79CWA" x="537" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_alXEElVJEemD67R2QwZykA" x="537" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Og43IE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Og43IU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Og43I02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_alwssFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_alwssVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_alxTwFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Og43Ik2qEemQQPVBE79CWA" x="537" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_alwsslVJEemD67R2QwZykA" x="537" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Oh91ME2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Oh91MU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oh91M02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_amvkIFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_amvkIVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_amvkI1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Oh91Mk2qEemQQPVBE79CWA" x="197" y="148"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_amvkIlVJEemD67R2QwZykA" x="197" y="148"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OicWUE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OicWUU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OicWU02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_anOFQFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_anOFQVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_anOFQ1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OicWUk2qEemQQPVBE79CWA" x="197" y="48"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_anOFQlVJEemD67R2QwZykA" x="197" y="48"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OjPAgE2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OjPAgU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjPAg02qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_aoWtsFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_aoWtsVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aoWts1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OjPAgk2qEemQQPVBE79CWA" x="937" y="86"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aoWtslVJEemD67R2QwZykA" x="937" y="86"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OjmM4E2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OjmM4U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjmM402qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ao6uYFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ao6uYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ao6uY1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OjmM4k2qEemQQPVBE79CWA" x="937" y="-14"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ao6uYlVJEemD67R2QwZykA" x="937" y="-14"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ojv94E2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ojv94U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ojv9402qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_apEfYFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_apEfYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_apEfY1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ojv94k2qEemQQPVBE79CWA" x="937" y="-14"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_apEfYlVJEemD67R2QwZykA" x="937" y="-14"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OkXB4E2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OkXB4U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OkXB402qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_aqcYYFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_aqcYYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aqcYY1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OkXB4k2qEemQQPVBE79CWA" x="197" y="-72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aqcYYlVJEemD67R2QwZykA" x="197" y="-72"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Okp80E2qEemQQPVBE79CWA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Okp80U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Okp8002qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_arIU4FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_arIU4VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_arIU41VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Okp80k2qEemQQPVBE79CWA" x="197" y="-172"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arIU4lVJEemD67R2QwZykA" x="197" y="-172"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_hb9t2i8LEeexxefg2F1i1Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_hb9t2y8LEeexxefg2F1i1Q"/>
@@ -792,175 +792,175 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vrmSEv0EemT5f_Ewhfs6A" id="(0.5,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__vrmSUv0EemT5f_Ewhfs6A" id="(0.5,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OczoYE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjDakv0EemT5f_Ewhfs6A" target="_OczBUE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OczoYU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OczoZU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_afBLhFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vjDakv0EemT5f_Ewhfs6A" target="_afBLgFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_afBLhVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_afBLiVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OczoYk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OczoY02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OczoZE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_afBLhlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_afBLh1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_afBLiFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OdpV4U2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjqd0v0EemT5f_Ewhfs6A" target="_Odou0E2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OdpV4k2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OdpV5k2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_agcH0VVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vjqd0v0EemT5f_Ewhfs6A" target="_agbgwFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_agcH0lVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_agcu4lVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OdpV402qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OdpV5E2qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OdpV5U2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_agcH01VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_agcu4FVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_agcu4VVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OeK6VE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vlfxkv0EemT5f_Ewhfs6A" target="_OeK6UE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OeK6VU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeK6WU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ahIEUVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vlfxkv0EemT5f_Ewhfs6A" target="_ahHdQFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ahIEUlVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ahIEVlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OeK6Vk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeK6V02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeK6WE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ahIEU1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ahIEVFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ahIEVVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OeYVtE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vn70Ev0EemT5f_Ewhfs6A" target="_OeYVsE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OeYVtU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OeYVuU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ahaYMFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vn70Ev0EemT5f_Ewhfs6A" target="_ahZxIFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ahaYMVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ahaYNVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OeYVtk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeYVt02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OeYVuE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ahaYMlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ahaYM1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ahaYNFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OfK_4E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vk4gEv0EemT5f_Ewhfs6A" target="_OfKY0E2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OfK_4U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfK_5U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ait_xFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vk4gEv0EemT5f_Ewhfs6A" target="_ait_wFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ait_xVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ait_yVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OfK_4k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfK_402qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfK_5E2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ait_xlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ait_x1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ait_yFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OfiMRE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vlfkEv0EemT5f_Ewhfs6A" target="_OfiMQE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OfiMRU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OfizUE2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ajZ8Q1VJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vlfkEv0EemT5f_Ewhfs6A" target="_ajZVMFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ajZ8RFVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ajZ8SFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OfiMRk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfiMR02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OfiMSE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ajZ8RVVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ajZ8RlVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ajZ8R1VJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ofr9RE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vpxGkv0EemT5f_Ewhfs6A" target="_Ofr9QE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ofr9RU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ofr9SU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ajvTdFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vpxGkv0EemT5f_Ewhfs6A" target="_ajvTcFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ajvTdVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ajv6glVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ofr9Rk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ofr9R02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ofr9SE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ajvTdlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ajv6gFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ajv6gVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OgVdhE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vmGoEv0EemT5f_Ewhfs6A" target="_OgVdgE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OgVdhU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgVdiU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_akvZAFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vmGoEv0EemT5f_Ewhfs6A" target="_akux8FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_akvZAVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_akvZBVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OgVdhk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgVdh02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgVdiE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_akvZAlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_akvZA1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_akvZBFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OgvGJE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjDUEv0EemT5f_Ewhfs6A" target="_OgvGIE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OgvGJU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OgvGKU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_alXrIFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vjDUEv0EemT5f_Ewhfs6A" target="_alXEEFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_alXrIVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_alXrJVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OgvGJk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgvGJ02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OgvGKE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_alXrIlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_alXrI1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_alXrJFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Og43JE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vrmMEv0EemT5f_Ewhfs6A" target="_Og43IE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Og43JU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Og43KU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_alxTwVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vrmMEv0EemT5f_Ewhfs6A" target="_alwssFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_alxTwlVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_alxTxlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Og43Jk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Og43J02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Og43KE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_alxTw1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_alxTxFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_alxTxVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Oh91NE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vmtsEv0EemT5f_Ewhfs6A" target="_Oh91ME2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Oh91NU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oh-cQE2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_amvkJFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vmtsEv0EemT5f_Ewhfs6A" target="_amvkIFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_amvkJVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_amwLMVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Oh91Nk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oh91N02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oh91OE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_amvkJlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_amvkJ1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_amwLMFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OicWVE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vlfqkv0EemT5f_Ewhfs6A" target="_OicWUE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OicWVU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OicWWU2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_anOFRFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vlfqkv0EemT5f_Ewhfs6A" target="_anOFQFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_anOFRVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_anOsUVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OicWVk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OicWV02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OicWWE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_anOFRlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_anOFR1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_anOsUFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OjPAhE2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vn76kv0EemT5f_Ewhfs6A" target="_OjPAgE2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OjPAhU2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjPnkE2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_aoWttFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vn76kv0EemT5f_Ewhfs6A" target="_aoWtsFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_aoWttVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aoWtuVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OjPAhk2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjPAh02qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjPAiE2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aoWttlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aoWtt1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aoWtuFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OjmM5E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vicQEv0EemT5f_Ewhfs6A" target="_OjmM4E2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OjmM5U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OjmM6U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ao6uZFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vicQEv0EemT5f_Ewhfs6A" target="_ao6uYFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ao6uZVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ao7VcFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OjmM5k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjmM502qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OjmM6E2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ao6uZlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ao6uZ1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ao6uaFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ojv95E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vjqYEv0EemT5f_Ewhfs6A" target="_Ojv94E2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ojv95U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ojv96U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_apEfZFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vjqYEv0EemT5f_Ewhfs6A" target="_apEfYFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_apEfZVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_apEfaVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ojv95k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ojv9502qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ojv96E2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_apEfZlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_apEfZ1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_apEfaFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OkXB5E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vpxNEv0EemT5f_Ewhfs6A" target="_OkXB4E2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OkXB5U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OkXB6U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_aqc_cFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vpxNEv0EemT5f_Ewhfs6A" target="_aqcYYFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_aqc_cVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_aqc_dVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OkXB5k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OkXB502qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OkXB6E2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aqc_clVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aqc_c1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aqc_dFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Okp81E2qEemQQPVBE79CWA" type="StereotypeCommentLink" source="__vpxAEv0EemT5f_Ewhfs6A" target="_Okp80E2qEemQQPVBE79CWA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Okp81U2qEemQQPVBE79CWA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Okp82U2qEemQQPVBE79CWA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_arIU5FVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__vpxAEv0EemT5f_Ewhfs6A" target="_arIU4FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_arIU5VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_arIU6VVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Okp81k2qEemQQPVBE79CWA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Okp8102qEemQQPVBE79CWA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Okp82E2qEemQQPVBE79CWA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_arIU5lVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_arIU51VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_arIU6FVJEemD67R2QwZykA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_UDyhIES5Eem_eeeaz1ENMQ" type="PapyrusUMLClassDiagram" name="EquipmentModelDetail" measurementUnit="Pixel">
@@ -1479,15 +1479,6 @@
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_1yD_8EvHEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_2gqLUUvHEemT5f_Ewhfs6A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_6OFfUEvHEemT5f_Ewhfs6A" type="Property_DataTypeAttributeLabel" fontColor="255" fontName="Segoe UI">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fLUYYEvOEemT5f_Ewhfs6A" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fLU_cEvOEemT5f_Ewhfs6A" key="fontHeight" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fLU_c0vOEemT5f_Ewhfs6A" key="bold" value="true"/>
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fLU_dUvOEemT5f_Ewhfs6A" key="italic" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiEquipment.uml#_5h3SgEvHEemT5f_Ewhfs6A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_6OFfUUvHEemT5f_Ewhfs6A"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_83aSAEvHEemT5f_Ewhfs6A" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_8L2MgEvHEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_83aSAUvHEemT5f_Ewhfs6A"/>
@@ -1524,11 +1515,12 @@
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_5CPsYkvJEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_-uPl4UvJEemT5f_Ewhfs6A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_9WH8YEvJEemT5f_Ewhfs6A" type="Property_DataTypeAttributeLabel" fontColor="255" fontName="Segoe UI">
+        <children xmi:type="notation:Shape" xmi:id="_9WH8YEvJEemT5f_Ewhfs6A" type="Property_DataTypeAttributeLabel" fontName="Segoe UI">
           <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fLU_cUvOEemT5f_Ewhfs6A" source="PapyrusCSSForceValue">
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fLU_ckvOEemT5f_Ewhfs6A" key="fontHeight" value="true"/>
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fLU_dEvOEemT5f_Ewhfs6A" key="bold" value="true"/>
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fLU_dkvOEemT5f_Ewhfs6A" key="italic" value="true"/>
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_j1VvwFVLEemD67R2QwZykA" key="fontColor" value="true"/>
           </eAnnotations>
           <element xmi:type="uml:Property" href="TapiEquipment.uml#_5CPsZUvJEemT5f_Ewhfs6A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_9WH8YUvJEemT5f_Ewhfs6A"/>
@@ -1797,285 +1789,285 @@
       <element xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8PgDEU2sEemQQPVBE79CWA" x="1936" y="581" height="61"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tTijIFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tTijIVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTijI1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_XpHVYFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XpHVYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XpHVY1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTijIlFnEemgMYGocegK5A" x="2580" y="560"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XpHVYlVJEemD67R2QwZykA" x="2580" y="560"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tTxzsFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tTxzsVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTxzs1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_XqKeQFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XqKeQVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XqKeQ1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tTxzslFnEemgMYGocegK5A" x="1340" y="320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XqKeQlVJEemD67R2QwZykA" x="1340" y="320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tUYQoFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tUYQoVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tUYQo1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Xs1-0FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Xs1-0VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Xs2l4FVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tUYQolFnEemgMYGocegK5A" x="2580" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Xs1-0lVJEemD67R2QwZykA" x="2580" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tU-GgFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tU-GgVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tU-Gg1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_XvGooFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XvGooVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XvHPsFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tU-GglFnEemgMYGocegK5A" x="860" y="-20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XvGoolVJEemD67R2QwZykA" x="860" y="-20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tWBPYFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tWBPYVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWBPY1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_XzCGYFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XzCGYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XzCGY1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tWBPYlFnEemgMYGocegK5A" x="860" y="-120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XzCGYlVJEemD67R2QwZykA" x="860" y="-120"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tWiMwFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tWiMwVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWiMw1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X002IFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X002IVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X01dMFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tWiMwlFnEemgMYGocegK5A" x="1926" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X002IlVJEemD67R2QwZykA" x="1926" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tXKe4FFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tXKe4VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXKe41FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X2qCIFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X2qCIVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X2qCI1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tXKe4lFnEemgMYGocegK5A" x="1926" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X2qCIlVJEemD67R2QwZykA" x="1926" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tXTo0FFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tXTo0VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXTo01FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X3KYcFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X3KYcVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X3KYc1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tXTo0lFnEemgMYGocegK5A" x="1926" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X3KYclVJEemD67R2QwZykA" x="1926" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tX0mMFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tX0mMVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tX0mM1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X4jfkFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X4jfkVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X4jfk1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tX0mMlFnEemgMYGocegK5A" x="860" y="560"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X4jfklVJEemD67R2QwZykA" x="860" y="560"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tZYFYFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tZYFYVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZYFY1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X6muAFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X6muAVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X6muA1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tZYFYlFnEemgMYGocegK5A" x="860" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X6muAlVJEemD67R2QwZykA" x="860" y="460"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tZ6Q4FFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tZ6Q4VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZ6Q41FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X8iAoFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X8iAoVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X8insFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tZ6Q4lFnEemgMYGocegK5A" x="1400" y="560"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X8iAolVJEemD67R2QwZykA" x="1400" y="560"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ta36MFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ta36MVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ta36M1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YEUqsFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YEUqsVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YEUqs1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ta36MlFnEemgMYGocegK5A" x="1980" y="305"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YEUqslVJEemD67R2QwZykA" x="1980" y="305"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tbrLcFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tbrLcVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbrLc1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YGktcFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YGktcVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YGlUgFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tbrLclFnEemgMYGocegK5A" x="1980" y="205"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YGktclVJEemD67R2QwZykA" x="1980" y="205"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tbwrAFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tbwrAVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbwrA1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YG5dkFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YG5dkVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YG5dk1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tbwrAlFnEemgMYGocegK5A" x="1980" y="205"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YG5dklVJEemD67R2QwZykA" x="1980" y="205"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tb7DEFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tb7DEVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tb7DE1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YHZM0FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YHZM0VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YHZM01VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tb7DElFnEemgMYGocegK5A" x="-680" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YHZM0lVJEemD67R2QwZykA" x="-680" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tcjVMFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tcjVMVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tcjVM1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YI_vUFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YI_vUVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YI_vU1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tcjVMlFnEemgMYGocegK5A" x="-160" y="380"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YI_vUlVJEemD67R2QwZykA" x="-160" y="380"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tdXNgFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tdXNgVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdXNg1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YMtxsFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YMtxsVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YMtxs1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tdXNglFnEemgMYGocegK5A" x="-1020" y="420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YMtxslVJEemD67R2QwZykA" x="-1020" y="420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tdwPEFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tdwPEVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdwPE1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YNqz8FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YNqz8VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YNrbAFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tdwPElFnEemgMYGocegK5A" x="360" y="420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YNqz8lVJEemD67R2QwZykA" x="360" y="420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_teBU0FFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_teBU0VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_teBU01FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YOViUFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YOViUVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YOViU1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_teBU0lFnEemgMYGocegK5A" x="-540" y="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOViUlVJEemD67R2QwZykA" x="-540" y="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_telVgFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_telVgVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_telVg1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YPxFsFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YPxFsVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YPxFs1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_telVglFnEemgMYGocegK5A" y="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YPxFslVJEemD67R2QwZykA" y="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tfDPkFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tfDPkVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfDPk1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YRJlwFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YRJlwVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YRJlw1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tfDPklFnEemgMYGocegK5A" y="660"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YRJlwlVJEemD67R2QwZykA" y="660"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tfU8YFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tfU8YVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfU8Y1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YR07MFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YR07MVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YR07M1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tfU8YlFnEemgMYGocegK5A" x="-440" y="660"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YR07MlVJEemD67R2QwZykA" x="-440" y="660"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tfmpMFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tfmpMVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfmpM1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YSg3sFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YSg3sVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YSg3s1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tfmpMlFnEemgMYGocegK5A" x="-140" y="840"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YSg3slVJEemD67R2QwZykA" x="-140" y="840"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tgZ6cFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tgZ6cVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tgZ6c1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YUHaMFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YUHaMVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YUIBQVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tgZ6clFnEemgMYGocegK5A" x="1580" y="-100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YUIBQFVJEemD67R2QwZykA" x="1580" y="-100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_th7kcFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_th7kcVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_th7kc1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YVf6QFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YVf6QVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YVf6Q1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_th7kclFnEemgMYGocegK5A" x="1580" y="-200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YVf6QlVJEemD67R2QwZykA" x="1580" y="-200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tiGjkFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tiGjkVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiGjk1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YWKBkFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YWKBkVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YWKooFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tiGjklFnEemgMYGocegK5A" x="1580" y="-200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YWKBklVJEemD67R2QwZykA" x="1580" y="-200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tiu1sFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tiu1sVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiu1s1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YXHq4FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YXHq4VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YXHq41VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tiu1slFnEemgMYGocegK5A" x="1780" y="-300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YXHq4lVJEemD67R2QwZykA" x="1780" y="-300"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tjj8IFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tjj8IVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjj8I1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YYZdQFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YYZdQVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YYZdQ1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tjj8IlFnEemgMYGocegK5A" x="1780" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YYZdQlVJEemD67R2QwZykA" x="1780" y="-400"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tjsfAFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tjsfAVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjsfA1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YYkcYFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YYkcYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YYkcY1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tjsfAlFnEemgMYGocegK5A" x="1780" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YYkcYlVJEemD67R2QwZykA" x="1780" y="-400"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tj3eIFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tj3eIVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tj3eI1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YY3-YFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YY3-YVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YY3-Y1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tj3eIlFnEemgMYGocegK5A" x="1780" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YY3-YlVJEemD67R2QwZykA" x="1780" y="-400"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tkmd8FFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tkmd8VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tkmd81FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YZqokFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YZqokVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YZqok1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tkmd8lFnEemgMYGocegK5A" x="2580" y="-300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YZqoklVJEemD67R2QwZykA" x="2580" y="-300"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tlZIIFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tlZIIVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlZII1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YafH8FVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YafH8VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YafH81VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tlZIIlFnEemgMYGocegK5A" x="2333" y="-84"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YafH8lVJEemD67R2QwZykA" x="2333" y="-84"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tlxioFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tlxioVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlyJsFFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YbDIoFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YbDIoVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YbDIo1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tlxiolFnEemgMYGocegK5A" x="2333" y="-184"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YbDIolVJEemD67R2QwZykA" x="2333" y="-184"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tmMZYFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tmMZYVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmMZY1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_YbhpwFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_YbhpwVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ybhpw1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tmMZYlFnEemgMYGocegK5A" x="2136" y="581"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YbhpwlVJEemD67R2QwZykA" x="2136" y="581"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_tmiXoFFnEemgMYGocegK5A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_tmiXoVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmiXo1FnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Yb4PEFVJEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Yb4PEVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yb4PE1VJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tmiXolFnEemgMYGocegK5A" x="2136" y="481"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yb4PElVJEemD67R2QwZykA" x="2136" y="481"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_UDyhIUS5Eem_eeeaz1ENMQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_UDyhIkS5Eem_eeeaz1ENMQ"/>
@@ -2775,355 +2767,355 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVCfsE2tEemQQPVBE79CWA" id="(1.0,0.4098360655737705)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVCfsU2tEemQQPVBE79CWA" id="(0.0,0.46)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tTijJFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvs210S5Eem_eeeaz1ENMQ" target="_tTijIFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tTijJVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTijKVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_XpH8cFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Yvs210S5Eem_eeeaz1ENMQ" target="_XpHVYFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XpH8cVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XpIjglVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tTijJlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTijJ1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTijKFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XpH8clVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XpIjgFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XpIjgVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tTxztFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvuFIkS5Eem_eeeaz1ENMQ" target="_tTxzsFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tTxztVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tTyawlFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_XqKeRFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_YvuFIkS5Eem_eeeaz1ENMQ" target="_XqKeQFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XqKeRVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XqKeSVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tTxztlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTyawFFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tTyawVFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XqKeRlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XqKeR1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XqKeSFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tUYQpFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_tUYQoFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tUYQpVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tUYQqVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Xs2l4VVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_Xs1-0FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Xs2l4lVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Xs2l5lVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tUYQplFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tUYQp1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tUYQqFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xs2l41VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xs2l5FVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xs2l5VVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tU-GhFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_tU-GgFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tU-GhVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tU-GiVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_XvHPsVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_XvGooFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XvHPslVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XvHPtlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tU-GhlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tU-Gh1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tU-GiFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XvHPs1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XvHPtFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XvHPtVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tWB2cFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvs2o0S5Eem_eeeaz1ENMQ" target="_tWBPYFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tWB2cVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWB2dVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_XzCGZFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Yvs2o0S5Eem_eeeaz1ENMQ" target="_XzCGYFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XzCGZVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XzCtclVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tWB2clFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWB2c1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWB2dFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XzCGZlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XzCtcFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XzCtcVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tWiMxFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_tWiMwFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tWiMxVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWiMyVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_X01dMVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_X002IFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X01dMlVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X01dNlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tWiMxlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWiMx1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWiMyFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X01dM1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X01dNFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X01dNVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tXKe5FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvtdsES5Eem_eeeaz1ENMQ" target="_tXKe4FFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tXKe5VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXKe6VFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_X2qpMFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_YvtdsES5Eem_eeeaz1ENMQ" target="_X2qCIFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X2qpMVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X2qpNVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tXKe5lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXKe51FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXKe6FFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X2qpMlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X2qpM1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X2qpNFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tXTo1FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_QbC-0ElZEemT5f_Ewhfs6A" target="_tXTo0FFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tXTo1VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tXUP4lFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_X3KYdFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_QbC-0ElZEemT5f_Ewhfs6A" target="_X3KYcFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X3KYdVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X3KYeVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tXTo1lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXUP4FFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tXUP4VFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X3KYdlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X3KYd1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X3KYeFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tX0mNFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_tX0mMFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tX0mNVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tX0mOVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_X4jflFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_X4jfkFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X4jflVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X4jfmVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tX0mNlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tX0mN1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tX0mOFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X4jfllVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4jfl1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4jfmFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tZYFZFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_YvteBES5Eem_eeeaz1ENMQ" target="_tZYFYFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tZYFZVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZYFaVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_X6muBFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_YvteBES5Eem_eeeaz1ENMQ" target="_X6muAFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X6muBVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X6muCVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tZYFZlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZYFZ1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZYFaFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X6muBlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X6muB1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X6muCFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tZ6Q5FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_tZ6Q4FFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tZ6Q5VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tZ638lFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_X8insVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_X8iAoFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X8inslVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X8jOwFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tZ6Q5lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZ638FFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tZ638VFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X8ins1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X8intFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X8intVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ta36NFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_ta36MFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ta36NVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ta36OVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YEUqtFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_YEUqsFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YEUqtVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YEVRwFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ta36NlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ta36N1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ta36OFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YEUqtlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YEUqt1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YEUquFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tbrLdFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MMsq4ElgEemT5f_Ewhfs6A" target="_tbrLcFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tbrLdVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbrLeVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YGlUgVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_MMsq4ElgEemT5f_Ewhfs6A" target="_YGktcFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YGlUglVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YGlUhlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tbrLdlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbrLd1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbrLeFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YGlUg1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YGlUhFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YGlUhVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tbwrBFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_V8cGoElgEemT5f_Ewhfs6A" target="_tbwrAFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tbwrBVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tbwrCVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YG5dlFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_V8cGoElgEemT5f_Ewhfs6A" target="_YG5dkFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YG5dlVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YG6EoVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tbwrBlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbwrB1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tbwrCFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YG5dllVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YG5dl1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YG6EoFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tb7DFFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_jqTmgEqtEemT5f_Ewhfs6A" target="_tb7DEFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tb7DFVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tb7DGVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YHZM1FVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_jqTmgEqtEemT5f_Ewhfs6A" target="_YHZM0FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YHZM1VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YHZM2VVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tb7DFlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tb7DF1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tb7DGFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YHZM1lVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YHZM11VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YHZM2FVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tcjVNFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_-KwtEEvDEemT5f_Ewhfs6A" target="_tcjVMFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tcjVNVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tcjVOVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YJBkgFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_-KwtEEvDEemT5f_Ewhfs6A" target="_YI_vUFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YJBkgVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YJBkhVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tcjVNlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tcjVN1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tcjVOFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YJBkglVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YJBkg1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YJBkhFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tdXNhFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_7n5SQEvEEemT5f_Ewhfs6A" target="_tdXNgFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tdXNhVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdXNiVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YMtxtFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_7n5SQEvEEemT5f_Ewhfs6A" target="_YMtxsFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YMtxtVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YMtxuVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tdXNhlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdXNh1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdXNiFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YMtxtlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YMtxt1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YMtxuFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tdwPFFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MawgkEvHEemT5f_Ewhfs6A" target="_tdwPEFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tdwPFVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tdwPGVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YNrbAVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_MawgkEvHEemT5f_Ewhfs6A" target="_YNqz8FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YNrbAlVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YNrbBlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tdwPFlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdwPF1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tdwPGFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YNrbA1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YNrbBFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YNrbBVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_teBU1FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_rjM_QEvHEemT5f_Ewhfs6A" target="_teBU0FFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_teBU1VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_teB74lFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YOWJYFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_rjM_QEvHEemT5f_Ewhfs6A" target="_YOViUFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YOWJYVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YOWJZVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_teBU1lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_teB74FFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_teB74VFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YOWJYlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YOWJY1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YOWJZFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_telVhFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_6zavEEvJEemT5f_Ewhfs6A" target="_telVgFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_telVhVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tel8klFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YPxFtFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_6zavEEvJEemT5f_Ewhfs6A" target="_YPxFsFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YPxFtVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YPxFuVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_telVhlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tel8kFFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tel8kVFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YPxFtlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YPxFt1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YPxFuFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tfD2oFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_9Zye8EvKEemT5f_Ewhfs6A" target="_tfDPkFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tfD2oVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfD2pVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YRJlxFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_9Zye8EvKEemT5f_Ewhfs6A" target="_YRJlwFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YRJlxVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YRJlyVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tfD2olFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfD2o1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfD2pFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YRJlxlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YRJlx1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YRJlyFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tfU8ZFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MSkREEvLEemT5f_Ewhfs6A" target="_tfU8YFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tfU8ZVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfU8aVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YR07NFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_MSkREEvLEemT5f_Ewhfs6A" target="_YR07MFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YR07NVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YR07OVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tfU8ZlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfU8Z1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfU8aFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YR07NlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YR07N1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YR07OFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tfmpNFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_iYsasEvLEemT5f_Ewhfs6A" target="_tfmpMFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tfmpNVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tfmpOVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YSg3tFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_iYsasEvLEemT5f_Ewhfs6A" target="_YSg3sFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YSg3tVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YShewlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tfmpNlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfmpN1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tfmpOFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YSg3tlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YShewFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YShewVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tgZ6dFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_tgZ6cFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tgZ6dVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tgZ6eVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YUIBQlVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_YUHaMFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YUIBQ1VJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YUIoUFVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tgZ6dlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tgZ6d1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tgZ6eFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YUIBRFVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YUIBRVVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YUIBRlVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_th7kdFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_TTeRkEvXEemT5f_Ewhfs6A" target="_th7kcFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_th7kdVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_th7keVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YVf6RFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_TTeRkEvXEemT5f_Ewhfs6A" target="_YVf6QFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YVf6RVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YVghUlVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_th7kdlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_th7kd1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_th7keFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YVf6RlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YVghUFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YVghUVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tiGjlFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_WUpjkEvXEemT5f_Ewhfs6A" target="_tiGjkFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tiGjlVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiHKolFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YWKooVVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_WUpjkEvXEemT5f_Ewhfs6A" target="_YWKBkFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YWKoolVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YWKoplVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tiGjllFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiHKoFFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiHKoVFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YWKoo1VJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YWKopFVJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YWKopVVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tiu1tFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_tiu1sFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tiu1tVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tiu1uVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YXIR8FVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_YXHq4FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YXIR8VVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YXIR9VVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tiu1tlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiu1t1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tiu1uFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YXIR8lVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YXIR81VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YXIR9FVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tjj8JFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_I4JjYEvxEemT5f_Ewhfs6A" target="_tjj8IFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tjj8JVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjj8KVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YYZdRFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_I4JjYEvxEemT5f_Ewhfs6A" target="_YYZdQFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YYZdRVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YYZdSVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tjj8JlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjj8J1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjj8KFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YYZdRlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YYZdR1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YYZdSFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tjtGEFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="__DqVEEvxEemT5f_Ewhfs6A" target="_tjsfAFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tjtGEVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tjtGFVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YYlDcFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="__DqVEEvxEemT5f_Ewhfs6A" target="_YYkcYFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YYlDcVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YYlDdVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tjtGElFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjtGE1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tjtGFFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YYlDclVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YYlDc1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YYlDdFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tj3eJFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_DpB9sEvyEemT5f_Ewhfs6A" target="_tj3eIFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tj3eJVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tj3eKVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YY3-ZFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_DpB9sEvyEemT5f_Ewhfs6A" target="_YY3-YFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YY3-ZVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YY3-aVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tj3eJlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tj3eJ1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tj3eKFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YY3-ZlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YY3-Z1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YY3-aFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tkmd9FFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_7M57YEvwEemT5f_Ewhfs6A" target="_tkmd8FFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tkmd9VFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tkmd-VFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YZqolFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_7M57YEvwEemT5f_Ewhfs6A" target="_YZqokFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YZqolVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YZqomVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tkmd9lFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tkmd91FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tkmd-FFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YZqollVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YZqol1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YZqomFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tlZIJFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_4jT6oE2rEemQQPVBE79CWA" target="_tlZIIFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tlZIJVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlZIKVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YafvAFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_4jT6oE2rEemQQPVBE79CWA" target="_YafH8FVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YafvAVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YafvBVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tlZIJlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlZIJ1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlZIKFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YafvAlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YafvA1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YafvBFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tlyJsVFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_MccoQE2sEemQQPVBE79CWA" target="_tlxioFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tlyJslFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tlyJtlFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YbDIpFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_MccoQE2sEemQQPVBE79CWA" target="_YbDIoFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YbDIpVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YbDvsVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tlyJs1FnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlyJtFFnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlyJtVFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YbDIplVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YbDIp1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YbDvsFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tmMZZFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_8PgDEE2sEemQQPVBE79CWA" target="_tmMZYFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tmMZZVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmMZaVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_YbhpxFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_8PgDEE2sEemQQPVBE79CWA" target="_YbhpwFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_YbhpxVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YbiQ0FVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tmMZZlFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmMZZ1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmMZaFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YbhpxlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ybhpx1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YbhpyFVJEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_tmiXpFFnEemgMYGocegK5A" type="StereotypeCommentLink" source="_Tt3yAE2tEemQQPVBE79CWA" target="_tmiXoFFnEemgMYGocegK5A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_tmiXpVFnEemgMYGocegK5A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tmiXqVFnEemgMYGocegK5A" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Yb4PFFVJEemD67R2QwZykA" type="StereotypeCommentLink" source="_Tt3yAE2tEemQQPVBE79CWA" target="_Yb4PEFVJEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Yb4PFVVJEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Yb4PGVVJEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tmiXplFnEemgMYGocegK5A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmiXp1FnEemgMYGocegK5A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tmiXqFFnEemgMYGocegK5A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Yb4PFlVJEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yb4PF1VJEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Yb4PGFVJEemD67R2QwZykA"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEquipment.uml
+++ b/UML/TapiEquipment.uml
@@ -224,10 +224,6 @@ It will expose all dynamic properties and some critical static properties.</body
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cneKUEvIEemT5f_Ewhfs6A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cnoiYEvIEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_5h3SgEvHEemT5f_Ewhfs6A" name="actualHolder" type="_MSjC8EvLEemT5f_Ewhfs6A" isReadOnly="true">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6ZPJ8EvIEemT5f_Ewhfs6A"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6ZXs0EvIEemT5f_Ewhfs6A" value="*"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_8L2MgEvHEemT5f_Ewhfs6A" name="commonActualProperties" type="_jqSYYEqtEemT5f_Ewhfs6A" isReadOnly="true"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_AOW_sEvIEemT5f_Ewhfs6A" name="commonEquipmentProperties" type="_-KwGAEvDEemT5f_Ewhfs6A" isReadOnly="true"/>
       </packagedElement>
@@ -458,7 +454,7 @@ For example:&#xD;
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_EZB3EEvNEemT5f_Ewhfs6A" name="expectedEquipment" type="_5CPsYEvJEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fVNJoEvNEemT5f_Ewhfs6A"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fVW6oEvNEemT5f_Ewhfs6A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fVW6oEvNEemT5f_Ewhfs6A" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_SWpBcEvNEemT5f_Ewhfs6A" name="actualEquipment" type="_rjMYMEvHEemT5f_Ewhfs6A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d2S7oEvNEemT5f_Ewhfs6A"/>
@@ -742,11 +738,9 @@ In some cases it may not be relevant to represent the pin detail and hence the r
   <OpenModel_Profile:Experimental xmi:id="_LUlisEvHEemT5f_Ewhfs6A" base_Element="_LUifYkvHEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_wHEMAEvHEemT5f_Ewhfs6A" base_Element="_rjMYMEvHEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_1yD_8UvHEemT5f_Ewhfs6A" base_StructuralFeature="_1yD_8EvHEemT5f_Ewhfs6A"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_5h3SgUvHEemT5f_Ewhfs6A" base_StructuralFeature="_5h3SgEvHEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_8L2MgUvHEemT5f_Ewhfs6A" base_StructuralFeature="_8L2MgEvHEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_AOW_sUvIEemT5f_Ewhfs6A" base_StructuralFeature="_AOW_sEvIEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_FOR2UEvIEemT5f_Ewhfs6A" base_Element="_1yD_8EvHEemT5f_Ewhfs6A"/>
-  <OpenModel_Profile:Experimental xmi:id="_Hgz5oEvIEemT5f_Ewhfs6A" base_Element="_5h3SgEvHEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_KLLOIEvIEemT5f_Ewhfs6A" base_Element="_8L2MgEvHEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:Experimental xmi:id="_Ma_7sEvIEemT5f_Ewhfs6A" base_Element="_AOW_sEvIEemT5f_Ewhfs6A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_5CQTcEvJEemT5f_Ewhfs6A" base_StructuralFeature="_5CPsYkvJEemT5f_Ewhfs6A"/>
@@ -806,7 +800,6 @@ In some cases it may not be relevant to represent the pin detail and hence the r
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ffUlkvxEemT5f_Ewhfs6A" base_Property="_VlGeADmkEemDl_QGWIY6yg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ffUl0vxEemT5f_Ewhfs6A" base_Property="_y1arcD9MEemsT7Uwjmld0w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ffUmEvxEemT5f_Ewhfs6A" base_Property="_1yD_8EvHEemT5f_Ewhfs6A"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ffUmUvxEemT5f_Ewhfs6A" base_Property="_5h3SgEvHEemT5f_Ewhfs6A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ffUmkvxEemT5f_Ewhfs6A" base_Property="_8L2MgEvHEemT5f_Ewhfs6A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ffUm0vxEemT5f_Ewhfs6A" base_Property="_AOW_sEvIEemT5f_Ewhfs6A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2ff7oEvxEemT5f_Ewhfs6A" base_Property="_PY9k0EvMEemT5f_Ewhfs6A"/>

--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -30,7 +30,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnKzGY6QEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnJk8Y6QEeeyZasfnNSonw" x="222" y="25" height="104"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnJk8Y6QEeeyZasfnNSonw" x="232" y="23" height="104"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BsudMI6YEeeyZasfnNSonw" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_BsudMo6YEeeyZasfnNSonw" type="Enumeration_NameLabel"/>
@@ -241,7 +241,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jL3PYEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jInPYEeiPPoPDo3q5jA" x="507" y="21" width="290" height="106"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jInPYEeiPPoPDo3q5jA" x="520" y="21" width="290" height="106"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__ZU_8XkzEeiO-c_khjKlFQ" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="__ZU_83kzEeiO-c_khjKlFQ" type="Enumeration_NameLabel"/>
@@ -349,7 +349,7 @@
       <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DY-LUYoJEeivCevppATXng" x="52" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Er39oIoJEeivCevppATXng" type="Enumeration_Shape">
+    <children xmi:type="notation:Shape" xmi:id="_Er39oIoJEeivCevppATXng" type="Enumeration_Shape" fontColor="255" lineColor="255">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ieWIgPKvEeiTnqcAgKK24Q" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ieWIgfKvEeiTnqcAgKK24Q" key="fontColor" value="true"/>
       </eAnnotations>
@@ -365,10 +365,6 @@
         <children xmi:type="notation:Shape" xmi:id="_pTmvgooJEeivCevppATXng" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_byLK0IoJEeivCevppATXng"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_pTmvg4oJEeivCevppATXng"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_pTmvhIoJEeivCevppATXng" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_dSypAIoJEeivCevppATXng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_pTmvhYoJEeivCevppATXng"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_pTmvhooJEeivCevppATXng" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_eedK4IoJEeivCevppATXng"/>
@@ -386,10 +382,6 @@
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_hpTWQIoJEeivCevppATXng"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_pTmvjYoJEeivCevppATXng"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OoX7oIoMEeivCevppATXng" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_IFVFYIoMEeivCevppATXng"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OoX7oYoMEeivCevppATXng"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_OoYisIoMEeivCevppATXng" type="EnumerationLiteral_LiteralLabel">
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_Fug_AIoMEeivCevppATXng"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_OoYisYoMEeivCevppATXng"/>
@@ -398,13 +390,17 @@
           <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_GbrnAIoMEeivCevppATXng"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_OoYis4oMEeivCevppATXng"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_LYVKIFVSEemD67R2QwZykA" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiPhotonicMedia.uml#_J-ZiwFVSEemD67R2QwZykA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LYVKIVVSEemD67R2QwZykA"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Er39pooJEeivCevppATXng"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Er39p4oJEeivCevppATXng"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_Er39qIoJEeivCevppATXng"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er39qYoJEeivCevppATXng"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er39oYoJEeivCevppATXng" x="49" y="214" height="219"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er39oYoJEeivCevppATXng" x="49" y="214" height="206"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EMsiYLqdEeimKvjOEffRIA" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_EMsiYrqdEeimKvjOEffRIA" type="Enumeration_NameLabel"/>
@@ -497,125 +493,125 @@
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCyqQcG-EeiAg83ctgK3eQ" x="279" y="145"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PwXacFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PwXacVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PwYBgFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G4xn4FVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G4xn4VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G4yO8FVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PwXaclJqEemV99d_1db7sQ" x="422" y="25"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G4xn4lVNEemD67R2QwZykA" x="422" y="25"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Pwv08FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Pwv08VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pwv081JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G5I0QFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G5I0QVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5JbUFVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pwv08lJqEemV99d_1db7sQ" x="517" y="291"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G5I0QlVNEemD67R2QwZykA" x="517" y="291"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Pw8CMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Pw8CMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pw8CM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G5YE0FVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G5YE0VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5ZS8FVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pw8CMlJqEemV99d_1db7sQ" x="664" y="279"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G5YE0lVNEemD67R2QwZykA" x="664" y="279"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PxIPcFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PxIPcVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxIPc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G5pxoFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G5pxoVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5pxo1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxIPclJqEemV99d_1db7sQ" x="941" y="159"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G5pxolVNEemD67R2QwZykA" x="941" y="159"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PxT1oFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PxT1oVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxT1o1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G51X0FVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G51X0VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G51X01VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxT1olJqEemV99d_1db7sQ" x="1017" y="19"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G51X0lVNEemD67R2QwZykA" x="1017" y="19"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PxnXoFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PxnXoVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxnXo1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G6TR4FVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G6TR4VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6TR41VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxnXolJqEemV99d_1db7sQ" x="257" y="485"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G6TR4lVNEemD67R2QwZykA" x="257" y="485"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PxxvsFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PxxvsVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pxxvs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G6e4EFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G6e4EVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6e4E1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PxxvslJqEemV99d_1db7sQ" x="707" y="21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G6e4ElVNEemD67R2QwZykA" x="707" y="21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PyN0kFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PyN0kVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyN0k1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G6_1cFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G6_1cVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6_1c1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PyN0klJqEemV99d_1db7sQ" x="1156" y="163"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G6_1clVNEemD67R2QwZykA" x="1156" y="163"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PydsMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PydsMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PydsM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G7RiQFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G7RiQVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7RiQ1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PydsMlJqEemV99d_1db7sQ" x="601" y="494"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G7RiQlVNEemD67R2QwZykA" x="601" y="494"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PyoEQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PyoEQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyorUFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G7jPEFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G7jPEVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7jPE1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PyoEQlJqEemV99d_1db7sQ" x="252" y="34"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G7jPElVNEemD67R2QwZykA" x="252" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PyzDYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PyzDYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyzDY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G7uOMFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G7uOMVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7uOM1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PyzDYlJqEemV99d_1db7sQ" x="249" y="214"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G7uOMlVNEemD67R2QwZykA" x="249" y="214"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Py5xEFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Py5xEVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Py5xE1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G750YFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G750YVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G750Y1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Py5xElJqEemV99d_1db7sQ" x="249" y="114"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G750YlVNEemD67R2QwZykA" x="249" y="114"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PzCT8FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PzCT8VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzCT81JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G8GosFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G8GosVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8Gos1VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzCT8lJqEemV99d_1db7sQ" x="727" y="494"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G8GoslVNEemD67R2QwZykA" x="727" y="494"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PzNTEFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PzNTEVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzNTE1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G8lJ0FVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G8lJ0VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8lJ01VNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzNTElJqEemV99d_1db7sQ" x="968" y="492"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G8lJ0lVNEemD67R2QwZykA" x="968" y="492"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_PzXrIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PzXrIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzXrI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_G8_ZgFVNEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_G8_ZgVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G9AAkFVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzXrIlJqEemV99d_1db7sQ" x="479" y="145"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G8_ZglVNEemD67R2QwZykA" x="479" y="145"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_w3tFAY6QEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_w3tFAo6QEeeyZasfnNSonw"/>
@@ -634,7 +630,7 @@
     <edges xmi:type="notation:Connector" xmi:id="_LhPS8YoJEeivCevppATXng" type="Abstraction_Edge" source="_Er39oIoJEeivCevppATXng" target="_DY-LUIoJEeivCevppATXng">
       <children xmi:type="notation:DecorationNode" xmi:id="_LhPS9IoJEeivCevppATXng" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_bpezMKvGEei1V6VHLzh4gA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LhPS9YoJEeivCevppATXng" x="7" y="21"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LhPS9YoJEeivCevppATXng" x="8" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_LhPS9ooJEeivCevppATXng" type="Abstraction_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_brlE8KvGEei1V6VHLzh4gA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -643,158 +639,158 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_LhPS8ooJEeivCevppATXng"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LhPS84oJEeivCevppATXng" points="[0, -21, -3, 81]$[3, -94, 0, 8]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMIoJEeivCevppATXng" id="(0.5294117647058824,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMYoJEeivCevppATXng" id="(0.4866666666666667,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMIoJEeivCevppATXng" id="(0.5032679738562091,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMYoJEeivCevppATXng" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PwYBgVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_PwXacFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PwYBglJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PwYBhlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G4yO8VVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_G4xn4FVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G4yO8lVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G4yO9lVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PwYBg1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PwYBhFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PwYBhVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G4yO81VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G4yO9FVNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G4yO9VVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Pwv09FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_BsudMI6YEeeyZasfnNSonw" target="_Pwv08FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Pwv09VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pwv0-VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G5JbUVVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_BsudMI6YEeeyZasfnNSonw" target="_G5I0QFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G5JbUlVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5JbVlVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pwv09lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pwv091JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pwv0-FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5JbU1VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5JbVFVNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5JbVVVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Pw8CNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_GaDH8I6YEeeyZasfnNSonw" target="_Pw8CMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Pw8CNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pw8COVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G5ZS8VVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_GaDH8I6YEeeyZasfnNSonw" target="_G5YE0FVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G5ZS8lVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5ZS9lVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pw8CNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pw8CN1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pw8COFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5ZS81VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5ZS9FVNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5ZS9VVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PxIPdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_I9O2YI6YEeeyZasfnNSonw" target="_PxIPcFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PxIPdVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxIPeVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G5pxpFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_I9O2YI6YEeeyZasfnNSonw" target="_G5pxoFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G5pxpVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5pxqVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxIPdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxIPd1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxIPeFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5pxplVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5pxp1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5pxqFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PxT1pFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Lm61cI6YEeeyZasfnNSonw" target="_PxT1oFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PxT1pVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxT1qVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G51X1FVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_Lm61cI6YEeeyZasfnNSonw" target="_G51X0FVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G51X1VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G51X2VVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxT1plJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxT1p1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxT1qFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G51X1lVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G51X11VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G51X2FVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PxnXpFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xu7CoI8ZEeedErNofqJXiw" target="_PxnXoFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PxnXpVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxnXqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G6TR5FVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_xu7CoI8ZEeedErNofqJXiw" target="_G6TR4FVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G6TR5VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6TR6VVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxnXplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxnXp1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxnXqFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G6TR5lVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6TR51VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6TR6FVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PxxvtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_wB7jIXPYEeiPPoPDo3q5jA" target="_PxxvsFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PxxvtVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PxxvuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G6e4FFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_wB7jIXPYEeiPPoPDo3q5jA" target="_G6e4EFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G6e4FVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6e4GVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PxxvtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pxxvt1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PxxvuFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G6e4FlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6e4F1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6e4GFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PyN0lFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="__ZU_8XkzEeiO-c_khjKlFQ" target="_PyN0kFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PyN0lVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyN0mVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G6_1dFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="__ZU_8XkzEeiO-c_khjKlFQ" target="_G6_1cFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G6_1dVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6_1eVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PyN0llJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyN0l1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyN0mFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G6_1dlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6_1d1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6_1eFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PydsNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_PydsMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PydsNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PydsOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G7RiRFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_G7RiQFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G7RiRVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7RiSVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PydsNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PydsN1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PydsOFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G7RiRlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7RiR1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7RiSFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PyorUVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_DY-LUIoJEeivCevppATXng" target="_PyoEQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PyorUlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyorVlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G7jPFFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_DY-LUIoJEeivCevppATXng" target="_G7jPEFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G7jPFVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7jPGVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PyorU1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyorVFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyorVVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G7jPFlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7jPF1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7jPGFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PyzDZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Er39oIoJEeivCevppATXng" target="_PyzDYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PyzDZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PyzDaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G7uONFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_Er39oIoJEeivCevppATXng" target="_G7uOMFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G7uONVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7uOOVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PyzDZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyzDZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PyzDaFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G7uONlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7uON1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7uOOFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Py5xFFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_Py5xEFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Py5xFVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Py5xGVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G750ZFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_G750YFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G750ZVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G750aVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Py5xFlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Py5xF1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Py5xGFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G750ZlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G750Z1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G750aFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PzC7AFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_EMsiYLqdEeimKvjOEffRIA" target="_PzCT8FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PzC7AVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzC7BVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G8GotFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_EMsiYLqdEeimKvjOEffRIA" target="_G8GosFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G8GotVVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8GouVVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PzC7AlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzC7A1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzC7BFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G8GotlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8Got1VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8GouFVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PzNTFFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_lnxLALqdEeimKvjOEffRIA" target="_PzNTEFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PzNTFVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzNTGVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G8lw4FVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_lnxLALqdEeimKvjOEffRIA" target="_G8lJ0FVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G8lw4VVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8lw5VVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PzNTFlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzNTF1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzNTGFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G8lw4lVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8lw41VNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8lw5FVNEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PzXrJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_PzXrIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PzXrJVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PzYSMFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_G9AAkVVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_G8_ZgFVNEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_G9AAklVNEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G9AAllVNEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PzXrJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzXrJ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PzXrKFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G9AAk1VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G9AAlFVNEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G9AAlVVNEemD67R2QwZykA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_gKM6AI6dEeeyZasfnNSonw" type="layersTree" name="Layers Tree Editor"/>
@@ -900,13 +896,13 @@
         </children>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4rH_DHjAEeixydPRZ8lIKA" x="-259" y="-447" width="159" height="62"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_QTyQkFJqEemV99d_1db7sQ" type="StereotypeComment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QTyQkVJqEemV99d_1db7sQ"/>
-        <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTyQk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+      <children xmi:type="notation:Shape" xmi:id="_UM6IAFZsEemtU7otE81P8g" type="StereotypeComment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UM6IAVZsEemtU7otE81P8g"/>
+        <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UM6IA1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
           <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
         </styles>
         <element xsi:nil="true"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QTyQklJqEemV99d_1db7sQ" x="-59" y="-447"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UM6IAlZsEemtU7otE81P8g" x="-59" y="-447"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8QyEXiGEeiPPoPDo3q5jA" x="-210" y="-456" width="575" height="62"/>
@@ -1411,205 +1407,205 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BnMvEVJkEemV99d_1db7sQ" x="884" y="-62" width="324" height="116"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QTmqYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QTmqYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTmqY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UMl-8FZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UMl-8VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UMl-81ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QTmqYlJqEemV99d_1db7sQ" x="-10" y="-456"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UMl-8lZsEemtU7otE81P8g" x="-10" y="-456"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QUXfYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QUXfYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QUXfY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UN5mgFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UN5mgVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UN5mg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QUXfYlJqEemV99d_1db7sQ" x="-116" y="-308"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UN5mglZsEemtU7otE81P8g" x="-116" y="-308"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QU6R8FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QU6R8VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU6R81JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UOp0cFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UOp0cVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOp0c1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU6R8lJqEemV99d_1db7sQ" x="-116" y="-408"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UOp0clZsEemtU7otE81P8g" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QU_KcFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QU_KcVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU_Kc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UOyXUFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UOyXUVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOyXU1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QU_KclJqEemV99d_1db7sQ" x="-116" y="-408"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UOyXUlZsEemtU7otE81P8g" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QVHGQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QVHGQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVHGQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UO8IUFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UO8IUVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UO8IU1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVHGQlJqEemV99d_1db7sQ" x="-116" y="-408"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UO8IUlZsEemtU7otE81P8g" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QVoDoFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QVoDoVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVoDo1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UP5xoFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UP5xoVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UP6YsFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVoDolJqEemV99d_1db7sQ" x="-112" y="-117"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UP5xolZsEemtU7otE81P8g" x="-112" y="-117"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QWOgkFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QWOgkVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWOgk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_URH5oFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_URH5oVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URIgsFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWOgklJqEemV99d_1db7sQ" x="-112" y="-217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_URH5olZsEemtU7otE81P8g" x="-112" y="-217"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QWjQsFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QWjQsVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWjQs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_URno4FZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_URno4VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URno41ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWjQslJqEemV99d_1db7sQ" x="874" y="-459"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_URno4lZsEemtU7otE81P8g" x="874" y="-459"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QXHRYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QXHRYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QXHRY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_USfyoFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_USfyoVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USfyo1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QXHRYlJqEemV99d_1db7sQ" x="767" y="-299"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_USfyolZsEemtU7otE81P8g" x="767" y="-299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QYdVMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QYdVMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYd8QFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UTBXEFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UTBXEVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTBXE1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QYdVMlJqEemV99d_1db7sQ" x="767" y="-399"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UTBXElZsEemtU7otE81P8g" x="767" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QYiNsFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QYiNsVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYiNs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UTIEwFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UTIEwVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTIEw1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QYiNslJqEemV99d_1db7sQ" x="767" y="-399"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UTIEwlZsEemtU7otE81P8g" x="767" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QZB88FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QZB88VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZCkAFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UUAOgFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UUAOgVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UUAOg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QZB88lJqEemV99d_1db7sQ" x="423" y="-100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UUAOglZsEemtU7otE81P8g" x="423" y="-100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QZ-_MFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QZ-_MVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZ-_M1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UVT2EFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UVT2EVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UVUdIFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QZ-_MlJqEemV99d_1db7sQ" x="744" y="-131"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UVT2ElZsEemtU7otE81P8g" x="744" y="-131"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QbNHMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QbNHMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbNHM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UXwGEFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UXwGEVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UXwGE1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QbNHMlJqEemV99d_1db7sQ" x="307" y="-306"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UXwGElZsEemtU7otE81P8g" x="307" y="-306"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QbpzIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QbpzIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbqaMFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UYXKEFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UYXKEVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYXKE1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QbpzIlJqEemV99d_1db7sQ" x="307" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UYXKElZsEemtU7otE81P8g" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Qbv5wFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Qbv5wVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qbv5w1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UYfs8FZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UYfs8VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYfs81ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qbv5wlJqEemV99d_1db7sQ" x="307" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UYfs8lZsEemtU7otE81P8g" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Qb0yQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Qb0yQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qb0yQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UYlMgFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UYlMgVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYlMg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qb0yQlJqEemV99d_1db7sQ" x="307" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UYlMglZsEemtU7otE81P8g" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QcTTYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QcTTYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QcTTY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UZLpcFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UZLpcVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZLpc1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QcTTYlJqEemV99d_1db7sQ" x="1044" y="-295"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UZLpclZsEemtU7otE81P8g" x="1044" y="-295"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Qcv_UFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Qcv_UVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qcv_U1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UZ5bIFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UZ5bIVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZ5bI1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qcv_UlJqEemV99d_1db7sQ" x="1044" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UZ5bIlZsEemtU7otE81P8g" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Qc1e4FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Qc1e4VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc1e41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UaB-AFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UaB-AVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaClEFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qc1e4lJqEemV99d_1db7sQ" x="1044" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UaB-AlZsEemtU7otE81P8g" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Qc6-cFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Qc6-cVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc6-c1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UaKg4FZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UaKg4VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaKg41ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qc6-clJqEemV99d_1db7sQ" x="1044" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UaKg4lZsEemtU7otE81P8g" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QdYRcFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QdYRcVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QdYRc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ua9yIFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ua9yIVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ua9yI1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QdYRclJqEemV99d_1db7sQ" x="1203" y="-149"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ua9yIlZsEemtU7otE81P8g" x="1203" y="-149"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QeGqMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QeGqMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QeGqM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UcSn0FZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UcSn0VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UcSn01ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QeGqMlJqEemV99d_1db7sQ" x="-120" y="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UcSn0lZsEemtU7otE81P8g" x="-120" y="67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QfMPUFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QfMPUVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QfMPU1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UdzDsFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UdzDsVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UdzDs1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QfMPUlJqEemV99d_1db7sQ" x="206" y="48"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UdzDslZsEemtU7otE81P8g" x="206" y="48"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QgJRkFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QgJRkVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QgJRk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UfwLgFZsEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UfwLgVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UfwLg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QgJRklJqEemV99d_1db7sQ" x="1084" y="-62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UfwLglZsEemtU7otE81P8g" x="1084" y="-62"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
@@ -1956,268 +1952,268 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmBogFJlEemV99d_1db7sQ" id="(0.24,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmBogVJlEemV99d_1db7sQ" id="(0.15432098765432098,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QTmqZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_-8QyEHiGEeiPPoPDo3q5jA" target="_QTmqYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QTmqZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTmqaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UMl-9FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_-8QyEHiGEeiPPoPDo3q5jA" target="_UMl-8FZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UMl-9VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UMmmAFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QTmqZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTmqZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTmqaFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UMl-9lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl-91ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl--FZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QTyQlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_4rH-0HjAEeixydPRZ8lIKA" target="_QTyQkFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QTyQlVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QTyQmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UM6IBFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_4rH-0HjAEeixydPRZ8lIKA" target="_UM6IAFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UM6IBVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UM6ICVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QTyQllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTyQl1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QTyQmFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UM6IBlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UM6IB1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UM6ICFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QUXfZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_QUXfYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QUXfZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QUYGcFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UN5mhFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_UN5mgFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UN5mhVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UN5miVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QUXfZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QUXfZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QUXfaFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UN5mhlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UN5mh1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UN5miFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QU6R9FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_QU6R8FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QU6R9VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU6R-VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UOp0dFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_UOp0cFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UOp0dVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOp0eVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QU6R9lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU6R91JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU6R-FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UOp0dlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOp0d1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOp0eFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QU_KdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_QU_KcFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QU_KdVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QU_xglJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UOyXVFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_UOyXUFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UOyXVVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOyXWVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QU_KdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU_xgFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QU_xgVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UOyXVlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOyXV1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOyXWFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QVHGRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_IKgrEFJkEemV99d_1db7sQ" target="_QVHGQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QVHGRVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVHGSVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UO8IVFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_IKgrEFJkEemV99d_1db7sQ" target="_UO8IUFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UO8IVVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UO8vYlZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QVHGRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVHGR1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVHGSFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UO8IVlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UO8vYFZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UO8vYVZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QVoDpFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_QVoDoFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QVoDpVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QVoDqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UP6YsVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_UP5xoFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UP6YslZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UP6YtlZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QVoDplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVoDp1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QVoDqFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UP6Ys1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UP6YtFZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UP6YtVZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QWOglFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_eVdssLs6Eeiljfl0umr-iQ" target="_QWOgkFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QWOglVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWOgmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_URIgsVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_eVdssLs6Eeiljfl0umr-iQ" target="_URH5oFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_URIgslZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URIgtlZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QWOgllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWOgl1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWOgmFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_URIgs1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URIgtFZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URIgtVZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QWjQtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_7NoX0HjAEeixydPRZ8lIKA" target="_QWjQsFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QWjQtVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QWjQuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_URno5FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_7NoX0HjAEeixydPRZ8lIKA" target="_URno4FZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_URno5VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URno6VZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QWjQtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWjQt1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QWjQuFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_URno5lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URno51ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URno6FZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QXHRZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_QXHRYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QXHRZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QXH4cFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_USfypFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_USfyoFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_USfypVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USfyqVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QXHRZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QXHRZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QXHRaFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_USfyplZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USfyp1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USfyqFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QYd8QVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_QYdVMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QYd8QlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYd8RlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UTBXFFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_UTBXEFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UTBXFVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTBXGVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QYd8Q1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYd8RFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYd8RVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UTBXFlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTBXF1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTBXGFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QYiNtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_QYiNsFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QYiNtVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QYiNuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UTIr0FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_UTIEwFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UTIr0VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTIr1VZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QYiNtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYiNt1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYiNuFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UTIr0lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTIr01ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTIr1FZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QZCkAVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_-Be4sHkyEeiO-c_khjKlFQ" target="_QZB88FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QZCkAlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZCkBlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UUAOhFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_-Be4sHkyEeiO-c_khjKlFQ" target="_UUAOgFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UUAOhVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UUAOiVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QZCkA1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZCkBFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZCkBVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UUAOhlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUAOh1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUAOiFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QZ-_NFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_QZ-_MFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QZ-_NVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QZ-_OVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UVUdIVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_UVT2EFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UVUdIlZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UVUdJlZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QZ-_NlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZ-_N1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZ-_OFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UVUdI1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVUdJFZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVUdJVZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QbNHNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_QbNHMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QbNHNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbNHOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UXwGFFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_UXwGEFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UXwGFVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UXwGGVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QbNHNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbNHN1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbNHOFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UXwGFlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UXwGF1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UXwGGFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QbqaMVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_QbpzIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QbqaMlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QbqaNlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UYXKFFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_UYXKEFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UYXKFVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYXKGVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QbqaM1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbqaNFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QbqaNVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYXKFlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYXKF1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYXKGFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Qbv5xFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_Qbv5wFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Qbv5xVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qbv5yVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UYgUAFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_UYfs8FZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UYgUAVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYgUBVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qbv5xlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qbv5x1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qbv5yFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYgUAlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYgUA1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYgUBFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Qb0yRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_UYJsoFJkEemV99d_1db7sQ" target="_Qb0yQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Qb0yRVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qb0ySVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UYlzkFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_UYJsoFJkEemV99d_1db7sQ" target="_UYlMgFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UYlzkVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYlzlVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qb0yRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qb0yR1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qb0ySFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYlzklZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYlzk1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYlzlFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QcTTZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_QcTTYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QcTTZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QcTTaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UZLpdFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_UZLpcFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UZLpdVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZMQgFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QcTTZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QcTTZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QcTTaFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UZLpdlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZLpd1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZLpeFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Qcv_VFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_Qcv_UFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Qcv_VVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qcv_WVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UZ5bJFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_UZ5bIFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UZ5bJVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZ5bKVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qcv_VlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qcv_V1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qcv_WFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UZ5bJlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZ5bJ1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZ5bKFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Qc1e5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_Qc1e4FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Qc1e5VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc1e6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UaClEVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_UaB-AFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UaClElZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaClFlZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qc1e5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc1e51JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc1e6FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UaClE1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaClFFZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaClFVZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Qc6-dFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_HfzEsFJlEemV99d_1db7sQ" target="_Qc6-cFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Qc6-dVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qc6-eVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UaKg5FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_HfzEsFJlEemV99d_1db7sQ" target="_UaKg4FZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UaKg5VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaKg6VZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qc6-dlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc6-d1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qc6-eFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UaKg5lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaKg51ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaKg6FZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QdYRdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_QdYRcFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QdYRdVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QdYReVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ua9yJFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_Ua9yIFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ua9yJVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ua9yKVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QdYRdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QdYRd1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QdYReFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ua9yJlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ua9yJ1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ua9yKFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QeGqNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_QeGqMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QeGqNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QeHRQFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UcSn1FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_UcSn0FZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UcSn1VZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UcSn2VZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QeGqNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QeGqN1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QeGqOFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UcSn1lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UcSn11ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UcSn2FZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QfMPVFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_KblyUFJjEemV99d_1db7sQ" target="_QfMPUFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QfMPVVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QfM2YVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UdzDtFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_KblyUFJjEemV99d_1db7sQ" target="_UdzDsFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UdzDtVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UdzqwFZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QfMPVlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QfMPV1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QfM2YFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UdzDtlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UdzDt1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UdzDuFZsEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QgJRlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_BnMvEFJkEemV99d_1db7sQ" target="_QgJRkFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QgJRlVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QgJRmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UfwLhFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_BnMvEFJkEemV99d_1db7sQ" target="_UfwLgFZsEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UfwLhVZsEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UfwLiVZsEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QgJRllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QgJRl1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QgJRmFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UfwLhlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfwLh1ZsEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfwLiFZsEemtU7otE81P8g"/>
     </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="OtsiResourceSpec" measurementUnit="Pixel">
+  <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="ResourceSpec" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_xbRtvnkvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRtv3kvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRtwHkvEeiO-c_khjKlFQ" type="Class_FloatingNameLabel">
@@ -2250,7 +2246,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRt_HkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuMXkvEeiO-c_khjKlFQ" x="121" y="-135" width="213" height="78"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuMXkvEeiO-c_khjKlFQ" x="121" y="-134" width="213" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRupnkvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRup3kvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -2276,7 +2272,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRuuHkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRu4nkvEeiO-c_khjKlFQ" x="209" y="-443" width="503" height="69"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRu4nkvEeiO-c_khjKlFQ" x="209" y="-448" width="660" height="69"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRu43kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRu5HkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -2293,6 +2289,11 @@
           <layoutConstraint xmi:type="notation:Location" xmi:id="_51_V8bucEeiljfl0umr-iQ"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_51_V8rucEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_q8LKsFZrEemtU7otE81P8g" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+          </styles>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_w72iYHk2EeiO-c_khjKlFQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_51_V87ucEeiljfl0umr-iQ"/>
         </children>
@@ -2336,7 +2337,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRvTXkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRvgnkvEeiO-c_khjKlFQ" x="472" y="-133" width="425" height="164"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRvgnkvEeiO-c_khjKlFQ" x="357" y="-135" width="326" height="164"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRvg3kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRvhHkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -2366,7 +2367,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRv7XkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwInkvEeiO-c_khjKlFQ" x="488" y="-299" width="321" height="81"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRwInkvEeiO-c_khjKlFQ" x="392" y="-301" width="265" height="81"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRyc3kvEeiO-c_khjKlFQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbRydHkvEeiO-c_khjKlFQ" type="Class_NameLabel"/>
@@ -2396,7 +2397,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRysXkvEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRy5nkvEeiO-c_khjKlFQ" x="103" y="-298" width="309" height="79"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbRy5nkvEeiO-c_khjKlFQ" x="103" y="-297" width="272" height="79"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xbRzE3kvEeiO-c_khjKlFQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xbRzFHkvEeiO-c_khjKlFQ" showTitle="true"/>
@@ -2854,77 +2855,317 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z_3Rsrs8Eeiljfl0umr-iQ" x="781" y="-133"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P2DLsFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P2DLsVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2DywFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__DTGcFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__DTGcVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__DTGc1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P2DLslJqEemV99d_1db7sQ" x="321" y="-135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__DTGclZqEemtU7otE81P8g" x="321" y="-135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P2mlUFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P2mlUVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2mlU1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__EhOcFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__EhOcVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Eh1gFZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P2mlUlJqEemV99d_1db7sQ" x="321" y="-235"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__EhOclZqEemtU7otE81P8g" x="321" y="-235"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P278gFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P278gVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P278g1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__FPnMFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__FPnMVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__FQOQFZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P278glJqEemV99d_1db7sQ" x="409" y="-443"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__FPnMlZqEemtU7otE81P8g" x="409" y="-443"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P3fWIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P3fWIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P3fWI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__HN9IFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__HN9IVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__HN9I1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P3fWIlJqEemV99d_1db7sQ" x="672" y="-133"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__HN9IlZqEemtU7otE81P8g" x="672" y="-133"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P4oloFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P4oloVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P4pMsFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__J1MQFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__J1MQVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__J1zUFZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P4ololJqEemV99d_1db7sQ" x="672" y="-233"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__J1MQlZqEemtU7otE81P8g" x="672" y="-233"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P5Ht0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P5Ht0VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P5Ht01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__LcV0FZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__LcV0VZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__LcV01ZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P5Ht0lJqEemV99d_1db7sQ" x="688" y="-299"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__LcV0lZqEemtU7otE81P8g" x="688" y="-299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P6K2sFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P6K2sVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6K2s1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__MKukFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__MKukVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__MLVoFZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P6K2slJqEemV99d_1db7sQ" x="688" y="-399"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__MKuklZqEemtU7otE81P8g" x="688" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P6p-4FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P6p-4VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6p-41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__Ou6YFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__Ou6YVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Ou6Y1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P6p-4lJqEemV99d_1db7sQ" x="303" y="-298"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Ou6YlZqEemtU7otE81P8g" x="303" y="-298"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P7Gq0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P7Gq0VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P7Gq01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="__PfvYFZqEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__PfvYVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__PfvY1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P7Gq0lJqEemV99d_1db7sQ" x="303" y="-398"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__PfvYlZqEemtU7otE81P8g" x="303" y="-398"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JT9eB1ZrEemtU7otE81P8g" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JT9eCFZrEemtU7otE81P8g" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JT9eCVZrEemtU7otE81P8g" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JT9eClZrEemtU7otE81P8g" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT9eC1ZrEemtU7otE81P8g" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JT9eDFZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_cRshMJqYEeid4dfn4JFJZg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JT9eN1ZrEemtU7otE81P8g"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JT9eOFZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_MpIOQI51EeeyZasfnNSonw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JT9eY1ZrEemtU7otE81P8g"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JT9eZFZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_kt1T0JmXEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JT9ej1ZrEemtU7otE81P8g"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT9ekFZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT9ekVZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT9eklZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT9ek1ZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT9elFZrEemtU7otE81P8g" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT9elVZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT9ellZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT9el1ZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT9emFZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT9emVZrEemtU7otE81P8g" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT9emlZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT9em1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT9enFZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT9enVZrEemtU7otE81P8g"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT9e0lZrEemtU7otE81P8g" x="-210" y="-149" width="283" height="98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JT-sEVZrEemtU7otE81P8g" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JT-sElZrEemtU7otE81P8g" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JT-sE1ZrEemtU7otE81P8g" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JT-sFFZrEemtU7otE81P8g" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT-sFVZrEemtU7otE81P8g" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JT-sFlZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qOx7ApozEeiOmuqNbykpsw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JT-sQVZrEemtU7otE81P8g"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT-sQlZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT-sQ1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT-sRFZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT-sRVZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT-sRlZrEemtU7otE81P8g" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT-sR1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT-sSFZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT-sSVZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT-sSlZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT-sS1ZrEemtU7otE81P8g" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT-sTFZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT-sTVZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT-sTlZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT-sT1ZrEemtU7otE81P8g"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT-shFZrEemtU7otE81P8g" x="695" y="-296" height="74"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JT_TJVZrEemtU7otE81P8g" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JT_TJlZrEemtU7otE81P8g" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JT_TJ1ZrEemtU7otE81P8g" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JT_TKFZrEemtU7otE81P8g" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT_6MFZrEemtU7otE81P8g" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JT_6MVZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JT_6XFZrEemtU7otE81P8g"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT_6XVZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT_6XlZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT_6X1ZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT_6YFZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT_6YVZrEemtU7otE81P8g" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT_6YlZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT_6Y1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT_6ZFZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT_6ZVZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JT_6ZlZrEemtU7otE81P8g" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JT_6Z1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JT_6aFZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JT_6aVZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT_6alZrEemtU7otE81P8g"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JT_6n1ZrEemtU7otE81P8g" x="-205" y="-297" height="65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JUAhQVZrEemtU7otE81P8g" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUAhQlZrEemtU7otE81P8g" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUAhQ1ZrEemtU7otE81P8g" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUAhRFZrEemtU7otE81P8g" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JUAhRVZrEemtU7otE81P8g" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JUAhRlZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_J3v2UHZlEeiPPoPDo3q5jA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JUAhcVZrEemtU7otE81P8g"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JUAhclZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JUAhc1ZrEemtU7otE81P8g" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JUAhdFZrEemtU7otE81P8g" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_GXqq45s9EeikSLSDi2qpXA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JUAhn1ZrEemtU7otE81P8g"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JUAhoFZrEemtU7otE81P8g" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JUAhoVZrEemtU7otE81P8g" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JUAholZrEemtU7otE81P8g" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_tRWUMrudEeiljfl0umr-iQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JUAhzVZrEemtU7otE81P8g"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JUAhzlZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JUAhz1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JUAh0FZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUAh0VZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JUAh0lZrEemtU7otE81P8g" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JUAh01ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JUAh1FZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JUAh1VZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUAh1lZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JUAh11ZrEemtU7otE81P8g" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JUAh2FZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JUAh2VZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JUAh2lZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUAh21ZrEemtU7otE81P8g"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUAiEFZrEemtU7otE81P8g" x="695" y="-135" width="289" height="89"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JUBvi1ZrEemtU7otE81P8g" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvjFZrEemtU7otE81P8g" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvjVZrEemtU7otE81P8g" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvjlZrEemtU7otE81P8g" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JUBvj1ZrEemtU7otE81P8g" visible="false" type="Class_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JUBvkFZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JUBvkVZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JUBvklZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUBvk1ZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JUBvlFZrEemtU7otE81P8g" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JUBvlVZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JUBvllZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JUBvl1ZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUBvmFZrEemtU7otE81P8g"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_JUBvmVZrEemtU7otE81P8g" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_JUBvmlZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_JUBvm1ZrEemtU7otE81P8g"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_JUBvnFZrEemtU7otE81P8g"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUBvnVZrEemtU7otE81P8g"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUBvx1ZrEemtU7otE81P8g" x="-185" y="-451" width="212" height="65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JVhkMFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JVhkMVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JVhkM1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JVhkMlZrEemtU7otE81P8g" x="114" y="-136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JWmiQFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JWmiQVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JWnJUFZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JWmiQlZrEemtU7otE81P8g" x="594" y="-294"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JW1LwFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JW1LwVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JW1Lw1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JW1LwlZrEemtU7otE81P8g" x="594" y="-394"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JXf6IFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JXghMFZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXghMlZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXghMVZrEemtU7otE81P8g" x="119" y="-284"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JXqSMFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JXqSMVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXq5QFZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXqSMlZrEemtU7otE81P8g" x="119" y="-384"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JXsHYFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JXsHYVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXsHY1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXsHYlZrEemtU7otE81P8g" x="119" y="-384"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JYq-0FZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JYq-0VZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JYq-01ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JYq-0lZrEemtU7otE81P8g" x="577" y="-124"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JZh6cFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JZh6cVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JZh6c1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JZh6clZrEemtU7otE81P8g" x="127" y="-438"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-Nm_IFZrEemtU7otE81P8g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-Nm_IVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-Nm_I1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Nm_IlZrEemtU7otE81P8g" x="895" y="-396"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_xbR3JHkvEeiO-c_khjKlFQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_xbR3JXkvEeiO-c_khjKlFQ"/>
@@ -2943,9 +3184,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3TnkvEeiO-c_khjKlFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3UnkvEeiO-c_khjKlFQ" points="[614, -299, -643984, -643984]$[614, -374, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3U3kvEeiO-c_khjKlFQ" id="(0.3925233644859813,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3VHkvEeiO-c_khjKlFQ" id="(0.805168986083499,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR3UnkvEeiO-c_khjKlFQ" points="[508, -301, -643984, -643984]$[508, -379, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3U3kvEeiO-c_khjKlFQ" id="(0.4377358490566038,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR3VHkvEeiO-c_khjKlFQ" id="(0.453030303030303,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xbR393kvEeiO-c_khjKlFQ" type="Abstraction_Edge" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_xbRupnkvEeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_xbR3-HkvEeiO-c_khjKlFQ" type="Abstraction_NameLabel">
@@ -2958,9 +3199,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_xbR3_HkvEeiO-c_khjKlFQ"/>
       <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR4AHkvEeiO-c_khjKlFQ" points="[292, -298, -643984, -643984]$[292, -374, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR4AXkvEeiO-c_khjKlFQ" id="(0.6084142394822006,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR4AnkvEeiO-c_khjKlFQ" id="(0.16302186878727634,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbR4AHkvEeiO-c_khjKlFQ" points="[256, -297, -643984, -643984]$[256, -379, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR4AXkvEeiO-c_khjKlFQ" id="(0.5625,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbR4AnkvEeiO-c_khjKlFQ" id="(0.07121212121212121,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_oJK2t3k0EeiO-c_khjKlFQ" type="StereotypeCommentLink" target="_oJK2s3k0EeiO-c_khjKlFQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_oJK2uHk0EeiO-c_khjKlFQ"/>
@@ -3001,11 +3242,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_MtNH8IuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_xbRyc3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH84uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2yA1QJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH9IuXEeiu6boZkiJHCA" x="-10" y="-6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH9IuXEeiu6boZkiJHCA" y="5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH9YuXEeiu6boZkiJHCA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_20BAYJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH9ouXEeiu6boZkiJHCA" x="11" y="-6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MtNH9ouXEeiu6boZkiJHCA" x="12" y="6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_MtNH94uXEeiu6boZkiJHCA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_22fsoJo3EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -3025,9 +3266,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_MtNH8YuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MtNH8ouXEeiu6boZkiJHCA" points="[331, -134, -643984, -643984]$[280, -219, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MtNH8ouXEeiu6boZkiJHCA" points="[331, -133, -643984, -643984]$[280, -218, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zac2IFJbEemV99d_1db7sQ" id="(0.4647887323943662,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYw8IuXEeiu6boZkiJHCA" id="(0.3818770226537217,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIYw8IuXEeiu6boZkiJHCA" id="(0.43014705882352944,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QoX9AIuXEeiu6boZkiJHCA" type="Association_Edge" source="_xbRu43kvEeiO-c_khjKlFQ" target="_xbRvg3kvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_QoX9A4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -3056,879 +3297,315 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_QoX9AYuXEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QoX9AouXEeiu6boZkiJHCA" points="[534, -65, -643984, -643984]$[552, -219, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SIuVcIuXEeiu6boZkiJHCA" id="(0.4447058823529412,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RzyAMIuXEeiu6boZkiJHCA" id="(0.5389408099688473,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QoX9AouXEeiu6boZkiJHCA" points="[487, -63, -643984, -643984]$[505, -217, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SIuVcIuXEeiu6boZkiJHCA" id="(0.4662576687116564,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RzyAMIuXEeiu6boZkiJHCA" id="(0.44150943396226416,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P2DywVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_P2DLsFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P2DywlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2DyxlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__DTtgFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="__DTGcFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__DTtgVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__DTthVZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P2Dyw1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2DyxFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2DyxVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__DTtglZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__DTtg1ZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__DTthFZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P2mlVFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="_P2mlUFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P2mlVVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P2nMYlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__Eh1gVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="__EhOcFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__Eh1glZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Eh1hlZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P2mlVlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2nMYFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P2nMYVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Eh1g1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Eh1hFZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Eh1hVZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P278hFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="_P278gFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P278hVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P278iVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__FQOQVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="__FPnMFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__FQOQlZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__FQORlZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P278hlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P278h1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P278iFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__FQOQ1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__FQORFZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__FQORVZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P3fWJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRu43kvEeiO-c_khjKlFQ" target="_P3fWIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P3fWJVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P3fWKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__HN9JFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRu43kvEeiO-c_khjKlFQ" target="__HN9IFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__HN9JVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__HN9KVZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P3fWJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P3fWJ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P3fWKFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__HN9JlZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__HN9J1ZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__HN9KFZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P4pMsVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_QoX9AIuXEeiu6boZkiJHCA" target="_P4oloFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P4pMslJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P4pMtlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__J1zUVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_QoX9AIuXEeiu6boZkiJHCA" target="__J1MQFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__J1zUlZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__J1zVlZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P4pMs1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P4pMtFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P4pMtVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__J1zU1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__J1zVFZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__J1zVVZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P5Ht1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_P5Ht0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P5Ht1VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P5Ht2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__LcV1FZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRvg3kvEeiO-c_khjKlFQ" target="__LcV0FZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__LcV1VZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__LcV2VZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P5Ht1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P5Ht11JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P5Ht2FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__LcV1lZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__LcV11ZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__LcV2FZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P6K2tFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="_P6K2sFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P6K2tVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6K2uVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__MLVoVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="__MKukFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__MLVolZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__MLVplZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P6K2tlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6K2t1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6K2uFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MLVo1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__MLVpFZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__MLVpVZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P6p-5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_P6p-4FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P6p-5VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P6p-6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__Ou6ZFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="__Ou6YFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__Ou6ZVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Ou6aVZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P6p-5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6p-51JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P6p-6FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Ou6ZlZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Ou6Z1ZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Ou6aFZqEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P7Gq1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_xbR393kvEeiO-c_khjKlFQ" target="_P7Gq0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P7Gq1VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P7Gq2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="__PfvZFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbR393kvEeiO-c_khjKlFQ" target="__PfvYFZqEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="__PfvZVZqEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__PgWcFZqEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P7Gq1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P7Gq11JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P7Gq2FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__PfvZlZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__PfvZ1ZqEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__PfvaFZqEemtU7otE81P8g"/>
     </edges>
-  </notation:Diagram>
-  <notation:Diagram xmi:id="_3bpg4IoMEeivCevppATXng" type="PapyrusUMLClassDiagram" name="McResourceSpec" measurementUnit="Pixel">
-    <children xmi:type="notation:Shape" xmi:id="_SvF9cJozEeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_SvF9cpozEeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_SvF9c5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_SvF9dJozEeiOmuqNbykpsw" y="15"/>
+    <edges xmi:type="notation:Connector" xmi:id="_JUBvYFZrEemtU7otE81P8g" type="Association_Edge" source="_JT_TJVZrEemtU7otE81P8g" target="_JT9eB1ZrEemtU7otE81P8g" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvYVZrEemtU7otE81P8g" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBvYlZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvY1ZrEemtU7otE81P8g" x="7"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_SvF9dZozEeiOmuqNbykpsw" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_SvF9dpozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_SvF9d5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_SvF9eJozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9eZozEeiOmuqNbykpsw"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvZFZrEemtU7otE81P8g" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBvZVZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvZlZrEemtU7otE81P8g" x="-8" y="1"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_SvF9epozEeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_SvF9e5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_SvF9fJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_SvF9fZozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9fpozEeiOmuqNbykpsw"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvZ1ZrEemtU7otE81P8g" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBvaFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvaVZrEemtU7otE81P8g" x="12" y="18"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_SvF9f5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_SvF9gJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_SvF9gZozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_SvF9gpozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9g5ozEeiOmuqNbykpsw"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvalZrEemtU7otE81P8g" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBva1ZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvbFZrEemtU7otE81P8g" x="-14" y="17"/>
       </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvF9cZozEeiOmuqNbykpsw" x="382" y="-442" width="559" height="65"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_aiK4MJozEeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_aiK4MpozEeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_aiK4M5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_aiK4NJozEeiOmuqNbykpsw" y="15"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvbVZrEemtU7otE81P8g" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBvblZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvb1ZrEemtU7otE81P8g" x="12" y="19"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_aiK4NZozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_RtdE0Jo0EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qOx7ApozEeiOmuqNbykpsw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RtdE0Zo0EeiOmuqNbykpsw"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_aiK4NpozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_aiK4N5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_aiK4OJozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4OZozEeiOmuqNbykpsw"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUBvcFZrEemtU7otE81P8g" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBvcVZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUBvclZrEemtU7otE81P8g" x="-14" y="20"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_aiK4OpozEeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_aiK4O5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_aiK4PJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_aiK4PZozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4PpozEeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_aiK4P5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_aiK4QJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_aiK4QZozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_aiK4QpozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4Q5ozEeiOmuqNbykpsw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aiK4MZozEeiOmuqNbykpsw" x="553" y="-295" height="74"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_a2-DgpozEeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_a2-DhJozEeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_a2-DhZozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_a2-DhpozEeiOmuqNbykpsw" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_a2-Dh5ozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_Sx4WQJo0EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_qtbl45ozEeiOmuqNbykpsw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Sx4WQZo0EeiOmuqNbykpsw"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_a2-DiJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_a2-DiZozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_a2-DipozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-Di5ozEeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_a2-DjJozEeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_a2-DjZozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_a2-DjpozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_a2-Dj5ozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-DkJozEeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_a2-DkZozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_a2-DkpozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_a2-Dk5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_a2-DlJozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-DlZozEeiOmuqNbykpsw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a2-Dg5ozEeiOmuqNbykpsw" x="847" y="-292" height="69"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_lvNYYJozEeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_lvNYYpozEeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lvNYY5ozEeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lvNYZJozEeiOmuqNbykpsw" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_lvNYZZozEeiOmuqNbykpsw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_m-ufgJozEeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_J3v2UHZlEeiPPoPDo3q5jA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_m-ufgZozEeiOmuqNbykpsw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_KCLYUJs-EeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Thpl4MG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Thpl4cG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_GXqq45s9EeikSLSDi2qpXA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KCLYUZs-EeikSLSDi2qpXA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_4CPq8LudEeiljfl0umr-iQ" type="Property_ClassAttributeLabel">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ub5AkMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ub5AkcG-EeiAg83ctgK3eQ" key="fontColor" value="true"/>
-          </eAnnotations>
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_tRWUMrudEeiljfl0umr-iQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_4CPq8budEeiljfl0umr-iQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_lvNYZpozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_lvNYZ5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_lvNYaJozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYaZozEeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_lvNYapozEeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_lvNYa5ozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_lvNYbJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_lvNYbZozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYbpozEeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_lvNYb5ozEeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_lvNYcJozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_lvNYcZozEeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_lvNYcpozEeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYc5ozEeiOmuqNbykpsw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lvNYYZozEeiOmuqNbykpsw" x="536" y="-125" width="316" height="89"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_F5DNQpo1EeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNQ5o1EeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNRJo1EeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5DNRZo1EeiOmuqNbykpsw" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5DNRpo1EeiOmuqNbykpsw" visible="false" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5DNR5o1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5DNSJo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5DNSZo1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNSpo1EeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5DNS5o1EeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5DNTJo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5DNTZo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5DNTpo1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNT5o1EeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5DNUJo1EeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5DNUZo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5DNUpo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5DNU5o1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNVJo1EeiOmuqNbykpsw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5DNfpo1EeiOmuqNbykpsw" x="-83" y="-448" width="277" height="65"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_F5JT0Jo1EeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JT0Zo1EeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JT0po1EeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JT05o1EeiOmuqNbykpsw" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JT1Jo1EeiOmuqNbykpsw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_F5JT1Zo1EeiOmuqNbykpsw" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUAJo1EeiOmuqNbykpsw"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUAZo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUApo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUA5o1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUBJo1EeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUBZo1EeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUBpo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUB5o1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUCJo1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUCZo1EeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUCpo1EeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUC5o1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUDJo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUDZo1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUDpo1EeiOmuqNbykpsw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUQ5o1EeiOmuqNbykpsw" x="-91" y="-294" height="65"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_F5JUXpo1EeiOmuqNbykpsw" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUX5o1EeiOmuqNbykpsw" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUYJo1EeiOmuqNbykpsw" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUYZo1EeiOmuqNbykpsw" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUYpo1EeiOmuqNbykpsw" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_wxOEsJstEeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_cRshMJqYEeid4dfn4JFJZg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxOEsZstEeikSLSDi2qpXA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_wxULUJstEeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_MpIOQI51EeeyZasfnNSonw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxULUZstEeikSLSDi2qpXA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_wxULUpstEeikSLSDi2qpXA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_kt1T0JmXEeiOmuqNbykpsw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_wxULU5stEeikSLSDi2qpXA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUu5o1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUvJo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUvZo1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUvpo1EeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUv5o1EeiOmuqNbykpsw" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUwJo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUwZo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUwpo1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUw5o1EeiOmuqNbykpsw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_F5JUxJo1EeiOmuqNbykpsw" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_F5JUxZo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_F5JUxpo1EeiOmuqNbykpsw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_F5JUx5o1EeiOmuqNbykpsw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JUyJo1EeiOmuqNbykpsw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F5JU_Zo1EeiOmuqNbykpsw" x="-96" y="-146" width="283" height="98"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_WDKY0JqMEeid4dfn4JFJZg" type="Class_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_WDUw4JqMEeid4dfn4JFJZg" type="Class_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WDUw4ZqMEeid4dfn4JFJZg" type="Class_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WDVX8JqMEeid4dfn4JFJZg" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_WDVX8ZqMEeid4dfn4JFJZg" type="Class_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_WDVX8pqMEeid4dfn4JFJZg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_WDVX85qMEeid4dfn4JFJZg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_WDVX9JqMEeid4dfn4JFJZg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WDVX9ZqMEeid4dfn4JFJZg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_WDV_AJqMEeid4dfn4JFJZg" type="Class_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_WDV_AZqMEeid4dfn4JFJZg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_WDV_ApqMEeid4dfn4JFJZg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_WDV_A5qMEeid4dfn4JFJZg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WDV_BJqMEeid4dfn4JFJZg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_WDV_BZqMEeid4dfn4JFJZg" type="Class_NestedClassifierCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_WDV_BpqMEeid4dfn4JFJZg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_WDV_B5qMEeid4dfn4JFJZg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_WDV_CJqMEeid4dfn4JFJZg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WDV_CZqMEeid4dfn4JFJZg"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_WCN9oJqMEeid4dfn4JFJZg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WDKY0ZqMEeid4dfn4JFJZg" x="341" y="-291" height="62"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P9P_4FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P9P_4VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P9P_41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P9P_4lJqEemV99d_1db7sQ" x="582" y="-442"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P90noFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P90noVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P90no1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P90nolJqEemV99d_1db7sQ" x="753" y="-295"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P-L0AFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P-L0AVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-MbEFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-L0AlJqEemV99d_1db7sQ" x="753" y="-395"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P-QsgFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P-QsgVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-Qsg1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-QsglJqEemV99d_1db7sQ" x="753" y="-395"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P-wbwFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P-wbwVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-wbw1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-wbwlJqEemV99d_1db7sQ" x="1047" y="-292"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P_KEYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P_KEYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_KEY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_KEYlJqEemV99d_1db7sQ" x="1047" y="-392"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P_OV0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P_OV0VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_O84FJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_OV0lJqEemV99d_1db7sQ" x="1047" y="-392"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_P_rBwFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P_rBwVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_rBw1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_rBwlJqEemV99d_1db7sQ" x="736" y="-125"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QAaBkFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QAaBkVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QAaBk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QAaBklJqEemV99d_1db7sQ" x="117" y="-448"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QA_QYFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QA_QYVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QA_QY1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QA_QYlJqEemV99d_1db7sQ" x="109" y="-294"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QBXD0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QBXq4FJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBXq4lJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBXq4VJqEemV99d_1db7sQ" x="109" y="-394"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QBdKcFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QBdKcVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBdKc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBdKclJqEemV99d_1db7sQ" x="109" y="-394"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QB_V8FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QB_V8VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QB_9AFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QB_V8lJqEemV99d_1db7sQ" x="104" y="-146"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QDGJMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QDGJMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDGJM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_WCN9oJqMEeid4dfn4JFJZg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QDGJMlJqEemV99d_1db7sQ" x="541" y="-291"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QDZrMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QDZrMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDZrM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dkJeAJqMEeid4dfn4JFJZg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QDZrMlJqEemV99d_1db7sQ" x="541" y="-391"/>
-    </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_3bpg4YoMEeivCevppATXng" name="diagram_compatibility_version" stringValue="1.4.0"/>
-    <styles xmi:type="notation:DiagramStyle" xmi:id="_3bpg4ooMEeivCevppATXng"/>
-    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_6ePdIIuWEeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
-      <owner xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    </styles>
-    <element xmi:type="uml:Package" href="TapiPhotonicMedia.uml#_UyBxsBKOEeajhbtskMXJfw"/>
-    <edges xmi:type="notation:Connector" xmi:id="_c-z5wZozEeiOmuqNbykpsw" type="Abstraction_Edge" source="_aiK4MJozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_c-z5xJozEeiOmuqNbykpsw" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_I9qDIJo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_c-z5xZozEeiOmuqNbykpsw" x="5" y="6"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_c-z5xpozEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_I-a4IJo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_c-z5x5ozEeiOmuqNbykpsw" x="-14" y="1"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_c-z5wpozEeiOmuqNbykpsw"/>
-      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c-z5w5ozEeiOmuqNbykpsw" points="[732, -295, -643984, -643984]$[732, -377, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c_q1YJozEeiOmuqNbykpsw" id="(0.6228373702422145,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c_q1YZozEeiOmuqNbykpsw" id="(0.627906976744186,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dbbkUJozEeiOmuqNbykpsw" type="Abstraction_Edge" source="_a2-DgpozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dbbkU5ozEeiOmuqNbykpsw" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Jl7kEJo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dbbkVJozEeiOmuqNbykpsw" x="13" y="-3"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dbbkVZozEeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JmgL0Jo0EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dbbkVpozEeiOmuqNbykpsw" x="-7" y="-6"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_dbbkUZozEeiOmuqNbykpsw"/>
-      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dbbkUpozEeiOmuqNbykpsw" points="[911, -292, -643984, -643984]$[911, -377, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dcZNoJozEeiOmuqNbykpsw" id="(0.2098360655737705,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dcZNoZozEeiOmuqNbykpsw" id="(0.9463327370304114,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qPcpYJozEeiOmuqNbykpsw" type="Association_Edge" source="_aiK4MJozEeiOmuqNbykpsw" target="_lvNYYJozEeiOmuqNbykpsw" routing="Rectilinear">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vKZgcJozEeiOmuqNbykpsw" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vKZgcZozEeiOmuqNbykpsw" key="routing" value="true"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpY5ozEeiOmuqNbykpsw" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__LT_UJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpZJozEeiOmuqNbykpsw" x="20" y="51"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpZZozEeiOmuqNbykpsw" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__L4nEJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpZpozEeiOmuqNbykpsw" y="53"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpZ5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__MdO0JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpaJozEeiOmuqNbykpsw" x="29" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpaZozEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__NH9MJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpapozEeiOmuqNbykpsw" x="-29" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpa5ozEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__Nsk8JozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpbJozEeiOmuqNbykpsw" x="12" y="-23"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_qPcpbZozEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__ORMsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qPcpbpozEeiOmuqNbykpsw" x="-13" y="-20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_qPcpYZozEeiOmuqNbykpsw"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qPcpYpozEeiOmuqNbykpsw" points="[720, -221, -643984, -643984]$[720, -125, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qQr_gJozEeiOmuqNbykpsw" id="(0.5778546712802768,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qQr_gZozEeiOmuqNbykpsw" id="(0.5822784810126582,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_quGUQJozEeiOmuqNbykpsw" type="Association_Edge" source="_a2-DgpozEeiOmuqNbykpsw" target="_lvNYYJozEeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_quGUQ5ozEeiOmuqNbykpsw" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__PCBsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGURJozEeiOmuqNbykpsw" x="-72" y="13"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_quGURZozEeiOmuqNbykpsw" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__P49UJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGURpozEeiOmuqNbykpsw" x="-89" y="9"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_quGUR5ozEeiOmuqNbykpsw" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__QpyUJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUSJozEeiOmuqNbykpsw" x="41" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_quGUSZozEeiOmuqNbykpsw" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__RUgsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUSpozEeiOmuqNbykpsw" x="-41" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_quGUS5ozEeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__SFVsJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUTJozEeiOmuqNbykpsw" x="13" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_quGUTZozEeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__SwEEJozEeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_quGUTpozEeiOmuqNbykpsw" x="-11" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_quGUQZozEeiOmuqNbykpsw"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_quGUQpozEeiOmuqNbykpsw" points="[990, -223, -643984, -643984]$[990, -80, -643984, -643984]$[852, -80, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvbxAJozEeiOmuqNbykpsw" id="(0.46885245901639344,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvbxAZozEeiOmuqNbykpsw" id="(1.0,0.5168539325842697)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_F5DNMJo1EeiOmuqNbykpsw" type="Abstraction_Edge" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_F5DNQpo1EeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNMZo1EeiOmuqNbykpsw" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5DNMpo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5DNM5o1EeiOmuqNbykpsw" x="4" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5DNNJo1EeiOmuqNbykpsw" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5DNNZo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5DNNpo1EeiOmuqNbykpsw" x="-14" y="1"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_F5DNN5o1EeiOmuqNbykpsw"/>
-      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5DNO5o1EeiOmuqNbykpsw" points="[46, -294, -643984, -643984]$[46, -383, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5DNPJo1EeiOmuqNbykpsw" id="(0.49458483754512633,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5DNPZo1EeiOmuqNbykpsw" id="(0.4657039711191336,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_F5JURJo1EeiOmuqNbykpsw" type="Association_Edge" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_F5JUXpo1EeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JURZo1EeiOmuqNbykpsw" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JURpo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUR5o1EeiOmuqNbykpsw" x="7"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUSJo1EeiOmuqNbykpsw" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUSZo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUSpo1EeiOmuqNbykpsw" x="-8" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUS5o1EeiOmuqNbykpsw" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUTJo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUTZo1EeiOmuqNbykpsw" x="12" y="18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUTpo1EeiOmuqNbykpsw" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUT5o1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUUJo1EeiOmuqNbykpsw" x="-14" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUUZo1EeiOmuqNbykpsw" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUUpo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUU5o1EeiOmuqNbykpsw" x="12" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_F5JUVJo1EeiOmuqNbykpsw" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_F5JUVZo1EeiOmuqNbykpsw" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_F5JUVpo1EeiOmuqNbykpsw" x="-14" y="20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_F5JUV5o1EeiOmuqNbykpsw"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_JUBvc1ZrEemtU7otE81P8g"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F5JUW5o1EeiOmuqNbykpsw" points="[45, -229, -643984, -643984]$[45, -186, -643984, -643984]$[40, -186, -643984, -643984]$[40, -146, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXJo1EeiOmuqNbykpsw" id="(0.48014440433212996,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5JUXZo1EeiOmuqNbykpsw" id="(0.4876325088339223,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JUBvd1ZrEemtU7otE81P8g" points="[-79, -242, -643984, -643984]$[-79, -199, -643984, -643984]$[-84, -199, -643984, -643984]$[-84, -159, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUBveFZrEemtU7otE81P8g" id="(0.48014440433212996,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUBveVZrEemtU7otE81P8g" id="(0.4876325088339223,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dkQywJqMEeid4dfn4JFJZg" type="Abstraction_Edge" source="_WDKY0JqMEeid4dfn4JFJZg" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dkQyw5qMEeid4dfn4JFJZg" type="Abstraction_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_88LQ0JqMEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dkQyxJqMEeid4dfn4JFJZg" x="9" y="-4"/>
+    <edges xmi:type="notation:Connector" xmi:id="_JUCWcFZrEemtU7otE81P8g" type="Abstraction_Edge" source="_JT_TJVZrEemtU7otE81P8g" target="_JUBvi1ZrEemtU7otE81P8g" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWcVZrEemtU7otE81P8g" type="Abstraction_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWclZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWc1ZrEemtU7otE81P8g" x="4" y="1"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dkRZ0JqMEeid4dfn4JFJZg" type="Abstraction_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8_JsUJqMEeid4dfn4JFJZg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dkRZ0ZqMEeid4dfn4JFJZg" x="-11" y="1"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWdFZrEemtU7otE81P8g" type="Abstraction_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWdVZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWdlZrEemtU7otE81P8g" x="-14" y="1"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_dkQywZqMEeid4dfn4JFJZg"/>
-      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dkJeAJqMEeid4dfn4JFJZg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dkQywpqMEeid4dfn4JFJZg" points="[428, -291, -643984, -643984]$[428, -377, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dpnM0JqMEeid4dfn4JFJZg" id="(0.4673913043478261,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dpnM0ZqMEeid4dfn4JFJZg" id="(0.08050089445438283,1.0)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_JUCWd1ZrEemtU7otE81P8g"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JUCWe1ZrEemtU7otE81P8g" points="[-78, -307, -643984, -643984]$[-78, -396, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUCWfFZrEemtU7otE81P8g" id="(0.49458483754512633,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUCWfVZrEemtU7otE81P8g" id="(0.5518867924528302,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PPGIgLtQEeiljfl0umr-iQ" type="Association_Edge" source="_SvF9cJozEeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw" routing="Rectilinear">
-      <children xmi:type="notation:DecorationNode" xmi:id="_PPH9sLtQEeiljfl0umr-iQ" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_QkOIYLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPH9sbtQEeiljfl0umr-iQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PPH9srtQEeiljfl0umr-iQ" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Qn-nALtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPH9s7tQEeiljfl0umr-iQ" y="6"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PPH9tLtQEeiljfl0umr-iQ" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_QrvssLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPH9tbtQEeiljfl0umr-iQ" x="46" y="-19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PPH9trtQEeiljfl0umr-iQ" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_QvxRELtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPH9t7tQEeiljfl0umr-iQ" x="-48" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PPH9uLtQEeiljfl0umr-iQ" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Qz7YULtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPH9ubtQEeiljfl0umr-iQ" x="8" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PPH9urtQEeiljfl0umr-iQ" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Q2_TYLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PPH9u7tQEeiljfl0umr-iQ" x="-11" y="-14"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_PPGIgbtQEeiljfl0umr-iQ"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Yh4IJ--EeiO_KvaRsULdw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PPGIgrtQEeiljfl0umr-iQ" points="[529, -377, -643984, -643984]$[529, -343, -643984, -643984]$[605, -343, -643984, -643984]$[605, -377, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QhXBoLtQEeiljfl0umr-iQ" id="(0.26475849731663686,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QhXosLtQEeiljfl0umr-iQ" id="(0.39892665474060823,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cumakLtQEeiljfl0umr-iQ" type="Association_Edge" source="_WDKY0JqMEeid4dfn4JFJZg" target="_aiK4MJozEeiOmuqNbykpsw" routing="Rectilinear" lineColor="0">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QwSRgMG-EeiAg83ctgK3eQ" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QwSRgcG-EeiAg83ctgK3eQ" key="lineColor" value="true"/>
+    <edges xmi:type="notation:Connector" xmi:id="_JUCWflZrEemtU7otE81P8g" type="Association_Edge" source="_JT-sEVZrEemtU7otE81P8g" target="_JUAhQVZrEemtU7otE81P8g" routing="Rectilinear">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JUCWf1ZrEemtU7otE81P8g" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JUCWgFZrEemtU7otE81P8g" key="routing" value="true"/>
       </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_cunBoLtQEeiljfl0umr-iQ" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dPnc8LtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBobtQEeiljfl0umr-iQ" x="1" y="-18"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWgVZrEemtU7otE81P8g" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWglZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWg1ZrEemtU7otE81P8g" x="10" y="7"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_cunBortQEeiljfl0umr-iQ" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dUHicLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBo7tQEeiljfl0umr-iQ" x="2" y="10"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWhFZrEemtU7otE81P8g" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWhVZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWhlZrEemtU7otE81P8g" x="-8" y="7"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_cunBpLtQEeiljfl0umr-iQ" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dW_3ULtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBpbtQEeiljfl0umr-iQ" x="27" y="-19"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWh1ZrEemtU7otE81P8g" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWiFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWiVZrEemtU7otE81P8g" x="29" y="-20"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_cunBprtQEeiljfl0umr-iQ" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_daHcwLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBp7tQEeiljfl0umr-iQ" x="-28" y="18"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWilZrEemtU7otE81P8g" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWi1ZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWjFZrEemtU7otE81P8g" x="-29" y="20"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_cunBqLtQEeiljfl0umr-iQ" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_dcv6ALtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBqbtQEeiljfl0umr-iQ" x="12" y="-21"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWjVZrEemtU7otE81P8g" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWjlZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWj1ZrEemtU7otE81P8g" x="12" y="-23"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_cunBqrtQEeiljfl0umr-iQ" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_df1qQLtQEeiljfl0umr-iQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cunBq7tQEeiljfl0umr-iQ" x="-9" y="-15"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_JUCWkFZrEemtU7otE81P8g" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUCWkVZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JUCWklZrEemtU7otE81P8g" x="-13" y="-20"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_cumakbtQEeiljfl0umr-iQ"/>
-      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_crzlQLtQEeiljfl0umr-iQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cumakrtQEeiljfl0umr-iQ" points="[420, -229, -643984, -643984]$[420, -190, -643984, -643984]$[583, -190, -643984, -643984]$[583, -221, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c0YScLtQEeiljfl0umr-iQ" id="(0.42934782608695654,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c0YScbtQEeiljfl0umr-iQ" id="(0.10726643598615918,1.0)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_JUCWk1ZrEemtU7otE81P8g"/>
+      <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JUCWl1ZrEemtU7otE81P8g" points="[846, -222, -643984, -643984]$[846, -135, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUCWmFZrEemtU7otE81P8g" id="(0.5224913494809689,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUCWmVZrEemtU7otE81P8g" id="(0.5224913494809689,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NDF3oMMqEei3gLXE4_XcoA" type="Association_Edge" source="_F5DNQpo1EeiOmuqNbykpsw" target="_SvF9cJozEeiOmuqNbykpsw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3o8MqEei3gLXE4_XcoA" type="Association_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PJ82cMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3pMMqEei3gLXE4_XcoA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3pcMqEei3gLXE4_XcoA" type="Association_NameLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PMo-EMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3psMqEei3gLXE4_XcoA" x="-2" y="-11"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3p8MqEei3gLXE4_XcoA" type="Association_TargetRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PO7dEMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3qMMqEei3gLXE4_XcoA" x="15" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3qcMqEei3gLXE4_XcoA" type="Association_SourceRoleLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PRmWkMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3qsMqEei3gLXE4_XcoA" x="-15" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3q8MqEei3gLXE4_XcoA" type="Association_SourceMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PVCFEMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3rMMqEei3gLXE4_XcoA" x="10" y="16"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NDF3rcMqEei3gLXE4_XcoA" type="Association_TargetMultiplicityLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_PYLfsMMqEei3gLXE4_XcoA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NDF3rsMqEei3gLXE4_XcoA" x="-7" y="13"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_NDF3ocMqEei3gLXE4_XcoA"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NDF3osMqEei3gLXE4_XcoA" points="[280, -410, -643984, -643984]$[382, -411, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PbcPEMMqEei3gLXE4_XcoA" id="(1.0,0.5846153846153846)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PbcPEcMqEei3gLXE4_XcoA" id="(0.0,0.49230769230769234)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P9P_5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_SvF9cJozEeiOmuqNbykpsw" target="_P9P_4FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P9P_5VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P9P_6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P9P_5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P9P_51JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P9P_6FJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P90npFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_aiK4MJozEeiOmuqNbykpsw" target="_P90noFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P90npVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P90nqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P90nplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P90np1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P90nqFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P-MbEVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_c-z5wZozEeiOmuqNbykpsw" target="_P-L0AFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P-MbElJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-MbFlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P-MbE1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-MbFFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-MbFVJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P-QshFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_qPcpYJozEeiOmuqNbykpsw" target="_P-QsgFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P-QshVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-QsiVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P-QshlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-Qsh1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-QsiFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P-wbxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_a2-DgpozEeiOmuqNbykpsw" target="_P-wbwFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P-wbxVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P-wbyVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_a2384JozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P-wbxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-wbx1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P-wbyFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P_KEZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_dbbkUJozEeiOmuqNbykpsw" target="_P_KEYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P_KEZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_KEaVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dbVdsJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_KEZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_KEZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_KEaFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P_O84VJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_quGUQJozEeiOmuqNbykpsw" target="_P_OV0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P_O84lJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_O85lJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qtbl4JozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_O841JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_O85FJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_O85VJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P_rBxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_lvNYYJozEeiOmuqNbykpsw" target="_P_rBwFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P_rBxVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_rByVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_rBxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_rBx1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_rByFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QAaBlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5DNQpo1EeiOmuqNbykpsw" target="_QAaBkFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QAaBlVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QAaBmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QAaBllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QAaBl1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QAaBmFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QA_QZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5JT0Jo1EeiOmuqNbykpsw" target="_QA_QYFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QA_QZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QA_3cFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QA_QZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QA_QZ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QA_QaFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QBXq41JqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5DNMJo1EeiOmuqNbykpsw" target="_QBXD0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QBXq5FJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBXq6FJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QBXq5VJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBXq5lJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBXq51JqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QBdKdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5JURJo1EeiOmuqNbykpsw" target="_QBdKcFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QBdKdVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QBdKeVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QBdKdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBdKd1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QBdKeFJqEemV99d_1db7sQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QB_9AVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_F5JUXpo1EeiOmuqNbykpsw" target="_QB_V8FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QB_9AlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QCAkEFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JVhkNFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JT9eB1ZrEemtU7otE81P8g" target="_JVhkMFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JVhkNVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JViLQlZrEemtU7otE81P8g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QB_9A1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QB_9BFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QB_9BVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JVhkNlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JViLQFZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JViLQVZrEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QDGJNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_WDKY0JqMEeid4dfn4JFJZg" target="_QDGJMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QDGJNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDGJOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_WCN9oJqMEeid4dfn4JFJZg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_JWnwYFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JT-sEVZrEemtU7otE81P8g" target="_JWmiQFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JWnwYVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JWoXcFZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QDGJNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDGJN1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDGJOFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JWnwYlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWnwY1ZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWnwZFZrEemtU7otE81P8g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QDZrNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_dkQywJqMEeid4dfn4JFJZg" target="_QDZrMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QDZrNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QDaSQlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_dkJeAJqMEeid4dfn4JFJZg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_JW1LxFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUCWflZrEemtU7otE81P8g" target="_JW1LwFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JW1LxVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JW1y0FZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QDZrNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDaSQFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QDaSQVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JW1LxlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JW1Lx1ZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JW1LyFZrEemtU7otE81P8g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JXghM1ZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JT_TJVZrEemtU7otE81P8g" target="_JXf6IFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JXghNFZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXghOFZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXghNVZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXghNlZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXghN1ZrEemtU7otE81P8g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JXq5QVZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUCWcFZrEemtU7otE81P8g" target="_JXqSMFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JXq5QlZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXq5RlZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXq5Q1ZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXq5RFZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXq5RVZrEemtU7otE81P8g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JXsHZFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUBvYFZrEemtU7otE81P8g" target="_JXsHYFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JXsHZVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXsHaVZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXsHZlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXsHZ1ZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXsHaFZrEemtU7otE81P8g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JYq-1FZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUAhQVZrEemtU7otE81P8g" target="_JYq-0FZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JYq-1VZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JYq-2VZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JYq-1lZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JYq-11ZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JYq-2FZrEemtU7otE81P8g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JZihgFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUBvi1ZrEemtU7otE81P8g" target="_JZh6cFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JZihgVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JZihhVZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JZihglZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JZihg1ZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JZihhFZrEemtU7otE81P8g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_lB49kFZrEemtU7otE81P8g" type="Association_Edge" source="_JUBvi1ZrEemtU7otE81P8g" target="_xbRupnkvEeiO-c_khjKlFQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_lB5koFZrEemtU7otE81P8g" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ltoCMFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lB5koVZrEemtU7otE81P8g" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lB5kolZrEemtU7otE81P8g" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lwBO4FZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lB5ko1ZrEemtU7otE81P8g" x="4" y="-17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lB5kpFZrEemtU7otE81P8g" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_lzjEAFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lB5kpVZrEemtU7otE81P8g" x="19" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lB5kplZrEemtU7otE81P8g" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l3ehwFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lB5kp1ZrEemtU7otE81P8g" x="-19" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lB5kqFZrEemtU7otE81P8g" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l57Y0FZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lB5kqVZrEemtU7otE81P8g" x="10" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_lB5kqlZrEemtU7otE81P8g" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_l8Y28FZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lB5kq1ZrEemtU7otE81P8g" x="-11" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_lB49kVZrEemtU7otE81P8g"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lB49klZrEemtU7otE81P8g" points="[80, -416, -643984, -643984]$[209, -414, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l_i4oFZrEemtU7otE81P8g" id="(1.0,0.5692307692307692)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l_jfsFZrEemtU7otE81P8g" id="(0.0,0.4927536231884058)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-LxMEFZrEemtU7otE81P8g" type="Dependency_Edge" source="_JT-sEVZrEemtU7otE81P8g" target="_xbRupnkvEeiO-c_khjKlFQ" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-LxME1ZrEemtU7otE81P8g" type="Dependency_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__q5cgFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-LxMFFZrEemtU7otE81P8g" x="11" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_-LxMFVZrEemtU7otE81P8g" type="Dependency_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="__t34AFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-LxMFlZrEemtU7otE81P8g" x="-7" y="4"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_-LxMEVZrEemtU7otE81P8g"/>
+      <element xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-LxMElZrEemtU7otE81P8g" points="[797, -296, -643984, -643984]$[797, -379, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oPxIFZrEemtU7otE81P8g" id="(0.35294117647058826,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oQYMFZrEemtU7otE81P8g" id="(0.8909090909090909,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-Nm_JFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_-LxMEFZrEemtU7otE81P8g" target="_-Nm_IFZrEemtU7otE81P8g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-Nm_JVZrEemtU7otE81P8g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-Nm_KVZrEemtU7otE81P8g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-Nm_JlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Nm_J1ZrEemtU7otE81P8g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Nm_KFZrEemtU7otE81P8g"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_47kdwPJSEeiTnqcAgKK24Q" type="PapyrusUMLClassDiagram" name="ServiceInterfaceSpec" measurementUnit="Pixel">
@@ -4066,213 +3743,213 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_byzeEfPiEeinaYo1FpF9OA" x="31" y="8" width="299" height="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QGL5cFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QGL5cVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGL5c1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6QfRsFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6QfRsVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Qf4wFVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGL5clJqEemV99d_1db7sQ" x="380" y="154"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6QfRslVMEemD67R2QwZykA" x="380" y="154"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QGYGsFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QGYGsVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGYGs1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6Qre8FVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6Qre8VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Qre81VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGYGslJqEemV99d_1db7sQ" x="195" y="151"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Qre8lVMEemD67R2QwZykA" x="195" y="151"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QGjF0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QGjF0VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGjF01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6Q79oFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6Q79oVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Q79o1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGjF0lJqEemV99d_1db7sQ" x="1173" y="-32"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Q79olVMEemD67R2QwZykA" x="1173" y="-32"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QGusAFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QGusAVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGusA1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6RewMFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6RewMVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6RewM1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGusAlJqEemV99d_1db7sQ" x="683" y="-21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6RewMlVMEemD67R2QwZykA" x="683" y="-21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QG5rIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QG5rIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QG5rI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6Ry5QFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6Ry5QVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ry5Q1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QG5rIlJqEemV99d_1db7sQ" x="662" y="391"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Ry5QlVMEemD67R2QwZykA" x="662" y="391"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QHEqQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QHEqQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHEqQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6R_tkFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6R_tkVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6R_tk1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QHEqQlJqEemV99d_1db7sQ" x="1166" y="389"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6R_tklVMEemD67R2QwZykA" x="1166" y="389"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QHgvIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QHgvIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHgvI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6SmKgFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6SmKgVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6SmxkFVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QHgvIlJqEemV99d_1db7sQ" x="225" y="281"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6SmKglVMEemD67R2QwZykA" x="225" y="281"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QHzDAFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QHzDAVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHzDA1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6TCPYFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6TCPYVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6TCPY1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z05pcPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QHzDAlJqEemV99d_1db7sQ" x="225" y="181"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6TCPYlVMEemD67R2QwZykA" x="225" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QH3UcFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QH3UcVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QH3Uc1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6TGg0FVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6TGg0VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6THH4FVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0gaEkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QH3UclJqEemV99d_1db7sQ" x="225" y="181"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6TGg0lVMEemD67R2QwZykA" x="225" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QISyQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QISyQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QITZUFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6TsWsFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6TsWsVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6TsWs1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QISyQlJqEemV99d_1db7sQ" x="668" y="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6TsWslVMEemD67R2QwZykA" x="668" y="135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QJTe4FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QJTe4VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJTe41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6UEKIFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6UEKIVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UEKI1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_2olSAPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJTe4lJqEemV99d_1db7sQ" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UEKIlVMEemD67R2QwZykA" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QJXJQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QJXJQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJXwUFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6ULe4FVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6ULe4VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6ULe41VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_3PqgIPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJXJQlJqEemV99d_1db7sQ" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ULe4lVMEemD67R2QwZykA" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QJbasFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QJbasVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJbas1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6UTasFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6UTasVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UTas1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_8ryxoPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJbaslJqEemV99d_1db7sQ" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UTaslVMEemD67R2QwZykA" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QJfsIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QJfsIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJfsI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6UaIYFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6UaIYVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UaIY1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_-HZ0APJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJfsIlJqEemV99d_1db7sQ" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UaIYlVMEemD67R2QwZykA" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QJj9kFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QJj9kVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJj9k1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6Ufn8FVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6Ufn8VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ufn81VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_OuQmoPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJj9klJqEemV99d_1db7sQ" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Ufn8lVMEemD67R2QwZykA" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QJo2EFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QJo2EVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJo2E1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6UlHgFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6UlHgVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UlHg1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Qv8xkPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QJo2ElJqEemV99d_1db7sQ" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UlHglVMEemD67R2QwZykA" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKE68FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKE68VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKFiAFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6VK9YFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6VLkcFVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VLkclVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKE68lJqEemV99d_1db7sQ" x="1157" y="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VLkcVVMEemD67R2QwZykA" x="1157" y="135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKX14FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKX14VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKX141JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6VnCQFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6VnCQVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VnCQ1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_32fPkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKX14lJqEemV99d_1db7sQ" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VnCQlVMEemD67R2QwZykA" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKcHUFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKcHUVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKcHU1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6VrTsFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6VrTsVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VrTs1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_4V4hUPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKcHUlJqEemV99d_1db7sQ" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VrTslVMEemD67R2QwZykA" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKgYwFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKgYwVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKgYw1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6VwMMFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6VwMMVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VwMM1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_5DM6UPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKgYwlJqEemV99d_1db7sQ" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VwMMlVMEemD67R2QwZykA" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKkqMFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKkqMVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKkqM1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6V1rwFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6V1rwVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V1rw1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_56YZ8PJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKkqMlJqEemV99d_1db7sQ" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6V1rwlVMEemD67R2QwZykA" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKo7oFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKo7oVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKo7o1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6V-OoFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6V-OoVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V-Oo1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_GZ48sPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKo7olJqEemV99d_1db7sQ" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6V-OolVMEemD67R2QwZykA" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QKtNEFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QKtNEVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKtNE1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6WGKcFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6WGKcVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WGKc1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_P7X6APJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QKtNElJqEemV99d_1db7sQ" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6WGKclVMEemD67R2QwZykA" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QLMVQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QLMVQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLMVQ1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6WsnYFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6WsnYVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WsnY1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLMVQlJqEemV99d_1db7sQ" x="231" y="8"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6WsnYlVMEemD67R2QwZykA" x="231" y="8"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QLmk8FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QLmk8VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLmk81JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6XB-kFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6XB-kVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XB-k1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_gfAHcPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLmk8lJqEemV99d_1db7sQ" x="231" y="-92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6XB-klVMEemD67R2QwZykA" x="231" y="-92"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QLsrkFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QLsrkVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLsrk1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_6XG3EFVMEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6XG3EVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XG3E1VMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_hQjgMPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLsrklJqEemV99d_1db7sQ" x="231" y="-92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6XG3ElVMEemD67R2QwZykA" x="231" y="-92"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_47kdwfJSEeiTnqcAgKK24Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_47kdwvJSEeiTnqcAgKK24Q"/>
@@ -4520,265 +4197,265 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hUMqEPPiEeinaYo1FpF9OA" id="(0.842809364548495,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hUMqEfPiEeinaYo1FpF9OA" id="(0.5282051282051282,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QGL5dFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_76u9kPJSEeiTnqcAgKK24Q" target="_QGL5cFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QGL5dVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGMgglJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6Qf4wVVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_76u9kPJSEeiTnqcAgKK24Q" target="_6QfRsFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6Qf4wlVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Qf4xlVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGL5dlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGMggFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGMggVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Qf4w1VMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Qf4xFVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Qf4xVVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QGYGtFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_8W-NoPJSEeiTnqcAgKK24Q" target="_QGYGsFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QGYGtVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGYGuVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6Qre9FVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_8W-NoPJSEeiTnqcAgKK24Q" target="_6Qre8FVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6Qre9VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6QsGAlVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGYGtlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGYGt1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGYGuFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Qre9lVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6QsGAFVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6QsGAVVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QGjF1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_RmCMYPJTEeiTnqcAgKK24Q" target="_QGjF0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QGjF1VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGjF2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6Q79pFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_RmCMYPJTEeiTnqcAgKK24Q" target="_6Q79oFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6Q79pVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Q79qVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGjF1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGjF11JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGjF2FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Q79plVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Q79p1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Q79qFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QGusBFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_R6EisPJTEeiTnqcAgKK24Q" target="_QGusAFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QGusBVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QGusCVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6RewNFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_R6EisPJTEeiTnqcAgKK24Q" target="_6RewMFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6RewNVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6RfXQFVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGusBlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGusB1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGusCFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6RewNlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6RewN1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6RewOFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QG5rJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_TEZn0PJTEeiTnqcAgKK24Q" target="_QG5rIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QG5rJVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QG5rKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6Ry5RFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_TEZn0PJTEeiTnqcAgKK24Q" target="_6Ry5QFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6Ry5RVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ry5SVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QG5rJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QG5rJ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QG5rKFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Ry5RlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ry5R1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ry5SFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QHEqRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_UOifsPJTEeiTnqcAgKK24Q" target="_QHEqQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QHEqRVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHEqSVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6R_tlFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_UOifsPJTEeiTnqcAgKK24Q" target="_6R_tkFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6R_tlVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6R_tmVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QHEqRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHEqR1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHEqSFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6R_tllVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6R_tl1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6R_tmFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QHgvJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_aYe5cPJTEeiTnqcAgKK24Q" target="_QHgvIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QHgvJVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHgvKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6SmxkVVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_aYe5cPJTEeiTnqcAgKK24Q" target="_6SmKgFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6SmxklVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6SmxllVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QHgvJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHgvJ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHgvKFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Smxk1VMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6SmxlFVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6SmxlVVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QHzDBFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_z0_wEPJTEeiTnqcAgKK24Q" target="_QHzDAFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QHzDBVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QHzDCVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6TCPZFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_z0_wEPJTEeiTnqcAgKK24Q" target="_6TCPYFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6TCPZVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6TCPaVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z05pcPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QHzDBlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHzDB1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QHzDCFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6TCPZlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6TCPZ1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6TCPaFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QH3UdFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_0ggLMPJTEeiTnqcAgKK24Q" target="_QH3UcFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QH3UdVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QH3UeVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6THH4VVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_0ggLMPJTEeiTnqcAgKK24Q" target="_6TGg0FVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6THH4lVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6THH5lVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0gaEkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QH3UdlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QH3Ud1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QH3UeFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6THH41VMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6THH5FVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6THH5VVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QITZUVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_lm3dcPJTEeiTnqcAgKK24Q" target="_QISyQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QITZUlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QITZVlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6TsWtFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_lm3dcPJTEeiTnqcAgKK24Q" target="_6TsWsFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6TsWtVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ts9wlVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QITZU1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QITZVFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QITZVVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6TsWtlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ts9wFVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ts9wVVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QJTe5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_2olSAfJTEeiTnqcAgKK24Q" target="_QJTe4FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QJTe5VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJTe6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6UEKJFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_2olSAfJTEeiTnqcAgKK24Q" target="_6UEKIFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6UEKJVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UEKKVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_2olSAPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJTe5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJTe51JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJTe6FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UEKJlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UEKJ1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UEKKFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QJXwUVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_3PqgIfJTEeiTnqcAgKK24Q" target="_QJXJQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QJXwUlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJXwVlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6ULe5FVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_3PqgIfJTEeiTnqcAgKK24Q" target="_6ULe4FVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6ULe5VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UMF8VVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_3PqgIPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJXwU1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJXwVFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJXwVVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6ULe5lVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ULe51VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UMF8FVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QJcBwFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_8ryxofJTEeiTnqcAgKK24Q" target="_QJbasFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QJcBwVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJcBxVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6UTatFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_8ryxofJTEeiTnqcAgKK24Q" target="_6UTasFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6UTatVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UTauVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_8ryxoPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJcBwlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJcBw1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJcBxFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UTatlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UTat1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UTauFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QJfsJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_-HZ0AfJTEeiTnqcAgKK24Q" target="_QJfsIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QJfsJVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJfsKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6UaIZFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_-HZ0AfJTEeiTnqcAgKK24Q" target="_6UaIYFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6UaIZVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UaIaVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_-HZ0APJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJfsJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJfsJ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJfsKFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UaIZlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UaIZ1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UaIaFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QJj9lFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_OuQmofJWEeiTnqcAgKK24Q" target="_QJj9kFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QJj9lVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJkkoFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6Ufn9FVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_OuQmofJWEeiTnqcAgKK24Q" target="_6Ufn8FVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6Ufn9VVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ufn-VVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_OuQmoPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJj9llJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJj9l1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJj9mFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Ufn9lVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ufn91VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ufn-FVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QJo2FFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_Qv8xkfJWEeiTnqcAgKK24Q" target="_QJo2EFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QJo2FVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QJo2GVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6UlHhFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_Qv8xkfJWEeiTnqcAgKK24Q" target="_6UlHgFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6UlHhVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UlukVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Qv8xkPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QJo2FlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJo2F1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QJo2GFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UlHhlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UlHh1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UlukFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKFiAVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_tNB9kPJTEeiTnqcAgKK24Q" target="_QKE68FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKFiAlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKFiBlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6VLkc1VMEemD67R2QwZykA" type="StereotypeCommentLink" source="_tNB9kPJTEeiTnqcAgKK24Q" target="_6VK9YFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6VLkdFVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VLkeFVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKFiA1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKFiBFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKFiBVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VLkdVVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VLkdlVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VLkd1VMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKX15FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_32fPkfJTEeiTnqcAgKK24Q" target="_QKX14FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKX15VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKX16VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6VnCRFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_32fPkfJTEeiTnqcAgKK24Q" target="_6VnCQFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6VnCRVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VnCSVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_32fPkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKX15lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKX151JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKX16FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VnCRlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VnCR1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VnCSFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKcHVFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_4V-n8PJTEeiTnqcAgKK24Q" target="_QKcHUFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKcHVVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKcHWVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6VrTtFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_4V-n8PJTEeiTnqcAgKK24Q" target="_6VrTsFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6VrTtVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VrTuVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_4V4hUPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKcHVlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKcHV1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKcHWFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VrTtlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VrTt1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VrTuFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKgYxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_5DM6UfJTEeiTnqcAgKK24Q" target="_QKgYwFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKgYxVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKgYyVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6VwMNFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_5DM6UfJTEeiTnqcAgKK24Q" target="_6VwMMFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6VwMNVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VwMOVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_5DM6UPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKgYxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKgYx1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKgYyFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VwMNlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VwMN1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VwMOFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKkqNFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_56YZ8fJTEeiTnqcAgKK24Q" target="_QKkqMFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKkqNVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKkqOVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6V1rxFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_56YZ8fJTEeiTnqcAgKK24Q" target="_6V1rwFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6V1rxVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V1ryVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_56YZ8PJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKkqNlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKkqN1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKkqOFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6V1rxlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V1rx1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V1ryFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKo7pFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_GZ_DUPJWEeiTnqcAgKK24Q" target="_QKo7oFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKo7pVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKo7qVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6V-OpFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_GZ_DUPJWEeiTnqcAgKK24Q" target="_6V-OoFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6V-OpVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V-OqVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_GZ48sPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKo7plJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKo7p1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKo7qFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6V-OplVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V-Op1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V-OqFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QKtNFFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_P7X6AfJWEeiTnqcAgKK24Q" target="_QKtNEFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QKtNFVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QKtNGVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6WGKdFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_P7X6AfJWEeiTnqcAgKK24Q" target="_6WGKcFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6WGKdVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WGKeVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_P7X6APJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QKtNFlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKtNF1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QKtNGFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6WGKdlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WGKd1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WGKeFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QLMVRFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_byzeEPPiEeinaYo1FpF9OA" target="_QLMVQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QLMVRVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLMVSVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6WsnZFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_byzeEPPiEeinaYo1FpF9OA" target="_6WsnYFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6WsnZVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WtOclVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QLMVRlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLMVR1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLMVSFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6WsnZlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WtOcFVMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WtOcVVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QLmk9FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_gfM7wPPiEeinaYo1FpF9OA" target="_QLmk8FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QLmk9VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLmk-VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6XB-lFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_gfM7wPPiEeinaYo1FpF9OA" target="_6XB-kFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6XB-lVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XB-mVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_gfAHcPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QLmk9lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLmk91JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLmk-FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6XB-llVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XB-l1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XB-mFVMEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QLsrlFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_hQmjgPPiEeinaYo1FpF9OA" target="_QLsrkFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QLsrlVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QLsrmVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_6XG3FFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_hQmjgPPiEeinaYo1FpF9OA" target="_6XG3EFVMEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6XG3FVVMEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XG3GVVMEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_hQjgMPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QLsrllJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLsrl1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QLsrmFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6XG3FlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XG3F1VMEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XG3GFVMEemD67R2QwZykA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_1hK84PPmEeinaYo1FpF9OA" type="PapyrusUMLClassDiagram" name="ResourceInterfaceSpec" measurementUnit="Pixel">
@@ -4896,85 +4573,85 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s45qEfPnEeinaYo1FpF9OA" x="590" y="298" width="253" height="70"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QNur4FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QNur4VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QNur41JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_TzDbEFVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_TzDbEVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzDbE1VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QNur4lJqEemV99d_1db7sQ" x="222" y="153"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzDbElVPEemD67R2QwZykA" x="222" y="153"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QOBm0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QOBm0VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOBm01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Tze44FVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Tze44VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tze441VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOBm0lJqEemV99d_1db7sQ" x="222" y="53"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tze44lVPEemD67R2QwZykA" x="222" y="53"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QOKwwFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QOKwwVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOKww1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_TzpQ8FVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_TzpQ8VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzpQ81VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOKwwlJqEemV99d_1db7sQ" x="240" y="34"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzpQ8lVPEemD67R2QwZykA" x="240" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QOVI0FJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QOVI0VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOVI01JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Tz7k0FVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Tz7k0VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tz7k01VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOVI0lJqEemV99d_1db7sQ" x="602" y="142"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tz7k0lVPEemD67R2QwZykA" x="602" y="142"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QOx0wFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QOx0wVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOx0w1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_T0qkoFVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T0qkoVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0qko1VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QOx0wlJqEemV99d_1db7sQ" x="616" y="-2"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T0qkolVPEemD67R2QwZykA" x="616" y="-2"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QPEIoFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QPEIoVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPEIo1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_T0_UwFVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T0_UwVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0_Uw1VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_yw4xIPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPEIolJqEemV99d_1db7sQ" x="616" y="-102"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T0_UwlVPEemD67R2QwZykA" x="616" y="-102"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QPe_YFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QPe_YVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPe_Y1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_T1m_0FVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T1m_0VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1nm4FVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPe_YlJqEemV99d_1db7sQ" x="505" y="299"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T1m_0lVPEemD67R2QwZykA" x="505" y="299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QPxTQFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QPxTQVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPx6UFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_T2ABYFVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T2ABYVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2ABY1VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QPxTQlJqEemV99d_1db7sQ" x="505" y="199"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T2ABYlVPEemD67R2QwZykA" x="505" y="199"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QQNYIFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QQNYIVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQNYI1JqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_T2sk8FVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T2sk8VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2sk81VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QQNYIlJqEemV99d_1db7sQ" x="790" y="298"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T2sk8lVPEemD67R2QwZykA" x="790" y="298"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QQfsAFJqEemV99d_1db7sQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QQfsAVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQgTEFJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_T3J38FVPEemD67R2QwZykA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_T3J38VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T3J381VPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QQfsAlJqEemV99d_1db7sQ" x="790" y="198"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T3J38lVPEemD67R2QwZykA" x="790" y="198"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_1hK84fPmEeinaYo1FpF9OA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_1hK84vPmEeinaYo1FpF9OA"/>
@@ -5042,105 +4719,105 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z82N8PPnEeinaYo1FpF9OA" id="(0.43478260869565216,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z82N8fPnEeinaYo1FpF9OA" id="(0.8032345013477089,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QNur5FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_82Bqn_PmEeinaYo1FpF9OA" target="_QNur4FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QNur5VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QNur6VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_TzDbFFVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_82Bqn_PmEeinaYo1FpF9OA" target="_TzDbEFVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_TzDbFVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzDbGVVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QNur5lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QNur51JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QNur6FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TzDbFlVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzDbF1VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzDbGFVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QOBm1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_82BqkfPmEeinaYo1FpF9OA" target="_QOBm0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QOBm1VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOBm2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Tze45FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_82BqkfPmEeinaYo1FpF9OA" target="_Tze44FVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Tze45VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tze46VVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOBm1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOBm11JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOBm2FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tze45lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tze451VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tze46FVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QOKwxFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_82Bq5_PmEeinaYo1FpF9OA" target="_QOKwwFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QOKwxVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOKwyVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_TzpQ9FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_82Bq5_PmEeinaYo1FpF9OA" target="_TzpQ8FVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_TzpQ9VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzpQ-VVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOKwxlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOKwx1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOKwyFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TzpQ9lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzpQ91VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzpQ-FVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QOVI1FJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_ccsWUPPnEeinaYo1FpF9OA" target="_QOVI0FJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QOVI1VJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOVI2VJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Tz7k1FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_ccsWUPPnEeinaYo1FpF9OA" target="_Tz7k0FVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Tz7k1VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tz8L4FVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOVI1lJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOVI11JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOVI2FJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tz7k1lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tz7k11VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tz7k2FVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QOx0xFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_fxd5wPPnEeinaYo1FpF9OA" target="_QOx0wFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QOx0xVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QOx0yVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_T0qkpFVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_fxd5wPPnEeinaYo1FpF9OA" target="_T0qkoFVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T0qkpVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0qkqVVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOx0xlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOx0x1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QOx0yFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T0qkplVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0qkp1VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0qkqFVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QPEIpFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_yw4xIfPnEeinaYo1FpF9OA" target="_QPEIoFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QPEIpVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPEIqVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_T0_70FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_yw4xIfPnEeinaYo1FpF9OA" target="_T0_UwFVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T0_70VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0_71VVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_yw4xIPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPEIplJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPEIp1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPEIqFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T0_70lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0_701VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0_71FVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QPe_ZFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_qeHpsPPnEeinaYo1FpF9OA" target="_QPe_YFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QPe_ZVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPe_aVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_T1nm4VVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_qeHpsPPnEeinaYo1FpF9OA" target="_T1m_0FVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T1nm4lVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1nm5lVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPe_ZlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPe_Z1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPe_aFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T1nm41VPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1nm5FVPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1nm5VVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QPx6UVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_zUAsUfPnEeinaYo1FpF9OA" target="_QPxTQFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QPx6UlJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QPx6VlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_T2ABZFVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_zUAsUfPnEeinaYo1FpF9OA" target="_T2ABYFVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T2ABZVVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2ABaVVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QPx6U1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPx6VFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPx6VVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T2ABZlVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2ABZ1VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2ABaFVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QQNYJFJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_s45qEPPnEeinaYo1FpF9OA" target="_QQNYIFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QQNYJVJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQNYKVJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_T2sk9FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_s45qEPPnEeinaYo1FpF9OA" target="_T2sk8FVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T2sk9VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2sk-VVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QQNYJlJqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQNYJ1JqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQNYKFJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T2sk9lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2sk91VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2sk-FVPEemD67R2QwZykA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QQgTEVJqEemV99d_1db7sQ" type="StereotypeCommentLink" source="_z7yeAPPnEeinaYo1FpF9OA" target="_QQfsAFJqEemV99d_1db7sQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QQgTElJqEemV99d_1db7sQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QQgTFlJqEemV99d_1db7sQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_T3J39FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_z7yeAPPnEeinaYo1FpF9OA" target="_T3J38FVPEemD67R2QwZykA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_T3J39VVPEemD67R2QwZykA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T3J3-VVPEemD67R2QwZykA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QQgTE1JqEemV99d_1db7sQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQgTFFJqEemV99d_1db7sQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QQgTFVJqEemV99d_1db7sQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T3J39lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T3J391VPEemD67R2QwZykA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T3J3-FVPEemD67R2QwZykA"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -96,9 +96,6 @@ License: This module is distributed under the Apache License 2.0</body>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_c-z5wJozEeiOmuqNbykpsw" name="McCepSpecAugmentsCep" client="_aiExkJozEeiOmuqNbykpsw">
         <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_dbVdsJozEeiOmuqNbykpsw" name="OtsCepSpecAugmentsCep" client="_a2384JozEeiOmuqNbykpsw">
-        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_qOr0YJozEeiOmuqNbykpsw" name="McCepHasMcPac" memberEnd="_qOx7ApozEeiOmuqNbykpsw _qOx7B5ozEeiOmuqNbykpsw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qOx7AJozEeiOmuqNbykpsw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qOx7AZozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
@@ -107,18 +104,6 @@ License: This module is distributed under the Apache License 2.0</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b0p28Jo3EeiOmuqNbykpsw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_b0v9kJo3EeiOmuqNbykpsw" value="1"/>
         </ownedEnd>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_qtbl4JozEeiOmuqNbykpsw" name="OtsCepHasMcPac" memberEnd="_qtbl45ozEeiOmuqNbykpsw _qthsgpozEeiOmuqNbykpsw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qtbl4ZozEeiOmuqNbykpsw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qtbl4pozEeiOmuqNbykpsw" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_qthsgpozEeiOmuqNbykpsw" name="class4" type="_a2384JozEeiOmuqNbykpsw" association="_qtbl4JozEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c--8EJo3EeiOmuqNbykpsw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c_LJUJo3EeiOmuqNbykpsw" value="1"/>
-        </ownedEnd>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_dkJeAJqMEeid4dfn4JFJZg" name="McAssemblySpecAugmentsCep" client="_WCN9oJqMEeid4dfn4JFJZg">
-        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_zJXKUJs5EeikSLSDi2qpXA" name="OtsiTtpHasLaserProperties" memberEnd="_zJdQ8ps5EeikSLSDi2qpXA _zJdQ95s5EeikSLSDi2qpXA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_zJdQ8Js5EeikSLSDi2qpXA" source="org.eclipse.papyrus">
@@ -149,19 +134,6 @@ License: This module is distributed under the Apache License 2.0</body>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_eIOh8bs6Eeiljfl0umr-iQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_eIUok7s6Eeiljfl0umr-iQ" name="otsicapabilitypac" type="_NhrjUHiHEeiPPoPDo3q5jA" association="_eDYeMLs6Eeiljfl0umr-iQ"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_crzlQLtQEeiljfl0umr-iQ" name="McAssemblyAggregatesMcCeps" memberEnd="_cr0MUrtQEeiljfl0umr-iQ _cr1acrtQEeiljfl0umr-iQ" navigableOwnedEnd="_cr0MUrtQEeiljfl0umr-iQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cr0MULtQEeiljfl0umr-iQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cr0MUbtQEeiljfl0umr-iQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_cr1acrtQEeiljfl0umr-iQ" name="mediachannelassemblyspec" type="_WCN9oJqMEeid4dfn4JFJZg" association="_crzlQLtQEeiljfl0umr-iQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_q4VVYLtQEeiljfl0umr-iQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_q4tI0LtQEeiljfl0umr-iQ" value="1"/>
-        </ownedEnd>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_cr0MUrtQEeiljfl0umr-iQ" name="mediachannelconnectionendpointspec" type="_aiExkJozEeiOmuqNbykpsw" aggregation="shared" association="_crzlQLtQEeiljfl0umr-iQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cr1acLtQEeiljfl0umr-iQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cr1acbtQEeiljfl0umr-iQ" value="*"/>
-        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_tRVGELudEeiljfl0umr-iQ" name="McCtpHasEgressPower" memberEnd="_tRWUMrudEeiljfl0umr-iQ _tRYwcbudEeiljfl0umr-iQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tRWUMLudEeiljfl0umr-iQ" source="org.eclipse.papyrus">
@@ -256,7 +228,7 @@ License: This module is distributed under the Apache License 2.0</body>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_bTHgIBKOEeajhbtskMXJfw" name="ObjectClasses">
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3qhKOEeajhbtskMXJfw" name="OtsiGServerAdaptationPac">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3qhKOEeajhbtskMXJfw" name="OtsiServerAdaptationPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lIJUIHZfEeiPPoPDo3q5jA" name="numberOfOtsi" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
@@ -484,13 +456,6 @@ related OTSi power-management capabilities exposed at the SIPs</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qOx7BpozEeiOmuqNbykpsw" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_a2384JozEeiOmuqNbykpsw" name="OtsConnectionEndPointSpec">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qtbl45ozEeiOmuqNbykpsw" name="_otsMediaChannel" type="_nBhMkI6cEeeyZasfnNSonw" isReadOnly="true" aggregation="composite" association="_qtbl4JozEeiOmuqNbykpsw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qthsgJozEeiOmuqNbykpsw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qthsgZozEeiOmuqNbykpsw" value="1"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_WCN9oJqMEeid4dfn4JFJZg" name="MediaChannelAssemblySpec"/>
       <packagedElement xmi:type="uml:Class" xmi:id="_sPmrcLTbEeiF8sBzK2t1Sw" name="TotalPowerThresholdPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_Of5m4LKiEei69qzpcujF2A">
           <body>Indication with severity warning raised when a total power value measured is above the threshold.</body>
@@ -742,14 +707,13 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_ErlpwIoJEeivCevppATXng" name="PhotonicLayerQualifier">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_a9CSkIoJEeivCevppATXng" name="OTSi"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_byLK0IoJEeivCevppATXng" name="OTSiA"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dSypAIoJEeivCevppATXng" name="OTSiG"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eedK4IoJEeivCevppATXng" name="NMC"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_fYfKMIoJEeivCevppATXng" name="NMCA"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gw1dMIoJEeivCevppATXng" name="SMC"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_hpTWQIoJEeivCevppATXng" name="SMCA"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_IFVFYIoMEeivCevppATXng" name="OCH"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Fug_AIoMEeivCevppATXng" name="OMS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_GbrnAIoMEeivCevppATXng" name="OTS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eedK4IoJEeivCevppATXng" name="OTSiMC"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_fYfKMIoJEeivCevppATXng" name="OTSiMCA"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gw1dMIoJEeivCevppATXng" name="MC"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_hpTWQIoJEeivCevppATXng" name="MCA"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Fug_AIoMEeivCevppATXng" name="OMSA"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_GbrnAIoMEeivCevppATXng" name="OTSA"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_J-ZiwFVSEemD67R2QwZykA" name="OCH"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_4qTT8LKeEei69qzpcujF2A" name="LaserControlType" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_75ksULKeEei69qzpcujF2A" name="FORCED-ON"/>
@@ -1057,29 +1021,15 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_l6_TYpmrEeiOmuqNbykpsw" base_Property="_l6_TYJmrEeiOmuqNbykpsw" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_aiExkZozEeiOmuqNbykpsw" base_Class="_aiExkJozEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_aiExkpozEeiOmuqNbykpsw" base_Class="_aiExkJozEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_a2-DgJozEeiOmuqNbykpsw" base_Class="_a2384JozEeiOmuqNbykpsw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_a2-DgZozEeiOmuqNbykpsw" base_Class="_a2384JozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_qOx7A5ozEeiOmuqNbykpsw" base_StructuralFeature="_qOx7ApozEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qOx7BJozEeiOmuqNbykpsw" base_Property="_qOx7ApozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_qOx7CJozEeiOmuqNbykpsw" base_StructuralFeature="_qOx7B5ozEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qOx7CZozEeiOmuqNbykpsw" base_Property="_qOx7B5ozEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qtbl5JozEeiOmuqNbykpsw" base_StructuralFeature="_qtbl45ozEeiOmuqNbykpsw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qtbl5ZozEeiOmuqNbykpsw" base_Property="_qtbl45ozEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_qthsg5ozEeiOmuqNbykpsw" base_StructuralFeature="_qthsgpozEeiOmuqNbykpsw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qthshJozEeiOmuqNbykpsw" base_Property="_qthsgpozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Experimental xmi:id="_VbmVEJo1EeiOmuqNbykpsw" base_Element="_aiExkJozEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:Experimental xmi:id="_WIP_sJo1EeiOmuqNbykpsw" base_Element="_a2384JozEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Specify xmi:id="_-QGz8Jo2EeiOmuqNbykpsw" base_Abstraction="_c-z5wJozEeiOmuqNbykpsw">
     <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
   </OpenModel_Profile:Specify>
-  <OpenModel_Profile:Specify xmi:id="__ffYMJo2EeiOmuqNbykpsw" base_Abstraction="_dbVdsJozEeiOmuqNbykpsw">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
-  </OpenModel_Profile:Specify>
   <OpenModel_Profile:StrictComposite xmi:id="_DOQI8Jo3EeiOmuqNbykpsw" base_Association="_qOr0YJozEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_EKZBEJo3EeiOmuqNbykpsw" base_Association="_qtbl4JozEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:Specify xmi:id="_gYYgMJqMEeid4dfn4JFJZg" base_Abstraction="_dkJeAJqMEeid4dfn4JFJZg">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topologyContext/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_nodeEdgePoint/TapiConnectivity:CepList:_cepList/TapiConnectivity:CepList:_connectionEndPoint</target>
-  </OpenModel_Profile:Specify>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_cRshMZqYEeid4dfn4JFJZg" base_StructuralFeature="_cRshMJqYEeid4dfn4JFJZg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cRtIQJqYEeid4dfn4JFJZg" base_Property="_cRshMJqYEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_awx_YpmYEeiOmuqNbykpsw" base_Class="_awx_YJmYEeiOmuqNbykpsw"/>
@@ -1088,12 +1038,9 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelClass xmi:id="_s27esJmTEeiOmuqNbykpsw" base_Class="_syPL8JmTEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_s21YEJmTEeiOmuqNbykpsw" base_Class="_syPL8JmTEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Experimental xmi:id="_Kqk4MJmVEeiOmuqNbykpsw" base_Element="_syPL8JmTEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_WCPLwJqMEeid4dfn4JFJZg" base_Class="_WCN9oJqMEeid4dfn4JFJZg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_WCOksJqMEeid4dfn4JFJZg" base_Class="_WCN9oJqMEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_Es15ApmWEeiOmuqNbykpsw" base_Class="_Es15AJmWEeiOmuqNbykpsw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_Es15AZmWEeiOmuqNbykpsw" base_Class="_Es15AJmWEeiOmuqNbykpsw"/>
   <OpenModel_Profile:Experimental xmi:id="_rS7w0JmdEeiOmuqNbykpsw" base_Element="_Es15AJmWEeiOmuqNbykpsw"/>
-  <OpenModel_Profile:Experimental xmi:id="_ScZwcJsvEeikSLSDi2qpXA" base_Element="_WCN9oJqMEeid4dfn4JFJZg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zJdQ85s5EeikSLSDi2qpXA" base_StructuralFeature="_zJdQ8ps5EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zJdQ9Js5EeikSLSDi2qpXA" base_Property="_zJdQ8ps5EeikSLSDi2qpXA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zJdQ-Js5EeikSLSDi2qpXA" base_StructuralFeature="_zJdQ95s5EeikSLSDi2qpXA"/>
@@ -1143,10 +1090,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_fgg4oLs8Eeiljfl0umr-iQ" base_StructuralFeature="_fgfqgLs8Eeiljfl0umr-iQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_QkC-sbtPEeiljfl0umr-iQ" base_Property="_QkC-sLtPEeiljfl0umr-iQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_QkDlwLtPEeiljfl0umr-iQ" base_StructuralFeature="_QkC-sLtPEeiljfl0umr-iQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cr0zYLtQEeiljfl0umr-iQ" base_Property="_cr0MUrtQEeiljfl0umr-iQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_cr0zYbtQEeiljfl0umr-iQ" base_StructuralFeature="_cr0MUrtQEeiljfl0umr-iQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_cr2BgLtQEeiljfl0umr-iQ" base_Property="_cr1acrtQEeiljfl0umr-iQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_cr2BgbtQEeiljfl0umr-iQ" base_StructuralFeature="_cr1acrtQEeiljfl0umr-iQ"/>
   <OpenModel_Profile:StrictComposite xmi:id="_PisvcLucEeiljfl0umr-iQ" base_Association="_2EwdEJs8EeikSLSDi2qpXA"/>
   <OpenModel_Profile:StrictComposite xmi:id="_R5F_ELucEeiljfl0umr-iQ" base_Association="_zJXKUJs5EeikSLSDi2qpXA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Y0kjcLucEeiljfl0umr-iQ" base_Property="_Y0j8YrucEeiljfl0umr-iQ"/>

--- a/YANG/tapi-equipment@2019-03-31.tree
+++ b/YANG/tapi-equipment@2019-03-31.tree
@@ -26,7 +26,7 @@ module: tapi-equipment
        |  |  +--ro equipment-location?            string
        |  |  +--ro geographical-location?         string
        |  |  +--ro is-expected-actual-mismatch?   boolean
-       |  |  +--ro expected-equipment
+       |  |  +--ro expected-equipment* []
        |  |  |  +--ro expected-non-field-replaceable-module* []
        |  |  |  |  +--ro common-equipment-properties
        |  |  |  |     +--ro asset-type-identifier?        string
@@ -65,11 +65,6 @@ module: tapi-equipment
        |  |  |  |     +--ro equipment-type-version?       string
        |  |  |  |     +--ro manufacturer-identifier?      string
        |  |  |  |     +--ro manufacturer-name?            string
-       |  |  |  +--ro actual-holder* []
-       |  |  |  |  +--ro common-holder-properties
-       |  |  |  |     +--ro holder-category?   holder-category
-       |  |  |  |     +--ro is-guided?         boolean
-       |  |  |  |     +--ro holder-location?   string
        |  |  |  +--ro common-actual-properties
        |  |  |  |  +--ro asset-instance-identifier?   string
        |  |  |  |  +--ro is-powered?                  boolean

--- a/YANG/tapi-equipment@2019-03-31.yang
+++ b/YANG/tapi-equipment@2019-03-31.yang
@@ -246,11 +246,6 @@ module tapi-equipment {
             uses actual-non-field-replaceable-module;
             description "none";
         }
-        list actual-holder {
-            config false;
-            uses actual-holder;
-            description "none";
-        }
         container common-actual-properties {
             config false;
             uses common-actual-properties;
@@ -436,7 +431,7 @@ module tapi-equipment {
             config false;
             description "none";
         }
-        container expected-equipment {
+        list expected-equipment {
             config false;
             uses expected-equipment;
             description "none";

--- a/YANG/tapi-photonic-media@2019-03-31.tree
+++ b/YANG/tapi-photonic-media@2019-03-31.tree
@@ -193,23 +193,6 @@ module: tapi-photonic-media
           +--ro measured-power-egress
              +--ro total-power?              decimal64
              +--ro power-spectral-density?   decimal64
-  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
-    +--ro ots-connection-end-point-spec
-       +--ro ots-media-channel
-          +--ro occupied-spectrum
-          |  +--ro upper-frequency?        uint64
-          |  +--ro lower-frequency?        uint64
-          |  +--ro frequency-constraint
-          |     +--ro adjustment-granularity?   adjustment-granularity
-          |     +--ro grid-type?                grid-type
-          +--ro measured-power-ingress
-          |  +--ro total-power?              decimal64
-          |  +--ro power-spectral-density?   decimal64
-          +--ro measured-power-egress
-             +--ro total-power?              decimal64
-             +--ro power-spectral-density?   decimal64
-  augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
-    +--ro media-channel-assembly-spec
   augment /tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point:
     +-- media-channel-connectivity-service-end-point-spec
        +-- mc-config

--- a/YANG/tapi-photonic-media@2019-03-31.yang
+++ b/YANG/tapi-photonic-media@2019-03-31.yang
@@ -129,20 +129,6 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
-        container ots-connection-end-point-spec {
-            uses ots-connection-end-point-spec;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
-        container media-channel-assembly-spec {
-            uses media-channel-assembly-spec;
-            description "none";
-        }
-        description "none";
-    }
     augment "/tapi-connectivity:create-connectivity-service/tapi-connectivity:input/tapi-connectivity:end-point" {
         container media-channel-connectivity-service-end-point-spec {
             uses media-channel-connectivity-service-end-point-spec;
@@ -286,7 +272,7 @@ module tapi-photonic-media {
     /**************************
     * package object-classes
     **************************/ 
-    grouping otsi-gserver-adaptation-pac {
+    grouping otsi-server-adaptation-pac {
         leaf number-of-otsi {
             type uint64;
             config false;
@@ -401,7 +387,7 @@ module tapi-photonic-media {
     grouping otsi-assembly-connection-end-point-spec {
         container otsi-adapter {
             config false;
-            uses otsi-gserver-adaptation-pac;
+            uses otsi-server-adaptation-pac;
             description "none";
         }
         description "none";
@@ -536,17 +522,6 @@ module tapi-photonic-media {
         }
         description "none";
     }
-    grouping ots-connection-end-point-spec {
-        container ots-media-channel {
-            config false;
-            uses media-channel-properties-pac;
-            description "none";
-        }
-        description "none";
-    }
-    grouping media-channel-assembly-spec {
-        description "none";
-    }
     grouping total-power-threshold-pac {
         leaf total-power-upper-warn-threshold-default {
             type decimal64 {
@@ -652,35 +627,31 @@ module tapi-photonic-media {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }
-    identity PHOTONIC_LAYER_QUALIFIER_OTSiG {
+    identity PHOTONIC_LAYER_QUALIFIER_OTSiMC {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }
-    identity PHOTONIC_LAYER_QUALIFIER_NMC {
+    identity PHOTONIC_LAYER_QUALIFIER_OTSiMCA {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }
-    identity PHOTONIC_LAYER_QUALIFIER_NMCA {
+    identity PHOTONIC_LAYER_QUALIFIER_MC {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }
-    identity PHOTONIC_LAYER_QUALIFIER_SMC {
+    identity PHOTONIC_LAYER_QUALIFIER_MCA {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }
-    identity PHOTONIC_LAYER_QUALIFIER_SMCA {
+    identity PHOTONIC_LAYER_QUALIFIER_OMSA {
+        base PHOTONIC_LAYER_QUALIFIER;
+        description "none";
+    }
+    identity PHOTONIC_LAYER_QUALIFIER_OTSA {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }
     identity PHOTONIC_LAYER_QUALIFIER_OCH {
-        base PHOTONIC_LAYER_QUALIFIER;
-        description "none";
-    }
-    identity PHOTONIC_LAYER_QUALIFIER_OMS {
-        base PHOTONIC_LAYER_QUALIFIER;
-        description "none";
-    }
-    identity PHOTONIC_LAYER_QUALIFIER_OTS {
         base PHOTONIC_LAYER_QUALIFIER;
         description "none";
     }


### PR DESCRIPTION
- Updated the PhotonicLayerQualifier enum
- removed the MediaChannelAssemblySpec and OtsConnectionEndPointSpec
- renamed the OtsiGServerAdaptationPac to OtsiServerAdatationPac
- removed the ActualEquipment::actualHolder attribute
- Changed the multiplicity of Equipment::expectedEquipment to list