### PR TITLE
Replaced TopologyConstraint pointers from references/leafref to UUID

### DIFF
--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -1010,149 +1010,149 @@
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-305" y="-246" width="321" height="141"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6qFvYFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6qFvYVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6qFvY1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WM5iYHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WM5iYXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WM5iY3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6qFvYlosEemu443YKSGnxQ" x="422" y="40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WM5iYnvSEemvrvzs5PR02w" x="422" y="40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6q-gM1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6q-gNFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6q-gNlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WN_ukHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WN_ukXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WN_uk3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6q-gNVosEemu443YKSGnxQ" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WN_uknvSEemvrvzs5PR02w" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6q-gRFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6q-gRVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6q-gR1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WOHDUHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WOHDUXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOHDU3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6q-gRlosEemu443YKSGnxQ" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WOHDUnvSEemvrvzs5PR02w" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6rIRN1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6rIROFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6rIROlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WONxAHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WONxAXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WONxA3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6rIROVosEemu443YKSGnxQ" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WONxAnvSEemvrvzs5PR02w" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6rRbIFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6rRbIVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6rRbI1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WOUesHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WOUesXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOUes3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6rRbIlosEemu443YKSGnxQ" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WOUesnvSEemvrvzs5PR02w" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6ruHEFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6ruHEVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6ruHE1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WOalUHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WOalUXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOalU3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ruHElosEemu443YKSGnxQ" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WOalUnvSEemvrvzs5PR02w" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6r34EFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6r34EVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6r34E1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WOhTAHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WOhTAXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOhTA3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6r34ElosEemu443YKSGnxQ" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WOhTAnvSEemvrvzs5PR02w" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6sKzAFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6sKzAVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6sKzA1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WO_0IHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WO_0IXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WO_0I3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6sKzAlosEemu443YKSGnxQ" x="408" y="-216"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WO_0InvSEemvrvzs5PR02w" x="409" y="-246"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6s6Z51osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6s6Z6FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6s6Z6losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WP5MAHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WP5MAXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WP5zEHvSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6s6Z6VosEemu443YKSGnxQ" x="919" y="230"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WP5MAnvSEemvrvzs5PR02w" x="919" y="230"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6tzx0VosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6tzx0losEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6tzx1FosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WQ0ZEHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WQ0ZEXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WQ0ZE3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6tzx01osEemu443YKSGnxQ" x="919" y="130"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WQ0ZEnvSEemvrvzs5PR02w" x="919" y="130"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6t87t1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6t87uFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6t87ulosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WQ6fsHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WQ6fsXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WQ6fs3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6t87uVosEemu443YKSGnxQ" x="919" y="130"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WQ6fsnvSEemvrvzs5PR02w" x="919" y="130"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6uP2p1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6uP2qFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6uP2qlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WRPP0HvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WRPP0XvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WRPP03vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6uP2qVosEemu443YKSGnxQ" x="918" y="13"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WRPP0nvSEemvrvzs5PR02w" x="918" y="13"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6u2Tl1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6u2TmFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6u2TmlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WR4wEHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WR4wEXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WR4wE3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6u2TmVosEemu443YKSGnxQ" x="347" y="315"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WR4wEnvSEemvrvzs5PR02w" x="347" y="315"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6wVhV1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6wVhWFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6wVhWlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WTMXoHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WTMXoXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WTMXo3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6wVhWVosEemu443YKSGnxQ" x="-100" y="-456"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WTMXonvSEemvrvzs5PR02w" x="-100" y="-456"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6w7XMFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6w7XMVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6w7XM1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WT47MHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WT47MXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WT5iQHvSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6w7XMlosEemu443YKSGnxQ" x="-142" y="182"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WT47MnvSEemvrvzs5PR02w" x="-142" y="182"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6x0vF1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6x0vGFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6x0vGlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WVEm8HvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WVEm8XvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WVEm83vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6x0vGVosEemu443YKSGnxQ" x="-147" y="-88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WVEm8nvSEemvrvzs5PR02w" x="-147" y="-88"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6zwow1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6zwoxFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6zwoxlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WWhYcHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WWhYcXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WWhYc3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6zwoxVosEemu443YKSGnxQ" x="915" y="-280"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WWhYcnvSEemvrvzs5PR02w" x="915" y="-280"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_61GFgFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_61GFgVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61GFg1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_WX3cQHvSEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WX3cQXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WX3cQ3vSEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_61GFglosEemu443YKSGnxQ" x="-105" y="-246"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WX3cQnvSEemvrvzs5PR02w" x="-105" y="-246"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmgeMTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmgeMjBFEeam35bpdXJzEw"/>
@@ -1654,186 +1654,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AIFfEAN7EemABdf1yJ9dlA" id="(0.0,0.9146341463414634)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AIFfEQN7EemABdf1yJ9dlA" id="(0.17491749174917492,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6qFvZFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_0G9yhzBFEeam35bpdXJzEw" target="_6qFvYFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6qFvZVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6qFvaVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6qFvZlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6qFvZ1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6qFvaFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6q-gN1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lT2KsIuQEeiu6boZkiJHCA" target="_6q-gM1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6q-gOFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6q-gPFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6q-gOVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6q-gOlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6q-gO1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6q-gSFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_3JCDkIuQEeiu6boZkiJHCA" target="_6q-gRFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6q-gSVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6q-gTVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6q-gSlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6q-gS1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6q-gTFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6rIRO1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_8oadYIuQEeiu6boZkiJHCA" target="_6rIRN1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6rIRPFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6rIRQFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6rIRPVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6rIRPlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6rIRP1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6rRbJFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_DM_ksIuREeiu6boZkiJHCA" target="_6rRbIFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6rRbJVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6rRbKVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6rRbJlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6rRbJ1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6rRbKFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6ruHFFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_G3oqcIuREeiu6boZkiJHCA" target="_6ruHEFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6ruHFVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6ruHGVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6ruHFlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ruHF1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ruHGFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6r34FFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_W6DjoK1bEeiIjuV0HZnJAQ" target="_6r34EFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6r34FVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6r34GVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6r34FlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6r34F1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6r34GFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6sKzBFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_0G91jDBFEeam35bpdXJzEw" target="_6sKzAFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6sKzBVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6sKzCVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6sKzBlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6sKzB1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6sKzCFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6s6Z61osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_0HHioDBFEeam35bpdXJzEw" target="_6s6Z51osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6s6Z7FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6s6Z8FosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6s6Z7VosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6s6Z7losEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6s6Z71osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6tzx1VosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_S_bisIuREeiu6boZkiJHCA" target="_6tzx0VosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6tzx1losEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6tzx2losEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6tzx11osEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6tzx2FosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6tzx2VosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6t87u1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_ZFXmMIuREeiu6boZkiJHCA" target="_6t87t1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6t87vFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6t87wFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6t87vVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6t87vlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6t87v1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6uP2q1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_0HHjqDBFEeam35bpdXJzEw" target="_6uP2p1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6uP2rFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6uP2sFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6uP2rVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6uP2rlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6uP2r1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6u2Tm1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_0HHlMDBFEeam35bpdXJzEw" target="_6u2Tl1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6u2TnFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6u2ToFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6u2TnVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6u2TnlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6u2Tn1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6wVhW1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_rwI9oPlIEeaQEoLj_Ia_cg" target="_6wVhV1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6wVhXFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6wVhYFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6wVhXVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6wVhXlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6wVhX1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6w7XNFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BDPgIP4xEea_VPdGG2-szQ" target="_6w7XMFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6w7XNVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6w7XOVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6w7XNlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6w7XN1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6w7XOFosEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6x0vG1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="__Y_BEIfVEeeirpBaj87qAw" target="_6x0vF1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6x0vHFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6x0vIFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6x0vHVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6x0vHlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6x0vH1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6zwox1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_6zwow1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6zwoyFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6zwozFosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6zwoyVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zwoylosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zwoy1osEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_61GFhFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="__j-OAK1aEeiIjuV0HZnJAQ" target="_61GFgFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_61GFhVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_61GFiVosEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_61GFhlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61GFh1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_61GFiFosEemu443YKSGnxQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IWdYwFotEemu443YKSGnxQ" type="InterfaceRealization_Edge" source="_0G9yhzBFEeam35bpdXJzEw" target="_rwI9oPlIEeaQEoLj_Ia_cg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_IWdYw1otEemu443YKSGnxQ" type="InterfaceRealization_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_KZj48FotEemu443YKSGnxQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1848,6 +1668,186 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IWdYwlotEemu443YKSGnxQ" points="[520, 126, -643984, -643984]$[608, 126, -643984, -643984]$[608, -301, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IiEy4FotEemu443YKSGnxQ" id="(1.0,0.4207920792079208)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IiEy4VotEemu443YKSGnxQ" id="(0.4418491484184915,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WM5iZHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_0G9yhzBFEeam35bpdXJzEw" target="_WM5iYHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WM5iZXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WM5iaXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WM5iZnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WM5iZ3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WM5iaHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WOAVoHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_lT2KsIuQEeiu6boZkiJHCA" target="_WN_ukHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WOAVoXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOAVpXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WOAVonvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOAVo3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOAVpHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WOHDVHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_3JCDkIuQEeiu6boZkiJHCA" target="_WOHDUHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WOHDVXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOHDWXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WOHDVnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOHDV3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOHDWHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WONxBHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_8oadYIuQEeiu6boZkiJHCA" target="_WONxAHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WONxBXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WONxCXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WONxBnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WONxB3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WONxCHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WOUetHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_DM_ksIuREeiu6boZkiJHCA" target="_WOUesHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WOUetXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOUeuXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WOUetnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOUet3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOUeuHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WOalVHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_G3oqcIuREeiu6boZkiJHCA" target="_WOalUHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WOalVXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOalWXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WOalVnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOalV3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOalWHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WOhTBHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_W6DjoK1bEeiIjuV0HZnJAQ" target="_WOhTAHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WOhTBXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WOhTCXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WOhTBnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOhTB3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WOhTCHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WO_0JHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_0G91jDBFEeam35bpdXJzEw" target="_WO_0IHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WO_0JXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WO_0KXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WO_0JnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WO_0J3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WO_0KHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WP5zEXvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_0HHioDBFEeam35bpdXJzEw" target="_WP5MAHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WP5zEnvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WP5zFnvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WP5zE3vSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WP5zFHvSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WP5zFXvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WQ0ZFHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_S_bisIuREeiu6boZkiJHCA" target="_WQ0ZEHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WQ0ZFXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WQ0ZGXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WQ0ZFnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WQ0ZF3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WQ0ZGHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WQ6ftHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_ZFXmMIuREeiu6boZkiJHCA" target="_WQ6fsHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WQ6ftXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WQ6fuXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WQ6ftnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WQ6ft3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WQ6fuHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WRPP1HvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_0HHjqDBFEeam35bpdXJzEw" target="_WRPP0HvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WRPP1XvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WRPP2XvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WRPP1nvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WRPP13vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WRPP2HvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WR4wFHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_0HHlMDBFEeam35bpdXJzEw" target="_WR4wEHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WR4wFXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WR4wGXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WR4wFnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WR4wF3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WR4wGHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WTM-sHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_rwI9oPlIEeaQEoLj_Ia_cg" target="_WTMXoHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WTM-sXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WTM-tXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WTM-snvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WTM-s3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WTM-tHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WT5iQXvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BDPgIP4xEea_VPdGG2-szQ" target="_WT47MHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WT5iQnvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WT5iRnvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WT5iQ3vSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WT5iRHvSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WT5iRXvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WVEm9HvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="__Y_BEIfVEeeirpBaj87qAw" target="_WVEm8HvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WVEm9XvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WVEm-XvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WVEm9nvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WVEm93vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WVEm-HvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WWhYdHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_WWhYcHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WWhYdXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WWhYeXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WWhYdnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WWhYd3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WWhYeHvSEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WX3cRHvSEemvrvzs5PR02w" type="StereotypeCommentLink" source="__j-OAK1aEeiIjuV0HZnJAQ" target="_WX3cQHvSEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WX3cRXvSEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WX3cSXvSEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WX3cRnvSEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WX3cR3vSEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WX3cSHvSEemvrvzs5PR02w"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityTopologySkeleton" measurementUnit="Pixel">
@@ -2057,7 +2057,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3OjBGEeam35bpdXJzEw" y="5"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU3aDBGEeam35bpdXJzEw" x="843" y="82" width="167" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU3aDBGEeam35bpdXJzEw" x="819" y="82" width="215" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU3yjBGEeam35bpdXJzEw" type="Constraint_PackagedElementShape">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3yzBGEeam35bpdXJzEw" type="Constraint_NameLabel"/>
@@ -2575,237 +2575,237 @@
       <element xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YdyUaLTEeeG6K0eZHmVww" x="834" y="-253" width="206" height="64"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5JPAp1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5JPAqFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5JPAqlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_etxDU3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_etxDVHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_etxDVnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5JPAqVosEemu443YKSGnxQ" x="78" y="-3"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_etxDVXvqEemvrvzs5PR02w" x="78" y="-3"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5JYKn1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5JYKoFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5JYKolosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_et6NT3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_et6NUHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_et6NUnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5JYKoVosEemu443YKSGnxQ" x="78" y="-103"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_et6NUXvqEemvrvzs5PR02w" x="78" y="-103"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5Jh7l1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5Jh7mFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5Jh7mlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_euD-Q3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_euD-RHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_euD-RnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5Jh7mVosEemu443YKSGnxQ" x="78" y="-103"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_euD-RXvqEemvrvzs5PR02w" x="78" y="-103"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5J02h1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5J02iFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5J02ilosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_euW5M3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_euW5NHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_euW5NnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5J02iVosEemu443YKSGnxQ" x="443" y="1"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_euW5NXvqEemvrvzs5PR02w" x="443" y="1"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5KHxcFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5KHxcVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5KHxc1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eugqN3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eugqOHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eugqOnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KHxclosEemu443YKSGnxQ" x="443" y="-99"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eugqOXvqEemvrvzs5PR02w" x="443" y="-99"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5KHxgVosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5KHxglosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5KHxhFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eup0J3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eup0KHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eup0KnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KHxg1osEemu443YKSGnxQ" x="443" y="-99"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eup0KXvqEemvrvzs5PR02w" x="443" y="-99"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5KkdYFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5KkdYVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5KkdY1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ewJB53vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ewJB6HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewJB6nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KkdYlosEemu443YKSGnxQ" x="41" y="288"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ewJB6XvqEemvrvzs5PR02w" x="41" y="288"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5LBJUFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5LBJUVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5LBJU1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ewlt13vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ewlt2HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewlt2nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5LBJUlosEemu443YKSGnxQ" x="1041" y="278"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ewlt2XvqEemvrvzs5PR02w" x="1041" y="278"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5Ld1QFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5Ld1QVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5Ld1Q1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_exCZx3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_exCZyHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exLjsHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5Ld1QlosEemu443YKSGnxQ" x="358" y="284"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_exCZyXvqEemvrvzs5PR02w" x="358" y="284"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5MDrI1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5MDrJFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5MDrJlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_exoPq3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_exoPrHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exoPrnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5MDrJVosEemu443YKSGnxQ" x="403" y="169"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_exoPrXvqEemvrvzs5PR02w" x="403" y="169"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5MWmF1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5MWmGFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5MWmGlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eyE7k3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eyE7lHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eyE7lnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5MWmGVosEemu443YKSGnxQ" x="738" y="428"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eyE7lXvqEemvrvzs5PR02w" x="738" y="428"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5MzSA1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5MzSBFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5MzSBlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eyhngHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eyhngXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eyhng3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5MzSBVosEemu443YKSGnxQ" x="1043" y="82"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eyhngnvqEemvrvzs5PR02w" x="1019" y="82"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5M9DB1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5M9DCFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5M9DClosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eyqxc3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eyqxdHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eyqxdnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5M9DCVosEemu443YKSGnxQ" x="1043" y="-18"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eyqxdXvqEemvrvzs5PR02w" x="1019" y="-18"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5NP981osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5NP99FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5NP99losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ey0icHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ey0icXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ey0ic3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5NP99VosEemu443YKSGnxQ" x="1043" y="-18"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ey0icnvqEemvrvzs5PR02w" x="1019" y="-18"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5N_k01osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5N_k1FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5N_k1losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ezHdYHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ezHdYXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezHdY3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5N_k1VosEemu443YKSGnxQ" x="213" y="-246"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ezHdYnvqEemvrvzs5PR02w" x="213" y="-246"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5OJV31osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5OJV4FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OJV4losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ezROZ3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ezROaHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezROanvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5OJV4VosEemu443YKSGnxQ" x="213" y="-346"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ezROaXvqEemvrvzs5PR02w" x="213" y="-346"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5OSfyVosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5OSfylosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OSfzFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ezaYWXvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ezaYWnvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezaYXHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5OSfy1osEemu443YKSGnxQ" x="213" y="-346"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ezaYW3vqEemvrvzs5PR02w" x="213" y="-346"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5OcQwFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5OcQwVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OcQw1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ezkJUHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ezkJUXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezkJU3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5OcQwlosEemu443YKSGnxQ" x="213" y="-346"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ezkJUnvqEemvrvzs5PR02w" x="213" y="-346"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5OvLsFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5OvLsVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OvLs1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ez3EQ3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ez3ERHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ez3ERnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5OvLslosEemu443YKSGnxQ" x="818" y="78"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ez3ERXvqEemvrvzs5PR02w" x="818" y="78"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5PCGp1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5PCGqFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5PCGqlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e0mrIHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e0mrIXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e0mrI3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5PCGqVosEemu443YKSGnxQ" x="1037" y="-92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e0mrInvqEemvrvzs5PR02w" x="1037" y="-92"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5P7egFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5P7egVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5P7eg1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e0wcJ3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e0wcKHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e0wcKnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5P7eglosEemu443YKSGnxQ" x="1037" y="-192"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e0wcKXvqEemvrvzs5PR02w" x="1037" y="-192"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5QEoc1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5QEodFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5QEodlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e05mF3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e05mGHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e05mGnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5QEodVosEemu443YKSGnxQ" x="1037" y="-192"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e05mGXvqEemvrvzs5PR02w" x="1037" y="-192"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5QrFY1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5QrFZFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5QrFZlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e1gDA3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e1gDBHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e1gDBnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5QrFZVosEemu443YKSGnxQ" x="749" y="-249"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e1gDBXvqEemvrvzs5PR02w" x="749" y="-249"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5RHxW1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5RHxXFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RHxXlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e2F443vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e2F45HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2F45nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_1ZroEHIYEeeSiaQ95-6r9w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5RHxXVosEemu443YKSGnxQ" x="771" y="290"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e2F45XvqEemvrvzs5PR02w" x="771" y="290"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5RasQFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5RasQVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RasQ1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e2Pp53vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e2Pp6HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2Pp6nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_XDNjcHIZEeeSiaQ95-6r9w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5RasQlosEemu443YKSGnxQ" x="771" y="190"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e2Pp6XvqEemvrvzs5PR02w" x="771" y="190"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5RasU1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5RasVFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RasVlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e2Yz0HvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e2Yz0XvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2Yz03vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#__jfwsHIYEeeSiaQ95-6r9w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5RasVVosEemu443YKSGnxQ" x="771" y="190"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e2Yz0nvqEemvrvzs5PR02w" x="771" y="190"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5RtnN1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5RtnOFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RtnOlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e2sV03vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e2sV1HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2sV1nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5RtnOVosEemu443YKSGnxQ" x="1034" y="-253"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e2sV1XvqEemvrvzs5PR02w" x="1034" y="-253"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5SAiIFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5SAiIVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5SAiI1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e21fx3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e21fyHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e21fynvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5SAiIlosEemu443YKSGnxQ" x="1034" y="-353"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e21fyXvqEemvrvzs5PR02w" x="1034" y="-353"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_5SAiM1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_5SAiNFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5SAiNlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_e2_Qw3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e2_QxHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2_QxnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5SAiNVosEemu443YKSGnxQ" x="1034" y="-353"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e2_QxXvqEemvrvzs5PR02w" x="1034" y="-353"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9y8uwTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9y8uwjBFEeam35bpdXJzEw"/>
@@ -3249,7 +3249,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_unw4AYuOEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_unw4AouOEeiu6boZkiJHCA" points="[990, 82, -643984, -643984]$[990, -33, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vgM74IuOEeiu6boZkiJHCA" id="(0.874251497005988,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vgM74IuOEeiu6boZkiJHCA" id="(0.7906976744186046,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vgNi8IuOEeiu6boZkiJHCA" id="(0.8216216216216217,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_yv1goIuOEeiu6boZkiJHCA" type="Association_Edge" source="_6_LyABMjEee0L_IMWjydgQ" target="_BlU3KDBGEeam35bpdXJzEw" routing="Rectilinear">
@@ -3271,17 +3271,17 @@
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_yv2HtIuOEeiu6boZkiJHCA" type="Association_SourceMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2MhBgKFIEeiKJbr6a5Jjpg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_yv2HtYuOEeiu6boZkiJHCA" x="11" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yv2HtYuOEeiu6boZkiJHCA" x="9" y="-13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_yv2HtouOEeiu6boZkiJHCA" type="Association_TargetMultiplicityLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_2PHCgKFIEeiKJbr6a5Jjpg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_yv2Ht4uOEeiu6boZkiJHCA" x="-6" y="16"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yv2Ht4uOEeiu6boZkiJHCA" x="-9" y="-10"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_yv1goYuOEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yv1goouOEeiu6boZkiJHCA" points="[870, -33, -643984, -643984]$[870, 82, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0xJ4IIuOEeiu6boZkiJHCA" id="(0.1783783783783784,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z74dAIuOEeiu6boZkiJHCA" id="(0.16167664670658682,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yv1goouOEeiu6boZkiJHCA" points="[881, -33, -643984, -643984]$[881, 82, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0xJ4IIuOEeiu6boZkiJHCA" id="(0.24324324324324326,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z74dAIuOEeiu6boZkiJHCA" id="(0.2930232558139535,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_4u1OoIuOEeiu6boZkiJHCA" type="Association_Edge" source="_6_LyABMjEee0L_IMWjydgQ" target="_luMgoBMjEee0L_IMWjydgQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_4u11sIuOEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -3342,7 +3342,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_8R9-MYuOEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8R9-MouOEeiu6boZkiJHCA" points="[983, 140, -643984, -643984]$[983, 278, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_992RMIuOEeiu6boZkiJHCA" id="(0.8383233532934131,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_992RMIuOEeiu6boZkiJHCA" id="(0.7627906976744186,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9kZPYIuOEeiu6boZkiJHCA" id="(0.8304093567251462,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__VTMUIuOEeiu6boZkiJHCA" type="Association_Edge" source="_BlU3KDBGEeam35bpdXJzEw" target="_BlU1BDBGEeam35bpdXJzEw" routing="Rectilinear">
@@ -3373,7 +3373,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="__VTMUYuOEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__VTMUouOEeiu6boZkiJHCA" points="[880, 140, -643984, -643984]$[880, 209, -643984, -643984]$[876, 209, -643984, -643984]$[876, 278, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AE2Z8IuPEeiu6boZkiJHCA" id="(0.19760479041916168,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AE2Z8IuPEeiu6boZkiJHCA" id="(0.2651162790697674,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AZkFsIuPEeiu6boZkiJHCA" id="(0.2046783625730994,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EplwcIuPEeiu6boZkiJHCA" type="Association_Edge" source="_luMgoBMjEee0L_IMWjydgQ" target="_BlU1BDBGEeam35bpdXJzEw" routing="Rectilinear" lineColor="0">
@@ -3624,295 +3624,326 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_96a6wKSdEeiKJbr6a5Jjpg" id="(1.0,0.49206349206349204)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_96bh0KSdEeiKJbr6a5Jjpg" id="(0.8596491228070176,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5JPAq1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU0MDBGEeam35bpdXJzEw" target="_5JPAp1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5JPArFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5JPAsFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_RdCHsHvXEemvrvzs5PR02w" type="Association_Edge" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU3KDBGEeam35bpdXJzEw" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_RdEj8HvXEemvrvzs5PR02w" type="Association_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TgvE0HvXEemvrvzs5PR02w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RdEj8XvXEemvrvzs5PR02w" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RdFLAHvXEemvrvzs5PR02w" type="Association_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TjePwHvXEemvrvzs5PR02w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RdFLAXvXEemvrvzs5PR02w" x="-79" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RdFLAnvXEemvrvzs5PR02w" type="Association_TargetRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TmknEHvXEemvrvzs5PR02w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RdFLA3vXEemvrvzs5PR02w" x="80" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RdFLBHvXEemvrvzs5PR02w" type="Association_SourceRoleLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TowYYHvXEemvrvzs5PR02w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RdFLBXvXEemvrvzs5PR02w" x="-24" y="-36"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RdFLBnvXEemvrvzs5PR02w" type="Association_SourceMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_TrsXoHvXEemvrvzs5PR02w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RdFLB3vXEemvrvzs5PR02w" x="13" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RdFLCHvXEemvrvzs5PR02w" type="Association_TargetMultiplicityLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Tt8aYHvXEemvrvzs5PR02w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RdFLCXvXEemvrvzs5PR02w" x="-11" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_RdCHsXvXEemvrvzs5PR02w"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ROxpQHvXEemvrvzs5PR02w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RdCHsnvXEemvrvzs5PR02w" points="[451, 30, -643984, -643984]$[841, 30, -643984, -643984]$[841, 82, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ri9wkHvXEemvrvzs5PR02w" id="(1.0,0.453125)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ri9wkXvXEemvrvzs5PR02w" id="(0.10697674418604651,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_etxDV3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU0MDBGEeam35bpdXJzEw" target="_etxDU3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_etxDWHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_etxDXHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5JPArVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5JPArlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5JPAr1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_etxDWXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_etxDWnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_etxDW3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5JYKo1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_SVZ1oIuOEeiu6boZkiJHCA" target="_5JYKn1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5JYKpFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5JYKqFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_et6NU3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_SVZ1oIuOEeiu6boZkiJHCA" target="_et6NT3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_et6NVHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_et6NWHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5JYKpVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5JYKplosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5JYKp1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_et6NVXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_et6NVnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_et6NV3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5Jh7m1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_YeNm8IuOEeiu6boZkiJHCA" target="_5Jh7l1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5Jh7nFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5Jh7oFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_euD-R3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_YeNm8IuOEeiu6boZkiJHCA" target="_euD-Q3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_euD-SHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_euD-THvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5Jh7nVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Jh7nlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Jh7n1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_euD-SXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_euD-SnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_euD-S3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5J02i1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU0cTBGEeam35bpdXJzEw" target="_5J02h1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5J02jFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5J02kFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_euW5N3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU0cTBGEeam35bpdXJzEw" target="_euW5M3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_euW5OHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_euW5PHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5J02jVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5J02jlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5J02j1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_euW5OXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_euW5OnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_euW5O3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5KHxdFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_jFNa0IuOEeiu6boZkiJHCA" target="_5KHxcFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5KHxdVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5KHxeVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eugqO3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_jFNa0IuOEeiu6boZkiJHCA" target="_eugqN3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eugqPHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eugqQHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5KHxdlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5KHxd1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5KHxeFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eugqPXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eugqPnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eugqP3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5KHxhVosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_mliuAIuOEeiu6boZkiJHCA" target="_5KHxgVosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5KHxhlosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5KHxilosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eup0K3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_mliuAIuOEeiu6boZkiJHCA" target="_eup0J3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eup0LHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eup0MHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5KHxh1osEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5KHxiFosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5KHxiVosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eup0LXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eup0LnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eup0L3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5KkdZFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU0sjBGEeam35bpdXJzEw" target="_5KkdYFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5KkdZVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5KkdaVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ewJB63vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU0sjBGEeam35bpdXJzEw" target="_ewJB53vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ewJB7HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewJB8HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5KkdZlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5KkdZ1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5KkdaFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ewJB7XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewJB7nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewJB73vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5LBJVFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU1BDBGEeam35bpdXJzEw" target="_5LBJUFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5LBJVVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5LBJWVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ewlt23vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU1BDBGEeam35bpdXJzEw" target="_ewlt13vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ewlt3HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewlt4HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5LBJVlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5LBJV1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5LBJWFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ewlt3XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewlt3nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewlt33vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5Ld1RFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU1WTBGEeam35bpdXJzEw" target="_5Ld1QFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5Ld1RVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5Ld1SVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_exLjsXvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU1WTBGEeam35bpdXJzEw" target="_exCZx3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_exLjsnvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exLjtnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5Ld1RlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Ld1R1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Ld1SFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_exLjs3vqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exLjtHvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exLjtXvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5MDrJ1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU2QjBGEeam35bpdXJzEw" target="_5MDrI1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5MDrKFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5MDrLFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_exyAoHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU2QjBGEeam35bpdXJzEw" target="_exoPq3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_exyAoXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exyApXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5MDrKVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5MDrKlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5MDrK1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_exyAonvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exyAo3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exyApHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5MWmG1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU2tzBGEeam35bpdXJzEw" target="_5MWmF1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5MWmHFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5MWmIFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eyE7l3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU2tzBGEeam35bpdXJzEw" target="_eyE7k3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eyE7mHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eyE7nHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5MWmHVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5MWmHlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5MWmH1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eyE7mXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eyE7mnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eyE7m3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5MzSB1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BlU3KDBGEeam35bpdXJzEw" target="_5MzSA1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5MzSCFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5MzSDFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eyhnhHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BlU3KDBGEeam35bpdXJzEw" target="_eyhngHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eyhnhXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eyhniXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5MzSCVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5MzSClosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5MzSC1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eyhnhnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eyhnh3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eyhniHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5M9DC1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_unw4AIuOEeiu6boZkiJHCA" target="_5M9DB1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5M9DDFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5M9DEFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eyqxd3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_unw4AIuOEeiu6boZkiJHCA" target="_eyqxc3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eyqxeHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eyqxfHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5M9DDVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5M9DDlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5M9DD1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eyqxeXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eyqxenvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eyqxe3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5NP991osEemu443YKSGnxQ" type="StereotypeCommentLink" source="__VTMUIuOEeiu6boZkiJHCA" target="_5NP981osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5NP9-FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5NP9_FosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ey0idHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="__VTMUIuOEeiu6boZkiJHCA" target="_ey0icHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ey0idXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ey0ieXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5NP9-VosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5NP9-losEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5NP9-1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ey0idnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ey0id3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ey0ieHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5N_k11osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_e4LtYMhsEeaVlemTikmRHw" target="_5N_k01osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5N_k2FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5N_k3FosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ezHdZHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_e4LtYMhsEeaVlemTikmRHw" target="_ezHdYHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ezHdZXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezHdaXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5N_k2VosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5N_k2losEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5N_k21osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ezHdZnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezHdZ3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezHdaHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5OJV41osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_EYfToBM4Eee0L_IMWjydgQ" target="_5OJV31osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5OJV5FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OJV6FosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ezROa3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_EYfToBM4Eee0L_IMWjydgQ" target="_ezROZ3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ezRObHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezROcHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5OJV5VosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OJV5losEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OJV51osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ezRObXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezRObnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezROb3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5OSfzVosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_9msK4IuNEeiu6boZkiJHCA" target="_5OSfyVosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5OSfzlosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OSf0losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ezaYXXvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_9msK4IuNEeiu6boZkiJHCA" target="_ezaYWXvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ezaYXnvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezaYYnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5OSfz1osEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OSf0FosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OSf0VosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ezaYX3vqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezaYYHvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezaYYXvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5OcQxFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_ExLboIuOEeiu6boZkiJHCA" target="_5OcQwFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5OcQxVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OcQyVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ezkJVHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_ExLboIuOEeiu6boZkiJHCA" target="_ezkJUHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ezkJVXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ezkJWXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5OcQxlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OcQx1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OcQyFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ezkJVnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezkJV3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ezkJWHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5OvLtFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_luMgoBMjEee0L_IMWjydgQ" target="_5OvLsFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5OvLtVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5OvLuVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ez3ER3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_luMgoBMjEee0L_IMWjydgQ" target="_ez3EQ3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ez3ESHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ez3ETHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5OvLtlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OvLt1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5OvLuFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ez3ESXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ez3ESnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ez3ES3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5PCGq1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_6_LyABMjEee0L_IMWjydgQ" target="_5PCGp1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5PCGrFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5PCGsFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e0mrJHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_6_LyABMjEee0L_IMWjydgQ" target="_e0mrIHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e0mrJXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e0mrKXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5PCGrVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5PCGrlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5PCGr1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e0mrJnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e0mrJ3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e0mrKHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5P7ehFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_yv1goIuOEeiu6boZkiJHCA" target="_5P7egFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5P7ehVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5P7eiVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e0wcK3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_yv1goIuOEeiu6boZkiJHCA" target="_e0wcJ3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e0wcLHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e0wcMHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5P7ehlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5P7eh1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5P7eiFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e0wcLXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e0wcLnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e0wcL3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5QEod1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_4u1OoIuOEeiu6boZkiJHCA" target="_5QEoc1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5QEoeFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5QEofFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e05mG3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_4u1OoIuOEeiu6boZkiJHCA" target="_e05mF3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e05mHHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e05mIHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5QEoeVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5QEoelosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5QEoe1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e05mHXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e05mHnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e05mH3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5QrFZ1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_GbpwIBM2Eee0L_IMWjydgQ" target="_5QrFY1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5QrFaFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5QrFbFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e1gDB3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_GbpwIBM2Eee0L_IMWjydgQ" target="_e1gDA3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e1gDCHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e1gDDHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5QrFaVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5QrFalosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5QrFa1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e1gDCXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e1gDCnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e1gDC3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5RHxX1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_1ZxusHIYEeeSiaQ95-6r9w" target="_5RHxW1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5RHxYFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RHxZFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e2F453vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_1ZxusHIYEeeSiaQ95-6r9w" target="_e2F443vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e2F46HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2F47HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_1ZroEHIYEeeSiaQ95-6r9w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5RHxYVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RHxYlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RHxY1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e2F46XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2F46nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2F463vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5RasRFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_XDTqEHIZEeeSiaQ95-6r9w" target="_5RasQFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5RasRVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RasSVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e2Pp63vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_XDTqEHIZEeeSiaQ95-6r9w" target="_e2Pp53vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e2Pp7HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2Pp8HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_XDNjcHIZEeeSiaQ95-6r9w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5RasRlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RasR1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RasSFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e2Pp7XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2Pp7nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2Pp73vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5RasV1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_IDRpEIuPEeiu6boZkiJHCA" target="_5RasU1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5RasWFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RasXFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e2Yz1HvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_IDRpEIuPEeiu6boZkiJHCA" target="_e2Yz0HvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e2Yz1XvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2Yz2XvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#__jfwsHIYEeeSiaQ95-6r9w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5RasWVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RasWlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RasW1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e2Yz1nvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2Yz13vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2Yz2HvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5RtnO1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_3YdyUKLTEeeG6K0eZHmVww" target="_5RtnN1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5RtnPFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5RtnQFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e2sV13vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_3YdyUKLTEeeG6K0eZHmVww" target="_e2sV03vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e2sV2HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2sV3HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5RtnPVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RtnPlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5RtnP1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e2sV2XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2sV2nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2sV23vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5SAiJFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_DXw14KLUEeeG6K0eZHmVww" target="_5SAiIFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5SAiJVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5SAiKVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e21fy3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_DXw14KLUEeeG6K0eZHmVww" target="_e21fx3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e21fzHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e21f0HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5SAiJlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5SAiJ1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5SAiKFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e21fzXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e21fznvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e21fz3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_5SAiN1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_szL8AIuOEeiu6boZkiJHCA" target="_5SAiM1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_5SAiOFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5SAiPFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_e2_Qx3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_szL8AIuOEeiu6boZkiJHCA" target="_e2_Qw3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e2_QyHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e2_QzHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5SAiOVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5SAiOlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5SAiO1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e2_QyXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2_QynvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e2_Qy3vqEemvrvzs5PR02w"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_Hdao8DBGEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
@@ -5759,117 +5790,117 @@
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iTC8alomEemu443YKSGnxQ" x="-149" y="298" height="67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2XvJZ1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2XvJaFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2XvJalosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ekiO03vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ekiO1HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ekiO1nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2XvJaVosEemu443YKSGnxQ" x="151" y="-236"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ekiO1XvqEemvrvzs5PR02w" x="151" y="-236"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2X4TX1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2X4TYFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2X4TYlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ekr_33vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ekr_4HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ekr_4nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2X4TYVosEemu443YKSGnxQ" x="151" y="-336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ekr_4XvqEemvrvzs5PR02w" x="151" y="-336"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2YCEU1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2YCEVFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2YCEVlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ek1w0HvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ek1w0XvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ek1w03vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2YCEVVosEemu443YKSGnxQ" x="151" y="-336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ek1w0nvqEemvrvzs5PR02w" x="151" y="-336"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2YCEZFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2YCEZVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2YCEZ1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ek1w4XvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ek1w4nvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ek1w5HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2YCEZlosEemu443YKSGnxQ" x="151" y="-336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ek1w43vqEemvrvzs5PR02w" x="151" y="-336"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2YU_Q1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2YU_RFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2YU_RlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_elIrx3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_elIryHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elIrynvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2YU_RVosEemu443YKSGnxQ" x="413" y="179"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_elIryXvqEemvrvzs5PR02w" x="413" y="179"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2Y7cMFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2Y7cMVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2Y7cM1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ellXs3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ellXtHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ellXtnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Y7cMlosEemu443YKSGnxQ" x="453" y="11"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ellXtXvqEemvrvzs5PR02w" x="453" y="11"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2ZEmJ1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2ZEmKFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2ZEmKlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eluhr3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eluhsHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eluhsnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2ZEmKVosEemu443YKSGnxQ" x="453" y="-89"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eluhsXvqEemvrvzs5PR02w" x="453" y="-89"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2ZFNMFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2ZFNMVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2ZFNM1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_emBckHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_emBckXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emBck3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2ZFNMlosEemu443YKSGnxQ" x="453" y="-89"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emBcknvqEemvrvzs5PR02w" x="453" y="-89"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2ZYIJ1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2ZYIKFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2ZYIKlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_emU-k3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_emU-lHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emU-lnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2ZYIKVosEemu443YKSGnxQ" x="368" y="294"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emU-lXvqEemvrvzs5PR02w" x="368" y="294"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2Z-lE1osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2Z-lFFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2Z-lFlosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_enElc3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_enEldHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_enEldnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Z-lFVosEemu443YKSGnxQ" x="759" y="-239"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_enEldXvqEemvrvzs5PR02w" x="759" y="-239"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2aka8FosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2aka8VosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2aka81osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_enqbU3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_enqbVHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_enqbVnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2aka8losEemu443YKSGnxQ" x="88" y="7"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_enqbVXvqEemvrvzs5PR02w" x="88" y="7"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2auL81osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2auL9FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2auL9losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_en0MV3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_en0MWHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_en0MWnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2auL9VosEemu443YKSGnxQ" x="88" y="-93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_en0MWXvqEemvrvzs5PR02w" x="88" y="-93"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2auMBFosEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2auMBVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2auMB1osEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_en9WQ3vqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_en9WRHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_en9WRnvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2auMBlosEemu443YKSGnxQ" x="88" y="-93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_en9WRXvqEemvrvzs5PR02w" x="88" y="-93"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_2bBG51osEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_2bBG6FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2bBG6losEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eoQRMHvqEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eoQRMXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eoQRM3vqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2bBG6VosEemu443YKSGnxQ" x="51" y="298"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eoQRMnvqEemvrvzs5PR02w" x="51" y="298"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_cHYpwVomEemu443YKSGnxQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_cHYpwlomEemu443YKSGnxQ"/>
@@ -6174,145 +6205,145 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTC8FVomEemu443YKSGnxQ" id="(0.5480769230769231,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTC8FlomEemu443YKSGnxQ" id="(0.7803921568627451,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2XvJa1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5J11omEemu443YKSGnxQ" target="_2XvJZ1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2XvJbFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2XvJcFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ekiO13vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5J11omEemu443YKSGnxQ" target="_ekiO03vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ekiO2HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ekiO3HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2XvJbVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2XvJblosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2XvJb1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ekiO2XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ekiO2nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ekiO23vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2X4TY1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5KGFomEemu443YKSGnxQ" target="_2X4TX1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2X4TZFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2X4TaFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ekr_43vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5KGFomEemu443YKSGnxQ" target="_ekr_33vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ekr_5HvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ekr_6HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2X4TZVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2X4TZlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2X4TZ1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ekr_5XvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ekr_5nvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ekr_53vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2YCEV1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5LZ1omEemu443YKSGnxQ" target="_2YCEU1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2YCEWFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2YCEXFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ek1w1HvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5LZ1omEemu443YKSGnxQ" target="_ek1w0HvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ek1w1XvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ek1w2XvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2YCEWVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2YCEWlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2YCEW1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ek1w1nvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek1w13vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek1w2HvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2YCEaFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iTC6_VomEemu443YKSGnxQ" target="_2YCEZFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2YCEaVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2YCEbVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ek1w5XvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iTC6_VomEemu443YKSGnxQ" target="_ek1w4XvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ek1w5nvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ek1w6nvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2YCEalosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2YCEa1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2YCEbFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ek1w53vqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek1w6HvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek1w6XvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2YU_R1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5KO1omEemu443YKSGnxQ" target="_2YU_Q1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2YU_SFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2YU_TFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_elIry3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5KO1omEemu443YKSGnxQ" target="_elIrx3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_elIrzHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elIr0HvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2YU_SVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2YU_SlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2YU_S1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_elIrzXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elIrznvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elIrz3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2Y7cNFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5MO1omEemu443YKSGnxQ" target="_2Y7cMFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2Y7cNVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2Y7cOVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ellXt3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5MO1omEemu443YKSGnxQ" target="_ellXs3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ellXuHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ellXvHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2Y7cNlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Y7cN1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Y7cOFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ellXuXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ellXunvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ellXu3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2ZEmK1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5NNVomEemu443YKSGnxQ" target="_2ZEmJ1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2ZEmLFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2ZEmMFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eluhs3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5NNVomEemu443YKSGnxQ" target="_eluhr3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eluhtHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eluhuHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2ZEmLVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ZEmLlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ZEmL1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eluhtXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eluhtnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eluht3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2ZFNNFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iTC8A1omEemu443YKSGnxQ" target="_2ZFNMFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2ZFNNVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2ZFNOVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_emBclHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iTC8A1omEemu443YKSGnxQ" target="_emBckHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_emBclXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emBcmXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2ZFNNlosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ZFNN1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ZFNOFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_emBclnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emBcl3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emBcmHvqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2ZYIK1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5M4VomEemu443YKSGnxQ" target="_2ZYIJ1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2ZYILFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2ZYIMFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_emU-l3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5M4VomEemu443YKSGnxQ" target="_emU-k3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_emU-mHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emU-nHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2ZYILVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ZYILlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ZYIL1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_emU-mXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emU-mnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emU-m3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2Z-lF1osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5NT1omEemu443YKSGnxQ" target="_2Z-lE1osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2Z-lGFosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2Z-lHFosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_enEld3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5NT1omEemu443YKSGnxQ" target="_enElc3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_enEleHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_enElfHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2Z-lGVosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Z-lGlosEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2Z-lG1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_enEleXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_enElenvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_enEle3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2aka9FosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iTC7NlomEemu443YKSGnxQ" target="_2aka8FosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2aka9VosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2aka-VosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_enqbV3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iTC7NlomEemu443YKSGnxQ" target="_enqbU3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_enqbWHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_enqbXHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2aka9losEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2aka91osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2aka-FosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_enqbWXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_enqbWnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_enqbW3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2auL91osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5Kf1omEemu443YKSGnxQ" target="_2auL81osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2auL-FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2auL_FosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_en0MW3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5Kf1omEemu443YKSGnxQ" target="_en0MV3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_en0MXHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_en0MYHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2auL-VosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2auL-losEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2auL-1osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_en0MXXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_en0MXnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_en0MX3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2auMCFosEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iS5Mz1omEemu443YKSGnxQ" target="_2auMBFosEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2auMCVosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2auMDVosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_en9WR3vqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iS5Mz1omEemu443YKSGnxQ" target="_en9WQ3vqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_en9WSHvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_en9WTHvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2auMClosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2auMC1osEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2auMDFosEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_en9WSXvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_en9WSnvqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_en9WS3vqEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2bBG61osEemu443YKSGnxQ" type="StereotypeCommentLink" source="_iTC8LlomEemu443YKSGnxQ" target="_2bBG51osEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2bBG7FosEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2bBG8FosEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eoQRNHvqEemvrvzs5PR02w" type="StereotypeCommentLink" source="_iTC8LlomEemu443YKSGnxQ" target="_eoQRMHvqEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eoQRNXvqEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eoQROXvqEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2bBG7VosEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2bBG7losEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2bBG71osEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eoQRNnvqEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eoQRN3vqEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eoQROHvqEemvrvzs5PR02w"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -66,7 +66,7 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_ijcPpWkHEeWZEqTYAF8eqA" name="_connPort" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_ijcPoGkHEeWZEqTYAF8eqA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IhU9EKRZEeW4kbhK1FSdyw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IirA4KRZEeW4kbhK1FSdyw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IirA4KRZEeW4kbhK1FSdyw" value="*"/>
         </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_4ErWsEUcEeWEwNCluy4jrw" name="ConnServiceHasTopLevelConnections" memberEnd="_4EtL4EUcEeWEwNCluy4jrw _4EuaAEUcEeWEwNCluy4jrw">
@@ -354,7 +354,17 @@ License: This module is distributed under the Apache License 2.0</body>
         <ownedEnd xmi:type="uml:Property" xmi:id="__AwDkQN6EemABdf1yJ9dlA" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_--c9gAN6EemABdf1yJ9dlA"/>
       </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_ROxpQHvXEemvrvzs5PR02w" name="ConnectionIsBoundedByNode" memberEnd="_RPASwHvXEemvrvzs5PR02w _RPD9IXvXEemvrvzs5PR02w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_RO-dkHvXEemvrvzs5PR02w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_RO_EoHvXEemvrvzs5PR02w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_RPD9IXvXEemvrvzs5PR02w" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_ROxpQHvXEemvrvzs5PR02w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fSJdYHvXEemvrvzs5PR02w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fSUcgHvXEemvrvzs5PR02w" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -492,6 +502,11 @@ The FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is 
           <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sWpTQJ_BEeiO_KvaRsULdw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sWp6UJ_BEeiO_KvaRsULdw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RPASwHvXEemvrvzs5PR02w" name="_boundingNode" isReadOnly="true" association="_ROxpQHvXEemvrvzs5PR02w">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RPCvAHvXEemvrvzs5PR02w" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RPD9IHvXEemvrvzs5PR02w" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" isReadOnly="true" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_obpMUEUcEeWEwNCluy4jrw"/>
@@ -1407,4 +1422,8 @@ The determination of a fault condition on a serial compound link connection with
   <OpenModel_Profile:OpenModelAttribute xmi:id="_tnQ6oVetEemG57ABxBTHSA" base_StructuralFeature="_tnQ6oFetEemG57ABxBTHSA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tnQ6oletEemG57ABxBTHSA" base_Property="_tnQ6oFetEemG57ABxBTHSA"/>
   <OpenModel_Profile:Specify xmi:id="_ZeIFUFoiEemu443YKSGnxQ" base_Abstraction="_YI3ikFoiEemu443YKSGnxQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RPA50HvXEemvrvzs5PR02w" base_StructuralFeature="_RPASwHvXEemvrvzs5PR02w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_RPCH8HvXEemvrvzs5PR02w" base_Property="_RPASwHvXEemvrvzs5PR02w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RPEkMHvXEemvrvzs5PR02w" base_StructuralFeature="_RPD9IXvXEemvrvzs5PR02w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_RPFLQHvXEemvrvzs5PR02w" base_Property="_RPD9IXvXEemvrvzs5PR02w"/>
 </xmi:XMI>

--- a/UML/TapiPathComputation.notation
+++ b/UML/TapiPathComputation.notation
@@ -677,214 +677,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AcGp8lowEemu443YKSGnxQ" x="948" y="507"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_AcQa81owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AcQa9FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AcQa9lowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AcQa9VowEemu443YKSGnxQ" x="948" y="407"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AcjV41owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AcjV5FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AcjV5lowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AcjV5VowEemu443YKSGnxQ" x="571" y="510"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ac2Q11owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ac2Q2FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ac2Q2lowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ac2Q2VowEemu443YKSGnxQ" x="975" y="-78"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AdS8w1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AdS8xFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AdS8xlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AdS8xVowEemu443YKSGnxQ" x="319" y="286"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Adl3u1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Adl3vFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Adl3vlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Adl3vVowEemu443YKSGnxQ" x="974" y="-11"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AefPk1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AefPlFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AefPllowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AefPlVowEemu443YKSGnxQ" x="543" y="-70"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AeyKgFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AeyKgVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AeyKg1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AeyKglowEemu443YKSGnxQ" x="543" y="-170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AeyKkVowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AeyKklowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AeyKlFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AeyKk1owEemu443YKSGnxQ" x="543" y="-170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ae7Uc1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ae7UdFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ae7UdlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ae7UdVowEemu443YKSGnxQ" x="543" y="-170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AfFFcFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AfFFcVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AfFFc1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AfFFclowEemu443YKSGnxQ" x="543" y="-170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AfFFgVowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AfFFglowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AfFFhFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AfFFg1owEemu443YKSGnxQ" x="543" y="-170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AfO2c1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AfO2dFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AfO2dlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AfO2dVowEemu443YKSGnxQ" x="543" y="-170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Afq7UFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Afq7UVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Afq7U1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Afq7UlowEemu443YKSGnxQ" x="541" y="192"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Af0sVlowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Af0sV1owEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Af0sWVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Af0sWFowEemu443YKSGnxQ" x="541" y="92"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AgRYQFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AgRYQVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AgRYQ1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AgRYQlowEemu443YKSGnxQ" x="928" y="164"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AguEMFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AguEMVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AguEM1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AguEMlowEemu443YKSGnxQ" x="945" y="331"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ag3OL1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ag3OMFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ag3OMlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ag3OMVowEemu443YKSGnxQ" x="945" y="231"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AhA_J1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AhA_KFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AhA_KlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AhA_KVowEemu443YKSGnxQ" x="945" y="231"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AhdrEFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AhdrEVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AhdrE1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AhdrElowEemu443YKSGnxQ" x="305" y="510"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AiWb4FowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AiWb4VowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AiWb41owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AiWb4lowEemu443YKSGnxQ" x="190" y="-157"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AigM51owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AigM6FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AigM6lowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AigM6VowEemu443YKSGnxQ" x="190" y="-257"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AipW0FowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AipW0VowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AipW01owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AipW0lowEemu443YKSGnxQ" x="190" y="-257"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AipW4VowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AipW4lowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AipW5FowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AipW41owEemu443YKSGnxQ" x="190" y="-257"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AjGCwFowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AjGCwVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AjGCw1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AjGCwlowEemu443YKSGnxQ" x="545" y="325"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Aj1po1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Aj1ppFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Aj1pplowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Aj1ppVowEemu443YKSGnxQ" x="762" y="-163"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_AklQg1owEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AklQhFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AklQhlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AklQhVowEemu443YKSGnxQ" x="930" y="66"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_LsEiUFowEemu443YKSGnxQ" type="Interface_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_LsEiUlowEemu443YKSGnxQ" type="Interface_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_LsEiU1owEemu443YKSGnxQ" type="Interface_FloatingNameLabel">
@@ -911,13 +703,237 @@
       <element xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsEiUVowEemu443YKSGnxQ" x="627" y="-166" height="71"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_LsNsTlowEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_LsNsT1owEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LsNsUVowEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_X75NEHvNEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_X75NEXvNEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X75NE3vNEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X75NEnvNEemvrvzs5PR02w" x="948" y="507"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yWfM03veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yWfM1HveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yWfM1nveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yWfM1XveEemvrvzs5PR02w" x="948" y="507"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yWyu0HveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yWyu0XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yWyu03veEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yWyu0nveEemvrvzs5PR02w" x="948" y="407"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yXOzs3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yXOztHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yXOztnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yXOztXveEemvrvzs5PR02w" x="571" y="510"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yX1Qp3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yX1QqHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yX1QqnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yX1QqXveEemvrvzs5PR02w" x="975" y="-78"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yYR8l3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yYR8mHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yYR8mnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yYR8mXveEemvrvzs5PR02w" x="319" y="286"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yYuBc3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yYuBdHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yYuBdnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yYuBdXveEemvrvzs5PR02w" x="974" y="-11"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZKtYHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZKtYXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZKtY3veEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZKtYnveEemvrvzs5PR02w" x="543" y="-70"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZUeZ3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZUeaHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZUeanveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZUeaXveEemvrvzs5PR02w" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZdoUHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZdoUXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZdoU3veEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZdoUnveEemvrvzs5PR02w" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZdoYXveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZdoYnveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZdoZHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZdoY3veEemvrvzs5PR02w" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZnZV3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZnZWHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZnZWnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZnZWXveEemvrvzs5PR02w" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZxKUHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZxKUXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZxKU3veEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZxKUnveEemvrvzs5PR02w" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yZ6UQHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yZ6UQXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZ6UQ3veEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yZ6UQnveEemvrvzs5PR02w" x="543" y="-170"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yaNPM3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yaNPNHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yaNPNnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yaNPNXveEemvrvzs5PR02w" x="541" y="192"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yagxMHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yagxMXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yagxM3veEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yagxMnveEemvrvzs5PR02w" x="541" y="92"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yazsI3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yazsJHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yazsJnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yazsJXveEemvrvzs5PR02w" x="928" y="164"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ybQYE3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ybQYFHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ybQYFnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ybQYFXveEemvrvzs5PR02w" x="945" y="331"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ybZiD3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ybZiEHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ybZiEnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ybZiEXveEemvrvzs5PR02w" x="945" y="231"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ybjTA3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ybjTBHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ybjTBnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ybjTBXveEemvrvzs5PR02w" x="945" y="231"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yb2N83veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yb2N9HveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yb2N9nveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yb2N9XveEemvrvzs5PR02w" x="305" y="510"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ydLqs3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ydLqtHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydLqtnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ydLqtXveEemvrvzs5PR02w" x="190" y="-157"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ydVbv3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ydVbwHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydVbwnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ydVbwXveEemvrvzs5PR02w" x="190" y="-257"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ydfMuXveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ydfMunveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydfMvHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ydfMu3veEemvrvzs5PR02w" x="190" y="-257"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ydoWo3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ydoWpHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydoWpnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ydoWpXveEemvrvzs5PR02w" x="190" y="-257"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yeFCk3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yeFClHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yeFClnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yeFClXveEemvrvzs5PR02w" x="545" y="325"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ye0pc3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ye0pdHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ye0pdnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ye0pdXveEemvrvzs5PR02w" x="544" y="-162"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yfafV3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yfafWHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yfafWnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yfafWXveEemvrvzs5PR02w" x="930" y="66"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yfuBW3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yfuBXHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yfuBXnveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsNsUFowEemu443YKSGnxQ" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yfuBXXveEemvrvzs5PR02w" x="827" y="-166"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_8OGbYTBGEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_8OGbYjBGEeam35bpdXJzEw"/>
@@ -1710,276 +1726,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AcGp91owEemu443YKSGnxQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AcGp-FowEemu443YKSGnxQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AcQa91owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_h_F8oFopEemu443YKSGnxQ" target="_AcQa81owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AcQa-FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AcQa_FowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AcQa-VowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AcQa-lowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AcQa-1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AcjV51owEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7bpATBGEeam35bpdXJzEw" target="_AcjV41owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AcjV6FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AcjV7FowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AcjV6VowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AcjV6lowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AcjV61owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ac2Q21owEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7bqJjBGEeam35bpdXJzEw" target="_Ac2Q11owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ac2Q3FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ac2Q4FowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ac2Q3VowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ac2Q3lowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ac2Q31owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AdS8x1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7bqZzBGEeam35bpdXJzEw" target="_AdS8w1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AdS8yFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AdS8zFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AdS8yVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AdS8ylowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AdS8y1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Adl3v1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7kzETBGEeam35bpdXJzEw" target="_Adl3u1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Adl3wFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Adl3xFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Adl3wVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Adl3wlowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Adl3w1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AefPl1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7kz7zBGEeam35bpdXJzEw" target="_AefPk1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AefPmFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AefPnFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AefPmVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AefPmlowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AefPm1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AeyKhFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_-qURcIuVEeiu6boZkiJHCA" target="_AeyKgFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AeyKhVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AeyKiVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AeyKhlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AeyKh1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AeyKiFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AeyKlVowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_IDVPQIuWEeiu6boZkiJHCA" target="_AeyKkVowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AeyKllowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AeyKmlowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AeyKl1owEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AeyKmFowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AeyKmVowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ae7Ud1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_KwZScIuWEeiu6boZkiJHCA" target="_Ae7Uc1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ae7UeFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ae7UfFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ae7UeVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ae7UelowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ae7Ue1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AfFFdFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_O44KwIuWEeiu6boZkiJHCA" target="_AfFFcFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AfFFdVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AfFFeVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AfFFdlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AfFFd1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AfFFeFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AfFFhVowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_YF9lYIuWEeiu6boZkiJHCA" target="_AfFFgVowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AfFFhlowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AfFFilowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AfFFh1owEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AfFFiFowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AfFFiVowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AfO2d1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_BZo84K1gEeiIjuV0HZnJAQ" target="_AfO2c1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AfO2eFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AfO2fFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AfO2eVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AfO2elowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AfO2e1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Afq7VFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7k0RDBGEeam35bpdXJzEw" target="_Afq7UFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Afq7VVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Afq7WVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Afq7VlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Afq7V1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Afq7WFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Af0sWlowEemu443YKSGnxQ" type="StereotypeCommentLink" source="__7bq1TBGEeam35bpdXJzEw" target="_Af0sVlowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Af0sW1owEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Af0sX1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Af0sXFowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Af0sXVowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Af0sXlowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AgRYRFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_jCJFgDJEEeamvfKYyWmELQ" target="_AgRYQFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AgRYRVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AgRYSVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AgRYRlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AgRYR1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AgRYSFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AguENFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_Jm3rgDM1EeaULOmJRJKM0Q" target="_AguEMFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AguENVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AguEOVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AguENlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AguEN1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AguEOFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ag3OM1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_kEvrkIuWEeiu6boZkiJHCA" target="_Ag3OL1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ag3ONFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ag3OOFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ag3ONVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ag3ONlowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ag3ON1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AhA_K1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_mb5JIIuWEeiu6boZkiJHCA" target="_AhA_J1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AhA_LFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AhA_MFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AhA_LVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AhA_LlowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AhA_L1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AhdrFFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_sBVWcE0REeaqn4OIuRCwEg" target="_AhdrEFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AhdrFVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AhdrGVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AhdrFlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AhdrF1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AhdrGFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AiWb5FowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_hxP6UMhuEeaVlemTikmRHw" target="_AiWb4FowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AiWb5VowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AiWb6VowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AiWb5lowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AiWb51owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AiWb6FowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AigM61owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_EAOn0BM8Eee0L_IMWjydgQ" target="_AigM51owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AigM7FowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AigM8FowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AigM7VowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AigM7lowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AigM71owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AipW1FowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_0f9WQIuVEeiu6boZkiJHCA" target="_AipW0FowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AipW1VowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AipW2VowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AipW1lowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AipW11owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AipW2FowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AipW5VowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_37ea4IuVEeiu6boZkiJHCA" target="_AipW4VowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AipW5lowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AipW6lowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AipW51owEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AipW6FowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AipW6VowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AjGCxFowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_RFVnkP4tEea_VPdGG2-szQ" target="_AjGCwFowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AjGCxVowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AjGCyVowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AjGCxlowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AjGCx1owEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AjGCyFowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Aj1pp1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_Ax_xQBM8Eee0L_IMWjydgQ" target="_Aj1po1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Aj1pqFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Aj_aolowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Aj1pqVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Aj_aoFowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Aj_aoVowEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AklQh1owEemu443YKSGnxQ" type="StereotypeCommentLink" source="_pBdREK1fEeiIjuV0HZnJAQ" target="_AklQg1owEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AklQiFowEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AklQjFowEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AklQiVowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AklQilowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AklQi1owEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_LsNsUlowEemu443YKSGnxQ" type="StereotypeCommentLink" source="_LsEiUFowEemu443YKSGnxQ" target="_LsNsTlowEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_LsNsU1owEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LsNsV1owEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LsNsVFowEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsNsVVowEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsNsVlowEemu443YKSGnxQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LuAcAFowEemu443YKSGnxQ" type="InterfaceRealization_Edge" source="__7kz7zBGEeam35bpdXJzEw" target="_LsEiUFowEemu443YKSGnxQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_LuAcA1owEemu443YKSGnxQ" type="InterfaceRealization_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_MFNbEFowEemu443YKSGnxQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -1994,6 +1740,296 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LuAcAlowEemu443YKSGnxQ" points="[495, -70, -643984, -643984]$[495, -136, -643984, -643984]$[627, -136, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MKuNMFowEemu443YKSGnxQ" id="(0.7203791469194313,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MKuNMVowEemu443YKSGnxQ" id="(0.0,0.4084507042253521)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_X75NFHvNEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_X75NEHvNEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_X75NFXvNEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_X75NGXvNEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X75NFnvNEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X75NF3vNEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X75NGHvNEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yWfM13veEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_yWfM03veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yWfM2HveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yWfM3HveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yWfM2XveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yWfM2nveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yWfM23veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yWyu1HveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_h_F8oFopEemu443YKSGnxQ" target="_yWyu0HveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yWyu1XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yWyu2XveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yWyu1nveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yWyu13veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yWyu2HveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yXOzt3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7bpATBGEeam35bpdXJzEw" target="_yXOzs3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yXOzuHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yXOzvHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yXOzuXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yXOzunveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yXOzu3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yX1Qq3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7bqJjBGEeam35bpdXJzEw" target="_yX1Qp3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yX1QrHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yX1QsHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yX1QrXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yX1QrnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yX1Qr3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yYR8m3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7bqZzBGEeam35bpdXJzEw" target="_yYR8l3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yYR8nHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yYR8oHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yYR8nXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yYR8nnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yYR8n3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yYuBd3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7kzETBGEeam35bpdXJzEw" target="_yYuBc3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yYuBeHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yYuBfHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yYuBeXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yYuBenveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yYuBe3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZKtZHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7kz7zBGEeam35bpdXJzEw" target="_yZKtYHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZKtZXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZKtaXveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZKtZnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZKtZ3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZKtaHveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZUea3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_-qURcIuVEeiu6boZkiJHCA" target="_yZUeZ3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZUebHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZUecHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZUebXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZUebnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZUeb3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZdoVHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_IDVPQIuWEeiu6boZkiJHCA" target="_yZdoUHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZdoVXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZdoWXveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZdoVnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZdoV3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZdoWHveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZdoZXveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_KwZScIuWEeiu6boZkiJHCA" target="_yZdoYXveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZdoZnveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZdoanveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZdoZ3veEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZdoaHveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZdoaXveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZnZW3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_O44KwIuWEeiu6boZkiJHCA" target="_yZnZV3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZnZXHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZnZYHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZnZXXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZnZXnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZnZX3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZxKVHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_YF9lYIuWEeiu6boZkiJHCA" target="_yZxKUHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZxKVXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZxKWXveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZxKVnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZxKV3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZxKWHveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yZ6URHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_BZo84K1gEeiIjuV0HZnJAQ" target="_yZ6UQHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yZ6URXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yZ6USXveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yZ6URnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZ6UR3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yZ6USHveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yaNPN3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7k0RDBGEeam35bpdXJzEw" target="_yaNPM3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yaNPOHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yaNPPHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yaNPOXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yaNPOnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yaNPO3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yagxNHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="__7bq1TBGEeam35bpdXJzEw" target="_yagxMHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yagxNXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yagxOXveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yagxNnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yagxN3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yagxOHveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yazsJ3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_jCJFgDJEEeamvfKYyWmELQ" target="_yazsI3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yazsKHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yazsLHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yazsKXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yazsKnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yazsK3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ybQYF3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_Jm3rgDM1EeaULOmJRJKM0Q" target="_ybQYE3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ybQYGHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ybQYHHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ybQYGXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybQYGnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybQYG3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ybZiE3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_kEvrkIuWEeiu6boZkiJHCA" target="_ybZiD3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ybZiFHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ybZiGHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ybZiFXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybZiFnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybZiF3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ybjTB3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_mb5JIIuWEeiu6boZkiJHCA" target="_ybjTA3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ybjTCHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ybjTDHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ybjTCXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybjTCnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybjTC3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yb2N93veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_sBVWcE0REeaqn4OIuRCwEg" target="_yb2N83veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yb2N-HveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yb2N_HveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yb2N-XveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yb2N-nveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yb2N-3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ydLqt3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_hxP6UMhuEeaVlemTikmRHw" target="_ydLqs3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ydLquHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydLqvHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ydLquXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydLqunveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydLqu3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ydVbw3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_EAOn0BM8Eee0L_IMWjydgQ" target="_ydVbv3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ydVbxHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydVbyHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ydVbxXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydVbxnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydVbx3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ydfMvXveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_0f9WQIuVEeiu6boZkiJHCA" target="_ydfMuXveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ydfMvnveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydfMwnveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ydfMv3veEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydfMwHveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydfMwXveEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ydoWp3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_37ea4IuVEeiu6boZkiJHCA" target="_ydoWo3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ydoWqHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ydoWrHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ydoWqXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydoWqnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ydoWq3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yeFCl3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_RFVnkP4tEea_VPdGG2-szQ" target="_yeFCk3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yeFCmHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yeFCnHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yeFCmXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yeFCmnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yeFCm3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ye0pd3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_Ax_xQBM8Eee0L_IMWjydgQ" target="_ye0pc3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ye0peHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ye0pfHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ye0peXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ye0penveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ye0pe3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yfafW3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_pBdREK1fEeiIjuV0HZnJAQ" target="_yfafV3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yfafXHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yfafYHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yfafXXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yfafXnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yfafX3veEemvrvzs5PR02w"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yfuBX3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_LsEiUFowEemu443YKSGnxQ" target="_yfuBW3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yfuBYHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yfuBZHveEemvrvzs5PR02w" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yfuBYXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yfuBYnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yfuBY3veEemvrvzs5PR02w"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SwLpIEQ7EeaktYCiiVTurg" type="PapyrusUMLClassDiagram" name="PathComputationServiceDetails" measurementUnit="Pixel">
@@ -2549,125 +2585,125 @@
       <element xmi:type="uml:Enumeration" href="TapiPathComputation.uml#_uLelgFofEemu443YKSGnxQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dLxiIVoqEemu443YKSGnxQ" x="-218" y="55"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xbCG4Hs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xbCG4Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbCG43s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ykU0gHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ykU0gXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ykU0g3veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xbCG4ns-EemfSIWqmJMEQA" x="820" y="-120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ykU0gnveEemvrvzs5PR02w" x="820" y="-120"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xcm0MHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xcm0MXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xcm0M3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ylOMZ3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ylOMaHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ylOManveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xcm0Mns-EemfSIWqmJMEQA" x="820" y="420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ylOMaXveEemvrvzs5PR02w" x="820" y="420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xdvcoHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xdvcoXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xdvco3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ymjpIHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ymjpIXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ymjpI3veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xdvcons-EemfSIWqmJMEQA" x="820" y="340"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ymjpInveEemvrvzs5PR02w" x="820" y="340"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xej8AHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xej8AXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xej8A3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yndBA3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yndBBHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yndBBnveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xej8Ans-EemfSIWqmJMEQA" x="260" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yndBBXveEemvrvzs5PR02w" x="260" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xf-RQHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xf-RQXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xf-RQ3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yofi0HveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yofi0XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yofi03veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xf-RQns-EemfSIWqmJMEQA" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yofi0nveEemvrvzs5PR02w" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xgEX4Hs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xgEX4Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgEX43s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yofi4XveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yofi4nveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yofi5HveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xgEX4ns-EemfSIWqmJMEQA" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yofi43veEemvrvzs5PR02w" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xgKegHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xgKegXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgKeg3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yopT03veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yopT1HveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yopT1nveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xgKegns-EemfSIWqmJMEQA" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yopT1XveEemvrvzs5PR02w" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xgRMMHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xgRMMXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgRMM3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yopT5HveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yopT5XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yopT53veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xgRMMns-EemfSIWqmJMEQA" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yopT5nveEemvrvzs5PR02w" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xgWrwHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xgWrwXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgWrw3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yoydw3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yoydxHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yoydxnveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xgWrwns-EemfSIWqmJMEQA" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yoydxXveEemvrvzs5PR02w" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xgenkHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xgenkXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgenk3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yoyd1HveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yoyd1XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yoyd13veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xgenkns-EemfSIWqmJMEQA" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yoyd1nveEemvrvzs5PR02w" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xg3pIHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xg3pIXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xg3pI3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ypPJsHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ypPJsXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ypPJs3veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xg3pIns-EemfSIWqmJMEQA" x="449" y="492"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ypPJsnveEemvrvzs5PR02w" x="449" y="492"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xiRXUHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xiRXUXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xiRXU3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yp0_kHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yp0_kXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yp0_k3veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xiRXUns-EemfSIWqmJMEQA" x="449" y="392"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yp0_knveEemvrvzs5PR02w" x="449" y="392"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xipx0Hs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xipx0Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xipx03s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yqIhkHveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yqIhkXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yqIhk3veEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xipx0ns-EemfSIWqmJMEQA" x="231" y="320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yqIhknveEemvrvzs5PR02w" x="231" y="320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xj69IHs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xj69IXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xj69I3s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_yrBSZ3veEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yrBSaHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yrBSanveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj69Ins-EemfSIWqmJMEQA" x="819" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yrBSaXveEemvrvzs5PR02w" x="819" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xmUw4Hs-EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xmUw4Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xmUw43s-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ytsy-XveEemvrvzs5PR02w" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ytsy-nveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ytsy_HveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_e2APUFoqEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xmUw4ns-EemfSIWqmJMEQA" x="-18" y="-45"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ytsy-3veEemvrvzs5PR02w" x="-18" y="-45"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_SwLpIUQ7EeaktYCiiVTurg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_SwLpIkQ7EeaktYCiiVTurg"/>
@@ -2826,9 +2862,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ZDO1oa1mEeiqCPid09Hqfw"/>
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZDO1oq1mEeiqCPid09Hqfw" points="[393, 80, -643984, -643984]$[520, 80, -643984, -643984]$[520, 40, -643984, -643984]$[620, 40, -643984, -643984]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZDO1oq1mEeiqCPid09Hqfw" points="[393, 80, -643984, -643984]$[530, 80, -643984, -643984]$[530, -19, -643984, -643984]$[620, -19, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jgZ_IK1mEeiqCPid09Hqfw" id="(1.0,0.09950248756218906)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jgZ_Ia1mEeiqCPid09Hqfw" id="(0.0,0.9580838323353293)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jgZ_Ia1mEeiqCPid09Hqfw" id="(0.0,0.5988023952095808)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ZcUrEK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_YifAYK1jEeiqCPid09Hqfw" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_ZcUrE61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
@@ -2907,155 +2943,155 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_h-wFoqEemu443YKSGnxQ" id="(0.3970037453183521,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_h-wVoqEemu443YKSGnxQ" id="(0.4180790960451977,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xbCG5Hs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Tx0sUEQ7EeaktYCiiVTurg" target="_xbCG4Hs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xbCG5Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xbCG6Xs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ykU0hHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_Tx0sUEQ7EeaktYCiiVTurg" target="_ykU0gHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ykU0hXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ykU0iXveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xbCG5ns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbCG53s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xbCG6Hs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ykU0hnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ykU0h3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ykU0iHveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xcm0NHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UdQ2AEQ7EeaktYCiiVTurg" target="_xcm0MHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xcm0NXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xcm0OXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ylOMa3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_UdQ2AEQ7EeaktYCiiVTurg" target="_ylOMZ3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ylOMbHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ylOMcHveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xcm0Nns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xcm0N3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xcm0OHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ylOMbXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ylOMbnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ylOMb3veEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xdvcpHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_U9GzsEQ7EeaktYCiiVTurg" target="_xdvcoHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xdvcpXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xdvcqXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ymjpJHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_U9GzsEQ7EeaktYCiiVTurg" target="_ymjpIHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ymjpJXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ymjpKXveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xdvcpns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xdvcp3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xdvcqHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ymjpJnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ymjpJ3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ymjpKHveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xej8BHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_xej8AHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xej8BXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xej8CXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yndBB3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_yndBA3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yndBCHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yndBDHveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xej8Bns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xej8B3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xej8CHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yndBCXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yndBCnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yndBC3veEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xf-RRHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_xf-RQHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xf-RRXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xf-RSXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yofi1HveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_yofi0HveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yofi1XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yofi2XveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xf-RRns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xf-RR3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xf-RSHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yofi1nveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yofi13veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yofi2HveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xgEX5Hs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_xgEX4Hs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xgEX5Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgEX6Xs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yofi5XveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_yofi4XveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yofi5nveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yofi6nveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xgEX5ns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgEX53s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgEX6Hs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yofi53veEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yofi6HveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yofi6XveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xgKehHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_xgKegHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xgKehXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgKeiXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yopT13veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_yopT03veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yopT2HveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yopT3HveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xgKehns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgKeh3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgKeiHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yopT2XveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yopT2nveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yopT23veEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xgRMNHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_xgRMMHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xgRMNXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgRMOXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yopT6HveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_yopT5HveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yopT6XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yopT7XveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xgRMNns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgRMN3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgRMOHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yopT6nveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yopT63veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yopT7HveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xgWrxHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_xgWrwHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xgWrxXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgWryXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yoydx3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_yoydw3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yoydyHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yoydzHveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xgWrxns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgWrx3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgWryHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yoydyXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yoydynveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yoydy3veEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xgenlHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_xgenkHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xgenlXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xgfOoHs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yoyd2HveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_yoyd1HveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yoyd2XveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yoyd3XveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xgenlns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgenl3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xgenmHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yoyd2nveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yoyd23veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yoyd3HveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xg3pJHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_xg3pIHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xg3pJXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xg3pKXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ypPJtHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_ypPJsHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ypPJtXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ypPJuXveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xg3pJns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xg3pJ3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xg3pKHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ypPJtnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ypPJt3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ypPJuHveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xiRXVHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_xiRXUHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xiRXVXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xiRXWXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yp0_lHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_yp0_kHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yp0_lXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yp0_mXveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xiRXVns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xiRXV3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xiRXWHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yp0_lnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yp0_l3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yp0_mHveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xipx1Hs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_xipx0Hs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xipx1Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xipx2Xs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yqIhlHveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_yqIhkHveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yqIhlXveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yqIhmXveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xipx1ns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xipx13s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xipx2Hs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yqIhlnveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yqIhl3veEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yqIhmHveEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xj69JHs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_xj69IHs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xj69JXs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xj69KXs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_yrBSa3veEemvrvzs5PR02w" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_yrBSZ3veEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yrBSbHveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yrBScHveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xj69Jns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xj69J3s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xj69KHs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yrBSbXveEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yrBSbnveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yrBSb3veEemvrvzs5PR02w"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xmUw5Hs-EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_e2APUVoqEemu443YKSGnxQ" target="_xmUw4Hs-EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xmUw5Xs-EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xmUw6Xs-EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ytsy_XveEemvrvzs5PR02w" type="StereotypeCommentLink" source="_e2APUVoqEemu443YKSGnxQ" target="_ytsy-XveEemvrvzs5PR02w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ytsy_nveEemvrvzs5PR02w"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ytszAnveEemvrvzs5PR02w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_e2APUFoqEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xmUw5ns-EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xmUw53s-EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xmUw6Hs-EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ytsy_3veEemvrvzs5PR02w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ytszAHveEemvrvzs5PR02w"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ytszAXveEemvrvzs5PR02w"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -299,27 +299,36 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_-fei4P4wEea_VPdGG2-szQ" name="TopologyConstraint">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_4xZ6cHvhEemvrvzs5PR02w" annotatedElement="_-fei4P4wEea_VPdGG2-szQ">
+          <body>The TopologyConstraint allows to specify topology entities in order to impose specific constraints (as denoted by the attribute name) on Connectivity/Path.&#xD;
+The  topology entities are specified by their instance uuid rather than using references/path (to allow for mapping to Yang 1.0).&#xD;
+This loose typing and reference necessitates that implementations validate not only the presence of the instance, but also that it is of the correct type as implied by the attribute name.&#xD;
+If this validation fails, then the implementation is expceted to return an error.&#xD;
+</body>
+        </ownedComment>
         <generalization xmi:type="uml:Generalization" xmi:id="_0cOqgFexEemG57ABxBTHSA">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nxcI8jLCEeaULOmJRJKM0Q" name="_includeTopology">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YQFpADLEEeaULOmJRJKM0Q"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YQFpAjLEEeaULOmJRJKM0Q" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_nxS_ADLCEeaULOmJRJKM0Q"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_c8MLxDLEEeaULOmJRJKM0Q" name="_avoidTopology">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hUfowDLEEeaULOmJRJKM0Q"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hUfowjLEEeaULOmJRJKM0Q" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_c8MLwDLEEeaULOmJRJKM0Q"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_wGVAhMF-EeaALJQAf08uAg" name="_includePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wGVAhMF-EeaALJQAf08uAg" name="_includePath">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ON4p8MF_EeaALJQAf08uAg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ON-wkMF_EeaALJQAf08uAg" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_wGVAgMF-EeaALJQAf08uAg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_xyluAsF-EeaALJQAf08uAg" name="_excludePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xyluAsF-EeaALJQAf08uAg" name="_excludePath">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e8ofMMF_EeaALJQAf08uAg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e8ofMsF_EeaALJQAf08uAg" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_xyfnYMF-EeaALJQAf08uAg"/>
@@ -328,13 +337,13 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <ownedComment xmi:type="uml:Comment" xmi:id="_xdX0kE5rEeeicu4cm-7qRg" annotatedElement="_Ca3vhP4zEea_VPdGG2-szQ">
             <body>This is a loose constraint - that is it is unordered and could be a partial list </body>
           </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_I_odAP4zEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_I_prIP4zEea_VPdGG2-szQ" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_Ca3vgP4zEea_VPdGG2-szQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MjEHhP4zEea_VPdGG2-szQ" name="_excludeLink">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OG3ckP4zEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OG3ckv4zEea_VPdGG2-szQ" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_MjEHgP4zEea_VPdGG2-szQ"/>
@@ -343,24 +352,24 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <ownedComment xmi:type="uml:Comment" xmi:id="_zUMzUE5rEeeicu4cm-7qRg" annotatedElement="_tAVeAE5qEeeicu4cm-7qRg">
             <body>This is a loose constraint - that is it is unordered and could be a partial list</body>
           </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1OubwE5qEeeicu4cm-7qRg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1OxfEE5qEeeicu4cm-7qRg" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_tATBwE5qEeeicu4cm-7qRg"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_5TDM0U5qEeeicu4cm-7qRg" name="_excludeNode">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-ZosIE5qEeeicu4cm-7qRg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-ZqhUE5qEeeicu4cm-7qRg" value="1"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_5TB-sE5qEeeicu4cm-7qRg"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_9vwqwB_fEem5B__-Dm9B_g" name="_includeNodeEdgePoint">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TGh0AB_gEem5B__-Dm9B_g"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_THA8MB_gEem5B__-Dm9B_g" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_UkjRMB_gEem5B__-Dm9B_g" name="_excludeNodeEdgePoint">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jrNHQB_gEem5B__-Dm9B_g"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jrkToB_gEem5B__-Dm9B_g" value="1"/>
         </ownedAttribute>

--- a/YANG/tapi-connectivity@2019-03-31.tree
+++ b/YANG/tapi-connectivity@2019-03-31.tree
@@ -71,34 +71,16 @@ module: tapi-connectivity
        |  |  +--rw is-exclusive?                    boolean
        |  |  +--rw tolerable-impact?                grades-of-impact
        |  +--rw topology-constraint* [local-id]
-       |  |  +--rw include-topology
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw avoid-topology
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw include-path
-       |  |  |  +--rw path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  |  +--rw exclude-path
-       |  |  |  +--rw path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  |  +--rw include-link
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  |  +--rw exclude-link
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  |  +--rw include-node
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  +--rw exclude-node
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  +--rw include-node-edge-point
-       |  |  |  +--rw topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  |  +--rw node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-       |  |  +--rw exclude-node-edge-point
-       |  |  |  +--rw topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  |  +--rw node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+       |  |  +--rw include-topology?            tapi-common:uuid
+       |  |  +--rw avoid-topology?              tapi-common:uuid
+       |  |  +--rw include-path?                tapi-common:uuid
+       |  |  +--rw exclude-path?                tapi-common:uuid
+       |  |  +--rw include-link?                tapi-common:uuid
+       |  |  +--rw exclude-link?                tapi-common:uuid
+       |  |  +--rw include-node?                tapi-common:uuid
+       |  |  +--rw exclude-node?                tapi-common:uuid
+       |  |  +--rw include-node-edge-point?     tapi-common:uuid
+       |  |  +--rw exclude-node-edge-point?     tapi-common:uuid
        |  |  +--rw preferred-transport-layer?   tapi-common:layer-protocol-name
        |  |  +--rw constraint-weight?           uint64
        |  |  +--rw local-id                     string
@@ -140,6 +122,9 @@ module: tapi-connectivity
           +--ro supported-client-link* [topology-uuid link-uuid]
           |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
           |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+          +--ro bounding-node
+          |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+          |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
           +--ro route* [local-id]
           |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
           |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
@@ -241,6 +226,9 @@ module: tapi-connectivity
     |        +--ro supported-client-link* [topology-uuid link-uuid]
     |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
     |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
+    |        +--ro bounding-node
+    |        |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
+    |        |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
     |        +--ro route* [local-id]
     |        |  +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
     |        |  |  +--ro topology-uuid                -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
@@ -367,34 +355,16 @@ module: tapi-connectivity
     |        |  +--ro is-exclusive?                    boolean
     |        |  +--ro tolerable-impact?                grades-of-impact
     |        +--ro topology-constraint* [local-id]
-    |        |  +--ro include-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro include-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |        |  +--ro exclude-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |        |  +--ro include-topology?            tapi-common:uuid
+    |        |  +--ro avoid-topology?              tapi-common:uuid
+    |        |  +--ro include-path?                tapi-common:uuid
+    |        |  +--ro exclude-path?                tapi-common:uuid
+    |        |  +--ro include-link?                tapi-common:uuid
+    |        |  +--ro exclude-link?                tapi-common:uuid
+    |        |  +--ro include-node?                tapi-common:uuid
+    |        |  +--ro exclude-node?                tapi-common:uuid
+    |        |  +--ro include-node-edge-point?     tapi-common:uuid
+    |        |  +--ro exclude-node-edge-point?     tapi-common:uuid
     |        |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
     |        |  +--ro constraint-weight?           uint64
     |        |  +--ro local-id                     string
@@ -498,34 +468,16 @@ module: tapi-connectivity
     |        |  +--ro is-exclusive?                    boolean
     |        |  +--ro tolerable-impact?                grades-of-impact
     |        +--ro topology-constraint* [local-id]
-    |        |  +--ro include-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro include-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |        |  +--ro exclude-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |        |  +--ro include-topology?            tapi-common:uuid
+    |        |  +--ro avoid-topology?              tapi-common:uuid
+    |        |  +--ro include-path?                tapi-common:uuid
+    |        |  +--ro exclude-path?                tapi-common:uuid
+    |        |  +--ro include-link?                tapi-common:uuid
+    |        |  +--ro exclude-link?                tapi-common:uuid
+    |        |  +--ro include-node?                tapi-common:uuid
+    |        |  +--ro exclude-node?                tapi-common:uuid
+    |        |  +--ro include-node-edge-point?     tapi-common:uuid
+    |        |  +--ro exclude-node-edge-point?     tapi-common:uuid
     |        |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
     |        |  +--ro constraint-weight?           uint64
     |        |  +--ro local-id                     string
@@ -624,34 +576,16 @@ module: tapi-connectivity
     |  |  |  +---w is-exclusive?                    boolean
     |  |  |  +---w tolerable-impact?                grades-of-impact
     |  |  +---w topology-constraint* [local-id]
-    |  |  |  +---w include-topology
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w avoid-topology
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w include-path
-    |  |  |  |  +---w path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w exclude-path
-    |  |  |  |  +---w path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w include-link
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w exclude-link
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w include-node
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w exclude-node
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w include-node-edge-point
-    |  |  |  |  +---w topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |  |  |  +---w exclude-node-edge-point
-    |  |  |  |  +---w topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |  |  |  +---w include-topology?            tapi-common:uuid
+    |  |  |  +---w avoid-topology?              tapi-common:uuid
+    |  |  |  +---w include-path?                tapi-common:uuid
+    |  |  |  +---w exclude-path?                tapi-common:uuid
+    |  |  |  +---w include-link?                tapi-common:uuid
+    |  |  |  +---w exclude-link?                tapi-common:uuid
+    |  |  |  +---w include-node?                tapi-common:uuid
+    |  |  |  +---w exclude-node?                tapi-common:uuid
+    |  |  |  +---w include-node-edge-point?     tapi-common:uuid
+    |  |  |  +---w exclude-node-edge-point?     tapi-common:uuid
     |  |  |  +---w preferred-transport-layer?   tapi-common:layer-protocol-name
     |  |  |  +---w constraint-weight?           uint64
     |  |  |  +---w local-id                     string
@@ -744,34 +678,16 @@ module: tapi-connectivity
     |        |  +--ro is-exclusive?                    boolean
     |        |  +--ro tolerable-impact?                grades-of-impact
     |        +--ro topology-constraint* [local-id]
-    |        |  +--ro include-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro include-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |        |  +--ro exclude-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |        |  +--ro include-topology?            tapi-common:uuid
+    |        |  +--ro avoid-topology?              tapi-common:uuid
+    |        |  +--ro include-path?                tapi-common:uuid
+    |        |  +--ro exclude-path?                tapi-common:uuid
+    |        |  +--ro include-link?                tapi-common:uuid
+    |        |  +--ro exclude-link?                tapi-common:uuid
+    |        |  +--ro include-node?                tapi-common:uuid
+    |        |  +--ro exclude-node?                tapi-common:uuid
+    |        |  +--ro include-node-edge-point?     tapi-common:uuid
+    |        |  +--ro exclude-node-edge-point?     tapi-common:uuid
     |        |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
     |        |  +--ro constraint-weight?           uint64
     |        |  +--ro local-id                     string
@@ -871,34 +787,16 @@ module: tapi-connectivity
     |  |  |  +---w is-exclusive?                    boolean
     |  |  |  +---w tolerable-impact?                grades-of-impact
     |  |  +---w topology-constraint* [local-id]
-    |  |  |  +---w include-topology
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w avoid-topology
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w include-path
-    |  |  |  |  +---w path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w exclude-path
-    |  |  |  |  +---w path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w include-link
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w exclude-link
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w include-node
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w exclude-node
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w include-node-edge-point
-    |  |  |  |  +---w topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |  |  |  +---w exclude-node-edge-point
-    |  |  |  |  +---w topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |  |  |  +---w include-topology?            tapi-common:uuid
+    |  |  |  +---w avoid-topology?              tapi-common:uuid
+    |  |  |  +---w include-path?                tapi-common:uuid
+    |  |  |  +---w exclude-path?                tapi-common:uuid
+    |  |  |  +---w include-link?                tapi-common:uuid
+    |  |  |  +---w exclude-link?                tapi-common:uuid
+    |  |  |  +---w include-node?                tapi-common:uuid
+    |  |  |  +---w exclude-node?                tapi-common:uuid
+    |  |  |  +---w include-node-edge-point?     tapi-common:uuid
+    |  |  |  +---w exclude-node-edge-point?     tapi-common:uuid
     |  |  |  +---w preferred-transport-layer?   tapi-common:layer-protocol-name
     |  |  |  +---w constraint-weight?           uint64
     |  |  |  +---w local-id                     string
@@ -991,34 +889,16 @@ module: tapi-connectivity
     |        |  +--ro is-exclusive?                    boolean
     |        |  +--ro tolerable-impact?                grades-of-impact
     |        +--ro topology-constraint* [local-id]
-    |        |  +--ro include-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro include-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |        |  +--ro exclude-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |        |  +--ro include-topology?            tapi-common:uuid
+    |        |  +--ro avoid-topology?              tapi-common:uuid
+    |        |  +--ro include-path?                tapi-common:uuid
+    |        |  +--ro exclude-path?                tapi-common:uuid
+    |        |  +--ro include-link?                tapi-common:uuid
+    |        |  +--ro exclude-link?                tapi-common:uuid
+    |        |  +--ro include-node?                tapi-common:uuid
+    |        |  +--ro exclude-node?                tapi-common:uuid
+    |        |  +--ro include-node-edge-point?     tapi-common:uuid
+    |        |  +--ro exclude-node-edge-point?     tapi-common:uuid
     |        |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
     |        |  +--ro constraint-weight?           uint64
     |        |  +--ro local-id                     string

--- a/YANG/tapi-connectivity@2019-03-31.yang
+++ b/YANG/tapi-connectivity@2019-03-31.yang
@@ -175,6 +175,11 @@ module tapi-connectivity {
             config false;
             description "none";
         }
+        container bounding-node {
+            uses tapi-topology:node-ref;
+            config false;
+            description "none";
+        }
         list route {
             key 'local-id';
             config false;

--- a/YANG/tapi-path-computation@2019-03-31.tree
+++ b/YANG/tapi-path-computation@2019-03-31.tree
@@ -39,34 +39,16 @@ module: tapi-path-computation
        |  |  +--rw is-exclusive?                    boolean
        |  |  +--rw tolerable-impact?                grades-of-impact
        |  +--rw topology-constraint* [local-id]
-       |  |  +--rw include-topology
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw avoid-topology
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw include-path
-       |  |  |  +--rw path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  |  +--rw exclude-path
-       |  |  |  +--rw path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  |  +--rw include-link
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  |  +--rw exclude-link
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  |  +--rw include-node
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  +--rw exclude-node
-       |  |  |  +--rw topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  +--rw include-node-edge-point
-       |  |  |  +--rw topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  |  +--rw node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-       |  |  +--rw exclude-node-edge-point
-       |  |  |  +--rw topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  |  +--rw node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+       |  |  +--rw include-topology?            tapi-common:uuid
+       |  |  +--rw avoid-topology?              tapi-common:uuid
+       |  |  +--rw include-path?                tapi-common:uuid
+       |  |  +--rw exclude-path?                tapi-common:uuid
+       |  |  +--rw include-link?                tapi-common:uuid
+       |  |  +--rw exclude-link?                tapi-common:uuid
+       |  |  +--rw include-node?                tapi-common:uuid
+       |  |  +--rw exclude-node?                tapi-common:uuid
+       |  |  +--rw include-node-edge-point?     tapi-common:uuid
+       |  |  +--rw exclude-node-edge-point?     tapi-common:uuid
        |  |  +--rw preferred-transport-layer?   tapi-common:layer-protocol-name
        |  |  +--rw constraint-weight?           uint64
        |  |  +--rw local-id                     string
@@ -161,34 +143,16 @@ module: tapi-path-computation
     |  |  |  +---w is-exclusive?                    boolean
     |  |  |  +---w tolerable-impact?                grades-of-impact
     |  |  +---w topology-constraint
-    |  |  |  +---w include-topology
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w avoid-topology
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w include-path
-    |  |  |  |  +---w path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w exclude-path
-    |  |  |  |  +---w path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w include-link
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w exclude-link
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w include-node
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w exclude-node
-    |  |  |  |  +---w topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w include-node-edge-point
-    |  |  |  |  +---w topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |  |  |  +---w exclude-node-edge-point
-    |  |  |  |  +---w topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  |  +---w node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |  |  |  +---w include-topology?            tapi-common:uuid
+    |  |  |  +---w avoid-topology?              tapi-common:uuid
+    |  |  |  +---w include-path?                tapi-common:uuid
+    |  |  |  +---w exclude-path?                tapi-common:uuid
+    |  |  |  +---w include-link?                tapi-common:uuid
+    |  |  |  +---w exclude-link?                tapi-common:uuid
+    |  |  |  +---w include-node?                tapi-common:uuid
+    |  |  |  +---w exclude-node?                tapi-common:uuid
+    |  |  |  +---w include-node-edge-point?     tapi-common:uuid
+    |  |  |  +---w exclude-node-edge-point?     tapi-common:uuid
     |  |  |  +---w preferred-transport-layer?   tapi-common:layer-protocol-name
     |  |  |  +---w constraint-weight?           uint64
     |  |  |  +---w local-id?                    string
@@ -243,34 +207,16 @@ module: tapi-path-computation
     |        |  +--ro is-exclusive?                    boolean
     |        |  +--ro tolerable-impact?                grades-of-impact
     |        +--ro topology-constraint* [local-id]
-    |        |  +--ro include-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro include-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |        |  +--ro exclude-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |        |  +--ro include-topology?            tapi-common:uuid
+    |        |  +--ro avoid-topology?              tapi-common:uuid
+    |        |  +--ro include-path?                tapi-common:uuid
+    |        |  +--ro exclude-path?                tapi-common:uuid
+    |        |  +--ro include-link?                tapi-common:uuid
+    |        |  +--ro exclude-link?                tapi-common:uuid
+    |        |  +--ro include-node?                tapi-common:uuid
+    |        |  +--ro exclude-node?                tapi-common:uuid
+    |        |  +--ro include-node-edge-point?     tapi-common:uuid
+    |        |  +--ro exclude-node-edge-point?     tapi-common:uuid
     |        |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
     |        |  +--ro constraint-weight?           uint64
     |        |  +--ro local-id                     string
@@ -374,34 +320,16 @@ module: tapi-path-computation
     |        |  +--ro is-exclusive?                    boolean
     |        |  +--ro tolerable-impact?                grades-of-impact
     |        +--ro topology-constraint* [local-id]
-    |        |  +--ro include-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path
-    |        |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node
-    |        |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro include-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-    |        |  +--ro exclude-node-edge-point
-    |        |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+    |        |  +--ro include-topology?            tapi-common:uuid
+    |        |  +--ro avoid-topology?              tapi-common:uuid
+    |        |  +--ro include-path?                tapi-common:uuid
+    |        |  +--ro exclude-path?                tapi-common:uuid
+    |        |  +--ro include-link?                tapi-common:uuid
+    |        |  +--ro exclude-link?                tapi-common:uuid
+    |        |  +--ro include-node?                tapi-common:uuid
+    |        |  +--ro exclude-node?                tapi-common:uuid
+    |        |  +--ro include-node-edge-point?     tapi-common:uuid
+    |        |  +--ro exclude-node-edge-point?     tapi-common:uuid
     |        |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
     |        |  +--ro constraint-weight?           uint64
     |        |  +--ro local-id                     string
@@ -471,34 +399,16 @@ module: tapi-path-computation
              |  +--ro is-exclusive?                    boolean
              |  +--ro tolerable-impact?                grades-of-impact
              +--ro topology-constraint* [local-id]
-             |  +--ro include-topology
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  +--ro avoid-topology
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  +--ro include-path
-             |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-             |  +--ro exclude-path
-             |  |  +--ro path-uuid?   -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-             |  +--ro include-link
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-             |  +--ro exclude-link
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro link-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-             |  +--ro include-node
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-             |  +--ro exclude-node
-             |  |  +--ro topology-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro node-uuid?       -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-             |  +--ro include-node-edge-point
-             |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-             |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
-             |  +--ro exclude-node-edge-point
-             |  |  +--ro topology-uuid?          -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro node-uuid?              -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-             |  |  +--ro node-edge-point-uuid?   -> /tapi-common:context/tapi-topology:topology-context/topology/node/node-edge-point/uuid
+             |  +--ro include-topology?            tapi-common:uuid
+             |  +--ro avoid-topology?              tapi-common:uuid
+             |  +--ro include-path?                tapi-common:uuid
+             |  +--ro exclude-path?                tapi-common:uuid
+             |  +--ro include-link?                tapi-common:uuid
+             |  +--ro exclude-link?                tapi-common:uuid
+             |  +--ro include-node?                tapi-common:uuid
+             |  +--ro exclude-node?                tapi-common:uuid
+             |  +--ro include-node-edge-point?     tapi-common:uuid
+             |  +--ro exclude-node-edge-point?     tapi-common:uuid
              |  +--ro preferred-transport-layer?   tapi-common:layer-protocol-name
              |  +--ro constraint-weight?           uint64
              |  +--ro local-id                     string

--- a/YANG/tapi-path-computation@2019-03-31.yang
+++ b/YANG/tapi-path-computation@2019-03-31.yang
@@ -284,44 +284,44 @@ module tapi-path-computation {
         description "none";
     }
     grouping topology-constraint {
-        container include-topology {
-            uses tapi-topology:topology-ref;
+        leaf include-topology {
+            type tapi-common:uuid;
             description "none";
         }
-        container avoid-topology {
-            uses tapi-topology:topology-ref;
+        leaf avoid-topology {
+            type tapi-common:uuid;
             description "none";
         }
-        container include-path {
-            uses tapi-path-computation:path-ref;
+        leaf include-path {
+            type tapi-common:uuid;
             description "none";
         }
-        container exclude-path {
-            uses tapi-path-computation:path-ref;
+        leaf exclude-path {
+            type tapi-common:uuid;
             description "none";
         }
-        container include-link {
-            uses tapi-topology:link-ref;
+        leaf include-link {
+            type tapi-common:uuid;
             description "This is a loose constraint - that is it is unordered and could be a partial list ";
         }
-        container exclude-link {
-            uses tapi-topology:link-ref;
+        leaf exclude-link {
+            type tapi-common:uuid;
             description "none";
         }
-        container include-node {
-            uses tapi-topology:node-ref;
+        leaf include-node {
+            type tapi-common:uuid;
             description "This is a loose constraint - that is it is unordered and could be a partial list";
         }
-        container exclude-node {
-            uses tapi-topology:node-ref;
+        leaf exclude-node {
+            type tapi-common:uuid;
             description "none";
         }
-        container include-node-edge-point {
-        	uses tapi-topology:node-edge-point-ref;
+        leaf include-node-edge-point {
+            type tapi-common:uuid;
             description "none";
         }
-        container exclude-node-edge-point {
-        	uses tapi-topology:node-edge-point-ref;
+        leaf exclude-node-edge-point {
+            type tapi-common:uuid;
             description "none";
         }
         leaf preferred-transport-layer {
@@ -335,7 +335,11 @@ module tapi-path-computation {
                 Negative values: -1 means 'strongly required to be excluded', -2 means 'less strongly required to be excluded', etc.";
         }
         uses tapi-common:local-class;
-        description "none";
+        description "The TopologyConstraint allows to specify topology entities in order to impose specific constraints (as denoted by the attribute name) on Connectivity/Path.
+            The  topology entities are specified by their instance uuid rather than using references/path (to allow for mapping to Yang 1.0).
+            This loose typing and reference necessitates that implementations validate not only the presence of the instance, but also that it is of the correct type as implied by the attribute name.
+            If this validation fails, then the implementation is expceted to return an error.
+            ";
     }
 
     /**************************


### PR DESCRIPTION
It was pointed on TAPI call @ 05/21/2019 that Yang 1.0 cannot handle such (leaf)references to read-only entities (in Topology subtree) from an configurable sub-tree (ConnectivityService subtree). So now the
attributes are more loosely scoped/typed to any UUID, rather than to specific sub-tree namespace