### PR TITLE
Further TAPI Eth enhancements according to MEF NRM OAM project

### DIFF
--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -4481,6 +4481,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4ZuWslb0EemG57ABxBTHSA" x="504" y="-321"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_FkuJkFe_EemG57ABxBTHSA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FkuJkVe_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FkuJk1e_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FkuJkle_EemG57ABxBTHSA" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Fw910Fe_EemG57ABxBTHSA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Fw910Ve_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Fw9101e_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Fw910le_EemG57ABxBTHSA" x="504" y="-321"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_--vAkU-wEeitY7qZgkO_XQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_--vAkk-wEeitY7qZgkO_XQ"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_bxG78IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -6921,6 +6937,26 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4Zu9w1b0EemG57ABxBTHSA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4Zu9xFb0EemG57ABxBTHSA"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FkuwoFe_EemG57ABxBTHSA" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="_FkuJkFe_EemG57ABxBTHSA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FkuwoVe_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FkuwpVe_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fkuwole_EemG57ABxBTHSA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fkuwo1e_EemG57ABxBTHSA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FkuwpFe_EemG57ABxBTHSA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Fw911Fe_EemG57ABxBTHSA" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="_Fw910Fe_EemG57ABxBTHSA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Fw911Ve_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Fw912Ve_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fw911le_EemG57ABxBTHSA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fw9111e_EemG57ABxBTHSA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fw912Fe_EemG57ABxBTHSA"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_ODB7UFhmEeiYiLRYKaTpTw" type="PapyrusUMLClassDiagram" name="EthSpecJobsPmProActive" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_4UpIAFiAEei2nODetmeP6A" type="Class_Shape">
@@ -7113,7 +7149,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8SR64liDEei2nODetmeP6A"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiEth.uml#_oF4ZgFEYEd6VSrclB-Ybig"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8SL0QViDEei2nODetmeP6A" x="959" y="466" width="227" height="140"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8SL0QViDEei2nODetmeP6A" x="959" y="602" width="227" height="129"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_haPsGViEEei2nODetmeP6A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_haPsGliEEei2nODetmeP6A" showTitle="true"/>
@@ -7199,17 +7235,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_HprpdFivEei2nODetmeP6A" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_HprpdVivEei2nODetmeP6A" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_HcydYF0XEeipas1p-rFJBA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_CxiCtERZEeKtRKTHZgJhIg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_HcydYV0XEeipas1p-rFJBA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_HcydYl0XEeipas1p-rFJBA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_CxiCsURZEeKtRKTHZgJhIg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_HcydY10XEeipas1p-rFJBA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_H4E8gIbrEeil5oKL3Vgl-g" type="Property_ClassAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_Ml3SQFfZEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_GFPJNlEZEd6VSrclB-Ybig"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_H4E8gYbrEeil5oKL3Vgl-g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ml3SQVfZEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Ml4gYFfZEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_CxiCtERZEeKtRKTHZgJhIg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ml4gYVfZEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Ml4gYlfZEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_CxiCsURZEeKtRKTHZgJhIg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ml4gY1fZEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Ml4gZFfZEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#__NKy0FfYEemG57ABxBTHSA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ml4gZVfZEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Ml4gZlfZEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#__NPEQFfYEemG57ABxBTHSA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ml4gZ1fZEemG57ABxBTHSA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_HprpdlivEei2nODetmeP6A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Hprpd1ivEei2nODetmeP6A"/>
@@ -7229,7 +7273,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Hprpg1ivEei2nODetmeP6A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_n4NGYLFVEd2MOdzuQUV2bQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HprpcVivEei2nODetmeP6A" x="365" y="472" height="79"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HprpcVivEei2nODetmeP6A" x="365" y="472" height="112"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0nQM01kbEei2nODetmeP6A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0nQM1FkbEei2nODetmeP6A" showTitle="true"/>
@@ -7849,6 +7893,10 @@
           <element xmi:type="uml:Property" href="TapiEth.uml#_VF54UkRhEeKsbYfVW3kmQQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_leN_gWAeEeiHT-m6nqduOA"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_ksBZ8FfZEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_kr76YFfZEemG57ABxBTHSA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ksBZ8VfZEemG57ABxBTHSA"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_baAIlmAeEeiHT-m6nqduOA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_baAIl2AeEeiHT-m6nqduOA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_baAImGAeEeiHT-m6nqduOA"/>
@@ -7867,7 +7915,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_baAIo2AeEeiHT-m6nqduOA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_6gIJAERfEeKsbYfVW3kmQQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_baAIkWAeEeiHT-m6nqduOA" x="364" y="564" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_baAIkWAeEeiHT-m6nqduOA" x="364" y="601" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_gd0V02AgEeiHT-m6nqduOA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_gd0V1GAgEeiHT-m6nqduOA" showTitle="true"/>
@@ -8837,6 +8885,18 @@
           <element xmi:type="uml:Property" href="TapiEth.uml#_Y4Y3kAVKEemxeNG9TDCtFQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Y_wq4QVKEemxeNG9TDCtFQ"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_Fo-pkFfiEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_FBtOMFfiEemG57ABxBTHSA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Fo-pkVfiEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wVY6sFfiEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_vylIkFfiEemG57ABxBTHSA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wVY6sVfiEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_FRKxEFfjEemG57ABxBTHSA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_EuQRQFfjEemG57ABxBTHSA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FRKxEVfjEemG57ABxBTHSA"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_QzpYhB3JEemKheKmU0GLKg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_QzpYhR3JEemKheKmU0GLKg"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_QzpYhh3JEemKheKmU0GLKg"/>
@@ -8855,7 +8915,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QzpYkR3JEemKheKmU0GLKg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_QzWdkB3JEemKheKmU0GLKg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QzoxcR3JEemKheKmU0GLKg" x="1279" y="-4" height="149"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QzoxcR3JEemKheKmU0GLKg" x="1279" y="-4" height="187"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_j5eKAB9iEem5B__-Dm9B_g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_j5eKAR9iEem5B__-Dm9B_g"/>
@@ -9053,7 +9113,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Cr8YTW4Eem8b5f98b_cVw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_3CgWIDW4Eem8b5f98b_cVw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3CrVQTW4Eem8b5f98b_cVw" x="454" y="637" width="329" height="53"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3CrVQTW4Eem8b5f98b_cVw" x="452" y="677" width="329" height="53"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_WuFTEDXlEem8b5f98b_cVw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_WuFTETXlEem8b5f98b_cVw"/>
@@ -9747,6 +9807,54 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1oHxwlb0EemG57ABxBTHSA" x="517" y="-141"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_IGkbQFe_EemG57ABxBTHSA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_IGkbQVe_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IGkbQ1e_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IGkbQle_EemG57ABxBTHSA" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_IK6IsFe_EemG57ABxBTHSA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_IK6IsVe_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IK6Is1e_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IK6Isle_EemG57ABxBTHSA" x="517" y="-141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VOWyEFfZEemG57ABxBTHSA" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_VOXZIFfZEemG57ABxBTHSA" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VOXZIVfZEemG57ABxBTHSA" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VOXZIlfZEemG57ABxBTHSA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VOXZI1fZEemG57ABxBTHSA" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Ygc08FfZEemG57ABxBTHSA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_uyMrEVEZEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ygc08VfZEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YgeDEFfZEemG57ABxBTHSA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_uyMrE1EZEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YgeDEVfZEemG57ABxBTHSA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YgeDElfZEemG57ABxBTHSA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_uyMrFVEZEd6VSrclB-Ybig"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YgeDE1fZEemG57ABxBTHSA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VOXZJFfZEemG57ABxBTHSA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VOXZJVfZEemG57ABxBTHSA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VOXZJlfZEemG57ABxBTHSA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VOXZJ1fZEemG57ABxBTHSA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VOXZKFfZEemG57ABxBTHSA" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VOXZKVfZEemG57ABxBTHSA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VOXZKlfZEemG57ABxBTHSA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VOXZK1fZEemG57ABxBTHSA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VOXZLFfZEemG57ABxBTHSA"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiEth.uml#_uyMrEFEZEd6VSrclB-Ybig"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VOWyEVfZEemG57ABxBTHSA" x="959" y="457"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_ODB7UVhmEeiYiLRYKaTpTw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_ODB7UlhmEeiYiLRYKaTpTw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_brdm8IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -10018,7 +10126,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_6CCS4V6fEeitO-Stqhyn1g"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_6CBEwF6fEeitO-Stqhyn1g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6CCS4l6fEeitO-Stqhyn1g" points="[364, 480, -643984, -643984]$[178, 480, -643984, -643984]$[178, 373, -643984, -643984]$[104, 373, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6GFFYF6fEeitO-Stqhyn1g" id="(0.0,0.10126582278481013)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6GFFYF6fEeitO-Stqhyn1g" id="(0.0,0.07142857142857142)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6GFFYV6fEeitO-Stqhyn1g" id="(0.9953703703703703,0.8)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9yDn4F6fEeitO-Stqhyn1g" type="Abstraction_Edge" source="_HprpcFivEei2nODetmeP6A" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
@@ -10033,7 +10141,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_9yDn4V6fEeitO-Stqhyn1g"/>
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_9yCZwF6fEeitO-Stqhyn1g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9yDn4l6fEeitO-Stqhyn1g" points="[364, 547, -643984, -643984]$[104, 547, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cF6fEeitO-Stqhyn1g" id="(0.0,0.9620253164556962)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cF6fEeitO-Stqhyn1g" id="(0.0,0.6785714285714286)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9045cV6fEeitO-Stqhyn1g" id="(1.0,0.49230769230769234)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_s5AthF6nEeitO-Stqhyn1g" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_s5AtgF6nEeitO-Stqhyn1g">
@@ -10216,13 +10324,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_JHuPxWA5Eei7_-Uhq6CryQ" type="Usage_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mKLKAIt1Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_JHuPxmA5Eei7_-Uhq6CryQ" x="-5" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JHuPxmA5Eei7_-Uhq6CryQ" x="42" y="-16"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_JHuPwWA5Eei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Usage" href="TapiEth.uml#_JHsakGA5Eei7_-Uhq6CryQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JHuPwmA5Eei7_-Uhq6CryQ" points="[789, 503, -643984, -643984]$[959, 503, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JKlWgGA5Eei7_-Uhq6CryQ" id="(1.0,0.379746835443038)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JKlWgWA5Eei7_-Uhq6CryQ" id="(0.0,0.2571428571428571)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JHuPwmA5Eei7_-Uhq6CryQ" points="[847, 502, -643984, -643984]$[902, 502, -643984, -643984]$[902, 628, -643984, -643984]$[959, 628, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JKlWgGA5Eei7_-Uhq6CryQ" id="(1.0,0.26785714285714285)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JKlWgWA5Eei7_-Uhq6CryQ" id="(0.0,0.1937984496124031)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JnyP4GA5Eei7_-Uhq6CryQ" type="Usage_Edge" source="_baAIkGAeEeiHT-m6nqduOA" target="_8SL0QFiDEei2nODetmeP6A" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_JnyP42A5Eei7_-Uhq6CryQ" visible="false" type="Usage_NameLabel">
@@ -10231,13 +10339,13 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_JnyP5WA5Eei7_-Uhq6CryQ" type="Usage_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_mWfHsIt1Eeiu6boZkiJHCA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_JnyP5mA5Eei7_-Uhq6CryQ" x="-6" y="-9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JnyP5mA5Eei7_-Uhq6CryQ" x="-9" y="12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_JnyP4WA5Eei7_-Uhq6CryQ"/>
       <element xmi:type="uml:Usage" href="TapiEth.uml#_JnwasGA5Eei7_-Uhq6CryQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JnyP4mA5Eei7_-Uhq6CryQ" points="[794, 581, -643984, -643984]$[959, 581, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JqjQAGA5Eei7_-Uhq6CryQ" id="(1.0,0.3050847457627119)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JqjQAWA5Eei7_-Uhq6CryQ" id="(0.0,0.8285714285714286)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JnyP4mA5Eei7_-Uhq6CryQ" points="[852, 643, -643984, -643984]$[880, 643, -643984, -643984]$[880, 648, -643984, -643984]$[959, 648, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JqjQAGA5Eei7_-Uhq6CryQ" id="(1.0,0.7966101694915254)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JqjQAWA5Eei7_-Uhq6CryQ" id="(0.0,0.35658914728682173)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MLunwGBDEei7_-Uhq6CryQ" type="Abstraction_Edge" source="_aUTr0GAeEeiHT-m6nqduOA" target="__ZXuoF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="255">
       <children xmi:type="notation:DecorationNode" xmi:id="_MLvO0GBDEei7_-Uhq6CryQ" visible="false" type="Abstraction_NameLabel">
@@ -10297,7 +10405,7 @@
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_8hwP8GBHEei7_-Uhq6CryQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8hyFImBHEei7_-Uhq6CryQ" points="[364, 580, -643984, -643984]$[160, 580, -643984, -643984]$[160, 388, -643984, -643984]$[104, 388, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8kwgoGBHEei7_-Uhq6CryQ" id="(0.0,0.2711864406779661)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8kxHsGBHEei7_-Uhq6CryQ" id="(0.9953703703703703,0.8848484848484849)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8kxHsGBHEei7_-Uhq6CryQ" id="(1.0,0.8848484848484849)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BNPSNGBJEei7_-Uhq6CryQ" type="StereotypeCommentLink" target="_BNPSMGBJEei7_-Uhq6CryQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_BNPSNWBJEei7_-Uhq6CryQ"/>
@@ -11315,7 +11423,7 @@
       <element xmi:type="uml:Generalization" href="TapiEth.uml#_u6KqsB3KEemKheKmU0GLKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vBaiMh3KEemKheKmU0GLKg" points="[1225, 19, -643984, -643984]$[1279, 19, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vSfrIB3KEemKheKmU0GLKg" id="(1.0,0.5851851851851851)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vSfrIR3KEemKheKmU0GLKg" id="(0.0,0.15436241610738255)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vSfrIR3KEemKheKmU0GLKg" id="(0.0,0.12299465240641712)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_wIHrkB3KEemKheKmU0GLKg" type="Generalization_Edge" source="_XvuDwF6gEeitO-Stqhyn1g" target="_QzoxcB3JEemKheKmU0GLKg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_wIHrkx3KEemKheKmU0GLKg" type="Generalization_StereotypeLabel">
@@ -11326,7 +11434,7 @@
       <element xmi:type="uml:Generalization" href="TapiEth.uml#_wA30EB3KEemKheKmU0GLKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wIHrkh3KEemKheKmU0GLKg" points="[1212, 117, -643984, -643984]$[1279, 117, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYEMEB3KEemKheKmU0GLKg" id="(1.0,0.16666666666666666)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYEMER3KEemKheKmU0GLKg" id="(0.0,0.8187919463087249)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYEMER3KEemKheKmU0GLKg" id="(0.0,0.6524064171122995)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_j5exEB9iEem5B__-Dm9B_g" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_j5eKAB9iEem5B__-Dm9B_g">
       <styles xmi:type="notation:FontStyle" xmi:id="_j5exER9iEem5B__-Dm9B_g"/>
@@ -11573,7 +11681,7 @@
       <element xmi:type="uml:Abstraction" href="TapiEth.uml#_sAu1UDW5Eem8b5f98b_cVw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sAwqgjW5Eem8b5f98b_cVw" points="[453, 640, -643984, -643984]$[140, 640, -643984, -643984]$[140, 399, -643984, -643984]$[104, 399, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_se1GkDW5Eem8b5f98b_cVw" id="(0.0,0.05660377358490566)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_se1GkTW5Eem8b5f98b_cVw" id="(0.9953703703703703,0.9575757575757575)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_se1GkTW5Eem8b5f98b_cVw" id="(1.0,0.9575757575757575)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_x_RQUDW5Eem8b5f98b_cVw" type="Abstraction_Edge" source="_3CrVQDW4Eem8b5f98b_cVw" target="__wf1MF0YEeipas1p-rFJBA" routing="Rectilinear" lineColor="16711680">
       <children xmi:type="notation:DecorationNode" xmi:id="_x_R3YDW5Eem8b5f98b_cVw" visible="false" type="Abstraction_NameLabel">
@@ -12364,6 +12472,56 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1oHxxlb0EemG57ABxBTHSA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1oHxx1b0EemG57ABxBTHSA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1oHxyFb0EemG57ABxBTHSA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_IGkbRFe_EemG57ABxBTHSA" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_IGkbQFe_EemG57ABxBTHSA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_IGkbRVe_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IGkbSVe_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IGkbRle_EemG57ABxBTHSA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IGkbR1e_EemG57ABxBTHSA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IGkbSFe_EemG57ABxBTHSA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_IK6ItFe_EemG57ABxBTHSA" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_IK6IsFe_EemG57ABxBTHSA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_IK6ItVe_EemG57ABxBTHSA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IK6IuVe_EemG57ABxBTHSA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IK6Itle_EemG57ABxBTHSA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IK6It1e_EemG57ABxBTHSA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IK6IuFe_EemG57ABxBTHSA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_feUmAFfZEemG57ABxBTHSA" type="Usage_Edge" source="_HprpcFivEei2nODetmeP6A" target="_VOWyEFfZEemG57ABxBTHSA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_feUmA1fZEemG57ABxBTHSA" type="Usage_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_syNd8FfZEemG57ABxBTHSA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_feUmBFfZEemG57ABxBTHSA" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_feVNEFfZEemG57ABxBTHSA" type="Usage_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_tFyhQFfZEemG57ABxBTHSA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_feVNEVfZEemG57ABxBTHSA" x="-10" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_feUmAVfZEemG57ABxBTHSA"/>
+      <element xmi:type="uml:Usage" href="TapiEth.uml#_feQUkFfZEemG57ABxBTHSA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_feUmAlfZEemG57ABxBTHSA" points="[847, 489, -643984, -643984]$[959, 489, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gATRsFfZEemG57ABxBTHSA" id="(1.0,0.15178571428571427)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gATRsVfZEemG57ABxBTHSA" id="(0.0,0.2807017543859649)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mDHIsFfZEemG57ABxBTHSA" type="Usage_Edge" source="_baAIkGAeEeiHT-m6nqduOA" target="_VOWyEFfZEemG57ABxBTHSA" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mDHvwFfZEemG57ABxBTHSA" type="Usage_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zcwqYFfZEemG57ABxBTHSA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mDHvwVfZEemG57ABxBTHSA" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mDHvwlfZEemG57ABxBTHSA" type="Usage_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_zt6r0FfZEemG57ABxBTHSA" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mDHvw1fZEemG57ABxBTHSA" x="14" y="-2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_mDHIsVfZEemG57ABxBTHSA"/>
+      <element xmi:type="uml:Usage" href="TapiEth.uml#_mDFTgFfZEemG57ABxBTHSA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mDHIslfZEemG57ABxBTHSA" points="[852, 612, -643984, -643984]$[880, 612, -643984, -643984]$[880, 550, -643984, -643984]$[959, 550, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mnqAMFfZEemG57ABxBTHSA" id="(1.0,0.2033898305084746)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mnqAMVfZEemG57ABxBTHSA" id="(0.0,0.8157894736842105)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_tC4KUGBLEei7_-Uhq6CryQ" type="PapyrusUMLClassDiagram" name="EthSpecJobsPmOnDemand" measurementUnit="Pixel">

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -758,6 +758,13 @@ The attribute is not used in case of 2-way loss measurement.</body>
             <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kr76YFfZEemG57ABxBTHSA" name="totalCountersNearEnd1LmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_kr76YVfZEemG57ABxBTHSA" annotatedElement="_kr76YFfZEemG57ABxBTHSA">
+            <body>This attribute contains the results of an on-demand synthetic loss measurement job in the ingress direction.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kr76YlfZEemG57ABxBTHSA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kr76Y1fZEemG57ABxBTHSA" value="1"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_OUb0kLF-Ed2MOdzuQUV2bQ" name="EthProActiveDmPerformanceData">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OUb0kbF-Ed2MOdzuQUV2bQ" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
@@ -785,6 +792,15 @@ The attribute is not used in case of 2-way loss measurement.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_kdmr0OxhEeGzwM2Uvwf5Xw" annotatedElement="_n4NGYLFVEd2MOdzuQUV2bQ">
           <body>This object class represents the PM current data collected in a pro-active loss measurement job (using LMM/LMR or SLM/SLR).</body>
         </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GFPJNlEZEd6VSrclB-Ybig" name="bidirectionalUas" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_joZ3QOxjEeGzwM2Uvwf5Xw" annotatedElement="_GFPJNlEZEd6VSrclB-Ybig">
+            <body>This attribute contains the bidirectional UAS (unavailable seconds) detected in the monitoring interval.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_mgvWUOxjEeGzwM2Uvwf5Xw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_CxiCtERZEeKtRKTHZgJhIg" name="statisticalFarEndLmParameters" visibility="public" type="_oF4ZgFEYEd6VSrclB-Ybig">
           <ownedComment xmi:type="uml:Comment" xmi:id="_CxiCtURZEeKtRKTHZgJhIg" annotatedElement="_CxiCtERZEeKtRKTHZgJhIg">
             <body>This attribute contains the statistical far end performnace parameters.</body>
@@ -795,14 +811,19 @@ The attribute is not used in case of 2-way loss measurement.</body>
             <body>This attribute contains the statistical near end performnace parameters.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GFPJNlEZEd6VSrclB-Ybig" name="bidirectionalUas" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_joZ3QOxjEeGzwM2Uvwf5Xw" annotatedElement="_GFPJNlEZEd6VSrclB-Ybig">
-            <body>This attribute contains the bidirectional UAS (unavailable seconds) detected in the monitoring interval.</body>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__NKy0FfYEemG57ABxBTHSA" name="totalCountersFarEndLmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__NKy0VfYEemG57ABxBTHSA" annotatedElement="__NKy0FfYEemG57ABxBTHSA">
+            <body>This attribute contains the results of an on-demand synthetic loss measurement job in the egress direction.</body>
           </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_mgvWUOxjEeGzwM2Uvwf5Xw">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          </defaultValue>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__NKy0lfYEemG57ABxBTHSA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__NKy01fYEemG57ABxBTHSA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__NPEQFfYEemG57ABxBTHSA" name="totalCountersNearEndLmParameters" visibility="public" type="_uyMrEFEZEd6VSrclB-Ybig">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__NPEQVfYEemG57ABxBTHSA" annotatedElement="__NPEQFfYEemG57ABxBTHSA">
+            <body>This attribute contains the results of an on-demand synthetic loss measurement job in the ingress direction.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__NPEQlfYEemG57ABxBTHSA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__NPEQ1fYEemG57ABxBTHSA" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_vqsqAFesEeiqWMdX2ZZi3w" name="EthOnDemand1DmPerformanceData">
@@ -1324,6 +1345,13 @@ If the particular ifAlias object does not contain any values, another chassis id
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_QzWdkB3JEemKheKmU0GLKg" name="EthMeasurementJobControlCommon" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_r3fMAFfiEemG57ABxBTHSA" annotatedElement="_QzWdkB3JEemKheKmU0GLKg">
+          <body>Time length over which each Availability Frame Loss Ratio value is calculated. This parameter allows to generalize SES and UAS.&#xD;
+MEF 35.1:&#xD;
+[R78]/[CR58] [O8] A SOAM PM Implementation MUST support a configurable parameter for the length of time over which each Availability flr value is calculated, with a range of 1s – 300s.  This parameter is equivalent to delta-t as specified by MEF 10.3.&#xD;
+[R79]/[CR59] [O8] The length of time over which each Availability flr value is calculated (delta-t) MUST be an integer multiple of the interval between each SLM/1SL frame transmission.&#xD;
+[D31]/[CD16] [O8] The default length of time over which each Availability flr value is calculated SHOULD be 1s.</body>
+        </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_2sFHr5VIEeKd8oT75MgdlA" name="priority" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_2sFHsJVIEeKd8oT75MgdlA" annotatedElement="_2sFHr5VIEeKd8oT75MgdlA">
             <body>This attribute contains the priority value on which the MEP performs the measurement.&#xD;
@@ -1384,6 +1412,38 @@ Note that a value of 0 means not applicable (NA), which is for the cases of sing
 [D8] A SOAM PM Implementation SHOULD support a configurable (in minutes) offset from ToD time for alignment of the start of Measurement Intervals other than the first Measurement Interval.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FBtOMFfiEemG57ABxBTHSA" name="flrAvailabilityDeltaTime">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oAzY4FfjEemG57ABxBTHSA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oBFswFfjEemG57ABxBTHSA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_b93A4FfiEemG57ABxBTHSA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vylIkFfiEemG57ABxBTHSA" name="flrAvailabilityThreshold">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_94R38FfiEemG57ABxBTHSA" annotatedElement="_vylIkFfiEemG57ABxBTHSA">
+            <body>Frame loss ratio threshold to be used in evaluating the Available/Unavailable state of each time interval (as specified by Availability Delta Time).&#xD;
+MEF 35.1:&#xD;
+[R81]/[CR61] A SOAM PM Implementation MUST support a configurable Availability frame loss ratio threshold to be used in evaluating the Available/Unavailable state of each delta-t interval per MEF 10.3&#xD;
+[R82]/[CR62] The Availability frame loss ratio threshold range of 0.00 through 1.00 MUST be supported in increments of 0.01.&#xD;
+[D33]/[CD18] [O8] The default Availability frame loss ratio threshold SHOULD be 0.1.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o6mHoFfjEemG57ABxBTHSA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o66QsFfjEemG57ABxBTHSA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralReal" xmi:id="_3U31UFfiEemG57ABxBTHSA" value="0.1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EuQRQFfjEemG57ABxBTHSA" name="flrAvailabilitySamples">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Vm5CUFfjEemG57ABxBTHSA" annotatedElement="_EuQRQFfjEemG57ABxBTHSA">
+            <body>Number of consecutive Availability Frame Loss Ratio measurements to be used to determine Available/Unavailable state transitions.&#xD;
+MEF 35.1:&#xD;
+[R80]/[CR60] [O8] The number range of 1 through 10 MUST be supported for the configurable number of consecutive Availability flr measurements to be used to determine Available/Unavailable state transitions.&#xD;
+This parameter is equivalent to the Availability parameter of n as specified by MEF 10.3.&#xD;
+[D32]/[CD17] [O8] The default number of n for Availability SHOULD be 10.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_q1uXkFfjEemG57ABxBTHSA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_q2BSgFfjEemG57ABxBTHSA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_KQ1wEFfjEemG57ABxBTHSA" value="10"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_q5_sMDW4Eem8b5f98b_cVw" name="EthProActive1DmSourcePerformanceData">
@@ -1633,6 +1693,8 @@ It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_M-QGADh9Eem1lYbrIE6BNw" name="EthConnectivityService"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_feQUkFfZEemG57ABxBTHSA" client="_n4NGYLFVEd2MOdzuQUV2bQ" supplier="_uyMrEFEZEd6VSrclB-Ybig"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_mDFTgFfZEemG57ABxBTHSA" client="_6gIJAERfEeKsbYfVW3kmQQ" supplier="_uyMrEFEZEd6VSrclB-Ybig"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_dP6U4JKmEdybINoKQq_hfQ" name="TypeDefinitions">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dQAbgJKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
@@ -2508,18 +2570,21 @@ The accuracy of the value is for further study.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GFPJMVEZEd6VSrclB-Ybig" name="ses" visibility="public">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GFPJMVEZEd6VSrclB-Ybig" name="hliCount" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_RvFFQOxjEeGzwM2Uvwf5Xw" annotatedElement="_GFPJMVEZEd6VSrclB-Ybig">
-            <body>This attribute contains the SES detected in the monitoring interval.</body>
+            <body>A generalized SES.&#xD;
+MEF 35.1: Count of High Loss Intervals during the Measurement Interval.</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_WQKq0OxjEeGzwM2Uvwf5Xw">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GFPJNFEZEd6VSrclB-Ybig" name="uas" visibility="public">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GFPJNFEZEd6VSrclB-Ybig" name="unavailableIntervals" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_QZy34OxkEeGzwM2Uvwf5Xw" annotatedElement="_GFPJNFEZEd6VSrclB-Ybig">
-            <body>This attribute contains UAS (unavailable seconds) detected in the monitoring interval.</body>
+            <body>A generalized UAS.&#xD;
+MEF 35.1: A 32-bit counter reflecting the number of delta-t intervals evaluated as Unavailable (i.e., for which A&lt;Controller, Responder>(delta-t) = 0).&#xD;
+</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_U6bxgOxkEeGzwM2Uvwf5Xw">
@@ -2952,8 +3017,8 @@ Bit 8 (MSB).</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_O0QvAEtNEemsleBFQ473Kg" name="MINIMUM_FRAME_LOSS_RATIO"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_RnK7gEtNEemsleBFQ473Kg" name="MAXIMUM_FRAME_LOSS_RATIO"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_UWV3gEtNEemsleBFQ473Kg" name="AVERAGE_FRAME_LOSS_RATIO"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YPky4EtNEemsleBFQ473Kg" name="SEVERE_ERRORED_SECONDS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_cWvckEtNEemsleBFQ473Kg" name="UNASSIGNED_ERRORED_SECONDS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YPky4EtNEemsleBFQ473Kg" name="HIGH_LOSS_INTERVALS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_cWvckEtNEemsleBFQ473Kg" name="UNAVAILABLE_INTERVALS"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_x3G-wDxBEeaRI-H69PghuA" name="Associations">
@@ -8369,4 +8434,16 @@ Bit 8 (MSB).</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_uwE2cFelEemG57ABxBTHSA" base_Property="_uwDoUFelEemG57ABxBTHSA"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_6hvGoFelEemG57ABxBTHSA" base_StructuralFeature="_6hufkFelEemG57ABxBTHSA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6hvGoVelEemG57ABxBTHSA" base_Property="_6hufkFelEemG57ABxBTHSA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="__NLZ4FfYEemG57ABxBTHSA" base_StructuralFeature="__NKy0FfYEemG57ABxBTHSA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__NMA8FfYEemG57ABxBTHSA" base_Property="__NKy0FfYEemG57ABxBTHSA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="__NPrUFfYEemG57ABxBTHSA" base_StructuralFeature="__NPEQFfYEemG57ABxBTHSA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__NPrUVfYEemG57ABxBTHSA" base_Property="__NPEQFfYEemG57ABxBTHSA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_kr76ZFfZEemG57ABxBTHSA" base_StructuralFeature="_kr76YFfZEemG57ABxBTHSA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_kr8hcFfZEemG57ABxBTHSA" base_Property="_kr76YFfZEemG57ABxBTHSA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_FBt1QFfiEemG57ABxBTHSA" base_StructuralFeature="_FBtOMFfiEemG57ABxBTHSA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_FBt1QVfiEemG57ABxBTHSA" base_Property="_FBtOMFfiEemG57ABxBTHSA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_vylIkVfiEemG57ABxBTHSA" base_StructuralFeature="_vylIkFfiEemG57ABxBTHSA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vylIklfiEemG57ABxBTHSA" base_Property="_vylIkFfiEemG57ABxBTHSA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_EuQRQVfjEemG57ABxBTHSA" base_StructuralFeature="_EuQRQFfjEemG57ABxBTHSA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_EuQ4UFfjEemG57ABxBTHSA" base_Property="_EuQRQFfjEemG57ABxBTHSA"/>
 </xmi:XMI>


### PR DESCRIPTION
TAPI Ethernet, added totalCountersFarEndLmParameters,
totalCountersNearEndLmParameters attributes to
EthProActiveLmPerformanceData. Added totalCountersNearEnd1LmParameters
attribute to EthProActive1LmPerformanceData class.

TAPI Ethernet, added flrAvailabilityDeltaTime, flrAvailabilityThreshold,
flrAvailabilitySamples to EthMeasurementJobControlCommon.

TAPI Ethernet, StatisticalLmPerformanceParameters class, uas attribute
renamed as unavailableIntervals, ses attribute renamed as hliCount.

Tapi Ethernet, EthPmParameterName enum, SEVERE_ERRORED_SECONDS replaced
with HIGH_LOSS_INTERVALS, UNASSIGNED_ERRORED_SECONDS replaced with
UNAVAILABLE_INTERVALS.