### PR TITLE
OTSI SIP spec #429

### DIFF
--- a/YANG/tapi-photonic-media@2019-03-31.tree
+++ b/YANG/tapi-photonic-media@2019-03-31.tree
@@ -64,20 +64,16 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-common:service-interface-point:
     +--rw otsi-service-interface-point-spec
        +--ro otsi-capability
-       |  +--ro supportable-lower-central-frequency* [central-frequency]
+       |  +--ro supportable-central-frequency-spectrum-band* []
+       |  |  +--ro lower-central-frequency?   uint64
+       |  |  +--ro upper-central-frequency?   uint64
        |  |  +--ro frequency-constraint
-       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  |  +--ro grid-type?                grid-type
-       |  |  +--ro central-frequency       uint64
-       |  +--ro supportable-upper-central-frequency* [central-frequency]
-       |  |  +--ro frequency-constraint
-       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  |  +--ro grid-type?                grid-type
-       |  |  +--ro central-frequency       uint64
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
        |  +--ro supportable-application-identifier* [application-code]
        |  |  +--ro application-identifier-type?   application-identifier-type
        |  |  +--ro application-code               string
-       |  +--ro supportable-modulation*                modulation-technique
+       |  +--ro supportable-modulation*                        modulation-technique
        |  +--ro total-power-warn-threshold
        |     +--ro total-power-upper-warn-threshold-default?   decimal64
        |     +--ro total-power-upper-warn-threshold-min?       decimal64
@@ -561,20 +557,16 @@ module: tapi-photonic-media
   augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
     +-- otsi-service-interface-point-spec
        +--ro otsi-capability
-       |  +--ro supportable-lower-central-frequency* [central-frequency]
+       |  +--ro supportable-central-frequency-spectrum-band* []
+       |  |  +--ro lower-central-frequency?   uint64
+       |  |  +--ro upper-central-frequency?   uint64
        |  |  +--ro frequency-constraint
-       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  |  +--ro grid-type?                grid-type
-       |  |  +--ro central-frequency       uint64
-       |  +--ro supportable-upper-central-frequency* [central-frequency]
-       |  |  +--ro frequency-constraint
-       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  |  +--ro grid-type?                grid-type
-       |  |  +--ro central-frequency       uint64
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
        |  +--ro supportable-application-identifier* [application-code]
        |  |  +--ro application-identifier-type?   application-identifier-type
        |  |  +--ro application-code               string
-       |  +--ro supportable-modulation*                modulation-technique
+       |  +--ro supportable-modulation*                        modulation-technique
        |  +--ro total-power-warn-threshold
        |     +--ro total-power-upper-warn-threshold-default?   decimal64
        |     +--ro total-power-upper-warn-threshold-min?       decimal64
@@ -598,20 +590,16 @@ module: tapi-photonic-media
   augment /tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip:
     +-- otsi-service-interface-point-spec
        +--ro otsi-capability
-       |  +--ro supportable-lower-central-frequency* [central-frequency]
+       |  +--ro supportable-central-frequency-spectrum-band* []
+       |  |  +--ro lower-central-frequency?   uint64
+       |  |  +--ro upper-central-frequency?   uint64
        |  |  +--ro frequency-constraint
-       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  |  +--ro grid-type?                grid-type
-       |  |  +--ro central-frequency       uint64
-       |  +--ro supportable-upper-central-frequency* [central-frequency]
-       |  |  +--ro frequency-constraint
-       |  |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  |  +--ro grid-type?                grid-type
-       |  |  +--ro central-frequency       uint64
+       |  |     +--ro adjustment-granularity?   adjustment-granularity
+       |  |     +--ro grid-type?                grid-type
        |  +--ro supportable-application-identifier* [application-code]
        |  |  +--ro application-identifier-type?   application-identifier-type
        |  |  +--ro application-code               string
-       |  +--ro supportable-modulation*                modulation-technique
+       |  +--ro supportable-modulation*                        modulation-technique
        |  +--ro total-power-warn-threshold
        |     +--ro total-power-upper-warn-threshold-default?   decimal64
        |     +--ro total-power-upper-warn-threshold-min?       decimal64

--- a/YANG/tapi-photonic-media@2019-03-31.yang
+++ b/YANG/tapi-photonic-media@2019-03-31.yang
@@ -271,7 +271,7 @@ module tapi-photonic-media {
     }
     /**************************
     * package object-classes
-    **************************/ 
+    **************************/
     grouping otsi-server-adaptation-pac {
         leaf number-of-otsi {
             type uint64;
@@ -393,17 +393,26 @@ module tapi-photonic-media {
         description "none";
     }
     grouping otsi-capability-pac {
-        list supportable-lower-central-frequency {
-            key 'central-frequency';
+        list supportable-central-frequency-spectrum-band {
+            leaf lower-central-frequency {
+                type uint64;
+                description "The lower central frequency can be tuned in the laser specified in MHz.
+                It is the oscillation frequency of the corresponding electromagnetic wave. ";
+            }
+            leaf upper-central-frequency {
+                type uint64;
+                description "The lower central frequency can be tuned in the laser specified in MHz.
+                It is the oscillation frequency of the corresponding electromagnetic wave. ";
+            }
+            container frequency-constraint {
+                uses frequency-constraint;
+                description "none";
+            }
             config false;
-            uses central-frequency;
-            description "The lower frequency of the channel spectrum";
-        }
-        list supportable-upper-central-frequency {
-            key 'central-frequency';
-            config false;
-            uses central-frequency;
-            description "The Upper frequency of the channel spectrum";
+            description "Each spectrum band supported for otsi trasmitter to be tuned on, is specified
+              as per it's lower and upper central frequencies supported and its frequency constraints,
+              consisting in the frequency Grid and the AdjustmentGranularity, used to uniquely identify all
+              central frequencies supported within the band.";
         }
         list supportable-application-identifier {
             key 'application-code';
@@ -614,7 +623,7 @@ module tapi-photonic-media {
 
     /**************************
     * package type-definitions
-    **************************/ 
+    **************************/
     identity PHOTONIC_LAYER_QUALIFIER {
         base tapi-common:LAYER_PROTOCOL_QUALIFIER;
         description "none";


### PR DESCRIPTION
This pull request replace current definition of the otsi tunability capabilities as two separate lists: supportable-lower-central-frequency and supportable-upper-central-frequency, by a single supportable-central-frequency-spectrum-band. After discussions into the TAPI calls on18/06/2019 and 25/06/2019, the group agreed on defining the tunabilty capabilities of otsi transmitters as a single list of bands defined by the lower and upper central frequencies of the band, and the frequency-contrains which specify the rest of feasible central frequencies within the band. An OTSi transmitter can have associated more than one band (i.e., C and L bands).