### PR TITLE
Replaced TopologyConstraint pointers from references/leafref to UUID

### DIFF
--- a/UML/TapiPathComputation.notation
+++ b/UML/TapiPathComputation.notation
@@ -2365,117 +2365,117 @@
       <element xmi:type="uml:Enumeration" href="TapiPathComputation.uml#_P377ECr1EeeA7tvtQmACtQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rRypEa1sEeiqCPid09Hqfw" x="63" y="-123"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xF6S0Hs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xF6S0Xs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xF6S03s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DJUZQH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DJUZQX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DJUZQ31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xF6S0ns7EemfSIWqmJMEQA" x="820" y="-72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DJUZQn1-EemO2pf_QsOonA" x="820" y="-72"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xHCUMHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xHCUMXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xHCUM3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DLaD8H1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DLaD8X1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DLaD831-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xHCUMns7EemfSIWqmJMEQA" x="821" y="381"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DLaD8n1-EemO2pf_QsOonA" x="821" y="381"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xIMx0Hs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xINY4Hs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xINY4ns7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DNV9o31-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DNV9pH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DNV9pn1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINY4Xs7EemfSIWqmJMEQA" x="817" y="280"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DNV9pX1-EemO2pf_QsOonA" x="817" y="280"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xI8_wHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xI8_wXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xI8_w3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DOYfcH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DOYfcX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DOYfc31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xI8_wns7EemfSIWqmJMEQA" x="260" y="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DOYfcn1-EemO2pf_QsOonA" x="260" y="59"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xKiUIHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xKiUIXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xKiUI3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DPt8MH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DPt8MX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DPt8M31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xKiUIns7EemfSIWqmJMEQA" x="260" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DPt8Mn1-EemO2pf_QsOonA" x="260" y="-41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xKpB0Hs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xKpB0Xs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xKpB03s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DP3tMH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DP3tMX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DP3tM31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xKpB0ns7EemfSIWqmJMEQA" x="260" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DP3tMn1-EemO2pf_QsOonA" x="260" y="-41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xKw9oHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xKw9oXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xKw9o3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DQBeMH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DQBeMX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQBeM31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xKw9ons7EemfSIWqmJMEQA" x="260" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DQBeMn1-EemO2pf_QsOonA" x="260" y="-41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xK3EQHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xK3EQXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xK3EQ3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DQKoI31-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DQKoJH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQKoJn1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xK3EQns7EemfSIWqmJMEQA" x="260" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DQKoJX1-EemO2pf_QsOonA" x="260" y="-41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xK9K4Hs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xK9K4Xs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xK9K43s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DQUZI31-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DQUZJH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQUZJn1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xK9K4ns7EemfSIWqmJMEQA" x="260" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DQUZJX1-EemO2pf_QsOonA" x="260" y="-41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xLEfoHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xLEfoXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xLEfo3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DQdjE31-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DQdjFH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQdjFn1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xLEfons7EemfSIWqmJMEQA" x="260" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DQdjFX1-EemO2pf_QsOonA" x="260" y="-41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xLfWYHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xLfWYXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xLfWY3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DRNJ8H1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DRNJ8X1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DRNJ831-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xLfWYns7EemfSIWqmJMEQA" x="449" y="492"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DRNJ8n1-EemO2pf_QsOonA" x="449" y="492"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xMO9QHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xMO9QXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xMO9Q3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DSQS0H1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DSQS0X1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DSQS031-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xMO9Qns7EemfSIWqmJMEQA" x="449" y="392"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DSQS0n1-EemO2pf_QsOonA" x="449" y="392"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xMp0AHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xMp0AXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xMp0A3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DTb-kH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DTb-kX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DTb-k31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xMp0Ans7EemfSIWqmJMEQA" x="231" y="320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DTb-kn1-EemO2pf_QsOonA" x="231" y="320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xN6_UHs7EemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xN6_UXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xN6_U3s7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_DVX4QH1-EemO2pf_QsOonA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DVX4QX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DVX4Q31-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xN6_Uns7EemfSIWqmJMEQA" x="819" y="91"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DVX4Qn1-EemO2pf_QsOonA" x="819" y="91"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_SwLpIUQ7EeaktYCiiVTurg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_SwLpIkQ7EeaktYCiiVTurg"/>
@@ -2700,145 +2700,145 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_acJwYK1mEeiqCPid09Hqfw" id="(0.3303303303303303,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pYqzAK1mEeiqCPid09Hqfw" id="(0.47766323024054985,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xF6S1Hs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Tx0sUEQ7EeaktYCiiVTurg" target="_xF6S0Hs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xF6S1Xs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xF6S2Xs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DJUZRH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_Tx0sUEQ7EeaktYCiiVTurg" target="_DJUZQH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DJUZRX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DJUZSX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xF6S1ns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xF6S13s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xF6S2Hs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DJUZRn1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DJUZR31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DJUZSH1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xHCUNHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UdQ2AEQ7EeaktYCiiVTurg" target="_xHCUMHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xHCUNXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xHCUOXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DLaD9H1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_UdQ2AEQ7EeaktYCiiVTurg" target="_DLaD8H1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DLaD9X1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DLaD-X1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xHCUNns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xHCUN3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xHCUOHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DLaD9n1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DLaD931-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DLaD-H1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xINY43s7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_U9GzsEQ7EeaktYCiiVTurg" target="_xIMx0Hs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xINY5Hs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xINY6Hs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DNV9p31-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_U9GzsEQ7EeaktYCiiVTurg" target="_DNV9o31-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DNV9qH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DNV9rH1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xINY5Xs7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xINY5ns7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xINY53s7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DNV9qX1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DNV9qn1-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DNV9q31-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xI8_xHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_xI8_wHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xI8_xXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xI8_yXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DOYfdH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_DOYfcH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DOYfdX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DOYfeX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xI8_xns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xI8_x3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xI8_yHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DOYfdn1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DOYfd31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DOYfeH1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xKiUJHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_xKiUIHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xKiUJXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xKiUKXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DPt8NH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_DPt8MH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DPt8NX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DPt8OX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xKiUJns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xKiUJ3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xKiUKHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DPt8Nn1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DPt8N31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DPt8OH1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xKpB1Hs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_xKpB0Hs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xKpB1Xs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xKpB2Xs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DP3tNH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_DP3tMH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DP3tNX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DP3tOX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xKpB1ns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xKpB13s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xKpB2Hs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DP3tNn1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DP3tN31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DP3tOH1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xKw9pHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_xKw9oHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xKw9pXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xKw9qXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DQBeNH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_DQBeMH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DQBeNX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQBeOX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xKw9pns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xKw9p3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xKw9qHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DQBeNn1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQBeN31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQBeOH1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xK3ERHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_xK3EQHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xK3ERXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xK3ESXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DQKoJ31-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_DQKoI31-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DQKoKH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQKoLH1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xK3ERns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xK3ER3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xK3ESHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DQKoKX1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQKoKn1-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQKoK31-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xK9K5Hs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_xK9K4Hs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xK9K5Xs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xK9K6Xs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DQUZJ31-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_DQUZI31-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DQUZKH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQUZLH1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xK9K5ns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xK9K53s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xK9K6Hs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DQUZKX1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQUZKn1-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQUZK31-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xLEfpHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_xLEfoHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xLEfpXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xLFGsHs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DQdjF31-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_DQdjE31-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DQdjGH1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DQdjHH1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xLEfpns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xLEfp3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xLEfqHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DQdjGX1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQdjGn1-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DQdjG31-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xLfWZHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_xLfWYHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xLfWZXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xLfWaXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DRNJ9H1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_DRNJ8H1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DRNJ9X1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DRNJ-X1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xLfWZns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xLfWZ3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xLfWaHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DRNJ9n1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DRNJ931-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DRNJ-H1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xMO9RHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_xMO9QHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xMO9RXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xMO9SXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DSQS1H1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_DSQS0H1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DSQS1X1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DSQS2X1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xMO9Rns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xMO9R3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xMO9SHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DSQS1n1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DSQS131-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DSQS2H1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xMp0BHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_xMp0AHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xMp0BXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xMp0CXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DTb-lH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_DTb-kH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DTb-lX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DTb-mX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xMp0Bns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xMp0B3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xMp0CHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DTb-ln1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DTb-l31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DTb-mH1-EemO2pf_QsOonA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xN6_VHs7EemfSIWqmJMEQA" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_xN6_UHs7EemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_xN6_VXs7EemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xN6_WXs7EemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_DVX4RH1-EemO2pf_QsOonA" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_DVX4QH1-EemO2pf_QsOonA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DVX4RX1-EemO2pf_QsOonA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DVX4SX1-EemO2pf_QsOonA" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xN6_Vns7EemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xN6_V3s7EemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xN6_WHs7EemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DVX4Rn1-EemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DVX4R31-EemO2pf_QsOonA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DVX4SH1-EemO2pf_QsOonA"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -288,24 +288,32 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <interfaceRealization xmi:type="uml:InterfaceRealization" xmi:id="_vItyEFrnEeexvMtO2oNM9g" client="_hv0W8MhuEeaVlemTikmRHw" supplier="_5ASPgN6MEeWd9KDn6x5Skg" contract="_5ASPgN6MEeWd9KDn6x5Skg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_-fei4P4wEea_VPdGG2-szQ" name="TopologyConstraint">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_SQAEgH1-EemO2pf_QsOonA" annotatedElement="_-fei4P4wEea_VPdGG2-szQ">
+          <body>The TopologyConstraint allows to specify topology entities in order to impose specific constraints (as denoted by the attribute name) on Connectivity/Path.&#xD;
+The  topology entities are specified by their instance uuid rather than using references/path (to allow for mapping to Yang 1.0).&#xD;
+This loose typing and reference necessitates that implementations validate not only the presence of the instance, but also that it is of the correct type as implied by the attribute name.&#xD;
+If this validation fails, then the implementation is expceted to return an error.</body>
+        </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nxcI8jLCEeaULOmJRJKM0Q" name="_includeTopology">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YQFpADLEEeaULOmJRJKM0Q"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YQFpAjLEEeaULOmJRJKM0Q" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_nxS_ADLCEeaULOmJRJKM0Q"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_c8MLxDLEEeaULOmJRJKM0Q" name="_avoidTopology">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hUfowDLEEeaULOmJRJKM0Q"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hUfowjLEEeaULOmJRJKM0Q" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_c8MLwDLEEeaULOmJRJKM0Q"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_wGVAhMF-EeaALJQAf08uAg" name="_includePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wGVAhMF-EeaALJQAf08uAg" name="_includePath">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ON4p8MF_EeaALJQAf08uAg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ON-wkMF_EeaALJQAf08uAg" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_wGVAgMF-EeaALJQAf08uAg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_xyluAsF-EeaALJQAf08uAg" name="_excludePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xyluAsF-EeaALJQAf08uAg" name="_excludePath">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e8ofMMF_EeaALJQAf08uAg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e8ofMsF_EeaALJQAf08uAg" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_xyfnYMF-EeaALJQAf08uAg"/>
@@ -314,13 +322,13 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <ownedComment xmi:type="uml:Comment" xmi:id="_xdX0kE5rEeeicu4cm-7qRg" annotatedElement="_Ca3vhP4zEea_VPdGG2-szQ">
             <body>This is a loose constraint - that is it is unordered and could be a partial list </body>
           </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_I_odAP4zEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_I_prIP4zEea_VPdGG2-szQ" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_Ca3vgP4zEea_VPdGG2-szQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MjEHhP4zEea_VPdGG2-szQ" name="_excludeLink">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OG3ckP4zEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OG3ckv4zEea_VPdGG2-szQ" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_MjEHgP4zEea_VPdGG2-szQ"/>
@@ -329,13 +337,13 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <ownedComment xmi:type="uml:Comment" xmi:id="_zUMzUE5rEeeicu4cm-7qRg" annotatedElement="_tAVeAE5qEeeicu4cm-7qRg">
             <body>This is a loose constraint - that is it is unordered and could be a partial list</body>
           </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1OubwE5qEeeicu4cm-7qRg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1OxfEE5qEeeicu4cm-7qRg" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_tATBwE5qEeeicu4cm-7qRg"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_5TDM0U5qEeeicu4cm-7qRg" name="_excludeNode">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-ZosIE5qEeeicu4cm-7qRg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-ZqhUE5qEeeicu4cm-7qRg" value="*"/>
           <association xmi:type="uml:Association" href="TapiConnectivity.uml#_5TB-sE5qEeeicu4cm-7qRg"/>

--- a/YANG/tapi-connectivity@2018-12-10.tree
+++ b/YANG/tapi-connectivity@2018-12-10.tree
@@ -97,26 +97,14 @@ module: tapi-connectivity
        |  +--rw route-objective-function?             route-objective-function
        |  +--rw route-direction?                      tapi-common:forwarding-direction
        |  +--rw is-exclusive?                         boolean
-       |  +--rw include-topology* [topology-uuid]
-       |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  +--rw avoid-topology* [topology-uuid]
-       |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  +--rw include-path* [path-uuid]
-       |  |  +--rw path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  +--rw exclude-path* [path-uuid]
-       |  |  +--rw path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  +--rw include-link* [topology-uuid link-uuid]
-       |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  +--rw exclude-link* [topology-uuid link-uuid]
-       |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  +--rw include-node* [topology-uuid node-uuid]
-       |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  +--rw exclude-node* [topology-uuid node-uuid]
-       |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  +--rw include-topology*                     tapi-common:uuid
+       |  +--rw avoid-topology*                       tapi-common:uuid
+       |  +--rw include-path*                         tapi-common:uuid
+       |  +--rw exclude-path*                         tapi-common:uuid
+       |  +--rw include-link*                         tapi-common:uuid
+       |  +--rw exclude-link*                         tapi-common:uuid
+       |  +--rw include-node*                         tapi-common:uuid
+       |  +--rw exclude-node*                         tapi-common:uuid
        |  +--rw preferred-transport-layer*            tapi-common:layer-protocol-name
        |  +--rw resilience-type
        |  |  +--rw restoration-policy?   restoration-policy
@@ -397,26 +385,14 @@ module: tapi-connectivity
     |        +--ro route-objective-function?             route-objective-function
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
-    |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        +--ro include-topology*                     tapi-common:uuid
+    |        +--ro avoid-topology*                       tapi-common:uuid
+    |        +--ro include-path*                         tapi-common:uuid
+    |        +--ro exclude-path*                         tapi-common:uuid
+    |        +--ro include-link*                         tapi-common:uuid
+    |        +--ro exclude-link*                         tapi-common:uuid
+    |        +--ro include-node*                         tapi-common:uuid
+    |        +--ro exclude-node*                         tapi-common:uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
@@ -533,26 +509,14 @@ module: tapi-connectivity
     |        +--ro route-objective-function?             route-objective-function
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
-    |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        +--ro include-topology*                     tapi-common:uuid
+    |        +--ro avoid-topology*                       tapi-common:uuid
+    |        +--ro include-path*                         tapi-common:uuid
+    |        +--ro exclude-path*                         tapi-common:uuid
+    |        +--ro include-link*                         tapi-common:uuid
+    |        +--ro exclude-link*                         tapi-common:uuid
+    |        +--ro include-node*                         tapi-common:uuid
+    |        +--ro exclude-node*                         tapi-common:uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
@@ -663,26 +627,14 @@ module: tapi-connectivity
     |  |  |  +---w route-direction?                 tapi-common:forwarding-direction
     |  |  |  +---w is-exclusive?                    boolean
     |  |  +---w topology-constraint
-    |  |  |  +---w include-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w avoid-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w include-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w exclude-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w include-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w exclude-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w include-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w exclude-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |  |  |  +---w include-topology*            tapi-common:uuid
+    |  |  |  +---w avoid-topology*              tapi-common:uuid
+    |  |  |  +---w include-path*                tapi-common:uuid
+    |  |  |  +---w exclude-path*                tapi-common:uuid
+    |  |  |  +---w include-link*                tapi-common:uuid
+    |  |  |  +---w exclude-link*                tapi-common:uuid
+    |  |  |  +---w include-node*                tapi-common:uuid
+    |  |  |  +---w exclude-node*                tapi-common:uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +---w resilience-constraint
     |  |  |  +---w resilience-type
@@ -795,26 +747,14 @@ module: tapi-connectivity
     |        +--ro route-objective-function?             route-objective-function
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
-    |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        +--ro include-topology*                     tapi-common:uuid
+    |        +--ro avoid-topology*                       tapi-common:uuid
+    |        +--ro include-path*                         tapi-common:uuid
+    |        +--ro exclude-path*                         tapi-common:uuid
+    |        +--ro include-link*                         tapi-common:uuid
+    |        +--ro exclude-link*                         tapi-common:uuid
+    |        +--ro include-node*                         tapi-common:uuid
+    |        +--ro exclude-node*                         tapi-common:uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
@@ -926,26 +866,14 @@ module: tapi-connectivity
     |  |  |  +---w route-direction?                 tapi-common:forwarding-direction
     |  |  |  +---w is-exclusive?                    boolean
     |  |  +---w topology-constraint
-    |  |  |  +---w include-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w avoid-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w include-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w exclude-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w include-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w exclude-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w include-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w exclude-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |  |  |  +---w include-topology*            tapi-common:uuid
+    |  |  |  +---w avoid-topology*              tapi-common:uuid
+    |  |  |  +---w include-path*                tapi-common:uuid
+    |  |  |  +---w exclude-path*                tapi-common:uuid
+    |  |  |  +---w include-link*                tapi-common:uuid
+    |  |  |  +---w exclude-link*                tapi-common:uuid
+    |  |  |  +---w include-node*                tapi-common:uuid
+    |  |  |  +---w exclude-node*                tapi-common:uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +---w resilience-constraint
     |  |  |  +---w resilience-type
@@ -1058,26 +986,14 @@ module: tapi-connectivity
     |        +--ro route-objective-function?             route-objective-function
     |        +--ro route-direction?                      tapi-common:forwarding-direction
     |        +--ro is-exclusive?                         boolean
-    |        +--ro include-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro avoid-topology* [topology-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        +--ro include-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro exclude-path* [path-uuid]
-    |        |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        +--ro include-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        +--ro include-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        +--ro include-topology*                     tapi-common:uuid
+    |        +--ro avoid-topology*                       tapi-common:uuid
+    |        +--ro include-path*                         tapi-common:uuid
+    |        +--ro exclude-path*                         tapi-common:uuid
+    |        +--ro include-link*                         tapi-common:uuid
+    |        +--ro exclude-link*                         tapi-common:uuid
+    |        +--ro include-node*                         tapi-common:uuid
+    |        +--ro exclude-node*                         tapi-common:uuid
     |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy

--- a/YANG/tapi-path-computation@2018-12-10.tree
+++ b/YANG/tapi-path-computation@2018-12-10.tree
@@ -55,26 +55,14 @@ module: tapi-path-computation
        |  |  +--rw route-direction?                 tapi-common:forwarding-direction
        |  |  +--rw is-exclusive?                    boolean
        |  +--rw topology-constraint
-       |  |  +--rw include-topology* [topology-uuid]
-       |  |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw avoid-topology* [topology-uuid]
-       |  |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  +--rw include-path* [path-uuid]
-       |  |  |  +--rw path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  |  +--rw exclude-path* [path-uuid]
-       |  |  |  +--rw path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-       |  |  +--rw include-link* [topology-uuid link-uuid]
-       |  |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  |  +--rw exclude-link* [topology-uuid link-uuid]
-       |  |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-       |  |  +--rw include-node* [topology-uuid node-uuid]
-       |  |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-       |  |  +--rw exclude-node* [topology-uuid node-uuid]
-       |  |  |  +--rw topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-       |  |  |  +--rw node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+       |  |  +--rw include-topology*            tapi-common:uuid
+       |  |  +--rw avoid-topology*              tapi-common:uuid
+       |  |  +--rw include-path*                tapi-common:uuid
+       |  |  +--rw exclude-path*                tapi-common:uuid
+       |  |  +--rw include-link*                tapi-common:uuid
+       |  |  +--rw exclude-link*                tapi-common:uuid
+       |  |  +--rw include-node*                tapi-common:uuid
+       |  |  +--rw exclude-node*                tapi-common:uuid
        |  |  +--rw preferred-transport-layer*   tapi-common:layer-protocol-name
        |  +--rw objective-function
        |  |  +--rw bandwidth-optimization?   tapi-common:directive-value
@@ -178,26 +166,14 @@ module: tapi-path-computation
     |  |  |  +---w route-direction?                 tapi-common:forwarding-direction
     |  |  |  +---w is-exclusive?                    boolean
     |  |  +---w topology-constraint
-    |  |  |  +---w include-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w avoid-topology* [topology-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  +---w include-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w exclude-path* [path-uuid]
-    |  |  |  |  +---w path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |  |  |  +---w include-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w exclude-link* [topology-uuid link-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |  |  |  +---w include-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |  |  |  +---w exclude-node* [topology-uuid node-uuid]
-    |  |  |  |  +---w topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |  |  |  |  +---w node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |  |  |  +---w include-topology*            tapi-common:uuid
+    |  |  |  +---w avoid-topology*              tapi-common:uuid
+    |  |  |  +---w include-path*                tapi-common:uuid
+    |  |  |  +---w exclude-path*                tapi-common:uuid
+    |  |  |  +---w include-link*                tapi-common:uuid
+    |  |  |  +---w exclude-link*                tapi-common:uuid
+    |  |  |  +---w include-node*                tapi-common:uuid
+    |  |  |  +---w exclude-node*                tapi-common:uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +---w objective-function
     |  |     +---w bandwidth-optimization?   tapi-common:directive-value
@@ -263,26 +239,14 @@ module: tapi-path-computation
     |        |  +--ro route-direction?                 tapi-common:forwarding-direction
     |        |  +--ro is-exclusive?                    boolean
     |        +--ro topology-constraint
-    |        |  +--ro include-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  +--ro include-topology*            tapi-common:uuid
+    |        |  +--ro avoid-topology*              tapi-common:uuid
+    |        |  +--ro include-path*                tapi-common:uuid
+    |        |  +--ro exclude-path*                tapi-common:uuid
+    |        |  +--ro include-link*                tapi-common:uuid
+    |        |  +--ro exclude-link*                tapi-common:uuid
+    |        |  +--ro include-node*                tapi-common:uuid
+    |        |  +--ro exclude-node*                tapi-common:uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        +--ro objective-function
     |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
@@ -395,26 +359,14 @@ module: tapi-path-computation
     |        |  +--ro route-direction?                 tapi-common:forwarding-direction
     |        |  +--ro is-exclusive?                    boolean
     |        +--ro topology-constraint
-    |        |  +--ro include-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro avoid-topology* [topology-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  +--ro include-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro exclude-path* [path-uuid]
-    |        |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-    |        |  +--ro include-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro exclude-link* [topology-uuid link-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-    |        |  +--ro include-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-    |        |  +--ro exclude-node* [topology-uuid node-uuid]
-    |        |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-    |        |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+    |        |  +--ro include-topology*            tapi-common:uuid
+    |        |  +--ro avoid-topology*              tapi-common:uuid
+    |        |  +--ro include-path*                tapi-common:uuid
+    |        |  +--ro exclude-path*                tapi-common:uuid
+    |        |  +--ro include-link*                tapi-common:uuid
+    |        |  +--ro exclude-link*                tapi-common:uuid
+    |        |  +--ro include-node*                tapi-common:uuid
+    |        |  +--ro exclude-node*                tapi-common:uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        +--ro objective-function
     |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
@@ -493,26 +445,14 @@ module: tapi-path-computation
              |  +--ro route-direction?                 tapi-common:forwarding-direction
              |  +--ro is-exclusive?                    boolean
              +--ro topology-constraint
-             |  +--ro include-topology* [topology-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  +--ro avoid-topology* [topology-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  +--ro include-path* [path-uuid]
-             |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-             |  +--ro exclude-path* [path-uuid]
-             |  |  +--ro path-uuid    -> /tapi-common:context/tapi-path-computation:path-computation-context/path/uuid
-             |  +--ro include-link* [topology-uuid link-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-             |  +--ro exclude-link* [topology-uuid link-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro link-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/link/uuid
-             |  +--ro include-node* [topology-uuid node-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
-             |  +--ro exclude-node* [topology-uuid node-uuid]
-             |  |  +--ro topology-uuid    -> /tapi-common:context/tapi-topology:topology-context/topology/uuid
-             |  |  +--ro node-uuid        -> /tapi-common:context/tapi-topology:topology-context/topology/node/uuid
+             |  +--ro include-topology*            tapi-common:uuid
+             |  +--ro avoid-topology*              tapi-common:uuid
+             |  +--ro include-path*                tapi-common:uuid
+             |  +--ro exclude-path*                tapi-common:uuid
+             |  +--ro include-link*                tapi-common:uuid
+             |  +--ro exclude-link*                tapi-common:uuid
+             |  +--ro include-node*                tapi-common:uuid
+             |  +--ro exclude-node*                tapi-common:uuid
              |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
              +--ro objective-function
              |  +--ro bandwidth-optimization?   tapi-common:directive-value

--- a/YANG/tapi-path-computation@2018-12-10.yang
+++ b/YANG/tapi-path-computation@2018-12-10.yang
@@ -263,44 +263,36 @@ module tapi-path-computation {
         description "none";
     }
     grouping topology-constraint {
-        list include-topology {
-            uses tapi-topology:topology-ref;
-            key 'topology-uuid';
+        leaf-list include-topology {
+            type tapi-common:uuid;
             description "none";
         }
-        list avoid-topology {
-            uses tapi-topology:topology-ref;
-            key 'topology-uuid';
+        leaf-list avoid-topology {
+            type tapi-common:uuid;
             description "none";
         }
-        list include-path {
-            uses tapi-path-computation:path-ref;
-            key 'path-uuid';
+        leaf-list include-path {
+            type tapi-common:uuid;
             description "none";
         }
-        list exclude-path {
-            uses tapi-path-computation:path-ref;
-            key 'path-uuid';
+        leaf-list exclude-path {
+            type tapi-common:uuid;
             description "none";
         }
-        list include-link {
-            uses tapi-topology:link-ref;
-            key 'topology-uuid link-uuid';
+        leaf-list include-link {
+            type tapi-common:uuid;
             description "This is a loose constraint - that is it is unordered and could be a partial list ";
         }
-        list exclude-link {
-            uses tapi-topology:link-ref;
-            key 'topology-uuid link-uuid';
+        leaf-list exclude-link {
+            type tapi-common:uuid;
             description "none";
         }
-        list include-node {
-            uses tapi-topology:node-ref;
-            key 'topology-uuid node-uuid';
+        leaf-list include-node {
+            type tapi-common:uuid;
             description "This is a loose constraint - that is it is unordered and could be a partial list";
         }
-        list exclude-node {
-            uses tapi-topology:node-ref;
-            key 'topology-uuid node-uuid';
+        leaf-list exclude-node {
+            type tapi-common:uuid;
             description "none";
         }
         leaf-list preferred-transport-layer {


### PR DESCRIPTION
It was pointed on TAPI call @ 05/21/2019 that Yang 1.0 cannot handle such (leaf)references to read-only entities (in Topology subtree) from an configurable sub-tree (ConnectivityService subtree). So now the
attributes are more loosely scoped/typed to any UUID, rather than to specific sub-tree namespace