### PR TITLE
Modifications to OAM and Eth:

### DIFF
--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -2164,14 +2164,6 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_45d2YF6hEeitO-Stqhyn1g" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_45d2YV6hEeitO-Stqhyn1g" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_8B8DMF6hEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_Cwwkxa5TEeKbRfTRicRZzQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8B8DMV6hEeitO-Stqhyn1g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_8B8DMl6hEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_Cwwkx65TEeKbRfTRicRZzQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8B8DM16hEeitO-Stqhyn1g"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_8B8DNF6hEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_Cw5usa5TEeKbRfTRicRZzQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_8B8DNV6hEeitO-Stqhyn1g"/>
@@ -2316,7 +2308,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arsiJ16fEeitO-Stqhyn1g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_nTcS8FRxEeitkMFXBYQFcg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nT0GYVRxEeitkMFXBYQFcg" x="103" y="-28" width="219" height="157"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nT0GYVRxEeitkMFXBYQFcg" x="103" y="-28" width="219" height="135"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F-r4QFRyEeitkMFXBYQFcg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_F-r4QlRyEeitkMFXBYQFcg" type="Class_NameLabel"/>
@@ -2372,10 +2364,6 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-97TMF6hEeitO-Stqhyn1g" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_-976QF6hEeitO-Stqhyn1g" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="__tOCIF6hEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_iWO58CFREeWxnoblgNdj6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__tOCIV6hEeitO-Stqhyn1g"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="__tOpMF6hEeitO-Stqhyn1g" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_VRWTkVEEEd6VSrclB-Ybig"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="__tOpMV6hEeitO-Stqhyn1g"/>
@@ -3528,7 +3516,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKr8_v-vEeiABdf1yJ9dlA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_nkE94NYAEeidMu8ST4Ma3w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKizAf-vEeiABdf1yJ9dlA" x="-495" y="-11" height="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKizAf-vEeiABdf1yJ9dlA" x="-498" y="37" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F_PmYP-vEeiABdf1yJ9dlA" type="Class_Shape" fontColor="255" fontName="Segoe UI">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g1NLIASwEemABdf1yJ9dlA" source="PapyrusCSSForceValue">
@@ -3941,6 +3929,14 @@
           <element xmi:type="uml:Property" href="TapiEth.uml#_zrY80AVGEemxeNG9TDCtFQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_j3exUzoOEemSPvPXzEQ11A"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_KgLF0GsZEembs75vhmFVVA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_KfYboGsZEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_KgLF0WsZEembs75vhmFVVA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_WPZtEGsZEembs75vhmFVVA" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiEth.uml#_WPRKMGsZEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_WPaUIGsZEembs75vhmFVVA"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_oZdhZhglEem7b6CPWW1OrA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_oZdhZxglEem7b6CPWW1OrA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_oZdhaBglEem7b6CPWW1OrA"/>
@@ -3959,7 +3955,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oZeIeRglEem7b6CPWW1OrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_oZZ3ABglEem7b6CPWW1OrA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oZdhYRglEem7b6CPWW1OrA" x="-317" y="-115" width="234" height="73"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oZdhYRglEem7b6CPWW1OrA" x="-317" y="-115" width="234" height="106"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_4dQmEBguEem7b6CPWW1OrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_4dQmERguEem7b6CPWW1OrA"/>
@@ -4560,6 +4556,22 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_okRl0mbrEemNo6KemN3z2w" x="504" y="-321"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__XBAEGsYEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__XBAEWsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__XBAE2sYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__XBAEmsYEembs75vhmFVVA" x="491" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__lObMGsYEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__lObMWsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__lObM2sYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__lObMmsYEembs75vhmFVVA" x="504" y="-321"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_--vAkU-wEeitY7qZgkO_XQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_--vAkk-wEeitY7qZgkO_XQ"/>
@@ -6050,11 +6062,11 @@
     <edges xmi:type="notation:Connector" xmi:id="_-xFwEASwEemABdf1yJ9dlA" type="Association_Edge" source="_iN-8kE-xEeitY7qZgkO_XQ" target="_FKizAP-vEeiABdf1yJ9dlA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_-xGXIASwEemABdf1yJ9dlA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CNmTMASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXIQSwEemABdf1yJ9dlA" x="48" y="-67"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXIQSwEemABdf1yJ9dlA" x="66" y="-59"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-xGXIgSwEemABdf1yJ9dlA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CWcGIASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXIwSwEemABdf1yJ9dlA" x="65" y="-132"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-xGXIwSwEemABdf1yJ9dlA" x="86" y="-131"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-xGXJASwEemABdf1yJ9dlA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_CeOwMASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -6074,18 +6086,18 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_-xFwEQSwEemABdf1yJ9dlA"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_RLGcANZIEeidLb5WEUMFmw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-xFwEgSwEemABdf1yJ9dlA" points="[-456, -168, -643984, -643984]$[-456, -11, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-xFwEgSwEemABdf1yJ9dlA" points="[-455, -168, -643984, -643984]$[-455, 11, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIASxEemABdf1yJ9dlA" id="(0.03944315545243619,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIQSxEemABdf1yJ9dlA" id="(0.09848484848484848,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CFzpIQSxEemABdf1yJ9dlA" id="(0.10606060606060606,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__b3ycASwEemABdf1yJ9dlA" type="Association_Edge" source="_iN-8kE-xEeitY7qZgkO_XQ" target="_F_PmYP-vEeiABdf1yJ9dlA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="__b4ZgASwEemABdf1yJ9dlA" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_E_Uz8ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZgQSwEemABdf1yJ9dlA" x="115" y="59"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZgQSwEemABdf1yJ9dlA" x="141" y="65"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__b4ZggSwEemABdf1yJ9dlA" type="Association_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FHPZ0ASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZgwSwEemABdf1yJ9dlA" x="96" y="134"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__b4ZgwSwEemABdf1yJ9dlA" x="128" y="148"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__b4ZhASwEemABdf1yJ9dlA" type="Association_TargetRoleLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_FPGVUASxEemABdf1yJ9dlA" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -7100,6 +7112,26 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_okSM42brEemNo6KemN3z2w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_okSM5GbrEemNo6KemN3z2w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_okSM5WbrEemNo6KemN3z2w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__XBAFGsYEembs75vhmFVVA" type="StereotypeCommentLink" source="_S_jqkE-xEeitY7qZgkO_XQ" target="__XBAEGsYEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="__XBAFWsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__XBAGWsYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__XBAFmsYEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__XBAF2sYEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__XBAGGsYEembs75vhmFVVA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="__lObNGsYEembs75vhmFVVA" type="StereotypeCommentLink" source="_z8BPIU-yEeitY7qZgkO_XQ" target="__lObMGsYEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="__lObNWsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__lObOWsYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_z8BPIE-yEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__lObNmsYEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__lObN2sYEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__lObOGsYEembs75vhmFVVA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_ODB7UFhmEeiYiLRYKaTpTw" type="PapyrusUMLClassDiagram" name="EthSpecJobsPmProActive" measurementUnit="Pixel">
@@ -10079,6 +10111,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rO5ZAmbrEemNo6KemN3z2w" x="517" y="-141"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_8UqCUGsYEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8UqCUWsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8UuTwGsYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8UqCUmsYEembs75vhmFVVA" x="88" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8fIM8GsYEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8fI0AGsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8fI0AmsYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8fI0AWsYEembs75vhmFVVA" x="517" y="-141"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_ODB7UVhmEeiYiLRYKaTpTw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_ODB7UlhmEeiYiLRYKaTpTw"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_brdm8IqaEeiT7s5en7ligw" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -12846,6 +12894,26 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rO5ZBmbrEemNo6KemN3z2w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rO5ZB2brEemNo6KemN3z2w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rO5ZCGbrEemNo6KemN3z2w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8Uu60GsYEembs75vhmFVVA" type="StereotypeCommentLink" source="_4UpIAFiAEei2nODetmeP6A" target="_8UqCUGsYEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8Uu60WsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8Uvh4msYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8Uu60msYEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Uvh4GsYEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Uvh4WsYEembs75vhmFVVA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8fI0A2sYEembs75vhmFVVA" type="StereotypeCommentLink" source="_gB1O8FiBEei2nODetmeP6A" target="_8fIM8GsYEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8fI0BGsYEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8fI0CGsYEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_qeSSgFUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8fI0BWsYEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8fI0BmsYEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8fI0B2sYEembs75vhmFVVA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_tC4KUGBLEei7_-Uhq6CryQ" type="PapyrusUMLClassDiagram" name="EthSpecJobsPmOnDemand" measurementUnit="Pixel">
@@ -17377,10 +17445,6 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__OAotBhQEem7b6CPWW1OrA" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__OBPwBhQEem7b6CPWW1OrA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_jbKXYBhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_iWO58CFREeWxnoblgNdj6g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbKXYRhREem7b6CPWW1OrA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_jbKXYhhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_VRWTkVEEEd6VSrclB-Ybig"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_jbKXYxhREem7b6CPWW1OrA"/>
@@ -17493,14 +17557,6 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_H8BhtBhREem7b6CPWW1OrA" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_H8BhtRhREem7b6CPWW1OrA" type="Class_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_jbOBxBhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_Cwwkxa5TEeKbRfTRicRZzQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbOBxRhREem7b6CPWW1OrA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_jbOo0BhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiEth.uml#_Cwwkx65TEeKbRfTRicRZzQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jbOo0RhREem7b6CPWW1OrA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_jbOo0hhREem7b6CPWW1OrA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiEth.uml#_Cw5usa5TEeKbRfTRicRZzQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_jbOo0xhREem7b6CPWW1OrA"/>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -300,23 +300,6 @@ An arbitrary amount of data to be included in a Data TLV.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_H3g4oK5SEeKXNfjfbIxfYg" annotatedElement="_nTcS8FRxEeitkMFXBYQFcg">
           <body>This object class models the MEP functions that are common to MEP Sink and MEP Source.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Cwwkxa5TEeKbRfTRicRZzQ" name="isCcEnabled" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_V9mv8K5aEeKbRfTRicRZzQ" annotatedElement="_Cwwkxa5TEeKbRfTRicRZzQ">
-            <body>This attribute models the MI_CC_Enable signal defined in G.8021 and configured as specified in G8051.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_WYR5wK5aEeKbRfTRicRZzQ">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          </defaultValue>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Cwwkx65TEeKbRfTRicRZzQ" name="ccPeriod" visibility="public" type="_XmBCIHmuEd2GobjTM4neEA">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_AnqQoK5bEeKbRfTRicRZzQ" annotatedElement="_Cwwkx65TEeKbRfTRicRZzQ">
-            <body>This attribute models the MI_CC_Period signal defined in G.8021 and configured as specified in G8051. &#xD;
-It is the period at which the CCM message should be sent. &#xD;
-Default values are: 3.33 ms for PS, 100 ms for PM, 1 s for FM.</body>
-          </ownedComment>
-          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_ZbmagFVPEeitkMFXBYQFcg" type="_XmBCIHmuEd2GobjTM4neEA" instance="_e6NogHmuEd2GobjTM4neEA"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Cw5usa5TEeKbRfTRicRZzQ" name="ccPriority" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_J7RKAK5bEeKbRfTRicRZzQ" annotatedElement="_Cw5usa5TEeKbRfTRicRZzQ">
             <body>This attribute models the MI_CC_Pri signal defined in G.8021 and configured as specified in G8051. It is the priority at which the CCM message should be sent.</body>
@@ -389,14 +372,6 @@ It also provides the management of the dual-ended maintenance job, such as test.
         <ownedComment xmi:type="uml:Comment" xmi:id="_qSV7ELxpEeKKo62JMbvqmA" annotatedElement="_VUpVoFRyEeitkMFXBYQFcg">
           <body>This object contains the configuration parameters for detecting &quot;degraded signal&quot; (DEG).</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_iWO58CFREeWxnoblgNdj6g" name="dm1Priority" visibility="public">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_wos6ACFREeWxnoblgNdj6g" annotatedElement="_iWO58CFREeWxnoblgNdj6g">
-            <body>This attribute indicates the list of 1DM priorities for the MepSink.</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nINbMCFREeWxnoblgNdj6g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nIOpUCFREeWxnoblgNdj6g" value="*"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_VRWTkVEEEd6VSrclB-Ybig" name="aisPriority" visibility="public" isOrdered="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_kfSykK5sEeKbRfTRicRZzQ" annotatedElement="_VRWTkVEEEd6VSrclB-Ybig">
             <body>This attribute models the MI_AIS_Pri signal defined in G.8021 and configured as specified in G8051. It is the priority at which the AIS messages should be sent.</body>
@@ -1355,6 +1330,26 @@ If the particular ifAlias object does not contain any values, another chassis id
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JdIS0GaXEemNo6KemN3z2w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JduvwGaXEemNo6KemN3z2w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KfYboGsZEembs75vhmFVVA" name="isCcEnabled" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KfYboWsZEembs75vhmFVVA" annotatedElement="_KfYboGsZEembs75vhmFVVA">
+            <body>This attribute models the MI_CC_Enable signal defined in G.8021 and configured as specified in G8051.&#xD;
+ITU-T G.8013/Y.1731 (2015)/Amd.1 (11/2018): When ETH-CC transmission is enabled in a MEG,&#xD;
+all MEPs are enabled to periodically transmit frames with ETH-CC information to their peer MEPs in the MEG.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_KfYbomsZEembs75vhmFVVA">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WPRKMGsZEembs75vhmFVVA" name="ccPeriod" visibility="public" type="_XmBCIHmuEd2GobjTM4neEA">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_WPRKMWsZEembs75vhmFVVA" annotatedElement="_WPRKMGsZEembs75vhmFVVA">
+            <body>This attribute models the MI_CC_Period signal defined in G.8021 and configured as specified in G8051. &#xD;
+It is the period at which the CCM message should be sent. &#xD;
+Default values are: 3.33 ms for PS, 100 ms for PM, 1 s for FM.&#xD;
+ITU-T G.8013/Y.1731 (2015)/Amd.1 (11/2018): The ETH-CC transmission period is the same for all MEPs in the MEG.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_WPRKMmsZEembs75vhmFVVA" type="_XmBCIHmuEd2GobjTM4neEA" instance="_e6NogHmuEd2GobjTM4neEA"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_hKDiEBjuEemR9Pg4e1yNpA" name="EthTestJobSinkPoint">
@@ -7590,12 +7585,8 @@ Frame delay variation is a measure of the variations in the frame delay between 
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_VNqwYlUhEeitkMFXBYQFcg" base_Class="_VNqwYFUhEeitkMFXBYQFcg"/>
   <OpenModel_Profile_3:OpenModelClass xmi:id="_YvnNIVUhEeitkMFXBYQFcg" base_Class="_YvnNIFUhEeitkMFXBYQFcg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YvnNIlUhEeitkMFXBYQFcg" base_Class="_YvnNIFUhEeitkMFXBYQFcg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S_AccFVNEeitkMFXBYQFcg" base_Property="_Cwwkx65TEeKbRfTRicRZzQ"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_S_AccVVNEeitkMFXBYQFcg" base_StructuralFeature="_Cwwkx65TEeKbRfTRicRZzQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S_AcclVNEeitkMFXBYQFcg" base_Property="_Cw5usa5TEeKbRfTRicRZzQ"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_S_Acc1VNEeitkMFXBYQFcg" base_StructuralFeature="_Cw5usa5TEeKbRfTRicRZzQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S_MpsFVNEeitkMFXBYQFcg" base_Property="_Cwwkxa5TEeKbRfTRicRZzQ"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_S_MpsVVNEeitkMFXBYQFcg" base_StructuralFeature="_Cwwkxa5TEeKbRfTRicRZzQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S_MpslVNEeitkMFXBYQFcg" base_Property="_Cw5uua5TEeKbRfTRicRZzQ"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_S_Mps1VNEeitkMFXBYQFcg" base_StructuralFeature="_Cw5uua5TEeKbRfTRicRZzQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S_SwUFVNEeitkMFXBYQFcg" base_Property="_Cw5uva5TEeKbRfTRicRZzQ"/>
@@ -7610,8 +7601,6 @@ Frame delay variation is a measure of the variations in the frame delay between 
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_UhyBU1VOEeitkMFXBYQFcg" base_StructuralFeature="_RFsbQkKUEeGOU_Aog4a34g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Uh4H8FVOEeitkMFXBYQFcg" base_Property="_RFsbREKUEeGOU_Aog4a34g"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Uh4H8VVOEeitkMFXBYQFcg" base_StructuralFeature="_RFsbREKUEeGOU_Aog4a34g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F_W84FVSEeitkMFXBYQFcg" base_Property="_iWO58CFREeWxnoblgNdj6g"/>
-  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_F_W84VVSEeitkMFXBYQFcg" base_StructuralFeature="_iWO58CFREeWxnoblgNdj6g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F_W84lVSEeitkMFXBYQFcg" base_Property="_VRWTkFEEEd6VSrclB-Ybig"/>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_F_W841VSEeitkMFXBYQFcg" base_StructuralFeature="_VRWTkFEEEd6VSrclB-Ybig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_F_W85FVSEeitkMFXBYQFcg" base_Property="_VRWTkVEEEd6VSrclB-Ybig"/>
@@ -8533,4 +8522,8 @@ Frame delay variation is a measure of the variations in the frame delay between 
   </OpenModel_Profile_3:Specify>
   <OpenModel_Profile_3:OpenModelAttribute xmi:id="_50LVEGajEemNo6KemN3z2w" base_StructuralFeature="_50KG8GajEemNo6KemN3z2w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_50NKQGajEemNo6KemN3z2w" base_Property="_50KG8GajEemNo6KemN3z2w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_KfdUIGsZEembs75vhmFVVA" base_Property="_KfYboGsZEembs75vhmFVVA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_Kfd7MGsZEembs75vhmFVVA" base_StructuralFeature="_KfYboGsZEembs75vhmFVVA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_WPRxQGsZEembs75vhmFVVA" base_Property="_WPRKMGsZEembs75vhmFVVA"/>
+  <OpenModel_Profile_3:OpenModelAttribute xmi:id="_WPSYUGsZEembs75vhmFVVA" base_StructuralFeature="_WPRKMGsZEembs75vhmFVVA"/>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -10992,17 +10992,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_K3ZGVUqIEempws6eXu44Eg" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_K3ZGVkqIEempws6eXu44Eg" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_sGiYAGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_CGQ0IGuTEembs75vhmFVVA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_sGiYAWuTEembs75vhmFVVA"/>
+        <children xmi:type="notation:Shape" xmi:id="_nkx_QGvvEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_iKuKUGvvEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nkx_QWvvEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_sGi_EGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_aEY08EqIEempws6eXu44Eg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_sGi_EWuTEembs75vhmFVVA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_sGi_EmuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_fUVroEqIEempws6eXu44Eg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_sGi_E2uTEembs75vhmFVVA"/>
+        <children xmi:type="notation:Shape" xmi:id="_Hd7FoGvxEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_FoMTEGvxEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Hd7FoWvxEembs75vhmFVVA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_K3ZGV0qIEempws6eXu44Eg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_K3ZGWEqIEempws6eXu44Eg"/>
@@ -11016,7 +11012,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3ZGX0qIEempws6eXu44Eg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiOam.uml#_K3ZGUEqIEempws6eXu44Eg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3ZGUkqIEempws6eXu44Eg" x="860" y="460" height="107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3ZGUkqIEempws6eXu44Eg" x="540" y="460" width="281" height="81"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Y_CEgEqKEempws6eXu44Eg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_Y_CEgkqKEempws6eXu44Eg" type="Class_NameLabel"/>
@@ -11106,32 +11102,6 @@
       <element xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZA0NMUqKEempws6eXu44Eg" x="753" y="58" height="127"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_-_yi8EtHEemsleBFQ473Kg" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_-_zKAEtHEemsleBFQ473Kg" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_-_zKAUtHEemsleBFQ473Kg" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-_zxEEtHEemsleBFQ473Kg" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_-_0YIEtHEemsleBFQ473Kg" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_AcwQMEtIEemsleBFQ473Kg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_NckXANw0EeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AcwQMUtIEemsleBFQ473Kg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_AcxeUEtIEemsleBFQ473Kg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_Oy87INw0EeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AcxeUUtIEemsleBFQ473Kg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_AcxeUktIEemsleBFQ473Kg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiOam.uml#_V171sNw0EeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AcxeU0tIEemsleBFQ473Kg"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_-_0YIUtHEemsleBFQ473Kg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_-_0YIktHEemsleBFQ473Kg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_-_0YI0tHEemsleBFQ473Kg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-_0YJEtHEemsleBFQ473Kg"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiOam.uml#_GoZUgNw0EeaaobmDldrjOQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-_yi8UtHEemsleBFQ473Kg" x="843" y="208" height="91"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_Cf9eEEtIEemsleBFQ473Kg" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_Cf-FIEtIEemsleBFQ473Kg" type="Enumeration_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_Cf-FIUtIEemsleBFQ473Kg" type="Enumeration_FloatingNameLabel">
@@ -11198,17 +11168,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pLSfYktIEemsleBFQ473Kg" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_pLTGcEtIEemsleBFQ473Kg" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_joiQ8GuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_eRnsEGuSEembs75vhmFVVA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_joiQ8WuTEembs75vhmFVVA"/>
+        <children xmi:type="notation:Shape" xmi:id="_jLCF4GvxEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_NXmOwGvxEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jLCF4WvxEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_joktMGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_jLCs8GvxEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_VHvX4EtQEemsleBFQ473Kg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_joktMWuTEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jLCs8WvxEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_jolUQGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_jLDUAGvxEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_gPVRAEtIEemsleBFQ473Kg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jolUQWuTEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jLDUAWvxEembs75vhmFVVA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jLDUAmvxEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8Q4a4GvvEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jLDUA2vxEembs75vhmFVVA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jLDUBGvxEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_GZaxIGvwEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jLDUBWvxEembs75vhmFVVA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_pLTGcUtIEemsleBFQ473Kg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_pLTGcktIEemsleBFQ473Kg"/>
@@ -11222,7 +11200,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pLTGeUtIEemsleBFQ473Kg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiOam.uml#_YEFG0EtIEemsleBFQ473Kg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pLR4UUtIEemsleBFQ473Kg" x="864" y="336" height="105"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pLR4UUtIEemsleBFQ473Kg" x="840" y="360" height="125"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DI-FMEtQEemsleBFQ473Kg" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_DI-FMktQEemsleBFQ473Kg" type="Enumeration_NameLabel"/>
@@ -11260,7 +11238,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DI-FOUtQEemsleBFQ473Kg"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiOam.uml#_DI07QEtQEemsleBFQ473Kg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DI-FMUtQEemsleBFQ473Kg" x="1013" y="192" height="138"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DI-FMUtQEemsleBFQ473Kg" x="900" y="200" height="138"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_weSFoF1AEemG57ABxBTHSA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_weT60F1AEemG57ABxBTHSA" type="Class_NameLabel"/>
@@ -11396,6 +11374,34 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OEt8wmBnEemmf8tAu_V-ow" x="480" y="360"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yDT-MGvwEembs75vhmFVVA" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yDUlQGvwEembs75vhmFVVA" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yDUlQWvwEembs75vhmFVVA" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yDUlQmvwEembs75vhmFVVA" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yDVMUGvwEembs75vhmFVVA" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_6-kpAGvwEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_6-g-oGvwEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6-lQEGvwEembs75vhmFVVA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8yCKsGvwEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_8x-gUGvwEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8yCKsWvwEembs75vhmFVVA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yDVMUWvwEembs75vhmFVVA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yDVMUmvwEembs75vhmFVVA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yDVMU2vwEembs75vhmFVVA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yDVMVGvwEembs75vhmFVVA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yDVMVWvwEembs75vhmFVVA" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yDVMVmvwEembs75vhmFVVA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yDVMV2vwEembs75vhmFVVA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yDVMWGvwEembs75vhmFVVA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yDVMWWvwEembs75vhmFVVA"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiOam.uml#_yDEGkGvwEembs75vhmFVVA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yDT-MWvwEembs75vhmFVVA" x="860" y="500" width="261" height="81"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_G1BSgUqHEempws6eXu44Eg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_G1BSgkqHEempws6eXu44Eg"/>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -1248,6 +1248,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_baYg5WBoEemmf8tAu_V-ow" x="226" y="-187"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_wYVSQGtwEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_wYVSQWtwEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wYVSQ2twEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wYVSQmtwEembs75vhmFVVA" x="226" y="-187"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_dPf-21dMEeejsLaQeGcDdg"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJlFgIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -2398,6 +2406,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_baYg6WBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_baYg6mBoEemmf8tAu_V-ow"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_baYg62BoEemmf8tAu_V-ow"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_wYVSRGtwEembs75vhmFVVA" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_wYVSQGtwEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_wYVSRWtwEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_wYVSSWtwEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wYVSRmtwEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVSR2twEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVSSGtwEembs75vhmFVVA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_LeWqMHMLEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamDetails" measurementUnit="Pixel">
@@ -4635,6 +4653,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FvviQmZvEemNo6KemN3z2w" x="748" y="-471"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_3dJY0GtwEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3dJY0WtwEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3dJ_4GtwEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3dJY0mtwEembs75vhmFVVA" x="748" y="-471"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_LeXWvXMLEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OJ-HEIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -5828,6 +5854,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FwCdMmZvEemNo6KemN3z2w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FwCdM2ZvEemNo6KemN3z2w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FwCdNGZvEemNo6KemN3z2w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3dJ_4WtwEembs75vhmFVVA" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_3dJY0GtwEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3dJ_4mtwEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3dJ_5mtwEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3dJ_42twEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3dJ_5GtwEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3dJ_5WtwEembs75vhmFVVA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_QUOkQHMcEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamJobDetails" measurementUnit="Pixel">
@@ -7200,6 +7236,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K7JzkmblEemNo6KemN3z2w" x="300" y="47"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_DvFiAGtlEembs75vhmFVVA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DvFiAWtlEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvGJEGtlEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvFiAmtlEembs75vhmFVVA" x="300" y="47"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_QUOkQXMcEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_QUOkQnMcEeeSiaQ95-6r9w"/>
     <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_OKYWwIt6Eeiu6boZkiJHCA" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -8257,6 +8301,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K7KaomblEemNo6KemN3z2w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K7Kao2blEemNo6KemN3z2w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K7KapGblEemNo6KemN3z2w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DvGJEWtlEembs75vhmFVVA" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_DvFiAGtlEembs75vhmFVVA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DvGJEmtlEembs75vhmFVVA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DvGwImtlEembs75vhmFVVA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvGJE2tlEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvGwIGtlEembs75vhmFVVA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvGwIWtlEembs75vhmFVVA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_DvMJsINfEeelF8AE_WZtHQ" type="PapyrusUMLClassDiagram" name="OamConnSkeleton" measurementUnit="Pixel">
@@ -10938,21 +10992,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_K3ZGVUqIEempws6eXu44Eg" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_K3ZGVkqIEempws6eXu44Eg" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_qzmlkFoxEemu443YKSGnxQ" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_QgBiwEqIEempws6eXu44Eg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_qzmlkVoxEemu443YKSGnxQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_sGiYAGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_CGQ0IGuTEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sGiYAWuTEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_qzmlkloxEemu443YKSGnxQ" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_S6QnIFUpEemqz6oDgisDnw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_qzmlk1oxEemu443YKSGnxQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_qzmllFoxEemu443YKSGnxQ" type="Property_DataTypeAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_sGi_EGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_aEY08EqIEempws6eXu44Eg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_qzmllVoxEemu443YKSGnxQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sGi_EWuTEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_qzmllloxEemu443YKSGnxQ" type="Property_DataTypeAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_sGi_EmuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_fUVroEqIEempws6eXu44Eg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_qzmll1oxEemu443YKSGnxQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sGi_E2uTEembs75vhmFVVA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_K3ZGV0qIEempws6eXu44Eg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_K3ZGWEqIEempws6eXu44Eg"/>
@@ -10966,7 +11016,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3ZGX0qIEempws6eXu44Eg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiOam.uml#_K3ZGUEqIEempws6eXu44Eg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3ZGUkqIEempws6eXu44Eg" x="860" y="440" height="107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3ZGUkqIEempws6eXu44Eg" x="860" y="460" height="107"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Y_CEgEqKEempws6eXu44Eg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_Y_CEgkqKEempws6eXu44Eg" type="Class_NameLabel"/>
@@ -11148,17 +11198,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pLSfYktIEemsleBFQ473Kg" y="15"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_pLTGcEtIEemsleBFQ473Kg" type="DataType_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_C_NnsE1-EemSFtY4u6d2Cw" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_gPVRAEtIEemsleBFQ473Kg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C_NnsU1-EemSFtY4u6d2Cw"/>
+        <children xmi:type="notation:Shape" xmi:id="_joiQ8GuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_eRnsEGuSEembs75vhmFVVA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_joiQ8WuTEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C_Nnsk1-EemSFtY4u6d2Cw" type="Property_DataTypeAttributeLabel">
+        <children xmi:type="notation:Shape" xmi:id="_joktMGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
           <element xmi:type="uml:Property" href="TapiOam.uml#_VHvX4EtQEemsleBFQ473Kg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C_Nns01-EemSFtY4u6d2Cw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_joktMWuTEembs75vhmFVVA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_C_NntE1-EemSFtY4u6d2Cw" type="Property_DataTypeAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiOam.uml#_kk5jEEtIEemsleBFQ473Kg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_C_NntU1-EemSFtY4u6d2Cw"/>
+        <children xmi:type="notation:Shape" xmi:id="_jolUQGuTEembs75vhmFVVA" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiOam.uml#_gPVRAEtIEemsleBFQ473Kg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jolUQWuTEembs75vhmFVVA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_pLTGcUtIEemsleBFQ473Kg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_pLTGcktIEemsleBFQ473Kg"/>
@@ -11172,7 +11222,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pLTGeUtIEemsleBFQ473Kg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiOam.uml#_YEFG0EtIEemsleBFQ473Kg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pLR4UUtIEemsleBFQ473Kg" x="864" y="336" height="88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pLR4UUtIEemsleBFQ473Kg" x="864" y="336" height="105"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DI-FMEtQEemsleBFQ473Kg" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_DI-FMktQEemsleBFQ473Kg" type="Enumeration_NameLabel"/>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -782,18 +782,8 @@ Identification of the PM Session for which the TCA Function was configured.</bod
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_X3PdYEqHEempws6eXu44Eg" name="THRESHOLD_CROSSING_ALERT"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_GeBSUEqIEempws6eXu44Eg" name="AlarmConditionName"/>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_K3ZGUEqIEempws6eXu44Eg" name="PmParameter">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_lB_BgFUpEemqz6oDgisDnw" annotatedElement="_K3ZGUEqIEempws6eXu44Eg">
-          <body>MEF 35.1: For performance metrics that use Measurement Bins, thresholds are defined in terms of an Upper Bin Count (UBC). &#xD;
-The Upper Bin Count of bin k is the total of the counts for bins k and above, i.e. UBC(k) = count of bin (k) + count of bin (k+1) + ... + count of bin (n), where n is the last bin.&#xD;
-To configure a threshold, both the bin number, k, and the total count, N, need to be specified - this is represented as (N, k).  A threshold (N, k) is considered to have been crossed when UBC(k) >= N.</body>
-        </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_QgBiwEqIEempws6eXu44Eg" name="pmParameterName" type="_I86WoEqIEempws6eXu44Eg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_S6QnIFUpEemqz6oDgisDnw" name="pmParameterBinNumber">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pgJO4FUpEemqz6oDgisDnw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_phAxkFUpEemqz6oDgisDnw" value="1"/>
-        </ownedAttribute>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_K3ZGUEqIEempws6eXu44Eg" name="ThresholdSettings">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_CGQ0IGuTEembs75vhmFVVA" name="thresholdCrossingType" type="_GoZUgNw0EeaaobmDldrjOQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aEY08EqIEempws6eXu44Eg" name="pmParameterIntValue">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_auVw4EqIEempws6eXu44Eg"/>
@@ -805,9 +795,12 @@ To configure a threshold, both the bin number, k, and the total count, N, need t
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_I86WoEqIEempws6eXu44Eg" name="PmParameterName"/>
       <packagedElement xmi:type="uml:DataType" xmi:id="_YEFG0EtIEemsleBFQ473Kg" name="ThresholdParameter">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_gPVRAEtIEemsleBFQ473Kg" name="pmParameter" type="_K3ZGUEqIEempws6eXu44Eg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_eRnsEGuSEembs75vhmFVVA" name="pmParameterName" type="_I86WoEqIEempws6eXu44Eg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_VHvX4EtQEemsleBFQ473Kg" name="thresholdLocation" type="_DI07QEtQEemsleBFQ473Kg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_kk5jEEtIEemsleBFQ473Kg" name="thresholdCrossing" type="_GoZUgNw0EeaaobmDldrjOQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gPVRAEtIEemsleBFQ473Kg" name="pmParameter" type="_K3ZGUEqIEempws6eXu44Eg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_madmAGuTEembs75vhmFVVA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mapMMGuTEembs75vhmFVVA" value="2"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_DI07QEtQEemsleBFQ473Kg" name="ThresholdCrossingQualifier" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_QpLroEuBEemIp5Bbs_BvnQ" name="NOT_APPLICABLE"/>
@@ -1141,8 +1134,6 @@ To configure a threshold, both the bin number, k, and the total count, N, need t
   <OpenModel_Profile:Specify xmi:id="_yVKGoEqHEempws6eXu44Eg" base_Abstraction="_vhuVsEqHEempws6eXu44Eg">
     <target>/TapiCommon:Context:_context/TapiNotification:NotificationContext:_notificationContext/TapiNotification:NotificationContext:_notification</target>
   </OpenModel_Profile:Specify>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_QgBiwUqIEempws6eXu44Eg" base_Property="_QgBiwEqIEempws6eXu44Eg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_QgBiwkqIEempws6eXu44Eg" base_StructuralFeature="_QgBiwEqIEempws6eXu44Eg" partOfObjectKey="1"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_aEY08UqIEempws6eXu44Eg" base_Property="_aEY08EqIEempws6eXu44Eg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_aEY08kqIEempws6eXu44Eg" base_StructuralFeature="_aEY08EqIEempws6eXu44Eg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_fUVroUqIEempws6eXu44Eg" base_Property="_fUVroEqIEempws6eXu44Eg"/>
@@ -1151,8 +1142,6 @@ To configure a threshold, both the bin number, k, and the total count, N, need t
   <OpenModel_Profile:OpenModelAttribute xmi:id="_z8meMkqKEempws6eXu44Eg" base_StructuralFeature="_z8meMEqKEempws6eXu44Eg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gPV4EEtIEemsleBFQ473Kg" base_Property="_gPVRAEtIEemsleBFQ473Kg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_gPWfIEtIEemsleBFQ473Kg" base_StructuralFeature="_gPVRAEtIEemsleBFQ473Kg" partOfObjectKey="1"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_kk5jEUtIEemsleBFQ473Kg" base_Property="_kk5jEEtIEemsleBFQ473Kg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_kk6KIEtIEemsleBFQ473Kg" base_StructuralFeature="_kk5jEEtIEemsleBFQ473Kg" partOfObjectKey="3"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_VHvX4UtQEemsleBFQ473Kg" base_Property="_VHvX4EtQEemsleBFQ473Kg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_VHvX4ktQEemsleBFQ473Kg" base_StructuralFeature="_VHvX4EtQEemsleBFQ473Kg" partOfObjectKey="2"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gN2wsUtQEemsleBFQ473Kg" base_Property="_gN2wsEtQEemsleBFQ473Kg"/>
@@ -1175,8 +1164,6 @@ To configure a threshold, both the bin number, k, and the total count, N, need t
   <OpenModel_Profile:OpenModelAttribute xmi:id="_cdHbMJAdEei1rofSed2vtg" base_StructuralFeature="_cdDw0JAdEei1rofSed2vtg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_9VXqoJAdEei1rofSed2vtg" base_Property="_9VXDkJAdEei1rofSed2vtg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_9VXqoZAdEei1rofSed2vtg" base_StructuralFeature="_9VXDkJAdEei1rofSed2vtg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_S6R1QFUpEemqz6oDgisDnw" base_StructuralFeature="_S6QnIFUpEemqz6oDgisDnw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S6TqcFUpEemqz6oDgisDnw" base_Property="_S6QnIFUpEemqz6oDgisDnw"/>
   <OpenModel_Profile:Specify xmi:id="_lztZkFowEemu443YKSGnxQ" base_Abstraction="_iq_VIFowEemu443YKSGnxQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_5bX8cF1AEemG57ABxBTHSA" base_StructuralFeature="_5bXVYF1AEemG57ABxBTHSA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5bYjgF1AEemG57ABxBTHSA" base_Property="_5bXVYF1AEemG57ABxBTHSA"/>
@@ -1188,4 +1175,8 @@ To configure a threshold, both the bin number, k, and the total count, N, need t
   <OpenModel_Profile:Specify xmi:id="_8NilQF1EEemG57ABxBTHSA" base_Abstraction="_6TdeMF1EEemG57ABxBTHSA">
     <target>/TapiNotification::GetNotificationList/TapiNotification::output/TapiNotification::notification</target>
   </OpenModel_Profile:Specify>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_eRphQGuSEembs75vhmFVVA" base_Property="_eRnsEGuSEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eRqIUGuSEembs75vhmFVVA" base_StructuralFeature="_eRnsEGuSEembs75vhmFVVA" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_CGQ0IWuTEembs75vhmFVVA" base_Property="_CGQ0IGuTEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_CGRbMGuTEembs75vhmFVVA" base_StructuralFeature="_CGQ0IGuTEembs75vhmFVVA" partOfObjectKey="3"/>
 </xmi:XMI>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -753,14 +753,19 @@ Identification of the PM Session for which the TCA Function was configured.</bod
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_5b7WEF1AEemG57ABxBTHSA" name="tcainfo" type="_MQft0CCCEeeWCKlkirNtnw" association="_5V4YcF1AEemG57ABxBTHSA"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_yDEGkGvwEembs75vhmFVVA" name="PmParameterValue">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6-g-oGvwEembs75vhmFVVA" name="pmParameterIntValue">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6-g-oWvwEembs75vhmFVVA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8x-gUGvwEembs75vhmFVVA" name="pmParameterRealValue">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8x-gUWvwEembs75vhmFVVA"/>
+        </ownedAttribute>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_pdh3cF3eEeit4-HSxnZlvw" name="TypeDefinitions">
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_tqiDYF3eEeit4-HSxnZlvw" name="OamJobType"/>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_GoZUgNw0EeaaobmDldrjOQ" name="ThresholdCrossingType" isLeaf="true">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_NckXANw0EeaaobmDldrjOQ" name="THRESHOLD_ABOVE"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Oy87INw0EeaaobmDldrjOQ" name="THRESHOLD_BELOW"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_V171sNw0EeaaobmDldrjOQ" name="CLEARED"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_YE76AJAdEei1rofSed2vtg" name="PerceivedTcaSeverity" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YE76AZAdEei1rofSed2vtg" name="WARNING"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YE76ApAdEei1rofSed2vtg" name="CLEAR"/>
@@ -782,24 +787,25 @@ Identification of the PM Session for which the TCA Function was configured.</bod
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_X3PdYEqHEempws6eXu44Eg" name="THRESHOLD_CROSSING_ALERT"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_GeBSUEqIEempws6eXu44Eg" name="AlarmConditionName"/>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_K3ZGUEqIEempws6eXu44Eg" name="ThresholdSettings">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_CGQ0IGuTEembs75vhmFVVA" name="thresholdCrossingType" type="_GoZUgNw0EeaaobmDldrjOQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_aEY08EqIEempws6eXu44Eg" name="pmParameterIntValue">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_auVw4EqIEempws6eXu44Eg"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_fUVroEqIEempws6eXu44Eg" name="pmParameterRealValue">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kQW5sEqIEempws6eXu44Eg"/>
-        </ownedAttribute>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_K3ZGUEqIEempws6eXu44Eg" name="PmParameter">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iKuKUGvvEembs75vhmFVVA" name="pmParameterName" type="_I86WoEqIEempws6eXu44Eg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FoMTEGvxEembs75vhmFVVA" name="pmParameterValue" type="_yDEGkGvwEembs75vhmFVVA"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_I86WoEqIEempws6eXu44Eg" name="PmParameterName"/>
       <packagedElement xmi:type="uml:DataType" xmi:id="_YEFG0EtIEemsleBFQ473Kg" name="ThresholdParameter">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_eRnsEGuSEembs75vhmFVVA" name="pmParameterName" type="_I86WoEqIEempws6eXu44Eg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NXmOwGvxEembs75vhmFVVA" name="pmParameterName" type="_I86WoEqIEempws6eXu44Eg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_VHvX4EtQEemsleBFQ473Kg" name="thresholdLocation" type="_DI07QEtQEemsleBFQ473Kg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_gPVRAEtIEemsleBFQ473Kg" name="pmParameter" type="_K3ZGUEqIEempws6eXu44Eg">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_madmAGuTEembs75vhmFVVA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mapMMGuTEembs75vhmFVVA" value="2"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gPVRAEtIEemsleBFQ473Kg" name="pmParameterAboveThrs" type="_yDEGkGvwEembs75vhmFVVA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_madmAGuTEembs75vhmFVVA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mapMMGuTEembs75vhmFVVA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8Q4a4GvvEembs75vhmFVVA" name="pmParameterBelowThrs" type="_yDEGkGvwEembs75vhmFVVA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8Q4a4WvvEembs75vhmFVVA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8Q4a4mvvEembs75vhmFVVA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GZaxIGvwEembs75vhmFVVA" name="pmParameterClearThrs" type="_yDEGkGvwEembs75vhmFVVA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GZaxIWvwEembs75vhmFVVA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GZaxImvwEembs75vhmFVVA" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_DI07QEtQEemsleBFQ473Kg" name="ThresholdCrossingQualifier" isLeaf="true">
@@ -1134,10 +1140,6 @@ Identification of the PM Session for which the TCA Function was configured.</bod
   <OpenModel_Profile:Specify xmi:id="_yVKGoEqHEempws6eXu44Eg" base_Abstraction="_vhuVsEqHEempws6eXu44Eg">
     <target>/TapiCommon:Context:_context/TapiNotification:NotificationContext:_notificationContext/TapiNotification:NotificationContext:_notification</target>
   </OpenModel_Profile:Specify>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_aEY08UqIEempws6eXu44Eg" base_Property="_aEY08EqIEempws6eXu44Eg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_aEY08kqIEempws6eXu44Eg" base_StructuralFeature="_aEY08EqIEempws6eXu44Eg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_fUVroUqIEempws6eXu44Eg" base_Property="_fUVroEqIEempws6eXu44Eg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_fUfcoEqIEempws6eXu44Eg" base_StructuralFeature="_fUVroEqIEempws6eXu44Eg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_z8meMUqKEempws6eXu44Eg" base_Property="_z8meMEqKEempws6eXu44Eg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_z8meMkqKEempws6eXu44Eg" base_StructuralFeature="_z8meMEqKEempws6eXu44Eg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_gPV4EEtIEemsleBFQ473Kg" base_Property="_gPVRAEtIEemsleBFQ473Kg"/>
@@ -1175,8 +1177,18 @@ Identification of the PM Session for which the TCA Function was configured.</bod
   <OpenModel_Profile:Specify xmi:id="_8NilQF1EEemG57ABxBTHSA" base_Abstraction="_6TdeMF1EEemG57ABxBTHSA">
     <target>/TapiNotification::GetNotificationList/TapiNotification::output/TapiNotification::notification</target>
   </OpenModel_Profile:Specify>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_eRphQGuSEembs75vhmFVVA" base_Property="_eRnsEGuSEembs75vhmFVVA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_eRqIUGuSEembs75vhmFVVA" base_StructuralFeature="_eRnsEGuSEembs75vhmFVVA" partOfObjectKey="1"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_CGQ0IWuTEembs75vhmFVVA" base_Property="_CGQ0IGuTEembs75vhmFVVA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_CGRbMGuTEembs75vhmFVVA" base_StructuralFeature="_CGQ0IGuTEembs75vhmFVVA" partOfObjectKey="3"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_iKv_gGvvEembs75vhmFVVA" base_Property="_iKuKUGvvEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iKwmkGvvEembs75vhmFVVA" base_StructuralFeature="_iKuKUGvvEembs75vhmFVVA" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8Q5B8GvvEembs75vhmFVVA" base_Property="_8Q4a4GvvEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8Q5B8WvvEembs75vhmFVVA" base_StructuralFeature="_8Q4a4GvvEembs75vhmFVVA" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_GZbYMGvwEembs75vhmFVVA" base_Property="_GZaxIGvwEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GZbYMWvwEembs75vhmFVVA" base_StructuralFeature="_GZaxIGvwEembs75vhmFVVA" partOfObjectKey="1"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6-g-omvwEembs75vhmFVVA" base_Property="_6-g-oGvwEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6-hlsGvwEembs75vhmFVVA" base_StructuralFeature="_6-g-oGvwEembs75vhmFVVA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_8x-gUmvwEembs75vhmFVVA" base_Property="_8x-gUGvwEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8x-gU2vwEembs75vhmFVVA" base_StructuralFeature="_8x-gUGvwEembs75vhmFVVA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_FoMTEWvxEembs75vhmFVVA" base_Property="_FoMTEGvxEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FoM6IGvxEembs75vhmFVVA" base_StructuralFeature="_FoMTEGvxEembs75vhmFVVA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NXm10GvxEembs75vhmFVVA" base_Property="_NXmOwGvxEembs75vhmFVVA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NXm10WvxEembs75vhmFVVA" base_StructuralFeature="_NXmOwGvxEembs75vhmFVVA" partOfObjectKey="1"/>
 </xmi:XMI>


### PR DESCRIPTION
TAPI Eth: isCcEnabled and ccPeriod moved from EthMepCommon to
EthMegCommon.
TAPI Eth: removed dm1Priority of EthMepSink.
TAPI OAM: moved pmParameterName from PmParameter type to
ThresholdParameter type. Renamed PmParameterType as ThresholdSettings
type, [1..2]. Moved thresholdCrossing to ThresholdSettings type, and
renamed as thresholdCrossingType. Removed pmParameterBinNumber.