### PR TITLE
UML/YANG/TREE file updates to align & be consistent with PR #441  & PR #439

### DIFF
--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -659,53 +659,53 @@
       <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_FFtS8CzeEeaYO8M_h7XJ5A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HYAE4UtlEemIp5Bbs_BvnQ" x="24" y="274" height="73"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KSPxAFoiEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KSPxAVoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KSPxA1oiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_7UH7UJncEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7UH7UZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7UIiYJncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KSPxAloiEemu443YKSGnxQ" x="444" y="297"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7UH7UpncEemVaY_egjrbOQ" x="444" y="297"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KSir91oiEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KSir-FoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KSir-loiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_7Ug84JncEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7Ug84ZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Ug845ncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_adPI0NnqEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KSir-VoiEemu443YKSGnxQ" x="920" y="154"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7Ug84pncEemVaY_egjrbOQ" x="920" y="154"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KS_X4FoiEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KS_X4VoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KS_X41oiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_7U6lgJncEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7U6lgZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7U6lg5ncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_2wdyENnjEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KS_X4loiEemu443YKSGnxQ" x="542" y="7"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7U6lgpncEemVaY_egjrbOQ" x="542" y="7"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KTcD11oiEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KTcD2FoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KTcD2loiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_7VX4gJncEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7VX4gZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7VX4g5ncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KTcD2VoiEemu443YKSGnxQ" x="797" y="146"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7VX4gpncEemVaY_egjrbOQ" x="797" y="146"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KTl011oiEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KTl02FoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KTl02loiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_7Vi3oJncEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7Vi3oZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Vi3o5ncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KTl02VoiEemu443YKSGnxQ" x="219" y="140"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7Vi3opncEemVaY_egjrbOQ" x="219" y="140"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KVFCkFoiEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KVFCkVoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KVFCk1oiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_7WxmsJncEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7WxmsZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Wxms5ncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KVFCkloiEemu443YKSGnxQ" x="380" y="143"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7WxmspncEemVaY_egjrbOQ" x="380" y="143"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_6CIXQTA_Eea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_6CIXQjA_Eea4fKwSGMr6CA"/>
@@ -713,65 +713,65 @@
       <owner xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_KSPxBFoiEemu443YKSGnxQ" type="StereotypeCommentLink" source="_9tz_FDA_Eea4fKwSGMr6CA" target="_KSPxAFoiEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KSPxBVoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KSPxCVoiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_7UIiYZncEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9tz_FDA_Eea4fKwSGMr6CA" target="_7UH7UJncEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7UIiYpncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7UIiZpncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KSPxBloiEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KSPxB1oiEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KSPxCFoiEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7UIiY5ncEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7UIiZJncEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7UIiZZncEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KSir-1oiEemu443YKSGnxQ" type="StereotypeCommentLink" source="_9tz_uzA_Eea4fKwSGMr6CA" target="_KSir91oiEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KSir_FoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KSisAFoiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_7Ug85JncEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9tz_uzA_Eea4fKwSGMr6CA" target="_7Ug84JncEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7Ug85ZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Ug86ZncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_adPI0NnqEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KSir_VoiEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KSir_loiEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KSir_1oiEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7Ug85pncEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Ug855ncEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Ug86JncEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KS_X5FoiEemu443YKSGnxQ" type="StereotypeCommentLink" source="_9t0ACTA_Eea4fKwSGMr6CA" target="_KS_X4FoiEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KS_X5VoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KS_X6VoiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_7U6lhJncEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9t0ACTA_Eea4fKwSGMr6CA" target="_7U6lgJncEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7U6lhZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7U7MkpncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_2wdyENnjEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KS_X5loiEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KS_X51oiEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KS_X6FoiEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7U6lhpncEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7U7MkJncEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7U7MkZncEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KTcD21oiEemu443YKSGnxQ" type="StereotypeCommentLink" source="_9t0AjjA_Eea4fKwSGMr6CA" target="_KTcD11oiEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KTcD3FoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KTcD4FoiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_7VX4hJncEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9t0AjjA_Eea4fKwSGMr6CA" target="_7VX4gJncEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7VX4hZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7VX4iZncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KTcD3VoiEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KTcD3loiEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KTcD31oiEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7VX4hpncEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VX4h5ncEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VX4iJncEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KTl021oiEemu443YKSGnxQ" type="StereotypeCommentLink" source="_9t0AtDA_Eea4fKwSGMr6CA" target="_KTl011oiEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KTl03FoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KTl04FoiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_7Vi3pJncEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9t0AtDA_Eea4fKwSGMr6CA" target="_7Vi3oJncEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7Vi3pZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Vi3qZncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KTl03VoiEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KTl03loiEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KTl031oiEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7Vi3ppncEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Vi3p5ncEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Vi3qJncEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KVFClFoiEemu443YKSGnxQ" type="StereotypeCommentLink" source="_-exDkIk2Eeil5oKL3Vgl-g" target="_KVFCkFoiEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KVFClVoiEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KVFCmVoiEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_7WxmtJncEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_-exDkIk2Eeil5oKL3Vgl-g" target="_7WxmsJncEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7WxmtZncEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7WxmuZncEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KVFClloiEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KVFCl1oiEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KVFCmFoiEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7WxmtpncEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Wxmt5ncEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7WxmuJncEemVaY_egjrbOQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_iE1WsD3fEea-1_BGg-qcjQ" type="PapyrusUMLClassDiagram" name="Context" measurementUnit="Pixel">
@@ -1086,14 +1086,41 @@
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_mYh7MFqtEeexvMtO2oNM9g" type="Interface_OperationCompartment">
         <children xmi:type="notation:Shape" xmi:id="_pfg6QFqtEeexvMtO2oNM9g" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_kfrg4JnhEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
           <element xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_pfg6QVqtEeexvMtO2oNM9g"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_pfhhUFqtEeexvMtO2oNM9g" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_k_LgUJnhEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
           <element xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_pfhhUVqtEeexvMtO2oNM9g"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_OzQAkGNAEee0bPnI-Gt-mQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_lWhCQJnhEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
           <element xmi:type="uml:Operation" href="TapiCommon.uml#_OsQnwGNAEee0bPnI-Gt-mQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_OzQAkWNAEee0bPnI-Gt-mQ"/>
         </children>
@@ -1109,7 +1136,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mYh7OVqtEeexvMtO2oNM9g"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiCommon.uml#_JSfMgHrqEeavcODnuX7FyA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mYgtEVqtEeexvMtO2oNM9g" x="92" y="-8" width="212" height="111"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mYgtEVqtEeexvMtO2oNM9g" x="92" y="-8" width="551" height="111"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_1cD04FrmEeexvMtO2oNM9g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_1cD04VrmEeexvMtO2oNM9g" showTitle="true"/>
@@ -1605,37 +1632,37 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3eoXkot5Eeiu6boZkiJHCA" x="-99" y="-107"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_CjuIoFouEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_CjuIoVouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CjuIo1ouEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_hXDjEJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hXDjEZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hXEKIJnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CjuIolouEemu443YKSGnxQ" x="-99" y="-7"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hXDjEpnhEemrjrtN9v_T1A" x="-99" y="-7"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ck6bcFouEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ck6bcVouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ck6bc1ouEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_hYIhIJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hYIhIZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hYIhI5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ck6bclouEemu443YKSGnxQ" x="-99" y="-107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hYIhIpnhEemrjrtN9v_T1A" x="-99" y="-107"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ClNWZ1ouEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ClNWaFouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ClNWalouEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_hZFjYJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_hZFjYZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hZGKcJnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ClNWaVouEemu443YKSGnxQ" x="-98" y="193"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hZFjYpnhEemrjrtN9v_T1A" x="-98" y="193"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_CmGuS1ouEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_CmGuTFouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CmGuTlouEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_halYMJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_halYMZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_halYM5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiCommon.uml#_JSfMgHrqEeavcODnuX7FyA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CmGuTVouEemu443YKSGnxQ" x="292" y="-8"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_halYMpnhEemrjrtN9v_T1A" x="292" y="-8"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iE1WsT3fEea-1_BGg-qcjQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iE1Wsj3fEea-1_BGg-qcjQ"/>
@@ -1731,46 +1758,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7qkzkot5Eeiu6boZkiJHCA" points="[-143, 99, -643984, -643984]$[-127, 193, -643984, -643984]"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9yeUMIt5Eeiu6boZkiJHCA" id="(0.3863013698630137,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_CjuIpFouEemu443YKSGnxQ" type="StereotypeCommentLink" source="_jiNToD3fEea-1_BGg-qcjQ" target="_CjuIoFouEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_CjuIpVouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CjuIqVouEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CjuIplouEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CjuIp1ouEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CjuIqFouEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ck6bdFouEemu443YKSGnxQ" type="StereotypeCommentLink" source="_7qkzkIt5Eeiu6boZkiJHCA" target="_Ck6bcFouEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ck6bdVouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ck6beVouEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ck6bdlouEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ck6bd1ouEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ck6beFouEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ClNWa1ouEemu443YKSGnxQ" type="StereotypeCommentLink" source="_OAvhEMhqEeaVlemTikmRHw" target="_ClNWZ1ouEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ClNWbFouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ClNWcFouEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ClNWbVouEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ClNWblouEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ClNWb1ouEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_CmGuT1ouEemu443YKSGnxQ" type="StereotypeCommentLink" source="_mYgtEFqtEeexvMtO2oNM9g" target="_CmGuS1ouEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_CmGuUFouEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CmGuVFouEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Interface" href="TapiCommon.uml#_JSfMgHrqEeavcODnuX7FyA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CmGuUVouEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CmGuUlouEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CmGuU1ouEemu443YKSGnxQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Q4Nh8FouEemu443YKSGnxQ" type="InterfaceRealization_Edge" source="_OAvhEMhqEeaVlemTikmRHw" target="_mYgtEFqtEeexvMtO2oNM9g" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Q4Nh81ouEemu443YKSGnxQ" type="InterfaceRealization_StereotypeLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Q4Nh9FouEemu443YKSGnxQ" y="40"/>
@@ -1783,6 +1770,46 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Q4Nh8louEemu443YKSGnxQ" points="[29, 193, -643984, -643984]$[92, 46, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q65CgFouEemu443YKSGnxQ" id="(0.8958904109589041,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q65CgVouEemu443YKSGnxQ" id="(0.0,0.4864864864864865)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hXEKIZnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_jiNToD3fEea-1_BGg-qcjQ" target="_hXDjEJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hXEKIpnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hXEKJpnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hXEKI5nhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hXEKJJnhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hXEKJZnhEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hYIhJJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_7qkzkIt5Eeiu6boZkiJHCA" target="_hYIhIJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hYIhJZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hYIhKZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hYIhJpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hYIhJ5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hYIhKJnhEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hZGKcZnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_OAvhEMhqEeaVlemTikmRHw" target="_hZFjYJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hZGKcpnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hZGKdpnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hZGKc5nhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hZGKdJnhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hZGKdZnhEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_hal_QJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_mYgtEFqtEeexvMtO2oNM9g" target="_halYMJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_hal_QZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hal_RZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiCommon.uml#_JSfMgHrqEeavcODnuX7FyA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hal_QpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hal_Q5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hal_RJnhEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_-RwAgE0WEeaqn4OIuRCwEg" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
@@ -2142,14 +2169,6 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whVwAaeVEeeBGPv_1DT5og" x="582" y="31" height="96"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_whfhA6eVEeeBGPv_1DT5og" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_whfhBKeVEeeBGPv_1DT5og" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_whfhBqeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whfhBaeVEeeBGPv_1DT5og" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_ysqYEKeVEeeBGPv_1DT5og" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_ysqYEqeVEeeBGPv_1DT5og" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_ysqYE6eVEeeBGPv_1DT5og" type="Class_FloatingNameLabel">
@@ -2179,14 +2198,6 @@
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysqYEaeVEeeBGPv_1DT5og" x="38" y="37" height="74"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_ysxs06eVEeeBGPv_1DT5og" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ysxs1KeVEeeBGPv_1DT5og" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysyT4KeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysxs1aeVEeeBGPv_1DT5og" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BOChIKg2EeeAVfY3jqnvAA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_BODIMKg2EeeAVfY3jqnvAA" type="Class_NameLabel"/>
@@ -2222,14 +2233,6 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BOChIag2EeeAVfY3jqnvAA" x="310" y="38" height="81"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BOTm46g2EeeAVfY3jqnvAA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BOTm5Kg2EeeAVfY3jqnvAA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BOTm5qg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BOTm5ag2EeeAVfY3jqnvAA" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_FvpEEKg2EeeAVfY3jqnvAA" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_FvprIKg2EeeAVfY3jqnvAA" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_FvprIag2EeeAVfY3jqnvAA" type="Class_FloatingNameLabel">
@@ -2263,14 +2266,6 @@
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FvpEEag2EeeAVfY3jqnvAA" x="43" y="148" height="85"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Fv14Y6g2EeeAVfY3jqnvAA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Fv14ZKg2EeeAVfY3jqnvAA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Fv14Zqg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Fv14Zag2EeeAVfY3jqnvAA" x="200"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_qa14QMZUEeeAD9H5zOiMUQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_qa14QsZUEeeAD9H5zOiMUQ" type="Class_NameLabel"/>
@@ -2306,13 +2301,129 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa14QcZUEeeAD9H5zOiMUQ" x="331" y="144" height="86"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_qa90EMZUEeeAD9H5zOiMUQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_qa90EcZUEeeAD9H5zOiMUQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qa90E8ZUEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_8xyMIJncEemVaY_egjrbOQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8xyzMJncEemVaY_egjrbOQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8xyzMZncEemVaY_egjrbOQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8xyzMpncEemVaY_egjrbOQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8xyzM5ncEemVaY_egjrbOQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_-E5Z0JncEemVaY_egjrbOQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-E5Z0ZncEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-E6A4JncEemVaY_egjrbOQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-E6A4ZncEemVaY_egjrbOQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8xyzNJncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8xyzNZncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8xyzNpncEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xyzN5ncEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8xyzOJncEemVaY_egjrbOQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8xyzOZncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8xyzOpncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8xyzO5ncEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xyzPJncEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8xyzPZncEemVaY_egjrbOQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8xyzPpncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8xyzP5ncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8xyzQJncEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xyzQZncEemVaY_egjrbOQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xyMIZncEemVaY_egjrbOQ" x="54" y="255" height="62"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_--U8MJncEemVaY_egjrbOQ" type="Class_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_--U8MpncEemVaY_egjrbOQ" type="Class_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_--U8M5ncEemVaY_egjrbOQ" type="Class_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_--U8NJncEemVaY_egjrbOQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_--VjQJncEemVaY_egjrbOQ" type="Class_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_AJKXoJndEemVaY_egjrbOQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AJKXoZndEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AJK-sJndEemVaY_egjrbOQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AJK-sZndEemVaY_egjrbOQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_--VjQZncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_--VjQpncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_--VjQ5ncEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_--VjRJncEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_--VjRZncEemVaY_egjrbOQ" type="Class_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_--VjRpncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_--VjR5ncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_--VjSJncEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_--VjSZncEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_--VjSpncEemVaY_egjrbOQ" type="Class_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_--VjS5ncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_--VjTJncEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_--VjTZncEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_--VjTpncEemVaY_egjrbOQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_--U8MZncEemVaY_egjrbOQ" x="329" y="261" height="63"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_f5uCYJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_f5uCYZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f5upcJnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f5uCYpnhEemrjrtN9v_T1A" x="782" y="31"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_f72wYJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_f72wYZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f72wY5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f72wYpnhEemrjrtN9v_T1A" x="238" y="37"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_f-HaMJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_f-HaMZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f-IBQJnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f-HaMpnhEemrjrtN9v_T1A" x="510" y="38"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gAVAsJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gAVAsZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gAVAs5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gAVAspnhEemrjrtN9v_T1A" x="243" y="148"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gDDkkJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gDDkkZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gDDkk5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa90EsZUEeeAD9H5zOiMUQ" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gDDkkpnhEemrjrtN9v_T1A" x="531" y="144"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gGBZAJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gGBZAZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gGBZA5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gGBZApnhEemrjrtN9v_T1A" x="254" y="255"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gHyTkJnhEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gHyTkZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gHyTk5nhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gHyTkpnhEemrjrtN9v_T1A" x="529" y="261"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmLIQaeVEeeBGPv_1DT5og" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmLIQqeVEeeBGPv_1DT5og"/>
@@ -2320,55 +2431,75 @@
       <owner xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_whfhB6eVEeeBGPv_1DT5og" type="StereotypeCommentLink" source="_whVwAKeVEeeBGPv_1DT5og" target="_whfhA6eVEeeBGPv_1DT5og">
-      <styles xmi:type="notation:FontStyle" xmi:id="_whfhCKeVEeeBGPv_1DT5og"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_whfhDKeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_f5vQgJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_whVwAKeVEeeBGPv_1DT5og" target="_f5uCYJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_f5vQgZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f5v3kZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_whfhCaeVEeeBGPv_1DT5og" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whfhCqeVEeeBGPv_1DT5og"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whfhC6eVEeeBGPv_1DT5og"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f5vQgpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f5vQg5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f5v3kJnhEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ysyT4aeVEeeBGPv_1DT5og" type="StereotypeCommentLink" source="_ysqYEKeVEeeBGPv_1DT5og" target="_ysxs06eVEeeBGPv_1DT5og">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ysyT4qeVEeeBGPv_1DT5og"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysyT5qeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_f72wZJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ysqYEKeVEeeBGPv_1DT5og" target="_f72wYJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_f72wZZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f72waZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ysyT46eVEeeBGPv_1DT5og" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysyT5KeVEeeBGPv_1DT5og"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysyT5aeVEeeBGPv_1DT5og"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f72wZpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f72wZ5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f72waJnhEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BOTm56g2EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_BOChIKg2EeeAVfY3jqnvAA" target="_BOTm46g2EeeAVfY3jqnvAA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BOTm6Kg2EeeAVfY3jqnvAA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BOUN8Kg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_f-IBQZnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_BOChIKg2EeeAVfY3jqnvAA" target="_f-HaMJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_f-IBQpnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f-KdgJnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BOTm6ag2EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BOTm6qg2EeeAVfY3jqnvAA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BOTm66g2EeeAVfY3jqnvAA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f-IBQ5nhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f-J2cJnhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f-J2cZnhEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Fv14Z6g2EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_FvpEEKg2EeeAVfY3jqnvAA" target="_Fv14Y6g2EeeAVfY3jqnvAA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Fv14aKg2EeeAVfY3jqnvAA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Fv14bKg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_gAVAtJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_FvpEEKg2EeeAVfY3jqnvAA" target="_gAVAsJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gAVAtZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gAVAuZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fv14aag2EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fv14aqg2EeeAVfY3jqnvAA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fv14a6g2EeeAVfY3jqnvAA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gAVAtpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gAVAt5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gAVAuJnhEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qa90FMZUEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_qa14QMZUEeeAD9H5zOiMUQ" target="_qa90EMZUEeeAD9H5zOiMUQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_qa90FcZUEeeAD9H5zOiMUQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qa90GcZUEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_gDDklJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_qa14QMZUEeeAD9H5zOiMUQ" target="_gDDkkJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gDDklZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gDDkmZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qa90FsZUEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qa90F8ZUEeeAD9H5zOiMUQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qa90GMZUEeeAD9H5zOiMUQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gDDklpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gDDkl5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gDDkmJnhEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gGBZBJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_8xyMIJncEemVaY_egjrbOQ" target="_gGBZAJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gGBZBZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gGBZCZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gGBZBpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gGBZB5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gGBZCJnhEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gHyTlJnhEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_--U8MJncEemVaY_egjrbOQ" target="_gHyTkJnhEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gHyTlZnhEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gHyTmZnhEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gHyTlpnhEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gHyTl5nhEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gHyTmJnhEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -45,7 +45,8 @@ License: This module is distributed under the Apache License 2.0&#xD;
         </ownedComment>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjm98AEeW-BtRsuJPbqg" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjnN8AEeW-BtRsuJPbqg" annotatedElement="_xEvjm98AEeW-BtRsuJPbqg">
-            <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+            <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
 UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
 Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
 Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
@@ -54,8 +55,9 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjnt8AEeW-BtRsuJPbqg" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjn98AEeW-BtRsuJPbqg" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjoN8AEeW-BtRsuJPbqg">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_VbMx4JndEemVaY_egjrbOQ" annotatedElement="_xEvjn98AEeW-BtRsuJPbqg">
+            <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjod8AEeW-BtRsuJPbqg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjot8AEeW-BtRsuJPbqg" value="*"/>
@@ -75,8 +77,9 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MP7aAJLQEeaqpNd__7dv4w" name="name" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_-rk80JLSEeaqpNd__7dv4w">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_XYchsJndEemVaY_egjrbOQ" annotatedElement="_MP7aAJLQEeaqpNd__7dv4w">
+            <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ne02EJLQEeaqpNd__7dv4w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ne02EpLQEeaqpNd__7dv4w" value="*"/>
@@ -617,8 +620,14 @@ The timeticks type represents a non-negative integer that represents the time, m
     <packagedElement xmi:type="uml:Package" xmi:id="_FhzwMHrqEeavcODnuX7FyA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_JSfMgHrqEeavcODnuX7FyA" name="ServiceInterfacePoint">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN8FJvEeWcs7ZjyujtOg" name="getServiceInterfacePointDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8VJvEeWcs7ZjyujtOg" name="sipIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8VJvEeWcs7ZjyujtOg" name="uuid" type="_FRi-QNnWEeWIOYiRCk5bbQ" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="__qr5oJnhEemrjrtN9v_T1A" annotatedElement="_WHPN8VJvEeWcs7ZjyujtOg">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8lJvEeWcs7ZjyujtOg" name="sip" type="_It0sYEG-EeWMO5szP8dKiA" direction="out" effect="read"/>
         </ownedOperation>
@@ -629,8 +638,14 @@ The timeticks type represents a non-negative integer that represents the time, m
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_OsQnwGNAEee0bPnI-Gt-mQ" name="updateServiceInterfacePoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qZ9WgGNDEee0bPnI-Gt-mQ" name="sipIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qZ9WgGNDEee0bPnI-Gt-mQ" name="uuid" type="_FRi-QNnWEeWIOYiRCk5bbQ" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_BPtWsJniEemrjrtN9v_T1A" annotatedElement="_qZ9WgGNDEee0bPnI-Gt-mQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_ee1L0GNEEee0bPnI-Gt-mQ" name="state" type="_zSpnYNnjEeWIOYiRCk5bbQ" isUnique="false" effect="update"/>
         </ownedOperation>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -1010,149 +1010,149 @@
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j-OAa1aEeiIjuV0HZnJAQ" x="-305" y="-246" width="321" height="141"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1GKVQJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1GKVQZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1GKVQ5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uTLsMJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uTLsMZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uTLsM5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1GKVQpgQEemfbpUjK-Jv3g" x="422" y="40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uTLsMpnqEemrjrtN9v_T1A" x="422" y="40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1IuhEJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1IuhEZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1IvIIJgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uUq585nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uUq59JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uUq59pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1IuhEpgQEemfbpUjK-Jv3g" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUq59ZnqEemrjrtN9v_T1A" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1I6HQJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1I6HQZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1I6HQ5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uU0D4JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uU0D4ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uU0D45nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1I6HQpgQEemfbpUjK-Jv3g" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uU0D4pnqEemrjrtN9v_T1A" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1JG7kJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1JG7kZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JG7k5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uU0D8ZnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uU0D8pnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uU0D9JnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1JG7kpgQEemfbpUjK-Jv3g" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uU0D85nqEemrjrtN9v_T1A" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1JWzMJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1JWzMZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JWzM5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uU9045nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uU905JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uU905pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1JWzMpgQEemfbpUjK-Jv3g" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uU905ZnqEemrjrtN9v_T1A" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1JpuIJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1JpuIZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JpuI5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uVHl4JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uVHl4ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uVHl45nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1JpuIpgQEemfbpUjK-Jv3g" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uVHl4pnqEemrjrtN9v_T1A" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1J3wkJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1J3wkZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1J3wk5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uVHl8ZnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uVHl8pnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uVHl9JnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1J3wkpgQEemfbpUjK-Jv3g" x="422" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uVHl85nqEemrjrtN9v_T1A" x="422" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1KteEJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1KteEZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1KteE5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uVjqwJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uVjqwZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uVjqw5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1KteEpgQEemfbpUjK-Jv3g" x="409" y="-246"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uVjqwpnqEemrjrtN9v_T1A" x="409" y="-246"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1NQbwJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1NQbwZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NQbw5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uWdCo5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uWdCpJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uWdCppnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1NQbwpgQEemfbpUjK-Jv3g" x="919" y="230"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uWdCpZnqEemrjrtN9v_T1A" x="919" y="230"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1PKgQJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1PKgQZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1PLHUJgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uXWag5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uXWahJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uXWahpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1PKgQpgQEemfbpUjK-Jv3g" x="919" y="130"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uXWahZnqEemrjrtN9v_T1A" x="919" y="130"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1PWGcJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1PWGcZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1PWGc5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uXfkcJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uXfkcZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uXfkc5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1PWGcpgQEemfbpUjK-Jv3g" x="919" y="130"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uXfkcpnqEemrjrtN9v_T1A" x="919" y="130"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1RHBAJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1RHBAZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1RHBA5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uXyfY5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uXyfZJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uXyfZpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1RHBApgQEemfbpUjK-Jv3g" x="918" y="13"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uXyfZZnqEemrjrtN9v_T1A" x="918" y="13"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1SdE0JgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1SdE0ZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Sdr4JgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uY1oQ5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uY1oRJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uY1oRpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1SdE0pgQEemfbpUjK-Jv3g" x="347" y="315"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uY1oRZnqEemrjrtN9v_T1A" x="347" y="315"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1VIlYJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1VIlYZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1VIlY5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uaLFAJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uaLFAZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uaLFA5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1VIlYpgQEemfbpUjK-Jv3g" x="-100" y="-456"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uaLFApnqEemrjrtN9v_T1A" x="-100" y="-456"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1WX7gJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1WX7gZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1WX7g5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uanw95nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uanw-JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uanw-pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1WX7gpgQEemfbpUjK-Jv3g" x="-142" y="182"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uanw-ZnqEemrjrtN9v_T1A" x="-142" y="182"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1YliAJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1YliAZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1YliA5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ubqSxZnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ubqSxpnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ubqSyJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1YliApgQEemfbpUjK-Jv3g" x="-147" y="-88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ubqSx5nqEemrjrtN9v_T1A" x="-147" y="-88"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1br5UJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1br5UZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1br5U5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_udmMcJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_udmMcZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_udmMc5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1br5UpgQEemfbpUjK-Jv3g" x="915" y="-280"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udmMcpnqEemrjrtN9v_T1A" x="915" y="-280"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_1ejnIJgQEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_1ejnIZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1ejnI5gQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ufOkI5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ufOkJJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ufOkJpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1ejnIpgQEemfbpUjK-Jv3g" x="-105" y="-246"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufOkJZnqEemrjrtN9v_T1A" x="-105" y="-246"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmgeMTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmgeMjBFEeam35bpdXJzEw"/>
@@ -1669,185 +1669,185 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IiEy4FotEemu443YKSGnxQ" id="(1.0,0.4207920792079208)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IiEy4VotEemu443YKSGnxQ" id="(0.4418491484184915,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1GKVRJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_0G9yhzBFEeam35bpdXJzEw" target="_1GKVQJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1GKVRZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1GKVSZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uTLsNJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_0G9yhzBFEeam35bpdXJzEw" target="_uTLsMJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uTLsNZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uTLsOZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1GKVRpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1GKVR5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1GKVSJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uTLsNpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uTLsN5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uTLsOJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1IvIIZgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_lT2KsIuQEeiu6boZkiJHCA" target="_1IuhEJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1IvIIpgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1IvIJpgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uUq595nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lT2KsIuQEeiu6boZkiJHCA" target="_uUq585nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uUq5-JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uUq5_JnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1IvII5gQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1IvIJJgQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1IvIJZgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uUq5-ZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUq5-pnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUq5-5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1I6HRJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_3JCDkIuQEeiu6boZkiJHCA" target="_1I6HQJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1I6HRZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1I6HSZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uU0D5JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_3JCDkIuQEeiu6boZkiJHCA" target="_uU0D4JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uU0D5ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uU0D6ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1I6HRpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1I6HR5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1I6HSJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uU0D5pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uU0D55nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uU0D6JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1JG7lJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_8oadYIuQEeiu6boZkiJHCA" target="_1JG7kJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1JG7lZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JG7mZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uU0D9ZnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_8oadYIuQEeiu6boZkiJHCA" target="_uU0D8ZnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uU0D9pnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uU0D-pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1JG7lpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JG7l5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JG7mJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uU0D95nqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uU0D-JnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uU0D-ZnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1JWzNJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_DM_ksIuREeiu6boZkiJHCA" target="_1JWzMJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1JWzNZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JWzOZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uU9055nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DM_ksIuREeiu6boZkiJHCA" target="_uU9045nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uU906JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uU907JnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1JWzNpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JWzN5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JWzOJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uU906ZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uU906pnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uU9065nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1JpuJJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_G3oqcIuREeiu6boZkiJHCA" target="_1JpuIJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1JpuJZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JqVMJgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uVHl5JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_G3oqcIuREeiu6boZkiJHCA" target="_uVHl4JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uVHl5ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uVHl6ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1JpuJpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JpuJ5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JpuKJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uVHl5pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uVHl55nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uVHl6JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1J4XoJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_W6DjoK1bEeiIjuV0HZnJAQ" target="_1J3wkJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1J4XoZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1J4XpZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uVHl9ZnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_W6DjoK1bEeiIjuV0HZnJAQ" target="_uVHl8ZnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uVHl9pnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uVHl-pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WumhkK1bEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1J4XopgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1J4Xo5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1J4XpJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uVHl95nqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uVHl-JnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uVHl-ZnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1KteFJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_0G91jDBFEeam35bpdXJzEw" target="_1KteEJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1KteFZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1KuFIJgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uVjqxJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_0G91jDBFEeam35bpdXJzEw" target="_uVjqwJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uVjqxZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uVjqyZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1KteFpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1KteF5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1KteGJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uVjqxpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uVjqx5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uVjqyJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1NRC0JgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_0HHioDBFEeam35bpdXJzEw" target="_1NQbwJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1NRC0ZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NRC1ZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uWdCp5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_0HHioDBFEeam35bpdXJzEw" target="_uWdCo5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uWdCqJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uWdCrJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1NRC0pgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NRC05gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NRC1JgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uWdCqZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uWdCqpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uWdCq5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1PLHUZgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_S_bisIuREeiu6boZkiJHCA" target="_1PKgQJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1PLHUpgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1PLHVpgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uXWah5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_S_bisIuREeiu6boZkiJHCA" target="_uXWag5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uXWaiJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uXWajJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1PLHU5gQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1PLHVJgQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1PLHVZgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uXWaiZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uXWaipnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uXWai5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1PWGdJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_ZFXmMIuREeiu6boZkiJHCA" target="_1PWGcJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1PWGdZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1PWGeZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uXfkdJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZFXmMIuREeiu6boZkiJHCA" target="_uXfkcJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uXfkdZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uXfkeZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1PWGdpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1PWGd5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1PWGeJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uXfkdpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uXfkd5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uXfkeJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1RHBBJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_0HHjqDBFEeam35bpdXJzEw" target="_1RHBAJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1RHBBZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1RHBCZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uXyfZ5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_0HHjqDBFEeam35bpdXJzEw" target="_uXyfY5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uXyfaJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uXyfbJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1RHBBpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1RHBB5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1RHBCJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uXyfaZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uXyfapnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uXyfa5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1Sdr4ZgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_0HHlMDBFEeam35bpdXJzEw" target="_1SdE0JgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1Sdr4pgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Sdr5pgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uY1oR5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_0HHlMDBFEeam35bpdXJzEw" target="_uY1oQ5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uY1oSJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uY1oTJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1Sdr45gQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Sdr5JgQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Sdr5ZgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uY1oSZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uY1oSpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uY1oS5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1VIlZJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_rwI9oPlIEeaQEoLj_Ia_cg" target="_1VIlYJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1VIlZZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1VIlaZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uaLFBJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_rwI9oPlIEeaQEoLj_Ia_cg" target="_uaLFAJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uaLFBZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uaLFCZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1VIlZpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1VIlZ5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1VIlaJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uaLFBpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uaLFB5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uaLFCJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1WX7hJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_BDPgIP4xEea_VPdGG2-szQ" target="_1WX7gJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1WX7hZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1WYikpgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uanw-5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_BDPgIP4xEea_VPdGG2-szQ" target="_uanw95nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uanw_JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uanxAJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1WX7hpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1WYikJgQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1WYikZgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uanw_ZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uanw_pnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uanw_5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1YliBJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__Y_BEIfVEeeirpBaj87qAw" target="_1YliAJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1YliBZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1YliCZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ubqSyZnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__Y_BEIfVEeeirpBaj87qAw" target="_ubqSxZnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ubqSypnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ubqSzpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1YliBpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1YliB5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1YliCJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ubqSy5nqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ubqSzJnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ubqSzZnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1br5VJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_1br5UJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1br5VZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1bsgYJgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_udmMdJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_udmMcJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_udmMdZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_udmMeZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1br5VpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1br5V5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1br5WJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udmMdpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udmMd5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udmMeJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1ejnJJgQEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__j-OAK1aEeiIjuV0HZnJAQ" target="_1ejnIJgQEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_1ejnJZgQEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1ejnKZgQEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ufOkJ5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__j-OAK1aEeiIjuV0HZnJAQ" target="_ufOkI5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ufOkKJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ufOkLJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1ejnJpgQEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1ejnJ5gQEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1ejnKJgQEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ufOkKZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ufOkKpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ufOkK5nqEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityTopologySkeleton" measurementUnit="Pixel">
@@ -5790,117 +5790,117 @@
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iTC8alomEemu443YKSGnxQ" x="-149" y="298" height="67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cM4iAH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cM4iAX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cM4iA31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uIA-AJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uIA-AZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIA-A5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cM4iAn1KEemO2pf_QsOonA" x="151" y="-236"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uIA-ApnqEemrjrtN9v_T1A" x="151" y="-236"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cNp-EH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cNp-EX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cNp-E31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uIKH95nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uIKH-JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIKH-pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cNp-En1KEemO2pf_QsOonA" x="151" y="-336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uIKH-ZnqEemrjrtN9v_T1A" x="151" y="-336"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cN1kQH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cN1kQX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cN2LUH1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uIT48JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uIT48ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIT485nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cN1kQn1KEemO2pf_QsOonA" x="151" y="-336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uIT48pnqEemrjrtN9v_T1A" x="151" y="-336"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cOBxgH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cOBxgX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cOCYkH1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uIT5AZnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uIT5ApnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIT5BJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cOBxgn1KEemO2pf_QsOonA" x="151" y="-336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uIT5A5nqEemrjrtN9v_T1A" x="151" y="-336"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cOoOcH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cOoOcX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cOoOc31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uIwk45nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uIwk5JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIwk5pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cOoOcn1KEemO2pf_QsOonA" x="413" y="179"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uIwk5ZnqEemrjrtN9v_T1A" x="413" y="179"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cPaRkH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cPaRkX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cPaRk31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uJ83sJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uJ83sZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uJ83s5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cPaRkn1KEemO2pf_QsOonA" x="453" y="11"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uJ83spnqEemrjrtN9v_T1A" x="453" y="11"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cPzTIH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cPzTIX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cPzTI31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uKGot5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uKGouJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uKGoupnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cPzTIn1KEemO2pf_QsOonA" x="453" y="-89"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uKGouZnqEemrjrtN9v_T1A" x="453" y="-89"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cQIqUH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cQIqUX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cQIqU31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uKQZs5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uKQZtJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uKQZtpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cQIqUn1KEemO2pf_QsOonA" x="453" y="-89"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uKQZtZnqEemrjrtN9v_T1A" x="453" y="-89"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cQ3qIH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cQ3qIX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cQ3qI31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uKsek5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uKselJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uKselpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cQ3qIn1KEemO2pf_QsOonA" x="368" y="294"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uKselZnqEemrjrtN9v_T1A" x="368" y="294"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cSRYUH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cSRYUX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cSRYU31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uLl2cJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uLl2cZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uLl2c5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cSRYUn1KEemO2pf_QsOonA" x="759" y="-239"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uLl2cpnqEemrjrtN9v_T1A" x="759" y="-239"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cTrtkH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cTrtkX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cTsUoH1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uMLsU5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uMLsVJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uMLsVpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cTrtkn1KEemO2pf_QsOonA" x="88" y="7"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uMLsVZnqEemrjrtN9v_T1A" x="88" y="7"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cUQ8YH1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cUQ8YX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cUQ8Y31KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uMfOUJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uMfOUZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uMfOU5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cUQ8Yn1KEemO2pf_QsOonA" x="88" y="-93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uMfOUpnqEemrjrtN9v_T1A" x="88" y="-93"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cUfl4H1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cUfl4X1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cUfl431KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uMfOYZnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uMfOYpnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uMfOZJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cUfl4n1KEemO2pf_QsOonA" x="88" y="-93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uMfOY5nqEemrjrtN9v_T1A" x="88" y="-93"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cVRB8H1KEemO2pf_QsOonA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cVRB8X1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cVRpAH1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_uN0rE5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uN0rFJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uN0rFpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cVRB8n1KEemO2pf_QsOonA" x="51" y="298"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uN0rFZnqEemrjrtN9v_T1A" x="51" y="298"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_cHYpwVomEemu443YKSGnxQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_cHYpwlomEemu443YKSGnxQ"/>
@@ -6205,145 +6205,145 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTC8FVomEemu443YKSGnxQ" id="(0.5480769230769231,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTC8FlomEemu443YKSGnxQ" id="(0.7803921568627451,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cM5JEH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5J11omEemu443YKSGnxQ" target="_cM4iAH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cM5JEX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cM5JFX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uIA-BJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5J11omEemu443YKSGnxQ" target="_uIA-AJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uIA-BZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIA-CZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cM5JEn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cM5JE31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cM5JFH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIA-BpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIA-B5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIA-CJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cNqlIH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5KGFomEemu443YKSGnxQ" target="_cNp-EH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cNqlIX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cNqlJX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uIKH-5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5KGFomEemu443YKSGnxQ" target="_uIKH95nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uIKH_JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIKIAJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cNqlIn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cNqlI31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cNqlJH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIKH_ZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIKH_pnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIKH_5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cN2LUX1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5LZ1omEemu443YKSGnxQ" target="_cN1kQH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cN2LUn1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cN2LVn1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uIT49JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5LZ1omEemu443YKSGnxQ" target="_uIT48JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uIT49ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIT4-ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cN2LU31KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cN2LVH1KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cN2LVX1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIT49pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIT495nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIT4-JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cOCYkX1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iTC6_VomEemu443YKSGnxQ" target="_cOBxgH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cOCYkn1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cOCYln1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uIT5BZnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iTC6_VomEemu443YKSGnxQ" target="_uIT5AZnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uIT5BpnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIT5CpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cOCYk31KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cOCYlH1KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cOCYlX1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIT5B5nqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIT5CJnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIT5CZnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cOoOdH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5KO1omEemu443YKSGnxQ" target="_cOoOcH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cOoOdX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cOoOeX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uIwk55nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5KO1omEemu443YKSGnxQ" target="_uIwk45nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uIwk6JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uIwk7JnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cOoOdn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cOoOd31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cOoOeH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIwk6ZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIwk6pnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uIwk65nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cPaRlH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5MO1omEemu443YKSGnxQ" target="_cPaRkH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cPaRlX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cPaRmX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uJ83tJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5MO1omEemu443YKSGnxQ" target="_uJ83sJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uJ83tZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uJ83uZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cPaRln1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cPaRl31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cPaRmH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uJ83tpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uJ83t5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uJ83uJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cPz6MH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5NNVomEemu443YKSGnxQ" target="_cPzTIH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cPz6MX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cPz6NX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uKGou5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5NNVomEemu443YKSGnxQ" target="_uKGot5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uKGovJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uKGowJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cPz6Mn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cPz6M31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cPz6NH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uKGovZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uKGovpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uKGov5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cQIqVH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iTC8A1omEemu443YKSGnxQ" target="_cQIqUH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cQIqVX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cQIqWX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uKQZt5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iTC8A1omEemu443YKSGnxQ" target="_uKQZs5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uKQZuJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uKQZvJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cQIqVn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQIqV31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQIqWH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uKQZuZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uKQZupnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uKQZu5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cQ3qJH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5M4VomEemu443YKSGnxQ" target="_cQ3qIH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cQ3qJX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cQ3qKX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uKsel5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5M4VomEemu443YKSGnxQ" target="_uKsek5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uKsemJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uKsenJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cQ3qJn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQ3qJ31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQ3qKH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uKsemZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uKsempnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uKsem5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cSRYVH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5NT1omEemu443YKSGnxQ" target="_cSRYUH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cSRYVX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cSR_Yn1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uLl2dJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5NT1omEemu443YKSGnxQ" target="_uLl2cJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uLl2dZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uLl2eZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cSRYVn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cSR_YH1KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cSR_YX1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uLl2dpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uLl2d5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uLl2eJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cTsUoX1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iTC7NlomEemu443YKSGnxQ" target="_cTrtkH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cTsUon1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cTsUpn1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uMLsV5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iTC7NlomEemu443YKSGnxQ" target="_uMLsU5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uMLsWJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uMLsXJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cTsUo31KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cTsUpH1KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cTsUpX1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uMLsWZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMLsWpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMLsW5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cUQ8ZH1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5Kf1omEemu443YKSGnxQ" target="_cUQ8YH1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cUQ8ZX1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cUQ8aX1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uMfOVJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5Kf1omEemu443YKSGnxQ" target="_uMfOUJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uMfOVZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uMfOWZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cUQ8Zn1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUQ8Z31KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUQ8aH1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uMfOVpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMfOV5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMfOWJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cUgM8H1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iS5Mz1omEemu443YKSGnxQ" target="_cUfl4H1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cUgM8X1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cUgM9X1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uMfOZZnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iS5Mz1omEemu443YKSGnxQ" target="_uMfOYZnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uMfOZpnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uMfOapnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cUgM8n1KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUgM831KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUgM9H1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uMfOZ5nqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMfOaJnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMfOaZnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cVRpAX1KEemO2pf_QsOonA" type="StereotypeCommentLink" source="_iTC8LlomEemu443YKSGnxQ" target="_cVRB8H1KEemO2pf_QsOonA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cVRpAn1KEemO2pf_QsOonA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cVSQEH1KEemO2pf_QsOonA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_uN0rF5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iTC8LlomEemu443YKSGnxQ" target="_uN0rE5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uN0rGJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uN0rHJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cVRpA31KEemO2pf_QsOonA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cVRpBH1KEemO2pf_QsOonA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cVRpBX1KEemO2pf_QsOonA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uN0rGZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uN0rGpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uN0rG5nqEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -353,8 +353,6 @@ License: This module is distributed under the Apache License 2.0</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="__AwDkQN6EemABdf1yJ9dlA" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_--c9gAN6EemABdf1yJ9dlA"/>
       </packagedElement>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams">
       <packagedElement xmi:type="uml:Association" xmi:id="_ROxpQHvXEemvrvzs5PR02w" name="ConnectionIsBoundedByNode" memberEnd="_RPASwHvXEemvrvzs5PR02w _RPD9IXvXEemvrvzs5PR02w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_RO-dkHvXEemvrvzs5PR02w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_RO_EoHvXEemvrvzs5PR02w" key="nature" value="UML_Nature"/>
@@ -365,6 +363,7 @@ License: This module is distributed under the Apache License 2.0</body>
         </ownedEnd>
       </packagedElement>
     </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -379,8 +378,15 @@ License: This module is distributed under the Apache License 2.0</body>
     <packagedElement xmi:type="uml:Package" xmi:id="_QjobwC5zEea0_JngOlSKcA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_WHPN4FJvEeWcs7ZjyujtOg" name="ConnectivityService" isLeaf="true">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN5VJvEeWcs7ZjyujtOg" name="getConnectionDetails">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN5lJvEeWcs7ZjyujtOg" name="connectionIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN5lJvEeWcs7ZjyujtOg" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eDkjoJniEemrjrtN9v_T1A" annotatedElement="_WHPN5lJvEeWcs7ZjyujtOg">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN51JvEeWcs7ZjyujtOg" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" direction="out" effect="read"/>
         </ownedOperation>
@@ -391,16 +397,34 @@ License: This module is distributed under the Apache License 2.0</body>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN81JvEeWcs7ZjyujtOg" name="getConnectivityServiceDetails">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9FJvEeWcs7ZjyujtOg" name="serviceIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9FJvEeWcs7ZjyujtOg" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_W3TKMJniEemrjrtN9v_T1A" annotatedElement="_WHPN9FJvEeWcs7ZjyujtOg">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9VJvEeWcs7ZjyujtOg" name="service" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_AnTcAKU5EeWkWNPM1BHzGA" name="createConnectivityService">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_tlotoJgREemfbpUjK-Jv3g" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_YfJ40JniEemrjrtN9v_T1A" annotatedElement="_tlotoJgREemfbpUjK-Jv3g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_dJAnUJgKEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_mrpmAJndEemVaY_egjrbOQ" annotatedElement="_dJAnUJgKEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fshs8JgKEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ftG7wJgKEemfbpUjK-Jv3g" value="*"/>
@@ -433,10 +457,21 @@ License: This module is distributed under the Apache License 2.0</body>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_zEZcML2YEeWdore3Cxez9g" name="service" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_qH8fkL2NEeWdore3Cxez9g" name="updateConnectivityService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_JqtJcL2TEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_JqtJcL2TEeWdore3Cxez9g" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_bGbdEJniEemrjrtN9v_T1A" annotatedElement="_JqtJcL2TEeWdore3Cxez9g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_r9Ii8JgKEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_oHstQJndEemVaY_egjrbOQ" annotatedElement="_r9Ii8JgKEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tck8cJgKEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tdI9IJgKEemfbpUjK-Jv3g" value="*"/>
@@ -469,22 +504,27 @@ License: This module is distributed under the Apache License 2.0</body>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_L70owL2ZEeWdore3Cxez9g" name="service" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_lQR28L2WEeWdore3Cxez9g" name="deleteConnectivityService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_zDaPoL2WEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_zDaPoL2WEeWdore3Cxez9g" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_chSRgJniEemrjrtN9v_T1A" annotatedElement="_zDaPoL2WEeWdore3Cxez9g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_ARtOoPPkEeinaYo1FpF9OA" name="getConnectionEndPointDetails">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_JVgKYPPkEeinaYo1FpF9OA" name="topologyIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Lf_E8PPkEeinaYo1FpF9OA" name="nodeIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_N1arQPPkEeinaYo1FpF9OA" name="nepIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_QgLBUPPkEeinaYo1FpF9OA" name="cepIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_v41aMJnQEemVaY_egjrbOQ" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_fbh1EJniEemrjrtN9v_T1A" annotatedElement="_v41aMJnQEemVaY_egjrbOQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_U_XwgPPkEeinaYo1FpF9OA" name="connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" direction="out" effect="read"/>
         </ownedOperation>
@@ -1406,10 +1446,6 @@ The determination of a fault condition on a serial compound link connection with
   <OpenModel_Profile:OpenModelParameter xmi:id="_lCUXca1eEeiIjuV0HZnJAQ" base_Parameter="_lCUXcK1eEeiIjuV0HZnJAQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_3xRw8a1eEeiIjuV0HZnJAQ" base_Parameter="_3xRw8K1eEeiIjuV0HZnJAQ"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_ARtOofPkEeinaYo1FpF9OA" base_Operation="_ARtOoPPkEeinaYo1FpF9OA"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_JVhYgPPkEeinaYo1FpF9OA" base_Parameter="_JVgKYPPkEeinaYo1FpF9OA"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_Lf_sAPPkEeinaYo1FpF9OA" base_Parameter="_Lf_E8PPkEeinaYo1FpF9OA"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_N1bSUPPkEeinaYo1FpF9OA" base_Parameter="_N1arQPPkEeinaYo1FpF9OA"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_QgLBUfPkEeinaYo1FpF9OA" base_Parameter="_QgLBUPPkEeinaYo1FpF9OA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_U_XwgfPkEeinaYo1FpF9OA" base_Parameter="_U_XwgPPkEeinaYo1FpF9OA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_pbkGUP-1EeiABdf1yJ9dlA" base_StructuralFeature="_pbi4MP-1EeiABdf1yJ9dlA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_pbktYP-1EeiABdf1yJ9dlA" base_Property="_pbi4MP-1EeiABdf1yJ9dlA"/>
@@ -1446,4 +1482,5 @@ The determination of a fault condition on a serial compound link connection with
   <OpenModel_Profile:OpenModelParameter xmi:id="_dJAnUZgKEemfbpUjK-Jv3g" base_Parameter="_dJAnUJgKEemfbpUjK-Jv3g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_r9JKAJgKEemfbpUjK-Jv3g" base_Parameter="_r9Ii8JgKEemfbpUjK-Jv3g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_tlotoZgREemfbpUjK-Jv3g" base_Parameter="_tlotoJgREemfbpUjK-Jv3g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_v41aMZnQEemVaY_egjrbOQ" base_Parameter="_v41aMJnQEemVaY_egjrbOQ"/>
 </xmi:XMI>

--- a/UML/TapiEquipment.notation
+++ b/UML/TapiEquipment.notation
@@ -339,157 +339,157 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iEA1sVolEemu443YKSGnxQ" x="857" y="-266" height="79"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iA-8EHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iA-8EXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iA-8E3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_KwctIJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KwctIZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KwctI5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iA-8EnswEemfSIWqmJMEQA" x="537" y="148"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KwctIpniEemrjrtN9v_T1A" x="537" y="148"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iCBd4HswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iCBd4XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCBd43swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Kyk0EJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Kyk0EZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Kyk0E5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCBd4nswEemfSIWqmJMEQA" x="733" y="-258"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Kyk0EpniEemrjrtN9v_T1A" x="733" y="-258"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iCn60HswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iCn60XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCn603swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Kz2mcJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Kz2mcZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Kz2mc5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCn60nswEemfSIWqmJMEQA" x="733" y="-358"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Kz2mcpniEemrjrtN9v_T1A" x="733" y="-358"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iCxEwHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iCxEwXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCxEw3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K0MksJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K0MksZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K0Mks5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCxEwnswEemfSIWqmJMEQA" x="733" y="-358"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K0MkspniEemrjrtN9v_T1A" x="733" y="-358"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iCxE1XswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iCxE1nswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCxE2HswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K0anIJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K0anIZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K0anI5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCxE13swEemfSIWqmJMEQA" x="733" y="-358"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K0anIpniEemrjrtN9v_T1A" x="733" y="-358"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iDqcoHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iDqcoXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iDqco3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K14mwJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K14mwZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K14mw5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iDqconswEemfSIWqmJMEQA" x="937" y="-152"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K14mwpniEemrjrtN9v_T1A" x="937" y="-152"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iEHIkHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iEHIkXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iEHIk3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K3PRoJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K3PRoZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K3PRo5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iEHIknswEemfSIWqmJMEQA" x="937" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3PRopniEemrjrtN9v_T1A" x="937" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iEQSgHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iEQSgXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iEQSg3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K3cF8JniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K3cF8ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K3cF85niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iEQSgnswEemfSIWqmJMEQA" x="937" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K3cF8pniEemrjrtN9v_T1A" x="937" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iE_5YHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iE_5YXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iE_5Y3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K4a9YJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K4a9YZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K4bkcJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iE_5YnswEemfSIWqmJMEQA" x="537" y="-152"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K4a9YpniEemrjrtN9v_T1A" x="537" y="-152"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iFclWnswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iFclW3swEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iFclXXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K5PcwJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K5PcwZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K5Pcw5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iFclXHswEemfSIWqmJMEQA" x="537" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K5PcwpniEemrjrtN9v_T1A" x="537" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iFmWXnswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iFmWX3swEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iFvgQHswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K5cREJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K5cREZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K5cRE5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iFmWYHswEemfSIWqmJMEQA" x="537" y="-252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K5cREpniEemrjrtN9v_T1A" x="537" y="-252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iGfHIHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iGfHIXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iGfHI3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K6ZTUJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K6ZTUZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K6ZTU5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iGfHInswEemfSIWqmJMEQA" x="197" y="148"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K6ZTUpniEemrjrtN9v_T1A" x="197" y="148"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iG7zE3swEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iG7zFHswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iG7zFnswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K66QsJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K66QsZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K663wJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iG7zFXswEemfSIWqmJMEQA" x="197" y="48"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K66QspniEemrjrtN9v_T1A" x="197" y="48"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iH1K8HswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iH1K8XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iH1K83swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K8Ac4JniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K8Ac4ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K8Ac45niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iH1K8nswEemfSIWqmJMEQA" x="937" y="86"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K8Ac4pniEemrjrtN9v_T1A" x="937" y="86"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iIR24HswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iIR24XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iIR243swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K8haQJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K8haQZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K8haQ5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iIR24nswEemfSIWqmJMEQA" x="937" y="-14"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K8haQpniEemrjrtN9v_T1A" x="937" y="-14"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iIR28XswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iIR28nswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iIR29HswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K8rLQJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K8rLQZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K8rLQ5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iIR283swEemfSIWqmJMEQA" x="937" y="-14"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K8rLQpniEemrjrtN9v_T1A" x="937" y="-14"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iJ6OkHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iJ6OkXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iJ6Ok3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K-GHkJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K-GHkZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K-GHk5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iJ6OknswEemfSIWqmJMEQA" x="197" y="-72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K-GHkpniEemrjrtN9v_T1A" x="197" y="-72"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iKzmc3swEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iKzmdHswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iKzmdnswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_K-zSMJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_K-zSMZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K-zSM5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iKzmdXswEemfSIWqmJMEQA" x="197" y="-172"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K-zSMpniEemrjrtN9v_T1A" x="197" y="-172"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_iMS0MHswEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_iMS0MXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iMS0M3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_LAiXkJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LAiXkZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LAiXk5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iMS0MnswEemfSIWqmJMEQA" x="1057" y="-266"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LAiXkpniEemrjrtN9v_T1A" x="1057" y="-266"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_hb9t2i8LEeexxefg2F1i1Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_hb9t2y8LEeexxefg2F1i1Q"/>
@@ -849,195 +849,195 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jXxjoFolEemu443YKSGnxQ" id="(1.0,0.21929824561403508)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jXxjoVolEemu443YKSGnxQ" id="(0.0,0.4177215189873418)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iA-8FHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vjDakv0EemT5f_Ewhfs6A" target="_iA-8EHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iA-8FXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iA-8GXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_KwctJJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vjDakv0EemT5f_Ewhfs6A" target="_KwctIJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KwctJZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KwctKZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iA-8FnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iA-8F3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iA-8GHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KwctJpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KwctJ5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KwctKJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iCBd5HswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vjqd0v0EemT5f_Ewhfs6A" target="_iCBd4HswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iCBd5XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCBd6XswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Kyk0FJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vjqd0v0EemT5f_Ewhfs6A" target="_Kyk0EJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Kyk0FZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Kyk0GZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iCBd5nswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCBd53swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCBd6HswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Kyk0FpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Kyk0F5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Kyk0GJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iCn61HswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vlfxkv0EemT5f_Ewhfs6A" target="_iCn60HswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iCn61XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCn62XswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Kz2mdJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vlfxkv0EemT5f_Ewhfs6A" target="_Kz2mcJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Kz3NgJniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Kz3NhJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iCn61nswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCn613swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCn62HswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Kz3NgZniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Kz3NgpniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Kz3Ng5niEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iCxExHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vn70Ev0EemT5f_Ewhfs6A" target="_iCxEwHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iCxExXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCxEyXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K0MktJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vn70Ev0EemT5f_Ewhfs6A" target="_K0MksJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K0MktZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K0MkuZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iCxExnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCxEx3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCxEyHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K0MktpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K0Mkt5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K0MkuJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iCxE2XswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_iQgZkFolEemu443YKSGnxQ" target="_iCxE1XswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iCxE2nswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iCxE3nswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K0bOMJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iQgZkFolEemu443YKSGnxQ" target="_K0anIJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K0bOMZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K0bONZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iCxE23swEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCxE3HswEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iCxE3XswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K0bOMpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K0bOM5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K0bONJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iDqcpHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vk4gEv0EemT5f_Ewhfs6A" target="_iDqcoHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iDqcpXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iDqcqXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K14mxJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vk4gEv0EemT5f_Ewhfs6A" target="_K14mwJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K14mxZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K14myZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iDqcpnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iDqcp3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iDqcqHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K14mxpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K14mx5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K14myJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iEHIlHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vlfkEv0EemT5f_Ewhfs6A" target="_iEHIkHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iEHIlXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iEHImXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K3PRpJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vlfkEv0EemT5f_Ewhfs6A" target="_K3PRoJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K3PRpZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K3PRqZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iEHIlnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iEHIl3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iEHImHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K3PRppniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3PRp5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3PRqJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iEQShHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vpxGkv0EemT5f_Ewhfs6A" target="_iEQSgHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iEQShXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iEQSiXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K3cF9JniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vpxGkv0EemT5f_Ewhfs6A" target="_K3cF8JniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K3cF9ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K3cF-ZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iEQShnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iEQSh3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iEQSiHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K3cF9pniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3cF95niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3cF-JniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iE_5ZHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vmGoEv0EemT5f_Ewhfs6A" target="_iE_5YHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iE_5ZXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iE_5aXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K4bkcZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vmGoEv0EemT5f_Ewhfs6A" target="_K4a9YJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K4bkcpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K4bkdpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iE_5ZnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iE_5Z3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iE_5aHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K4bkc5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K4bkdJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K4bkdZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iFclXnswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vjDUEv0EemT5f_Ewhfs6A" target="_iFclWnswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iFclX3swEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iFclY3swEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K5PcxJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vjDUEv0EemT5f_Ewhfs6A" target="_K5PcwJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K5PcxZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K5PcyZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iFclYHswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iFclYXswEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iFclYnswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K5PcxpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5Pcx5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5PcyJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iFvgQXswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vrmMEv0EemT5f_Ewhfs6A" target="_iFmWXnswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iFvgQnswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iFvgRnswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K5cRFJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vrmMEv0EemT5f_Ewhfs6A" target="_K5cREJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K5cRFZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K5c4IpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iFvgQ3swEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iFvgRHswEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iFvgRXswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K5cRFpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5c4IJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K5c4IZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iGfHJHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vmtsEv0EemT5f_Ewhfs6A" target="_iGfHIHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iGfHJXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iGfHKXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K6ZTVJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vmtsEv0EemT5f_Ewhfs6A" target="_K6ZTUJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K6ZTVZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K6ZTWZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iGfHJnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iGfHJ3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iGfHKHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K6ZTVpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K6ZTV5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K6ZTWJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iG7zF3swEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vlfqkv0EemT5f_Ewhfs6A" target="_iG7zE3swEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iG7zGHswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iG7zHHswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K663wZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vlfqkv0EemT5f_Ewhfs6A" target="_K66QsJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K663wpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K663xpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iG7zGXswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iG7zGnswEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iG7zG3swEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K663w5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K663xJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K663xZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iH1K9HswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vn76kv0EemT5f_Ewhfs6A" target="_iH1K8HswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iH1K9XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iH1K-XswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K8Ac5JniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vn76kv0EemT5f_Ewhfs6A" target="_K8Ac4JniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K8Ac5ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K8Ac6ZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iH1K9nswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iH1K93swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iH1K-HswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K8Ac5pniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K8Ac55niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K8Ac6JniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iIR25HswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vicQEv0EemT5f_Ewhfs6A" target="_iIR24HswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iIR25XswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iIR26XswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K8haRJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vicQEv0EemT5f_Ewhfs6A" target="_K8haQJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K8haRZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K8haSZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iIR25nswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iIR253swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iIR26HswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K8haRpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K8haR5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K8haSJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iIR29XswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vjqYEv0EemT5f_Ewhfs6A" target="_iIR28XswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iIR29nswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iIR2-nswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K8rLRJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vjqYEv0EemT5f_Ewhfs6A" target="_K8rLQJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K8rLRZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K8ryUZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iIR293swEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iIR2-HswEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iIR2-XswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K8rLRpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K8rLR5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K8ryUJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iJ6OlHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vpxNEv0EemT5f_Ewhfs6A" target="_iJ6OkHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iJ6OlXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iJ6OmXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K-GHlJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vpxNEv0EemT5f_Ewhfs6A" target="_K-GHkJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K-GHlZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K-GHmZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iJ6OlnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iJ6Ol3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iJ6OmHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K-GHlpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K-GHl5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K-GHmJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iKzmd3swEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__vpxAEv0EemT5f_Ewhfs6A" target="_iKzmc3swEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iKzmeHswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iKzmfHswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_K-zSNJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__vpxAEv0EemT5f_Ewhfs6A" target="_K-zSMJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_K-zSNZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K-zSOZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iKzmeXswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iKzmenswEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iKzme3swEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K-zSNpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K-zSN5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K-zSOJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_iMS0NHswEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_iEA1sFolEemu443YKSGnxQ" target="_iMS0MHswEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_iMS0NXswEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iMS0OXswEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_LAiXlJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iEA1sFolEemu443YKSGnxQ" target="_LAiXkJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LAiXlZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LAiXmZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iMS0NnswEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iMS0N3swEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iMS0OHswEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LAiXlpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LAiXl5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LAiXmJniEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_UDyhIES5Eem_eeeaz1ENMQ" type="PapyrusUMLClassDiagram" name="EquipmentModelDetail" measurementUnit="Pixel">
@@ -1617,213 +1617,213 @@
       <element xmi:type="uml:Interface" href="TapiEquipment.uml#_EMk8UHspEemfSIWqmJMEQA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EM33QXspEemfSIWqmJMEQA" x="45" y="-250" height="119"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TiHM03syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TiHM1HsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TiHM1nsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MKxWEJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MKxWEZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MKxWE5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TiHM1XsyEemfSIWqmJMEQA" x="2580" y="560"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MKxWEpniEemrjrtN9v_T1A" x="1571" y="598"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tj5Vg3syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tj5VhHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tj5VhnsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ML8awJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ML8awZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ML8aw5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tj5VhXsyEemfSIWqmJMEQA" x="2580" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ML8awpniEemrjrtN9v_T1A" x="1571" y="58"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TlFoUHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TlFoUXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TlFoU3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MNFqQJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MNFqQZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MNFqQ5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TlFoUnsyEemfSIWqmJMEQA" x="860" y="-20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MNFqQpniEemrjrtN9v_T1A" x="199" y="192"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_To80oHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_To80oXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_To80o3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MPsSUJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MPsSUZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MPsSU5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_To80onsyEemfSIWqmJMEQA" x="860" y="-120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPsSUpniEemrjrtN9v_T1A" x="199" y="92"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tq4uUHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tq4uUXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tq4uU3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MRC9MJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MRC9MZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MRC9M5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tq4uUnsyEemfSIWqmJMEQA" x="1926" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MRC9MpniEemrjrtN9v_T1A" x="1028" y="58"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TshtEHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TshtEXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TshtE3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MS1s8JniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MS1s8ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MS1s85niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TshtEnsyEemfSIWqmJMEQA" x="1926" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MS1s8pniEemrjrtN9v_T1A" x="1028" y="-42"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ts0oA3syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ts0oBHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ts0oBnsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MTZGkJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MTZGkZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MTZGk5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ts0oBXsyEemfSIWqmJMEQA" x="1926" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MTZGkpniEemrjrtN9v_T1A" x="1028" y="-42"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TuKEwHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TuKEwXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TuKEw3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MU7XoJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MU7XoZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MU7Xo5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TuKEwnsyEemfSIWqmJMEQA" x="860" y="560"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MU7XopniEemrjrtN9v_T1A" x="173" y="587"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TwY5Y3syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TwY5ZHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TwY5ZnsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MXXAkJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MXXAkZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MXXnoJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TwY5ZXsyEemfSIWqmJMEQA" x="860" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MXXAkpniEemrjrtN9v_T1A" x="173" y="487"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tx4HIHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tx4HIXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tx4HI3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MYheMJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MYheMZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MYheM5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx4HInsyEemfSIWqmJMEQA" x="1400" y="560"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MYheMpniEemrjrtN9v_T1A" x="638" y="594"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T02ioHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T02ioXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T02io3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MbUTgJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MbUTgZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MbU6kJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T02ionsyEemfSIWqmJMEQA" x="1980" y="305"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MbUTgpniEemrjrtN9v_T1A" x="1082" y="343"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T28NUHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T28NUXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T28NU3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MdT3kJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MdT3kZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MdT3k5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T28NUnsyEemfSIWqmJMEQA" x="1980" y="205"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MdT3kpniEemrjrtN9v_T1A" x="1082" y="243"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T28NYXsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T28NYnsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T28NZHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MdcacJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MdcacZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mdcac5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T28NY3syEemfSIWqmJMEQA" x="1980" y="205"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MdcacpniEemrjrtN9v_T1A" x="1082" y="243"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UC17UHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UC17UXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UC17U3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MeqicJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MeqicZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Meqic5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UC17UnsyEemfSIWqmJMEQA" x="1580" y="-100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MeqicpniEemrjrtN9v_T1A" x="720" y="-18"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UEx1AHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UEx1AXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UEx1A3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MgxbQJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MgxbQZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MgxbQ5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UEx1AnsyEemfSIWqmJMEQA" x="1580" y="-200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MgxbQpniEemrjrtN9v_T1A" x="720" y="-118"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UE6-83syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UE6-9HsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UE6-9nsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MhInoJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MhInoZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MhIno5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UE6-9XsyEemfSIWqmJMEQA" x="1580" y="-200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MhInopniEemrjrtN9v_T1A" x="720" y="-118"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UF0W0HsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UF0W0XsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UF0W03syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Mi1QwJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Mi1QwZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mi1Qw5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UF0W0nsyEemfSIWqmJMEQA" x="1780" y="-300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mi1QwpniEemrjrtN9v_T1A" x="882" y="-262"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UHApoHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UHApoXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UHApo3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Mk6UYJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Mk6UYZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mk6UY5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UHAponsyEemfSIWqmJMEQA" x="1780" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mk6UYpniEemrjrtN9v_T1A" x="882" y="-362"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UHJzk3syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UHJzlHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UHJzlnsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MlKMAJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MlKMAZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MlKzEJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UHJzlXsyEemfSIWqmJMEQA" x="1780" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MlKMApniEemrjrtN9v_T1A" x="882" y="-362"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UHTkk3syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UHTklHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UHcugHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MmkhQJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MmkhQZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MmlIUJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UHTklXsyEemfSIWqmJMEQA" x="1780" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmkhQpniEemrjrtN9v_T1A" x="882" y="-362"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UIf3YHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UIf3YXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UIf3Y3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MnnDEJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MnnDEZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MnnDE5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UIf3YnsyEemfSIWqmJMEQA" x="2580" y="-300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MnnDEpniEemrjrtN9v_T1A" x="1571" y="-262"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UJiZMHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UJiZMXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UJiZM3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Moz88JniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Moz88ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Moz885niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UJiZMnsyEemfSIWqmJMEQA" x="2333" y="-84"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Moz88pniEemrjrtN9v_T1A" x="1324" y="-46"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UJ_FI3syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UJ_FJHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UJ_FJnsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MpQB0JniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MpQB0ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MpQB05niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UJ_FJXsyEemfSIWqmJMEQA" x="2333" y="-184"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MpQB0pniEemrjrtN9v_T1A" x="1324" y="-146"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UKk7AHsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UKk7AXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UKk7A3syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Mp-akJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Mp-akZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mp-ak5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UKk7AnsyEemfSIWqmJMEQA" x="2136" y="581"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mp-akpniEemrjrtN9v_T1A" x="1255" y="617"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ULKw4HsyEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ULKw4XsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ULKw43syEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MqdiwJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MqdiwZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mqdiw5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ULKw4nsyEemfSIWqmJMEQA" x="2136" y="481"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MqdiwpniEemrjrtN9v_T1A" x="1255" y="517"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ULxN13syEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ULxN2HsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ULxN2nsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_MrBjcJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MrBjcZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MrBjc5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiEquipment.uml#_EMk8UHspEemfSIWqmJMEQA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ULxN2XsyEemfSIWqmJMEQA" x="1104" y="-290"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MrBjcpniEemrjrtN9v_T1A" x="245" y="-250"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_UDyhIUS5Eem_eeeaz1ENMQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_UDyhIkS5Eem_eeeaz1ENMQ"/>
@@ -2300,265 +2300,265 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iJKIAHstEemfSIWqmJMEQA" id="(0.0,0.4247787610619469)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iJKIAXstEemfSIWqmJMEQA" id="(1.0,0.31092436974789917)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TiHM13syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Yvs210S5Eem_eeeaz1ENMQ" target="_TiHM03syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TiHM2HsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TiHM3HsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MKxWFJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Yvs210S5Eem_eeeaz1ENMQ" target="_MKxWEJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MKxWFZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MKxWGZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TiHM2XsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TiHM2nsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TiHM23syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MKxWFpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MKxWF5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MKxWGJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tj5Vh3syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_Tj5Vg3syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tj5ViHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tj5VjHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ML8axJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Yvur1US5Eem_eeeaz1ENMQ" target="_ML8awJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ML8axZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ML8ayZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tj5ViXsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tj5VinsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tj5Vi3syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ML8axpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ML8ax5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ML8ayJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TlFoVHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_TlFoUHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TlFoVXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TlFoWXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MNFqRJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_YvvTPUS5Eem_eeeaz1ENMQ" target="_MNFqQJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MNFqRZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MNGRUJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TlFoVnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TlFoV3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TlFoWHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MNFqRpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MNFqR5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MNFqSJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_To80pHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Yvs2o0S5Eem_eeeaz1ENMQ" target="_To80oHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_To80pXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_To80qXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MPsSVJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Yvs2o0S5Eem_eeeaz1ENMQ" target="_MPsSUJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MPsSVZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MPsSWZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_To80pnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_To80p3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_To80qHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MPsSVpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPsSV5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPsSWJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tq4uVHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_Tq4uUHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tq4uVXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tq4uWXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MRC9NJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Yvv6IUS5Eem_eeeaz1ENMQ" target="_MRC9MJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MRC9NZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MRC9OZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_qCBY4FRMEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tq4uVnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tq4uV3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tq4uWHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MRC9NpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MRC9N5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MRC9OJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TshtFHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_YvtdsES5Eem_eeeaz1ENMQ" target="_TshtEHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TshtFXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TshtGXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MS1s9JniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_YvtdsES5Eem_eeeaz1ENMQ" target="_MS1s8JniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MS1s9ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MS1s-ZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_xJVScFRPEeiyzdV8zVsJ_w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TshtFnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TshtF3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TshtGHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MS1s9pniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MS1s95niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MS1s-JniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ts0oB3syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_QbC-0ElZEemT5f_Ewhfs6A" target="_Ts0oA3syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ts0oCHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ts0oDHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MTZGlJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_QbC-0ElZEemT5f_Ewhfs6A" target="_MTZGkJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MTZGlZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MTZGmZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_PsaXMElZEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ts0oCXsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ts0oCnsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ts0oC3syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MTZGlpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MTZGl5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MTZGmJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TuKExHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_TuKEwHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TuKExXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TuKEyXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MU7XpJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Yvy9QES5Eem_eeeaz1ENMQ" target="_MU7XoJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MU7XpZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MU7-spniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TuKExnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TuKEx3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TuKEyHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MU7XppniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MU7-sJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MU7-sZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TwY5Z3syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_YvteBES5Eem_eeeaz1ENMQ" target="_TwY5Y3syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TwY5aHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TwY5bHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MXXnoZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_YvteBES5Eem_eeeaz1ENMQ" target="_MXXAkJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MXXnopniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MXXnppniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TwY5aXsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TwY5ansyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TwY5a3syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MXXno5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXXnpJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXXnpZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tx4HJHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_Tx4HIHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tx4HJXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tx4HKXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MYheNJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Yvy9qES5Eem_eeeaz1ENMQ" target="_MYheMJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MYheNZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MYheOZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNpD-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tx4HJnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tx4HJ3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tx4HKHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MYheNpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MYheN5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MYheOJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T02ipHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_T02ioHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T02ipXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T02iqXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MbU6kZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ESGL0ElgEemT5f_Ewhfs6A" target="_MbUTgJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MbU6kpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MbU6lpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_ESEWoElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T02ipnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T02ip3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T02iqHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MbU6k5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MbU6lJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MbU6lZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T28NVHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_MMsq4ElgEemT5f_Ewhfs6A" target="_T28NUHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T28NVXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T28NWXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MdT3lJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_MMsq4ElgEemT5f_Ewhfs6A" target="_MdT3kJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MdT3lZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MdUeoJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_LjmqkElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T28NVnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T28NV3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T28NWHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MdT3lpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MdT3l5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MdT3mJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T28NZXsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_V8cGoElgEemT5f_Ewhfs6A" target="_T28NYXsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T28NZnsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T28NansyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MdcadJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_V8cGoElgEemT5f_Ewhfs6A" target="_MdcacJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MdcadZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MdcaeZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_VSjcIElgEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T28NZ3syEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T28NaHsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T28NaXsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MdcadpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mdcad5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MdcaeJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UC17VHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_UC17UHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UC17VXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UC17WXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MeqidJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dOMqwEvWEemT5f_Ewhfs6A" target="_MeqicJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MeqidZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MerJgpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_dOLcoEvWEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UC17VnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UC17V3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UC17WHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MeqidpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MerJgJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MerJgZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UEx1BHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_TTeRkEvXEemT5f_Ewhfs6A" target="_UEx1AHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UEx1BXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UEx1CXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MgxbRJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_TTeRkEvXEemT5f_Ewhfs6A" target="_MgxbQJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MgxbRZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MgxbSZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_S0vuMEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UEx1BnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UEx1B3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UEx1CHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MgxbRpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MgxbR5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MgxbSJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UE6-93syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WUpjkEvXEemT5f_Ewhfs6A" target="_UE6-83syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UE6--HsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UE6-_HsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MhJOsJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WUpjkEvXEemT5f_Ewhfs6A" target="_MhInoJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MhJOsZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MhJOtZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_V181YEvXEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UE6--XsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UE6--nsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UE6--3syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MhJOspniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MhJOs5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MhJOtJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UF0W1HsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_UF0W0HsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UF0W1XsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UF0W2XsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Mi1QxJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_gPB_sEvwEemT5f_Ewhfs6A" target="_Mi1QwJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Mi1QxZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mi1QyZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_gO_jcEvwEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UF0W1nsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UF0W13syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UF0W2HsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mi1QxpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mi1Qx5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mi1QyJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UHAppHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_I4JjYEvxEemT5f_Ewhfs6A" target="_UHApoHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UHAppXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UHApqXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Mk6UZJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_I4JjYEvxEemT5f_Ewhfs6A" target="_Mk6UYJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Mk6UZZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mk6UaZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_I4IVQEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UHAppnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHApp3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHApqHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mk6UZpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mk6UZ5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mk6UaJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UHJzl3syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__DqVEEvxEemT5f_Ewhfs6A" target="_UHJzk3syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UHJzmHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UHJznHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MlKzEZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__DqVEEvxEemT5f_Ewhfs6A" target="_MlKMAJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MlKzEpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MlKzFpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_-o6SwEvxEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UHJzmXsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHJzmnsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHJzm3syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MlKzE5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MlKzFJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MlKzFZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UHcugXsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_DpB9sEvyEemT5f_Ewhfs6A" target="_UHTkk3syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UHcugnsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UHcuhnsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MmlIUZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DpB9sEvyEemT5f_Ewhfs6A" target="_MmkhQJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MmlIUpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MmlIVpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_DN0BUEvyEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UHcug3syEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHcuhHsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHcuhXsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MmlIU5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MmlIVJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MmlIVZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UIf3ZHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_7M57YEvwEemT5f_Ewhfs6A" target="_UIf3YHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UIf3ZXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UIf3aXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MnnDFJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_7M57YEvwEemT5f_Ewhfs6A" target="_MnnDEJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MnnDFZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MnnDGZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UIf3ZnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UIf3Z3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UIf3aHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MnnDFpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MnnDF5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MnnDGJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UJiZNHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_4jT6oE2rEemQQPVBE79CWA" target="_UJiZMHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UJiZNXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UJiZOXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Moz89JniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_4jT6oE2rEemQQPVBE79CWA" target="_Moz88JniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Moz89ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Moz8-ZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_4jJikE2rEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UJiZNnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UJiZN3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UJiZOHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Moz89pniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Moz895niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Moz8-JniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UJ_FJ3syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_MccoQE2sEemQQPVBE79CWA" target="_UJ_FI3syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UJ_FKHsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UJ_FLHsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MpQB1JniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_MccoQE2sEemQQPVBE79CWA" target="_MpQB0JniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MpQB1ZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MpQB2ZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_McPz8E2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UJ_FKXsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UJ_FKnsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UJ_FK3syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MpQB1pniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MpQB15niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MpQB2JniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UKk7BHsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_8PgDEE2sEemQQPVBE79CWA" target="_UKk7AHsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UKk7BXsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UKk7CXsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Mp_BoJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_8PgDEE2sEemQQPVBE79CWA" target="_Mp-akJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Mp_BoZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Mp_BpZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8PYHQE2sEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UKk7BnsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UKk7B3syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UKk7CHsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mp_BopniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mp_Bo5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mp_BpJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ULKw5HsyEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Tt3yAE2tEemQQPVBE79CWA" target="_ULKw4HsyEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ULKw5XsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ULKw6XsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MqdixJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Tt3yAE2tEemQQPVBE79CWA" target="_MqdiwJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MqdixZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MqdiyZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_Tt0usE2tEemQQPVBE79CWA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ULKw5nsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULKw53syEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULKw6HsyEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MqdixpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mqdix5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MqdiyJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ULxN23syEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_EM33QHspEemfSIWqmJMEQA" target="_ULxN13syEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ULxN3HsyEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ULxN4HsyEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_MrBjdJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_EM33QHspEemfSIWqmJMEQA" target="_MrBjcJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MrBjdZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MrCKgZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiEquipment.uml#_EMk8UHspEemfSIWqmJMEQA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ULxN3XsyEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULxN3nsyEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULxN33syEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MrBjdpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MrBjd5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MrCKgJniEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <css:ModelStyleSheets xmi:id="_pUoawHsuEemfSIWqmJMEQA">
@@ -3078,133 +3078,133 @@
       <element xmi:type="uml:Comment" href="TapiEquipment.uml#_87bG8ElkEemT5f_Ewhfs6A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UeM6Q3sxEemfSIWqmJMEQA" x="-607" y="-211" width="341" height="21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7TY_B3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7TY_CHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7TY_CnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Jfc_UJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Jfc_UZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jfc_U5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7TY_CXsxEemfSIWqmJMEQA" x="42" y="842"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jfc_UpniEemrjrtN9v_T1A" x="42" y="842"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7UIl4HsxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7UIl4XsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7UIl43sxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Jh7rkJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Jh7rkZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jh7rk5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7UIl4nsxEemfSIWqmJMEQA" x="22" y="390"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jh7rkpniEemrjrtN9v_T1A" x="22" y="390"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7VU4s3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7VU4tHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7VU4tnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JmCIcJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JmCIcZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JmCIc5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7VU4tXsxEemfSIWqmJMEQA" x="182" y="670"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JmCIcpniEemrjrtN9v_T1A" x="182" y="670"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7X2oQHsxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7X2oQXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7X2oQ3sxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JpYXYJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JpYXYZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JpYXY5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7X2oQnsxEemfSIWqmJMEQA" x="870" y="-10"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JpYXYpniEemrjrtN9v_T1A" x="870" y="-10"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7aOm0HsxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7aOm0XsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7aOm03sxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JtKEIJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JtKEIZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JtKrMJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7aOm0nsxEemfSIWqmJMEQA" x="870" y="-110"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JtKEIpniEemrjrtN9v_T1A" x="870" y="-110"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7aYX03sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7aYX1HsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7aYX1nsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JtfbUJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JtfbUZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JtfbU5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7aYX1XsxEemfSIWqmJMEQA" x="542" y="430"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JtfbUpniEemrjrtN9v_T1A" x="542" y="430"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7a-Ns3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7a-NtHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7a-NtnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JuAYsJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JuAYsZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JuAYs5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7a-NtXsxEemfSIWqmJMEQA" x="879" y="-211"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JuAYspniEemrjrtN9v_T1A" x="879" y="-211"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7cBWkHsxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7cBWkXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7cBWk3sxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JvbVAJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JvbVAZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JvbVA5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7cBWknsxEemfSIWqmJMEQA" x="-358" y="210"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JvbVApniEemrjrtN9v_T1A" x="-358" y="210"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7c6HY3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7c6HZHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7c6HZnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JwY-UJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JwY-UZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JwY-U5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiEquipment.uml#_BQiK0FogEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7c6HZXsxEemfSIWqmJMEQA" x="663" y="-127"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JwY-UpniEemrjrtN9v_T1A" x="223" y="-122"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7dD4Y3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7dD4ZHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7dD4ZnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JwnAwJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JwnAwZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JwnAw5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_K2ClIFojEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dD4ZXsxEemfSIWqmJMEQA" x="663" y="-227"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JwnAwpniEemrjrtN9v_T1A" x="223" y="-222"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7dWzV3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7dWzWHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7dWzWnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Jw4GgJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Jw4GgZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jw4tkJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dWzWXsxEemfSIWqmJMEQA" x="-258" y="670"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jw4GgpniEemrjrtN9v_T1A" x="-258" y="670"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7e2BEHsxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7e2BEXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7e2BE3sxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_JyugoJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JyugoZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jyugo5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7e2BEnsxEemfSIWqmJMEQA" x="870" y="570"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JyugopniEemrjrtN9v_T1A" x="870" y="570"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7hhhoHsxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7hhhoXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7hhho3sxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_J1aoQJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_J1aoQZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1aoQ5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7hhhonsxEemfSIWqmJMEQA" x="870" y="470"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J1aoQpniEemrjrtN9v_T1A" x="870" y="470"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7h0ck3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7h0clHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7h0clnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_J12GEJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_J12GEZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J12GE5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7h0clXsxEemfSIWqmJMEQA" x="-307" y="-33"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J12GEpniEemrjrtN9v_T1A" x="-307" y="-33"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7jAvY3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7jAvZHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7jAvZnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_J4YcsJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_J4YcsZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J4Ycs5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7jAvZXsxEemfSIWqmJMEQA" x="-531" y="445"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J4YcspniEemrjrtN9v_T1A" x="-531" y="445"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7j5gM3sxEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7j5gNHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7j5gNnsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_J6nRUJniEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_J6nRUZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J6nRU5niEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7j5gNXsxEemfSIWqmJMEQA" x="182" y="210"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_J6nRUpniEemrjrtN9v_T1A" x="182" y="210"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_4c8y0XswEemfSIWqmJMEQA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_4c8y0nswEemfSIWqmJMEQA"/>
@@ -3517,165 +3517,165 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeM8gXsxEemfSIWqmJMEQA" id="(0.2380038387715931,0.9917355371900827)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeM8gnsxEemfSIWqmJMEQA" id="(0.6174636174636174,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7TY_C3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Ud5-pXsxEemfSIWqmJMEQA" target="_7TY_B3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7TY_DHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7TY_EHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Jfc_VJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Ud5-pXsxEemfSIWqmJMEQA" target="_Jfc_UJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Jfc_VZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jfc_WZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_iYrMkEvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7TY_DXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7TY_DnsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7TY_D3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Jfc_VpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jfc_V5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jfc_WJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7UIl5HsxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDG_3sxEemfSIWqmJMEQA" target="_7UIl4HsxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7UIl5XsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7UIl6XsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Jh8SoJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDG_3sxEemfSIWqmJMEQA" target="_Jh7rkJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Jh8SoZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jh8SpZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_-KwGAEvDEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7UIl5nsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7UIl53sxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7UIl6HsxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Jh8SopniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jh8So5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jh8SpJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7VU4t3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDInHsxEemfSIWqmJMEQA" target="_7VU4s3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7VU4uHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7VU4vHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JmCvgJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDInHsxEemfSIWqmJMEQA" target="_JmCIcJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JmCvgZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JmCvhZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_9Zx34EvKEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7VU4uXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VU4unsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VU4u3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JmCvgpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JmCvg5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JmCvhJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7X2oRHsxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDI7HsxEemfSIWqmJMEQA" target="_7X2oQHsxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7X2oRXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7X2oSXsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JpYXZJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDI7HsxEemfSIWqmJMEQA" target="_JpYXYJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JpYXZZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JpY-cpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNej-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7X2oRnsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7X2oR3sxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7X2oSHsxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JpYXZpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JpY-cJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JpY-cZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7aOm1HsxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeM7VXsxEemfSIWqmJMEQA" target="_7aOm0HsxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7aOm1XsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7aOm2XsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JtKrMZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeM7VXsxEemfSIWqmJMEQA" target="_JtKEIJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JtKrMpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JtKrNpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_ayCpID-NEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7aOm1nsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aOm13sxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aOm2HsxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JtKrM5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JtKrNJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JtKrNZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7aYX13sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDK7HsxEemfSIWqmJMEQA" target="_7aYX03sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7aYX2HsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7aYX3HsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JtfbVJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDK7HsxEemfSIWqmJMEQA" target="_JtfbUJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JtfbVZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JtgCYpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_LUh4UEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7aYX2XsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aYX2nsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aYX23sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JtfbVpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JtgCYJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JtgCYZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7a-Nt3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDLVXsxEemfSIWqmJMEQA" target="_7a-Ns3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7a-NuHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7a-NvHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JuAYtJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDLVXsxEemfSIWqmJMEQA" target="_JuAYsJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JuAYtZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JuA_wJniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_BB_mUDmkEemDl_QGWIY6yg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7a-NuXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7a-NunsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7a-Nu3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JuAYtpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JuAYt5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JuAYuJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7cBWlHsxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDNg3sxEemfSIWqmJMEQA" target="_7cBWkHsxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7cBWlXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7cBWmXsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JvbVBJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDNg3sxEemfSIWqmJMEQA" target="_JvbVAJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JvbVBZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JvbVCZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_rjMYMEvHEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cBWlnsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7cBWl3sxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7cBWmHsxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JvbVBpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JvbVB5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JvbVCJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7c6HZ3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDOX3sxEemfSIWqmJMEQA" target="_7c6HY3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7c6HaHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7c6HbHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JwY-VJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDOX3sxEemfSIWqmJMEQA" target="_JwY-UJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JwY-VZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JwY-WZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiEquipment.uml#_BQiK0FogEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7c6HaXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7c6HansxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7c6Ha3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JwY-VpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JwY-V5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JwY-WJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7dD4Z3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDLR3sxEemfSIWqmJMEQA" target="_7dD4Y3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7dD4aHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7dD4bHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JwnAxJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDLR3sxEemfSIWqmJMEQA" target="_JwnAwJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JwnAxZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JwnAyZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEquipment.uml#_K2ClIFojEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7dD4aXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7dD4ansxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7dD4a3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JwnAxpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JwnAx5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JwnAyJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7dWzW3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDOg3sxEemfSIWqmJMEQA" target="_7dWzV3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7dWzXHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7dWzYHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Jw4tkZniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDOg3sxEemfSIWqmJMEQA" target="_Jw4GgJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Jw4tkpniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Jw4tlpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_MSjC8EvLEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7dWzXXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7dWzXnsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7dWzX3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Jw4tk5niEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jw4tlJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jw4tlZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7e2BFHsxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeDO3nsxEemfSIWqmJMEQA" target="_7e2BEHsxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7e2BFXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7e2BGXsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_JyugpJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeDO3nsxEemfSIWqmJMEQA" target="_JyugoJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JyugpZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JyugqZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEquipment.uml#_8SXNjj-HEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7e2BFnsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7e2BF3sxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7e2BGHsxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JyugppniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Jyugp5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JyugqJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7hhhpHsxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeM8MXsxEemfSIWqmJMEQA" target="_7hhhoHsxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7hhhpXsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7hhhqXsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_J1aoRJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeM8MXsxEemfSIWqmJMEQA" target="_J1aoQJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_J1aoRZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J1aoSZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiEquipment.uml#_X1qQMD-QEeaRI-H69PghuA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7hhhpnsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7hhhp3sxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7hhhqHsxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J1aoRpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1aoR5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J1aoSJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7h0cl3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeM3eXsxEemfSIWqmJMEQA" target="_7h0ck3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7h0cmHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7h0cnHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_J12tIJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeM3eXsxEemfSIWqmJMEQA" target="_J12GEJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_J12tIZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J12tJZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_jqSYYEqtEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7h0cmXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7h0cmnsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7h0cm3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J12tIpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J12tI5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J12tJJniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7jAvZ3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeM4lXsxEemfSIWqmJMEQA" target="_7jAvY3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7jAvaHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7jAvbHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_J4YctJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeM4lXsxEemfSIWqmJMEQA" target="_J4YcsJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_J4YctZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J4ZDwpniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_7n4rMEvEEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7jAvaXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7jAvansxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7jAva3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J4YctpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J4ZDwJniEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J4ZDwZniEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7j5gN3sxEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_UeM5bHsxEemfSIWqmJMEQA" target="_7j5gM3sxEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7j5gOHsxEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7j5gPHsxEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_J6nRVJniEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UeM5bHsxEemfSIWqmJMEQA" target="_J6nRUJniEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_J6nRVZniEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_J6nRWZniEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiEquipment.uml#_5CPsYEvJEemT5f_Ewhfs6A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7j5gOXsxEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7j5gOnsxEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7j5gO3sxEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_J6nRVpniEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J6nRV5niEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_J6nRWJniEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEquipment.uml
+++ b/UML/TapiEquipment.uml
@@ -648,13 +648,27 @@ In some cases it may not be relevant to represent the pin detail and hence the r
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_R3dQkHssEemfSIWqmJMEQA" name="getDevice">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_cbM8IHssEemfSIWqmJMEQA" name="deviceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_cbM8IHssEemfSIWqmJMEQA" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_PHXDAJniEemrjrtN9v_T1A" annotatedElement="_cbM8IHssEemfSIWqmJMEQA">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_evPbUHssEemfSIWqmJMEQA" name="device" type="_dOLcoEvWEemT5f_Ewhfs6A" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_SHEkcHstEemfSIWqmJMEQA" name="getPhysicalSpan">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SHEkcXstEemfSIWqmJMEQA" name="spanId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SHEkcXstEemfSIWqmJMEQA" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_RUwHoJniEemrjrtN9v_T1A" annotatedElement="_SHEkcXstEemfSIWqmJMEQA">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_SHEkcnstEemfSIWqmJMEQA" name="physicalSpan" type="_qCBY4FRMEeiyzdV8zVsJ_w" direction="out" effect="read"/>

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -15883,206 +15883,6 @@
       <element xmi:type="uml:Enumeration" href="TapiEth.uml#_6g4K8BjvEemR9Pg4e1yNpA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6hBU4RjvEemR9Pg4e1yNpA" x="1033" y="354" height="106"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_3U85MEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3U85MUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3U85M0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Pb3P4F3fEeit4-HSxnZlvw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3U85Mkt-EemIp5Bbs_BvnQ" x="216" y="87"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3VV6wEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3VV6wUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3VV6w0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_noRbAE-xEeitY7qZgkO_XQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3VV6wkt-EemIp5Bbs_BvnQ" x="771" y="133"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3VsgEEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3VsgEUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3VsgE0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AVftQE-zEeitY7qZgkO_XQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3VsgEkt-EemIp5Bbs_BvnQ" x="771" y="33"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3Vx_oEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3Vx_oUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3VymsEt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_Ay79MLEZEeiB1L1dQuD1kw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Vx_okt-EemIp5Bbs_BvnQ" x="771" y="33"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3WDscEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3WDscUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WDsc0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3WDsckt-EemIp5Bbs_BvnQ" x="772" y="35"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3WXOcEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3WXOcUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WXOc0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sD7H8FSIEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3WXOckt-EemIp5Bbs_BvnQ" x="772" y="-65"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3Wbf4Et-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3Wbf4Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WcG8Et-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_BrbEYLEZEeiB1L1dQuD1kw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Wbf4kt-EemIp5Bbs_BvnQ" x="772" y="-65"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3WiNkEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3WiNkUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WiNk0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_7tin0BjuEemR9Pg4e1yNpA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3WiNkkt-EemIp5Bbs_BvnQ" x="772" y="-65"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3WysQEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3WysQUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WysQ0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3WysQkt-EemIp5Bbs_BvnQ" x="359" y="88"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3XhsEEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3XhsEUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3XhsE0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3XhsEkt-EemIp5Bbs_BvnQ" x="359" y="-12"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3XvHcEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3XvHcUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3XvHc0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_HfynMFSJEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3XvHckt-EemIp5Bbs_BvnQ" x="770" y="221"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3YIwEEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3YIwEUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3YIwE0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_YRB34FUaEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YIwEkt-EemIp5Bbs_BvnQ" x="770" y="121"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3YOPoEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3YOPoUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3YOPo0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_i9c3QNeQEeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YOPokt-EemIp5Bbs_BvnQ" x="770" y="121"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3Yac4Et-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3Yac4Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Yac40t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Yac4kt-EemIp5Bbs_BvnQ" x="360" y="440"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3Y16sEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3Y16sUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Y16s0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c_7tQIqfEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y16skt-EemIp5Bbs_BvnQ" x="764" y="358"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3ZNHEEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3ZNHEUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZNHE0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_iURsMIrVEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZNHEkt-EemIp5Bbs_BvnQ" x="764" y="258"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3ZW4EEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3ZW4EUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZW4E0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_3iNz8IqxEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZW4Ekt-EemIp5Bbs_BvnQ" x="760" y="580"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3ZjFUEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3ZjFUUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZjFU0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-m3icIqxEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZjFUkt-EemIp5Bbs_BvnQ" x="760" y="480"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3ZmvsEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3ZmvsUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZnWwEt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_0jzpINoxEeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Zmvskt-EemIp5Bbs_BvnQ" x="760" y="480"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3Zxu0Et-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3Zxu0Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Zxu00t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_4uNtAIqxEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Zxu0kt-EemIp5Bbs_BvnQ" x="763" y="504"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3Z64wEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3Z64wUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Z64w0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_LDyCMIrKEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Z64wkt-EemIp5Bbs_BvnQ" x="763" y="404"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3aFQ0Et-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3aFQ0Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3aFQ00t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_XeN3wLEYEeiB1L1dQuD1kw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3aFQ0kt-EemIp5Bbs_BvnQ" x="1231" y="95"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3aZZ4Et-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3aZZ4Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3aZZ40t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3aZZ4kt-EemIp5Bbs_BvnQ" x="1231" y="205"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3awmQEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3awmQUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3awmQ0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3awmQkt-EemIp5Bbs_BvnQ" x="1088" y="479"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3cCYoEt-EemIp5Bbs_BvnQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3cCYoUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3cCYo0t-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_hKDiEBjuEemR9Pg4e1yNpA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3cCYokt-EemIp5Bbs_BvnQ" x="1230" y="19"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_p8rCMIMxEemCy9JSn498_g" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_p8v6sIMxEemCy9JSn498_g" type="Enumeration_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_p8v6sYMxEemCy9JSn498_g" type="Enumeration_FloatingNameLabel">
@@ -16179,13 +15979,213 @@
       <element xmi:type="uml:Enumeration" href="TapiEth.uml#_zZWYAIMxEemCy9JSn498_g"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zZ_4QIMxEemCy9JSn498_g" x="-22" y="615"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_8FVQsIMxEemCy9JSn498_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_8FVQsYMxEemCy9JSn498_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8FV3wIMxEemCy9JSn498_g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_4tpSAJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4tpSAZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4tpSA5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Pb3P4F3fEeit4-HSxnZlvw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4tpSApnAEemVaY_egjrbOQ" x="183" y="90"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4uF995nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4uF9-JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4uF9-pnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_noRbAE-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4uF9-ZnAEemVaY_egjrbOQ" x="771" y="133"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4u1k0JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4u1k0ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4u1k05nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AVftQE-zEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4u1k0pnAEemVaY_egjrbOQ" x="771" y="33"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4u_V0JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4u_V0ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4u_V05nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_Ay79MLEZEeiB1L1dQuD1kw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4u_V0pnAEemVaY_egjrbOQ" x="771" y="33"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4vcBw5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4vcBxJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4vcBxpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4vcBxZnAEemVaY_egjrbOQ" x="772" y="35"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4wB3rZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4wB3rpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4wB3sJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sD7H8FSIEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4wB3r5nAEemVaY_egjrbOQ" x="772" y="-65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4wLoqZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4wLoqpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4wLorJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_BrbEYLEZEeiB1L1dQuD1kw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4wLoq5nAEemVaY_egjrbOQ" x="772" y="-65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4wejkJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4wejkZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4wejk5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_7tin0BjuEemR9Pg4e1yNpA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4wejkpnAEemVaY_egjrbOQ" x="772" y="-65"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4w7Pg5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4w7PhJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4w7PhpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4w7PhZnAEemVaY_egjrbOQ" x="359" y="88"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4ytYMJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4ytYMZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4ytYM5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4ytYMpnAEemVaY_egjrbOQ" x="359" y="-12"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4zTOF5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4zTOGJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4zTOGpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_HfynMFSJEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4zTOGZnAEemVaY_egjrbOQ" x="770" y="221"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_40C085nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_40C09JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_40C09pnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_YRB34FUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_40C09ZnAEemVaY_egjrbOQ" x="770" y="121"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_40Ml85nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_40Ml9JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_40Ml9pnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_i9c3QNeQEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_40Ml9ZnAEemVaY_egjrbOQ" x="770" y="121"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_40pR4JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_40pR4ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_40pR45nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_40pR4pnAEemVaY_egjrbOQ" x="360" y="440"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_41iCsJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_41iCsZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_41iCs5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c_7tQIqfEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_41iCspnAEemVaY_egjrbOQ" x="764" y="358"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_42RpkJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_42RpkZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_42Rpk5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_iURsMIrVEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_42RpkpnAEemVaY_egjrbOQ" x="764" y="258"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_42baopnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_42bao5nAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_42bapZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_3iNz8IqxEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_42bapJnAEemVaY_egjrbOQ" x="760" y="580"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_42uVv5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_42uVwJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_42uVwpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-m3icIqxEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_42uVwZnAEemVaY_egjrbOQ" x="760" y="480"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_424GiZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_424GipnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_424GjJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_0jzpINoxEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_424Gi5nAEemVaY_egjrbOQ" x="760" y="480"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_43ULYJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_43ULYZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_43ULY5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_4uNtAIqxEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_43ULYpnAEemVaY_egjrbOQ" x="763" y="504"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_43w3U5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_43w3VJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_43w3VpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_LDyCMIrKEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_43w3VZnAEemVaY_egjrbOQ" x="763" y="404"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_44DyS5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_44DyTJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_44DyTpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_XeN3wLEYEeiB1L1dQuD1kw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_44DyTZnAEemVaY_egjrbOQ" x="1231" y="95"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_44qPO5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_44qPPJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_44qPPpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_44qPPZnAEemVaY_egjrbOQ" x="1231" y="205"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_45jAA5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_45jABJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_45jABpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_45jABZnAEemVaY_egjrbOQ" x="1088" y="479"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_47e5s5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_47e5tJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_47e5tpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_hKDiEBjuEemR9Pg4e1yNpA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_47e5tZnAEemVaY_egjrbOQ" x="1230" y="19"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_477lppnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_477lp5nAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_477lqZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_5_NRsIMxEemCy9JSn498_g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8FVQsoMxEemCy9JSn498_g" x="202" y="505"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_477lqJnAEemVaY_egjrbOQ" x="178" y="515"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_uH_zwWBVEeiBxvDM8HEDKw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_uH_zwmBVEeiBxvDM8HEDKw"/>
@@ -16487,256 +16487,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8IBkYBjuEemR9Pg4e1yNpA" id="(1.0,0.23595505617977527)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8IBkYRjuEemR9Pg4e1yNpA" id="(0.0,0.6166666666666667)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3U85NEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_wQYckGBVEeiBxvDM8HEDKw" target="_3U85MEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3U85NUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3U9gQEt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Pb3P4F3fEeit4-HSxnZlvw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3U85Nkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3U85N0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3U85OEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3VV6xEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_69WVkGBVEeiBxvDM8HEDKw" target="_3VV6wEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3VV6xUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3VV6yUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_noRbAE-xEeitY7qZgkO_XQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3VV6xkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VV6x0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VV6yEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3VsgFEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_6-TX0GBVEeiBxvDM8HEDKw" target="_3VsgEEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3VsgFUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3VsgGUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AVftQE-zEeitY7qZgkO_XQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3VsgFkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VsgF0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VsgGEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3VymsUt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_A3a0kLEZEeiB1L1dQuD1kw" target="_3Vx_oEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3Vymskt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Vymtkt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_Ay79MLEZEeiB1L1dQuD1kw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Vyms0t-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VymtEt-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3VymtUt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3WDsdEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_-ESRUGBVEeiBxvDM8HEDKw" target="_3WDscEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3WDsdUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WDseUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3WDsdkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WDsd0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WDseEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3WXOdEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_-FJM8GBVEeiBxvDM8HEDKw" target="_3WXOcEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3WXOdUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WXOeUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sD7H8FSIEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3WXOdkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WXOd0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WXOeEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3WcG8Ut-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_BvDnMLEZEeiB1L1dQuD1kw" target="_3Wbf4Et-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3WcG8kt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WcG9kt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_BrbEYLEZEeiB1L1dQuD1kw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3WcG80t-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WcG9Et-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WcG9Ut-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3WiNlEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_72nEQBjuEemR9Pg4e1yNpA" target="_3WiNkEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3WiNlUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WiNmUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_7tin0BjuEemR9Pg4e1yNpA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3WiNlkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WiNl0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WiNmEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3WysREt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_-EwycGBVEeiBxvDM8HEDKw" target="_3WysQEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3WysRUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WysSUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3WysRkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WysR0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WysSEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3XhsFEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_BZkzMIt5Eeiu6boZkiJHCA" target="_3XhsEEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3XhsFUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3XhsGUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3XhsFkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XhsF0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XhsGEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3XvHdEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_K4s_AGBWEeiBxvDM8HEDKw" target="_3XvHcEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3XvHdUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3XvHeUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_HfynMFSJEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3XvHdkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XvHd0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XvHeEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3YIwFEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_K5XtYGBWEeiBxvDM8HEDKw" target="_3YIwEEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3YIwFUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3YIwGUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_YRB34FUaEeitkMFXBYQFcg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YIwFkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YIwF0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YIwGEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3YO2sEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_UKuAEASxEemABdf1yJ9dlA" target="_3YOPoEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3YO2sUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3YO2tUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_i9c3QNeQEeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YO2skt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YO2s0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YO2tEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3Yac5Et-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_bIDloIqfEeiT7s5en7ligw" target="_3Yac4Et-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3Yac5Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3YbD8kt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Yac5kt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YbD8Et-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YbD8Ut-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3Y16tEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_dAGsYIqfEeiT7s5en7ligw" target="_3Y16sEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3Y16tUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Y16uUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c_7tQIqfEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Y16tkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Y16t0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Y16uEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3ZNHFEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_iUThYIrVEeiT7s5en7ligw" target="_3ZNHEEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3ZNHFUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZNHGUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_iURsMIrVEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3ZNHFkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZNHF0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZNHGEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3ZW4FEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_3iTTgIqxEeiT7s5en7ligw" target="_3ZW4EEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3ZW4FUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZW4GUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_3iNz8IqxEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3ZW4Fkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZW4F0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZW4GEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3ZjFVEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_-m5-sIqxEeiT7s5en7ligw" target="_3ZjFUEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3ZjFVUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZjFWUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-m3icIqxEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3ZjFVkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZjFV0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZjFWEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3ZnWwUt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_Utt_cASxEemABdf1yJ9dlA" target="_3ZmvsEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3ZnWwkt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3ZnWxkt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_0jzpINoxEeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3ZnWw0t-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZnWxEt-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3ZnWxUt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3Zxu1Et-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_4uRXYIqxEeiT7s5en7ligw" target="_3Zxu0Et-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3Zxu1Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Zxu2Ut-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_4uNtAIqxEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Zxu1kt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Zxu10t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Zxu2Et-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3Z64xEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_LD1skIrKEeiT7s5en7ligw" target="_3Z64wEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3Z64xUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Z64yUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_LDyCMIrKEeiT7s5en7ligw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Z64xkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Z64x0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Z64yEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3aFQ1Et-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_XeRiILEYEeiB1L1dQuD1kw" target="_3aFQ0Et-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3aFQ1Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3aFQ2Ut-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_XeN3wLEYEeiB1L1dQuD1kw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3aFQ1kt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aFQ10t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aFQ2Et-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3aZZ5Et-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_LOpqgP-vEeiABdf1yJ9dlA" target="_3aZZ4Et-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3aZZ5Ut-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3aZZ6Ut-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3aZZ5kt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZZ50t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZZ6Et-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3awmREt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_L-Tl0P-vEeiABdf1yJ9dlA" target="_3awmQEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3awmRUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3awmSUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3awmRkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3awmR0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3awmSEt-EemIp5Bbs_BvnQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3cCYpEt-EemIp5Bbs_BvnQ" type="StereotypeCommentLink" source="_hO0GQBjuEemR9Pg4e1yNpA" target="_3cCYoEt-EemIp5Bbs_BvnQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3cCYpUt-EemIp5Bbs_BvnQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3cCYqUt-EemIp5Bbs_BvnQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_hKDiEBjuEemR9Pg4e1yNpA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3cCYpkt-EemIp5Bbs_BvnQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3cCYp0t-EemIp5Bbs_BvnQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3cCYqEt-EemIp5Bbs_BvnQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_5_bUIIMxEemCy9JSn498_g" type="Abstraction_Edge" source="_zZ_RMIMxEemCy9JSn498_g" target="_p8rCMIMxEemCy9JSn498_g" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_5_b7MIMxEemCy9JSn498_g" type="Abstraction_NameLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_-QPCAIMxEemCy9JSn498_g" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -16752,15 +16502,265 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6fi-oIMxEemCy9JSn498_g" id="(0.4153846153846154,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6fjlsIMxEemCy9JSn498_g" id="(0.5228758169934641,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_8FV3wYMxEemCy9JSn498_g" type="StereotypeCommentLink" source="_5_bUIIMxEemCy9JSn498_g" target="_8FVQsIMxEemCy9JSn498_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_8FV3woMxEemCy9JSn498_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8FWe0IMxEemCy9JSn498_g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_4tpSBJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_wQYckGBVEeiBxvDM8HEDKw" target="_4tpSAJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4tpSBZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4tpSCZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Pb3P4F3fEeit4-HSxnZlvw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4tpSBpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4tpSB5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4tpSCJnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4uF9-5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_69WVkGBVEeiBxvDM8HEDKw" target="_4uF995nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4uF9_JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4uF-AJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_noRbAE-xEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4uF9_ZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4uF9_pnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4uF9_5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4u1k1JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_6-TX0GBVEeiBxvDM8HEDKw" target="_4u1k0JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4u1k1ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4u1k2ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_AVftQE-zEeitY7qZgkO_XQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4u1k1pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4u1k15nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4u1k2JnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4u_V1JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_A3a0kLEZEeiB1L1dQuD1kw" target="_4u_V0JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4u_V1ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4u_V2ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_Ay79MLEZEeiB1L1dQuD1kw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4u_V1pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4u_V15nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4u_V2JnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4vcBx5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_-ESRUGBVEeiBxvDM8HEDKw" target="_4vcBw5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4vcByJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4vcBzJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_oj4vsFSIEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4vcByZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4vcBypnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4vcBy5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4wB3sZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_-FJM8GBVEeiBxvDM8HEDKw" target="_4wB3rZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4wB3spnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4wB3tpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sD7H8FSIEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4wB3s5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4wB3tJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4wB3tZnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4wLorZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_BvDnMLEZEeiB1L1dQuD1kw" target="_4wLoqZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4wLorpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4wLospnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_BrbEYLEZEeiB1L1dQuD1kw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4wLor5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4wLosJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4wLosZnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4wejlJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_72nEQBjuEemR9Pg4e1yNpA" target="_4wejkJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4wejlZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4wejmZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_7tin0BjuEemR9Pg4e1yNpA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4wejlpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4wejl5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4wejmJnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4w7Ph5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_-EwycGBVEeiBxvDM8HEDKw" target="_4w7Pg5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4w7PiJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4w7PjJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4w7PiZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4w7PipnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4w7Pi5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4ytYNJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_BZkzMIt5Eeiu6boZkiJHCA" target="_4ytYMJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4ytYNZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4ytYOZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4ytYNpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4ytYN5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4ytYOJnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4zTOG5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_K4s_AGBWEeiBxvDM8HEDKw" target="_4zTOF5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4zTOHJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4zTOIJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_HfynMFSJEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4zTOHZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4zTOHpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4zTOH5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_40C095nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_K5XtYGBWEeiBxvDM8HEDKw" target="_40C085nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_40C0-JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_40C0_JnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_YRB34FUaEeitkMFXBYQFcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_40C0-ZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40C0-pnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40C0-5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_40Ml95nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_UKuAEASxEemABdf1yJ9dlA" target="_40Ml85nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_40Ml-JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_40Ml_JnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_i9c3QNeQEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_40Ml-ZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40Ml-pnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40Ml-5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_40pR5JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_bIDloIqfEeiT7s5en7ligw" target="_40pR4JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_40pR5ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_40pR6ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_40pR5pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40pR55nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40pR6JnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_41iCtJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_dAGsYIqfEeiT7s5en7ligw" target="_41iCsJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_41iCtZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_41iCuZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_c_7tQIqfEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_41iCtpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_41iCt5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_41iCuJnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_42RplJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_iUThYIrVEeiT7s5en7ligw" target="_42RpkJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_42RplZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_42RpmZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_iURsMIrVEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_42RplpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_42Rpl5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_42RpmJnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_42bappnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_3iTTgIqxEeiT7s5en7ligw" target="_42baopnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_42bap5nAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_42kkgpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_3iNz8IqxEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_42baqJnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_42kkgJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_42kkgZnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_42uVw5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_-m5-sIqxEeiT7s5en7ligw" target="_42uVv5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_42uVxJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_42uVyJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_-m3icIqxEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_42uVxZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_42uVxpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_42uVx5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_424GjZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_Utt_cASxEemABdf1yJ9dlA" target="_424GiZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_424GjpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_424GkpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_0jzpINoxEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_424Gj5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_424GkJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_424GkZnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_43ULZJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_4uRXYIqxEeiT7s5en7ligw" target="_43ULYJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_43ULZZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_43ULaZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_4uNtAIqxEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_43ULZpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_43ULZ5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_43ULaJnAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_43w3V5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_LD1skIrKEeiT7s5en7ligw" target="_43w3U5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_43w3WJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_43w3XJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_LDyCMIrKEeiT7s5en7ligw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_43w3WZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_43w3WpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_43w3W5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_44DyT5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_XeRiILEYEeiB1L1dQuD1kw" target="_44DyS5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_44DyUJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_44DyVJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_XeN3wLEYEeiB1L1dQuD1kw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_44DyUZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_44DyUpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_44DyU5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_44qPP5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_LOpqgP-vEeiABdf1yJ9dlA" target="_44qPO5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_44qPQJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_44qPRJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_WYQt0NePEeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_44qPQZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_44qPQpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_44qPQ5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_45jAB5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_L-Tl0P-vEeiABdf1yJ9dlA" target="_45jAA5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_45jACJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_45jADJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_SLwnQNn3EeidLb5WEUMFmw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_45jACZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_45jACpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_45jAC5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_47e5t5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_hO0GQBjuEemR9Pg4e1yNpA" target="_47e5s5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_47e5uJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_47e5vJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_hKDiEBjuEemR9Pg4e1yNpA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_47e5uZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_47e5upnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_47e5u5nAEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_477lqpnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_5_bUIIMxEemCy9JSn498_g" target="_477lppnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_477lq5nAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_477lr5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_5_NRsIMxEemCy9JSn498_g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8FV3w4MxEemCy9JSn498_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8FV3xIMxEemCy9JSn498_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8FV3xYMxEemCy9JSn498_g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_477lrJnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_477lrZnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_477lrpnAEemVaY_egjrbOQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_pmPTQBKjEemxeNG9TDCtFQ" type="PapyrusUMLClassDiagram" name="EthInterfaceJobsFm" measurementUnit="Pixel">
@@ -19452,349 +19452,349 @@
       <element xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_id2hQTkkEemjx6Nna_xyog" x="1100" y="160" width="241" height="61"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zS54Y2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zS54ZGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zS54ZmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iNdCkJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iNdCkZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iNdCk5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NoBnwBXLEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zS54ZWBsEemmf8tAu_V-ow" x="340" y="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iNdCkpnAEemVaY_egjrbOQ" x="340" y="160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTDpb2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTDpcGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTDpcmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iNv9g5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iNv9hJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iNv9hpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_l-v8gDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTDpcWBsEemmf8tAu_V-ow" x="340" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iNv9hZnAEemVaY_egjrbOQ" x="340" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTNaYGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTNaYWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTNaY2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iN5uhZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iN5uhpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iN5uiJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_nagI0DkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTNaYmBsEemmf8tAu_V-ow" x="340" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iN5uh5nAEemVaY_egjrbOQ" x="340" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTNac2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTNadGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTNadmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iOC4eZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iOC4epnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOC4fJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_oOE60DkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTNadWBsEemmf8tAu_V-ow" x="340" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iOC4e5nAEemVaY_egjrbOQ" x="340" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTWkWWBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTWkWmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTWkXGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iOMpeZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iOMpepnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOMpfJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_o_tzIDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTWkW2BsEemmf8tAu_V-ow" x="340" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iOMpe5nAEemVaY_egjrbOQ" x="340" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTgVU2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTgVVGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTgVVmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iOWaeZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iOWaepnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOWafJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_tLugkDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTgVVWBsEemmf8tAu_V-ow" x="340" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iOWae5nAEemVaY_egjrbOQ" x="340" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTgVZmBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTgVZ2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTgVaWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iOfkaZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iOfkapnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOfkbJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uEvzQDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTgVaGBsEemmf8tAu_V-ow" x="340" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iOfka5nAEemVaY_egjrbOQ" x="340" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zTzQR2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zTzQSGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTzQSmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iPGBU5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iPGBVJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPGBVpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTzQSWBsEemmf8tAu_V-ow" x="620" y="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iPGBVZnAEemVaY_egjrbOQ" x="620" y="160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zT9BV2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zT9BWGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUGLMGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iPY8Q5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iPY8RJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPY8RpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_QUL4EDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zT9BWWBsEemmf8tAu_V-ow" x="620" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iPY8RZnAEemVaY_egjrbOQ" x="620" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUGLQGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUGLQWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUGLQ2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iPiGM5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iPiGNJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPiGNpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_eYaAwDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUGLQmBsEemmf8tAu_V-ow" x="620" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iPiGNZnAEemVaY_egjrbOQ" x="620" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUP8MGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUP8MWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUP8M2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iPr3M5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iPr3NJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPr3NpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wDwBIDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUP8MmBsEemmf8tAu_V-ow" x="620" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iPr3NZnAEemVaY_egjrbOQ" x="620" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUP8Q2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUP8RGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUP8RmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iP-yIJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iP-yIZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iP-yI5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MF8YYDlWEemSPvPXzEQ11A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUP8RWBsEemmf8tAu_V-ow" x="620" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iP-yIpnAEemVaY_egjrbOQ" x="620" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUZGIGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUZGIWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUZGI2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iQuZAJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iQuZAZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iQuZA5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_M7B80F1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUZGImBsEemmf8tAu_V-ow" x="620" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iQuZApnAEemVaY_egjrbOQ" x="620" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUZGM2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUZGNGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUZGNmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iRBT8JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iRBT8ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iRBT85nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_jhcJAF1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUZGNWBsEemmf8tAu_V-ow" x="620" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iRBT8pnAEemVaY_egjrbOQ" x="620" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUsoIGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUsoIWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUsoI2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iRd_45nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iRd_5JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iRd_5pnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUsoImBsEemmf8tAu_V-ow" x="60" y="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iRd_5ZnAEemVaY_egjrbOQ" x="60" y="160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zU1yE2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zU1yFGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zU1yFmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iR6r0JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iR6r0ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iR6r05nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_JRFowDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zU1yFWBsEemmf8tAu_V-ow" x="60" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iR6r0pnAEemVaY_egjrbOQ" x="60" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zU_jEGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zU_jEWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zU_jE2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iSEc2ZnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iSEc2pnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iSEc3JnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_bNLa4DkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zU_jEmBsEemmf8tAu_V-ow" x="60" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iSEc25nAEemVaY_egjrbOQ" x="60" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zU_jI2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zU_jJGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zU_jJmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iSXXwJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iSXXwZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iSXXw5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sohQYDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zU_jJWBsEemmf8tAu_V-ow" x="60" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iSXXwpnAEemVaY_egjrbOQ" x="60" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVItCWBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVItCmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVItDGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iSghsJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iSghsZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iSghs5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_16iOUDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVItC2BsEemmf8tAu_V-ow" x="60" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iSghspnAEemVaY_egjrbOQ" x="60" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVItHGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVItHWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVItH2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iTG-o5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iTG-pJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iTG-ppnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_xtL2AF1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVItHmBsEemmf8tAu_V-ow" x="60" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iTG-pZnAEemVaY_egjrbOQ" x="60" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVSeCWBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVSeCmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVSeDGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iTZ5kJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iTZ5kZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iTZ5k5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9kmI4F1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVSeC2BsEemmf8tAu_V-ow" x="60" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iTZ5kpnAEemVaY_egjrbOQ" x="60" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVcPAGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVcPAWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVcPA2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iT2lgJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iT2lgZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iT2lg5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVcPAmBsEemmf8tAu_V-ow" x="240" y="300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iT2lgpnAEemVaY_egjrbOQ" x="240" y="300"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVcPNGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVcPNWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVcPN2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iUJgc5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iUJgdJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iUJgdpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVcPNmBsEemmf8tAu_V-ow" x="240" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iUJgdZnAEemVaY_egjrbOQ" x="240" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVlZAmBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVlZA2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVlZBWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iUmMYJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iUmMYZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iUmMY5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlZBGBsEemmf8tAu_V-ow" x="500" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iUmMYpnAEemVaY_egjrbOQ" x="500" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zVvJ82BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zVvJ9GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVvJ9mBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iVC4UJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iVC4UZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iVC4U5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVvJ9WBsEemmf8tAu_V-ow" x="500" y="300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iVC4UpnAEemVaY_egjrbOQ" x="500" y="300"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zV4T4GBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zV4T4WBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zV4T42BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iVVzQ5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iVVzRJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iVVzRpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zV4T4mBsEemmf8tAu_V-ow" x="960" y="300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iVVzRZnAEemVaY_egjrbOQ" x="960" y="300"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zV4UFGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zV4UFWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zV4UF2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iVouM5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iVouNJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iVouNpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zV4UFmBsEemmf8tAu_V-ow" x="1320" y="300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iVouNZnAEemVaY_egjrbOQ" x="1320" y="300"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zWCE-mBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zWCE-2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWCE_WBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iV7pK5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iV7pLJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iV7pLpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWCE_GBsEemmf8tAu_V-ow" x="1140" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iV7pLZnAEemVaY_egjrbOQ" x="1140" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zWL142BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zWL15GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWL15mBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iWYVG5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iWYVHJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iWYVHpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWL15WBsEemmf8tAu_V-ow" x="240" y="540"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iWYVHZnAEemVaY_egjrbOQ" x="240" y="540"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zWU_02BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zWU_1GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWU_1mBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iW-K8JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iW-K8ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iW-K85nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_lJFbwE-xEeitY7qZgkO_XQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWU_1WBsEemmf8tAu_V-ow" x="580" y="640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iW-K8pnAEemVaY_egjrbOQ" x="580" y="640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zWew0GBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zWew0WBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWew02BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iXRs85nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iXRs9JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iXRs9pnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MJVEYDkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWew0mBsEemmf8tAu_V-ow" x="580" y="540"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iXRs9ZnAEemVaY_egjrbOQ" x="580" y="540"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zWn6x2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zWn6yGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWn6ymBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iYBT0JnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iYBT0ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iYBT05nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_jrxwQE-xEeitY7qZgkO_XQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWn6yWBsEemmf8tAu_V-ow" x="580" y="540"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iYBT0pnAEemVaY_egjrbOQ" x="580" y="540"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zWxrz2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zWxr0GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWxr0mBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iYUOw5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iYUOxJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iYUOxpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Lb7L0DkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zWxr0WBsEemmf8tAu_V-ow" x="580" y="440"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iYUOxZnAEemVaY_egjrbOQ" x="580" y="440"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zXEms2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zXEmtGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXEmtmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iY6EoJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iY6EoZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iY6Eo5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_iN418E-xEeitY7qZgkO_XQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zXEmtWBsEemmf8tAu_V-ow" x="580" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iY6EopnAEemVaY_egjrbOQ" x="580" y="460"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zXOXs2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zXOXtGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXOXtmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iZM_k5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iZM_lJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iZM_lpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_KtbHEDkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zXOXtWBsEemmf8tAu_V-ow" x="580" y="360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZM_lZnAEemVaY_egjrbOQ" x="580" y="360"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zXXhq2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zXXhrGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXXhrmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iZprg5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iZprhJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iZprhpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zXXhrWBsEemmf8tAu_V-ow" x="940" y="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iZprhZnAEemVaY_egjrbOQ" x="940" y="160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zXhSr2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zXhSsGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXhSsmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iaGXcJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iaGXcZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iaGXc5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rDBAQDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zXhSsWBsEemmf8tAu_V-ow" x="940" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iaGXcpnAEemVaY_egjrbOQ" x="940" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zXrDoGBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zXrDoWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXrDo2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iaQIcJnAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iaQIcZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iaQIc5nAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_10m6kDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zXrDomBsEemmf8tAu_V-ow" x="940" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iaQIcpnAEemVaY_egjrbOQ" x="940" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zXrDs2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zXrDtGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXrDtmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_iaZSY5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iaZSZJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iaZSZpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9InTsDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zXrDtWBsEemmf8tAu_V-ow" x="940" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iaZSZZnAEemVaY_egjrbOQ" x="940" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zX9-k2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zX9-lGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zX9-lmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ia1-U5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ia1-VJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ia1-VpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zX9-lWBsEemmf8tAu_V-ow" x="1300" y="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ia1-VZnAEemVaY_egjrbOQ" x="1300" y="160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zYHIj2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zYHIkGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zYHIkmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ibI5Q5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ibI5RJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ibI5RpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uxTP4DkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zYHIkWBsEemmf8tAu_V-ow" x="1300" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ibI5RZnAEemVaY_egjrbOQ" x="1300" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zYQ5g2BsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zYQ5hGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zYQ5hmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ibSqQ5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ibSqRJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ibSqRpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4yhdMDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zYQ5hWBsEemmf8tAu_V-ow" x="1300" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ibSqRZnAEemVaY_egjrbOQ" x="1300" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_zYQ5lmBsEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zYQ5l2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zYQ5mWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ibvWM5nAEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ibvWNJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ibvWNpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#__0Y9cDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zYQ5mGBsEemmf8tAu_V-ow" x="1300" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ibvWNZnAEemVaY_egjrbOQ" x="1300" y="60"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vL3gsTiPEem1lYbrIE6BNw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vL3gsjiPEem1lYbrIE6BNw"/>
@@ -20201,435 +20201,435 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9uedoF1yEemG57ABxBTHSA" id="(0.08298755186721991,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9uedoV1yEemG57ABxBTHSA" id="(0.29850746268656714,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zS54Z2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_2hts4DiPEem1lYbrIE6BNw" target="_zS54Y2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zS54aGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zS54bGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iNdClJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_2hts4DiPEem1lYbrIE6BNw" target="_iNdCkJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iNdClZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iNdCmZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_NoBnwBXLEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zS54aWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zS54amBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zS54a2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iNdClpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iNdCl5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iNdCmJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTDpc2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_l-2qMDkhEemjx6Nna_xyog" target="_zTDpb2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTDpdGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTDpeGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iNv9h5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_l-2qMDkhEemjx6Nna_xyog" target="_iNv9g5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iNv9iJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iNv9jJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_l-v8gDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTDpdWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTDpdmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTDpd2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iNv9iZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iNv9ipnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iNv9i5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTNaZGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_nah-ADkhEemjx6Nna_xyog" target="_zTNaYGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTNaZWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTNaaWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iN5uiZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_nah-ADkhEemjx6Nna_xyog" target="_iN5uhZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iN5uipnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iN5ujpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_nagI0DkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTNaZmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTNaZ2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTNaaGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iN5ui5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iN5ujJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iN5ujZnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTNad2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_oOGwADkhEemjx6Nna_xyog" target="_zTNac2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTNaeGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTNafGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iOC4fZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_oOGwADkhEemjx6Nna_xyog" target="_iOC4eZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iOC4fpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOC4gpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_oOE60DkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTNaeWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTNaemBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTNae2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iOC4f5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOC4gJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOC4gZnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTWkXWBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_o_voUDkhEemjx6Nna_xyog" target="_zTWkWWBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTWkXmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTWkYmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iOMpfZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_o_voUDkhEemjx6Nna_xyog" target="_iOMpeZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iOMpfpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOMpgpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_o_tzIDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTWkX2BsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTWkYGBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTWkYWBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iOMpf5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOMpgJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOMpgZnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTgVV2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_tLwVwDkhEemjx6Nna_xyog" target="_zTgVU2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTgVWGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTgVXGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iOWafZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_tLwVwDkhEemjx6Nna_xyog" target="_iOWaeZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iOWafpnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOWagpnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_tLugkDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTgVWWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTgVWmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTgVW2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iOWaf5nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOWagJnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOWagZnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTgVamBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_uExBYDkhEemjx6Nna_xyog" target="_zTgVZmBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTgVa2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTgVb2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iOpVYJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_uExBYDkhEemjx6Nna_xyog" target="_iOfkaZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iOpVYZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iOpVZZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uEvzQDkhEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTgVbGBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTgVbWBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTgVbmBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iOpVYpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOpVY5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iOpVZJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zTzQS2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_24a8sDiPEem1lYbrIE6BNw" target="_zTzQR2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zTzQTGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTzQUGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iPGBV5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_24a8sDiPEem1lYbrIE6BNw" target="_iPGBU5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iPGBWJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPGBXJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTzQTWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTzQTmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTzQT2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iPGBWZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPGBWpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPGBW5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUGLMWBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_QUNGMDkiEemjx6Nna_xyog" target="_zT9BV2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUGLMmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUGLNmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iPY8R5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_QUNGMDkiEemjx6Nna_xyog" target="_iPY8Q5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iPY8SJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPY8TJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_QUL4EDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUGLM2BsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUGLNGBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUGLNWBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iPY8SZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPY8SpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPY8S5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUGLRGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_eYb18DkiEemjx6Nna_xyog" target="_zUGLQGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUGLRWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUGLSWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iPiGN5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_eYb18DkiEemjx6Nna_xyog" target="_iPiGM5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iPiGOJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPiGPJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_eYaAwDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUGLRmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUGLR2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUGLSGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iPiGOZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPiGOpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPiGO5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUP8NGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_wDx2UDkiEemjx6Nna_xyog" target="_zUP8MGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUP8NWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUP8OWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iPr3N5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_wDx2UDkiEemjx6Nna_xyog" target="_iPr3M5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iPr3OJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iPr3PJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_wDwBIDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUP8NmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUP8N2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUP8OGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iPr3OZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPr3OpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iPr3O5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUP8R2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_MF-NkDlWEemSPvPXzEQ11A" target="_zUP8Q2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUP8SGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUP8TGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iP-yJJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_MF-NkDlWEemSPvPXzEQ11A" target="_iP-yIJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iP-yJZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iP-yKZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MF8YYDlWEemSPvPXzEQ11A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUP8SWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUP8SmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUP8S2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iP-yJpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iP-yJ5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iP-yKJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUZGJGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_M7f24F1yEemG57ABxBTHSA" target="_zUZGIGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUZGJWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUZGKWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iQuZBJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_M7f24F1yEemG57ABxBTHSA" target="_iQuZAJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iQuZBZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iQuZCZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_M7B80F1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUZGJmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUZGJ2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUZGKGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iQuZBpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iQuZB5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iQuZCJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUZGN2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_jhelQF1yEemG57ABxBTHSA" target="_zUZGM2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUZGOGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUZGPGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iRBT9JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_jhelQF1yEemG57ABxBTHSA" target="_iRBT8JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iRBT9ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iRBT-ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_jhcJAF1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUZGOWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUZGOmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUZGO2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iRBT9pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRBT95nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRBT-JnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUsoJGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_3ODOcDiPEem1lYbrIE6BNw" target="_zUsoIGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUsoJWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUsoKWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iRd_55nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_3ODOcDiPEem1lYbrIE6BNw" target="_iRd_45nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iRd_6JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iRd_7JnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUsoJmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUsoJ2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUsoKGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iRd_6ZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRd_6pnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRd_65nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zU1yF2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_JRHd8DkiEemjx6Nna_xyog" target="_zU1yE2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zU1yGGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zU1yHGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iR6r1JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_JRHd8DkiEemjx6Nna_xyog" target="_iR6r0JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iR6r1ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iR6r2ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_JRFowDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zU1yGWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zU1yGmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zU1yG2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iR6r1pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iR6r15nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iR6r2JnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zU_jFGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_bNNQEDkiEemjx6Nna_xyog" target="_zU_jEGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zU_jFWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zU_jGWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iSEc3ZnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_bNNQEDkiEemjx6Nna_xyog" target="_iSEc2ZnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iSEc3pnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iSEc4pnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_bNLa4DkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zU_jFmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zU_jF2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zU_jGGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iSEc35nAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iSEc4JnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iSEc4ZnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zU_jJ2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_sojFkDkiEemjx6Nna_xyog" target="_zU_jI2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zU_jKGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zU_jLGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iSXXxJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_sojFkDkiEemjx6Nna_xyog" target="_iSXXwJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iSXXxZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iSXXyZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_sohQYDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zU_jKWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zU_jKmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zU_jK2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iSXXxpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iSXXx5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iSXXyJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVItDWBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_16kDgDkiEemjx6Nna_xyog" target="_zVItCWBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVItDmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVItEmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iSghtJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_16kDgDkiEemjx6Nna_xyog" target="_iSghsJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iSghtZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iSghuZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_16iOUDkiEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVItD2BsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVItEGBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVItEWBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iSghtpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iSght5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iSghuJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVItIGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_xtNrMF1yEemG57ABxBTHSA" target="_zVItHGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVItIWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVItJWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iTG-p5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_xtNrMF1yEemG57ABxBTHSA" target="_iTG-o5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iTG-qJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iTG-rJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_xtL2AF1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVItImBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVItI2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVItJGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iTG-qZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTG-qpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTG-q5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVSeDWBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_9kn-EF1yEemG57ABxBTHSA" target="_zVSeCWBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVSeDmBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVSeEmBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iTZ5lJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9kn-EF1yEemG57ABxBTHSA" target="_iTZ5kJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iTZ5lZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iTZ5mZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9kmI4F1yEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVSeD2BsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVSeEGBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVSeEWBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iTZ5lpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTZ5l5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iTZ5mJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVcPBGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_5OAUADiPEem1lYbrIE6BNw" target="_zVcPAGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVcPBWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVcPCWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iT2lhJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_5OAUADiPEem1lYbrIE6BNw" target="_iT2lgJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iT2lhZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iT2liZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVcPBmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVcPB2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVcPCGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iT2lhpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iT2lh5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iT2liJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVcPOGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_5x32EDiPEem1lYbrIE6BNw" target="_zVcPNGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVcPOWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVcPPWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iUJgd5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_5x32EDiPEem1lYbrIE6BNw" target="_iUJgc5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iUJgeJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iUJgfJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_zn1cMMOeEeaFfJxGCRaf4A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVcPOmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVcPO2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVcPPGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iUJgeZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iUJgepnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iUJge5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVlZBmBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_6O6-cDiPEem1lYbrIE6BNw" target="_zVlZAmBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVlZB2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVlZC2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iUmMZJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_6O6-cDiPEem1lYbrIE6BNw" target="_iUmMYJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iUmMZZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iUmMaZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_lSsioMOeEeaFfJxGCRaf4A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVlZCGBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVlZCWBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVlZCmBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iUmMZpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iUmMZ5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iUmMaJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zVvJ92BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_6nB8cDiPEem1lYbrIE6BNw" target="_zVvJ82BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zVvJ-GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zVvJ_GBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iVC4VJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_6nB8cDiPEem1lYbrIE6BNw" target="_iVC4UJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iVC4VZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iVC4WZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zVvJ-WBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVvJ-mBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zVvJ-2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iVC4VpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iVC4V5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iVC4WJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zV4T5GBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_7IWg0DiPEem1lYbrIE6BNw" target="_zV4T4GBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zV4T5WBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zV4T6WBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iVVzR5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_7IWg0DiPEem1lYbrIE6BNw" target="_iVVzQ5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iVVzSJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iVVzTJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_CXyBUE5DEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zV4T5mBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zV4T52BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zV4T6GBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iVVzSZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iVVzSpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iVVzS5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zV4UGGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_8QZuADiPEem1lYbrIE6BNw" target="_zV4UFGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zV4UGWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zV4UHWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iVouN5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_8QZuADiPEem1lYbrIE6BNw" target="_iVouM5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iVouOJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iVouPJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_JRx_AE5DEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zV4UGmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zV4UG2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zV4UHGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iVouOZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iVouOpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iVouO5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zWCE_mBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_8t2fADiPEem1lYbrIE6BNw" target="_zWCE-mBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zWCE_2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWCFA2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iV7pL5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_8t2fADiPEem1lYbrIE6BNw" target="_iV7pK5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iV7pMJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iV7pNJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_M-C1YE5DEeiMYveOdt1-rQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zWCFAGBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWCFAWBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWCFAmBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iV7pMZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iV7pMpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iV7pM5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zWL152BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_nyBv4DiQEem1lYbrIE6BNw" target="_zWL142BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zWL16GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWL17GBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iWYVH5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_nyBv4DiQEem1lYbrIE6BNw" target="_iWYVG5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iWYVIJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iWYVJJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiOam.uml#_ssZqINzDEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zWL16WBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWL16mBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWL162BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iWYVIZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iWYVIpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iWYVI5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zWU_12BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_QErM8DiUEem1lYbrIE6BNw" target="_zWU_02BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zWU_2GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWU_3GBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iW-K9JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_QErM8DiUEem1lYbrIE6BNw" target="_iW-K8JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iW-K9ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iW-K-ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_lJFbwE-xEeitY7qZgkO_XQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zWU_2WBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWU_2mBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWU_22BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iW-K9pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iW-K95nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iW-K-JnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zWew1GBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_MJWSgDkmEemjx6Nna_xyog" target="_zWew0GBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zWew1WBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWew2WBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iXRs95nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_MJWSgDkmEemjx6Nna_xyog" target="_iXRs85nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iXRs-JnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iXRs_JnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_MJVEYDkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zWew1mBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWew12BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWew2GBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iXRs-ZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iXRs-pnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iXRs-5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zWn6y2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_QmI7QDiUEem1lYbrIE6BNw" target="_zWn6x2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zWn6zGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWn60GBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iYBT1JnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_QmI7QDiUEem1lYbrIE6BNw" target="_iYBT0JnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iYBT1ZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iYBT2ZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_jrxwQE-xEeitY7qZgkO_XQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zWn6zWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWn6zmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWn6z2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iYBT1pnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYBT15nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYBT2JnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zWxr02BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_Lb8Z8DkmEemjx6Nna_xyog" target="_zWxrz2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zWxr1GBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zWxr2GBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iYUOx5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_Lb8Z8DkmEemjx6Nna_xyog" target="_iYUOw5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iYUOyJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iYUOzJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_Lb7L0DkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zWxr1WBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWxr1mBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zWxr12BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iYUOyZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYUOypnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iYUOy5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zXEmt2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_Rcab8DiUEem1lYbrIE6BNw" target="_zXEms2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zXEmuGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXEmvGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iY6EpJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_Rcab8DiUEem1lYbrIE6BNw" target="_iY6EoJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iY6EpZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iY6EqZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_iN418E-xEeitY7qZgkO_XQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zXEmuWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXEmumBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXEmu2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iY6EppnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iY6Ep5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iY6EqJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zXOXt2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_KtcVMDkmEemjx6Nna_xyog" target="_zXOXs2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zXOXuGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXOXvGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iZM_l5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_KtcVMDkmEemjx6Nna_xyog" target="_iZM_k5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iZM_mJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iZM_nJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_KtbHEDkmEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zXOXuWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXOXumBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXOXu2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iZM_mZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZM_mpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZM_m5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zXXhr2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_iZdJcDkkEemjx6Nna_xyog" target="_zXXhq2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zXXhsGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXXhtGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iZprh5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_iZdJcDkkEemjx6Nna_xyog" target="_iZprg5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iZpriJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iZprjJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_PONicBXLEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zXXhsWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXXhsmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXXhs2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iZpriZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZpripnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZpri5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zXhSs2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_rDC1cDkkEemjx6Nna_xyog" target="_zXhSr2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zXhStGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXhSuGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iaGXdJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_rDC1cDkkEemjx6Nna_xyog" target="_iaGXcJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iaGXdZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iaGXeZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_rDBAQDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zXhStWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXhStmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXhSt2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iaGXdpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iaGXd5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iaGXeJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zXrDpGBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_10ovwDkkEemjx6Nna_xyog" target="_zXrDoGBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zXrDpWBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXrDqWBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iaQIdJnAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_10ovwDkkEemjx6Nna_xyog" target="_iaQIcJnAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iaQIdZnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iaQIeZnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_10m6kDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zXrDpmBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXrDp2BsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXrDqGBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iaQIdpnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iaQId5nAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iaQIeJnAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zXrDt2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_9Ioh0DkkEemjx6Nna_xyog" target="_zXrDs2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zXrDuGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zXrDvGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_iaZSZ5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_9Ioh0DkkEemjx6Nna_xyog" target="_iaZSY5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iaZSaJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iaZSbJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_9InTsDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zXrDuWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXrDumBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zXrDu2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iaZSaZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iaZSapnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iaZSa5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zX9-l2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_id2hQDkkEemjx6Nna_xyog" target="_zX9-k2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zX9-mGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zX9-nGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ia1-V5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_id2hQDkkEemjx6Nna_xyog" target="_ia1-U5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ia1-WJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ia1-XJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiEth.uml#_CyVJMBXOEemlb5smEiStFg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zX9-mWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zX9-mmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zX9-m2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ia1-WZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ia1-WpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ia1-W5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zYHIk2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_uxVFEDkkEemjx6Nna_xyog" target="_zYHIj2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zYHIlGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zYHImGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ibI5R5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_uxVFEDkkEemjx6Nna_xyog" target="_ibI5Q5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ibI5SJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ibI5TJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_uxTP4DkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zYHIlWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zYHIlmBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zYHIl2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ibI5SZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ibI5SpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ibI5S5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zYQ5h2BsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_4yirUDkkEemjx6Nna_xyog" target="_zYQ5g2BsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zYQ5iGBsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zYQ5jGBsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ibSqR5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_4yirUDkkEemjx6Nna_xyog" target="_ibSqQ5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ibSqSJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ibSqTJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_4yhdMDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zYQ5iWBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zYQ5imBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zYQ5i2BsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ibSqSZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ibSqSpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ibSqS5nAEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zYQ5mmBsEemmf8tAu_V-ow" type="StereotypeCommentLink" source="__0aLkDkkEemjx6Nna_xyog" target="_zYQ5lmBsEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zYQ5m2BsEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zYQ5n2BsEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ibvWN5nAEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__0aLkDkkEemjx6Nna_xyog" target="_ibvWM5nAEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ibvWOJnAEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ibvWPJnAEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#__0Y9cDkkEemjx6Nna_xyog"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zYQ5nGBsEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zYQ5nWBsEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zYQ5nmBsEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ibvWOZnAEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ibvWOpnAEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ibvWO5nAEemVaY_egjrbOQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_eRRhYDlLEemSPvPXzEQ11A" type="PapyrusUMLClassDiagram" name="EthInterfaceJobsPmProActive" measurementUnit="Pixel">

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -1715,20 +1715,6 @@ It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_M-QGADh9Eem1lYbrIE6BNw" name="EthConnectivityService"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_feQUkFfZEemG57ABxBTHSA" client="_n4NGYLFVEd2MOdzuQUV2bQ" supplier="_uyMrEFEZEd6VSrclB-Ybig"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_mDFTgFfZEemG57ABxBTHSA" client="_6gIJAERfEeKsbYfVW3kmQQ" supplier="_uyMrEFEZEd6VSrclB-Ybig"/>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_M7B80F1yEemG57ABxBTHSA" client="_PONicBXLEemlb5smEiStFg">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_jhcJAF1yEemG57ABxBTHSA" client="_PONicBXLEemlb5smEiStFg">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_xtL2AF1yEemG57ABxBTHSA" client="_CyVJMBXOEemlb5smEiStFg">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_9kmI4F1yEemG57ABxBTHSA" client="_CyVJMBXOEemlb5smEiStFg">
-        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
-      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_dP6U4JKmEdybINoKQq_hfQ" name="TypeDefinitions">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dQAbgJKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
@@ -3088,6 +3074,120 @@ Frame delay variation is a measure of the variations in the frame delay between 
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YPky4EtNEemsleBFQ473Kg" name="HIGH_LOSS_INTERVALS"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_cWvckEtNEemsleBFQ473Kg" name="UNAVAILABLE_INTERVALS"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_zZWYAIMxEemCy9JSn498_g" name="EthAlarmConditionName">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_w2pVQIMyEemCy9JSn498_g" name="LOSS_OF_CONTINUITY">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_w2p8UIMyEemCy9JSn498_g" annotatedElement="_w2pVQIMyEemCy9JSn498_g">
+            <body>G.8021: The loss of continuity defect is calculated at the ETH layer. It monitors the presence of continuity in ETH trails.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Eud0QIMzEemCy9JSn498_g" name="UNEXPECTED_MEL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Eud0QYMzEemCy9JSn498_g" annotatedElement="_Eud0QIMzEemCy9JSn498_g">
+            <body>G.8021: Reception of a CCM frame with an invalid MEL value.&#xD;
+Monitoring of the connectivity in a maintenance entity group.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_t3cTYIOZEemCy9JSn498_g" name="UNEXPECTED_MEP">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_t3c6cIOZEemCy9JSn498_g" annotatedElement="_t3cTYIOZEemCy9JSn498_g">
+            <body>G.8021: Reception of a CCM frame with an invalid MEP value, but with valid MEL and MEG values.&#xD;
+Monitoring of the connectivity in a maintenance entity group.&#xD;
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_FSDjsIOaEemCy9JSn498_g" name="MISMERGE_UNEXPECTED_MEG">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_FSJqUIOaEemCy9JSn498_g" annotatedElement="_FSDjsIOaEemCy9JSn498_g">
+            <body>G.8021: Reception of a CCM frame with an invalid MEG value, but with a valid MEL value.&#xD;
+Monitoring of the connectivity in a maintenance entity group.&#xD;
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_N7qd0IOaEemCy9JSn498_g" name="UNEXPECTED_PERIODICITY">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_N7qd0YOaEemCy9JSn498_g" annotatedElement="_N7qd0IOaEemCy9JSn498_g">
+            <body>G.8021: Reception of a CCM frame with an invalid periodicity value, but with valid MEL, MEG and MEP values.&#xD;
+It detects the configuration of different periodicities at different MEPs belonging to the same MEG.&#xD;
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_I4wIIIObEemCy9JSn498_g" name="UNEXPECTED_PRIORITY">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_I41nsIObEemCy9JSn498_g" annotatedElement="_I4wIIIObEemCy9JSn498_g">
+            <body>G.8021: Reception of a CCM frame with an invalid priority value, but with valid MEL, MEG, MEP and periodicity values.&#xD;
+It detects the configuration of different priorities for CCM at different MEPs belonging to the same MEG.&#xD;
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_QmugcIObEemCy9JSn498_g" name="LOCKED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_QmugcYObEemCy9JSn498_g" annotatedElement="_QmugcIObEemCy9JSn498_g">
+            <body>G.8021: Reception of a LCK frame.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jVAkgIObEemCy9JSn498_g" name="AIS">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jVAkgYObEemCy9JSn498_g" annotatedElement="_jVAkgIObEemCy9JSn498_g">
+            <body>G.8021: Reception of an AIS frame.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_JUSYIIOcEemCy9JSn498_g" name="DEGRADED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_tPflwIOdEemCy9JSn498_g" annotatedElement="_JUSYIIOcEemCy9JSn498_g">
+            <body>G.8021: The defect is detected if there are MI_LM_DEGM (lmDegm of EthMepSink) consecutive bad seconds and cleared if there are MI_LM_M (lmM of EthMepSink) consecutive good seconds. &#xD;
+In order to declare a bad second the number of transmitted frames must exceed a threshold (MI_LM_TFMIN, lmTfMin of EthMepSink).&#xD;
+Furthermore, if the frame loss ratio (lost frames/transmitted frames) is greater than MI_LM_DEGTHR (lmDegThr of EthMepSink), a bad second is declared.&#xD;
+This defect is only defined for point-to-point ETH connections. It monitors the connectivity of an ETH trail.&#xD;
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_JHQW0IOeEemCy9JSn498_g" name="RDI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_JHQW0YOeEemCy9JSn498_g" annotatedElement="_JHQW0IOeEemCy9JSn498_g">
+            <body>G.8021: Remote defect indicator defect, reception by an MEP (indexed by &quot;i&quot;, this index not included in the &quot;cause&quot; cRDI) of a CCM frame with valid MEL, MEG, MEP and periodicity values and the RDI flag set to x; where x=0 (remote defect clear) and x=1 (remote defect set).</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ZP2yEIOeEemCy9JSn498_g" name="CSF">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ZP2yEYOeEemCy9JSn498_g" annotatedElement="_ZP2yEIOeEemCy9JSn498_g">
+            <body>G.8021 - ETH layer: Reception of a CSF frame that indicates a client loss of signal (dCSF-LOS) or a client forward defect indication (dCSF-FDI) or a client reverse defect indication (dCSF-RDI).&#xD;
+The CSF (CSF-LOS, CSF-FDI, and CSF-RDI) defect is calculated at the ETH layer. It monitors the presence of a CSF maintenance signal.&#xD;
+G.8021 - GFP: dCSF is Client-specific GFP-F and GFP-T (resp. Frame and Transparent) sink processes.&#xD;
+dCSF-RDI: GFP client signal fail-remote defect indication is raised when a GFP client management frame with the RDI UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.&#xD;
+dCSF-RDI is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.&#xD;
+dCSF-FDI: GFP client signal fail-forward defect indication is raised when a GFP client management frame with the FDI UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.&#xD;
+dCSF-FDI is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.&#xD;
+dCSF-LOS: GFP client signal fail-loss of signal is raised when a GFP client management frame with the LOS UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.&#xD;
+dCSF-LOS is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ucw0sIOeEemCy9JSn498_g" name="TOTAL_LINK_LOSS">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7t7IwIOeEemCy9JSn498_g" annotatedElement="_ucw0sIOeEemCy9JSn498_g">
+            <body>G.8021: LAG - fault cause will be raised if no ports are active for an aggregator.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_CzAVEIOfEemCy9JSn498_g" name="PARTIAL_LINK_LOSS">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_CzAVEYOfEemCy9JSn498_g" annotatedElement="_CzAVEIOfEemCy9JSn498_g">
+            <body>G.8021: LAG - fault cause shall be raised if the number of active ports is less than the provisioned threshold.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PL02cIOgEemCy9JSn498_g" name="PLM">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_PL02cYOgEemCy9JSn498_g" annotatedElement="_PL02cIOgEemCy9JSn498_g">
+            <body>G.806: The payload label mismatch defect (dPLM) shall be detected if the &quot;accepted TSL&quot; code does not match the &quot;expected TSL&quot; code. If the &quot;accepted TSL&quot; is &quot;equipped non-specific&quot;, the mismatch is not detected (TSL: Trail Signal Label).&#xD;
+Payload type supervision checks that compatible adaptation functions are used at the source and the sink.&#xD;
+This is normally done by adding a signal type identifier at the source adaptation function and comparing it with the expected identifier at the sink.&#xD;
+If they do not match, a payload mismatch is detected.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_kxwkoIPCEemCy9JSn498_g" name="LFD">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_kxwkoYPCEemCy9JSn498_g" annotatedElement="_kxwkoIPCEemCy9JSn498_g">
+            <body>G.806 - Server layer-specific GFP sink processes: GFP loss of frame delineation (dLFD) is raised when the frame delineation process (clause 6.3.1 of [ITU-T G.7041]) is not in the &quot;SYNC&quot; state.&#xD;
+dLFD is cleared when the frame delineation process is in the &quot;SYNC&quot; state.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wIX3kIPCEemCy9JSn498_g" name="EXM">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_wIX3kYPCEemCy9JSn498_g" annotatedElement="_wIX3kIPCEemCy9JSn498_g">
+            <body>G.806 - Common GFP sink processes: GFP extension header mismatch (dEXM) is raised when the accepted EXI (AcEXI) is different from the expected EXI.&#xD;
+dEXM is cleared when AcEXI matches the expected EXI or GFP_SF is active.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sW9mAIPDEemCy9JSn498_g" name="UPM">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sW9mAYPDEemCy9JSn498_g" annotatedElement="_sW9mAIPDEemCy9JSn498_g">
+            <body>G.806 - Client-specific GFP-F (Frame) and GFP-T (Transparent) sink processes: GFP user payload mismatch (dUPM) is raised when the accepted UPI (AcUPI) is different from the expected UPI.&#xD;
+dUPM is cleared when AcUPI matches the expected UPI or GFP_SF is active.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_x3G-wDxBEeaRI-H69PghuA" name="Associations">
       <packagedElement xmi:type="uml:Association" xmi:id="_ITi4QDN-Eea40e5DA9KE3w" name="EthCepSpecHasCtpPac" memberEnd="_ITjfUjN-Eea40e5DA9KE3w _ITkGYDN-Eea40e5DA9KE3w">
@@ -3696,6 +3796,23 @@ Frame delay variation is a measure of the variations in the frame delay between 
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_-vergEtGEemsleBFQ473Kg" client="_7Cjt0EtGEemsleBFQ473Kg">
         <supplier xmi:type="uml:Enumeration" href="TapiOam.uml#_I86WoEqIEempws6eXu44Eg"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_5_NRsIMxEemCy9JSn498_g" client="_zZWYAIMxEemCy9JSn498_g">
+        <supplier xmi:type="uml:Enumeration" href="TapiOam.uml#_GeBSUEqIEempws6eXu44Eg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_jhcJAF1yEemG57ABxBTHSA" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_xtL2AF1yEemG57ABxBTHSA" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_r-PDAMOdEeaFfJxGCRaf4A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_M7B80F1yEemG57ABxBTHSA" client="_PONicBXLEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_9kmI4F1yEemG57ABxBTHSA" client="_CyVJMBXOEemlb5smEiStFg">
+        <supplier xmi:type="uml:Operation" href="TapiOam.uml#_FHkjAE4wEeiMYveOdt1-rQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_feQUkFfZEemG57ABxBTHSA" client="_n4NGYLFVEd2MOdzuQUV2bQ" supplier="_uyMrEFEZEd6VSrclB-Ybig"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_mDFTgFfZEemG57ABxBTHSA" client="_6gIJAERfEeKsbYfVW3kmQQ" supplier="_uyMrEFEZEd6VSrclB-Ybig"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_fhZtAEWoEeaB8vMnkFQLXQ" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_kV26gEWoEeaB8vMnkFQLXQ">
@@ -3711,125 +3828,7 @@ Frame delay variation is a measure of the variations in the frame delay between 
         <importedPackage xmi:type="uml:Model" href="TapiOam.uml#_pYBToLwlEeSpn78DYJKtkA"/>
       </packageImport>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_MP5wgJKmEdybINoKQq_hfQ" name="Diagrams">
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_zZWYAIMxEemCy9JSn498_g" name="EthAlarmConditionName">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_w2pVQIMyEemCy9JSn498_g" name="LOSS_OF_CONTINUITY">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_w2p8UIMyEemCy9JSn498_g" annotatedElement="_w2pVQIMyEemCy9JSn498_g">
-            <body>G.8021: The loss of continuity defect is calculated at the ETH layer. It monitors the presence of continuity in ETH trails.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Eud0QIMzEemCy9JSn498_g" name="UNEXPECTED_MEL">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Eud0QYMzEemCy9JSn498_g" annotatedElement="_Eud0QIMzEemCy9JSn498_g">
-            <body>G.8021: Reception of a CCM frame with an invalid MEL value.&#xD;
-Monitoring of the connectivity in a maintenance entity group.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_t3cTYIOZEemCy9JSn498_g" name="UNEXPECTED_MEP">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_t3c6cIOZEemCy9JSn498_g" annotatedElement="_t3cTYIOZEemCy9JSn498_g">
-            <body>G.8021: Reception of a CCM frame with an invalid MEP value, but with valid MEL and MEG values.&#xD;
-Monitoring of the connectivity in a maintenance entity group.&#xD;
-</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_FSDjsIOaEemCy9JSn498_g" name="MISMERGE_UNEXPECTED_MEG">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_FSJqUIOaEemCy9JSn498_g" annotatedElement="_FSDjsIOaEemCy9JSn498_g">
-            <body>G.8021: Reception of a CCM frame with an invalid MEG value, but with a valid MEL value.&#xD;
-Monitoring of the connectivity in a maintenance entity group.&#xD;
-</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_N7qd0IOaEemCy9JSn498_g" name="UNEXPECTED_PERIODICITY">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_N7qd0YOaEemCy9JSn498_g" annotatedElement="_N7qd0IOaEemCy9JSn498_g">
-            <body>G.8021: Reception of a CCM frame with an invalid periodicity value, but with valid MEL, MEG and MEP values.&#xD;
-It detects the configuration of different periodicities at different MEPs belonging to the same MEG.&#xD;
-</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_I4wIIIObEemCy9JSn498_g" name="UNEXPECTED_PRIORITY">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_I41nsIObEemCy9JSn498_g" annotatedElement="_I4wIIIObEemCy9JSn498_g">
-            <body>G.8021: Reception of a CCM frame with an invalid priority value, but with valid MEL, MEG, MEP and periodicity values.&#xD;
-It detects the configuration of different priorities for CCM at different MEPs belonging to the same MEG.&#xD;
-</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_QmugcIObEemCy9JSn498_g" name="LOCKED">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_QmugcYObEemCy9JSn498_g" annotatedElement="_QmugcIObEemCy9JSn498_g">
-            <body>G.8021: Reception of a LCK frame.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jVAkgIObEemCy9JSn498_g" name="AIS">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_jVAkgYObEemCy9JSn498_g" annotatedElement="_jVAkgIObEemCy9JSn498_g">
-            <body>G.8021: Reception of an AIS frame.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_JUSYIIOcEemCy9JSn498_g" name="DEGRADED">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_tPflwIOdEemCy9JSn498_g" annotatedElement="_JUSYIIOcEemCy9JSn498_g">
-            <body>G.8021: The defect is detected if there are MI_LM_DEGM (lmDegm of EthMepSink) consecutive bad seconds and cleared if there are MI_LM_M (lmM of EthMepSink) consecutive good seconds. &#xD;
-In order to declare a bad second the number of transmitted frames must exceed a threshold (MI_LM_TFMIN, lmTfMin of EthMepSink).&#xD;
-Furthermore, if the frame loss ratio (lost frames/transmitted frames) is greater than MI_LM_DEGTHR (lmDegThr of EthMepSink), a bad second is declared.&#xD;
-This defect is only defined for point-to-point ETH connections. It monitors the connectivity of an ETH trail.&#xD;
-</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_JHQW0IOeEemCy9JSn498_g" name="RDI">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_JHQW0YOeEemCy9JSn498_g" annotatedElement="_JHQW0IOeEemCy9JSn498_g">
-            <body>G.8021: Remote defect indicator defect, reception by an MEP (indexed by &quot;i&quot;, this index not included in the &quot;cause&quot; cRDI) of a CCM frame with valid MEL, MEG, MEP and periodicity values and the RDI flag set to x; where x=0 (remote defect clear) and x=1 (remote defect set).</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ZP2yEIOeEemCy9JSn498_g" name="CSF">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_ZP2yEYOeEemCy9JSn498_g" annotatedElement="_ZP2yEIOeEemCy9JSn498_g">
-            <body>G.8021 - ETH layer: Reception of a CSF frame that indicates a client loss of signal (dCSF-LOS) or a client forward defect indication (dCSF-FDI) or a client reverse defect indication (dCSF-RDI).&#xD;
-The CSF (CSF-LOS, CSF-FDI, and CSF-RDI) defect is calculated at the ETH layer. It monitors the presence of a CSF maintenance signal.&#xD;
-G.8021 - GFP: dCSF is Client-specific GFP-F and GFP-T (resp. Frame and Transparent) sink processes.&#xD;
-dCSF-RDI: GFP client signal fail-remote defect indication is raised when a GFP client management frame with the RDI UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.&#xD;
-dCSF-RDI is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.&#xD;
-dCSF-FDI: GFP client signal fail-forward defect indication is raised when a GFP client management frame with the FDI UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.&#xD;
-dCSF-FDI is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.&#xD;
-dCSF-LOS: GFP client signal fail-loss of signal is raised when a GFP client management frame with the LOS UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.&#xD;
-dCSF-LOS is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ucw0sIOeEemCy9JSn498_g" name="TOTAL_LINK_LOSS">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_7t7IwIOeEemCy9JSn498_g" annotatedElement="_ucw0sIOeEemCy9JSn498_g">
-            <body>G.8021: LAG - fault cause will be raised if no ports are active for an aggregator.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_CzAVEIOfEemCy9JSn498_g" name="PARTIAL_LINK_LOSS">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_CzAVEYOfEemCy9JSn498_g" annotatedElement="_CzAVEIOfEemCy9JSn498_g">
-            <body>G.8021: LAG - fault cause shall be raised if the number of active ports is less than the provisioned threshold.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PL02cIOgEemCy9JSn498_g" name="PLM">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_PL02cYOgEemCy9JSn498_g" annotatedElement="_PL02cIOgEemCy9JSn498_g">
-            <body>G.806: The payload label mismatch defect (dPLM) shall be detected if the &quot;accepted TSL&quot; code does not match the &quot;expected TSL&quot; code. If the &quot;accepted TSL&quot; is &quot;equipped non-specific&quot;, the mismatch is not detected (TSL: Trail Signal Label).&#xD;
-Payload type supervision checks that compatible adaptation functions are used at the source and the sink.&#xD;
-This is normally done by adding a signal type identifier at the source adaptation function and comparing it with the expected identifier at the sink.&#xD;
-If they do not match, a payload mismatch is detected.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_kxwkoIPCEemCy9JSn498_g" name="LFD">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_kxwkoYPCEemCy9JSn498_g" annotatedElement="_kxwkoIPCEemCy9JSn498_g">
-            <body>G.806 - Server layer-specific GFP sink processes: GFP loss of frame delineation (dLFD) is raised when the frame delineation process (clause 6.3.1 of [ITU-T G.7041]) is not in the &quot;SYNC&quot; state.&#xD;
-dLFD is cleared when the frame delineation process is in the &quot;SYNC&quot; state.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wIX3kIPCEemCy9JSn498_g" name="EXM">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_wIX3kYPCEemCy9JSn498_g" annotatedElement="_wIX3kIPCEemCy9JSn498_g">
-            <body>G.806 - Common GFP sink processes: GFP extension header mismatch (dEXM) is raised when the accepted EXI (AcEXI) is different from the expected EXI.&#xD;
-dEXM is cleared when AcEXI matches the expected EXI or GFP_SF is active.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sW9mAIPDEemCy9JSn498_g" name="UPM">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_sW9mAYPDEemCy9JSn498_g" annotatedElement="_sW9mAIPDEemCy9JSn498_g">
-            <body>G.806 - Client-specific GFP-F (Frame) and GFP-T (Transparent) sink processes: GFP user payload mismatch (dUPM) is raised when the accepted UPI (AcUPI) is different from the expected UPI.&#xD;
-dUPM is cleared when AcUPI matches the expected UPI or GFP_SF is active.</body>
-          </ownedComment>
-        </ownedLiteral>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_5_NRsIMxEemCy9JSn498_g" client="_zZWYAIMxEemCy9JSn498_g">
-        <supplier xmi:type="uml:Enumeration" href="TapiOam.uml#_GeBSUEqIEempws6eXu44Eg"/>
-      </packagedElement>
-    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_MP5wgJKmEdybINoKQq_hfQ" name="Diagrams"/>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_xbDEIBM1Eee0L_IMWjydgQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1QwkoWm1EeiLh_06MH5Rjg" source="PapyrusVersion">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1Qwkomm1EeiLh_06MH5Rjg" key="Version" value="0.2.14"/>

--- a/UML/TapiNotification.notation
+++ b/UML/TapiNotification.notation
@@ -743,117 +743,117 @@
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_zF3b4FofEemu443YKSGnxQ"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_S3IJ4VonEemu443YKSGnxQ" x="912" y="265" height="84"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-YyE03tAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-YyE1HtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-YyE1ntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5ikgU5nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5ikgVJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5ikgVpnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-YyE1XtAEemfSIWqmJMEQA" x="671" y="244"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ikgVZnrEemrjrtN9v_T1A" x="671" y="244"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-Zhrs3tAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-ZhrtHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-ZhrtntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5jdRIJnrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5jdRIZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5jdRI5nrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_phsNMCzxEeaYO8M_h7XJ5A"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-ZhrtXtAEemfSIWqmJMEQA" x="222" y="522"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5jdRIpnrEemrjrtN9v_T1A" x="222" y="522"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-akNg3tAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-akNhHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-akNhntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5kpj8JnrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5kpj8ZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5kpj85nrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_oVDs4CzvEeaYO8M_h7XJ5A"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-akNhXtAEemfSIWqmJMEQA" x="261" y="232"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5kpj8pnrEemrjrtN9v_T1A" x="261" y="232"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-cDbQHtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-cDbQXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-cDbQ3tAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5li705nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5li71JnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5li71pnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_rZ7rwCzyEeaYO8M_h7XJ5A"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-cDbQntAEemfSIWqmJMEQA" x="261" y="132"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5li71ZnrEemrjrtN9v_T1A" x="261" y="132"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-cDbUXtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-cDbUntAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-cDbVHtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5lsFw5nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5lsFxJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5lsFxpnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_Nsg9cE8cEea3rq3M7G3w3w"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-cDbU3tAEemfSIWqmJMEQA" x="261" y="132"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5lsFxZnrEemrjrtN9v_T1A" x="261" y="132"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-cWWOXtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-cWWOntAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-cWWPHtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5l_nzZnrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5l_nzpnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5l_n0JnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Signal" href="TapiNotification.uml#_7CEIsC1qEeair-8ZDvf8jw"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-cWWO3tAEemfSIWqmJMEQA" x="522" y="468"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5l_nz5nrEemrjrtN9v_T1A" x="522" y="468"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-d1j_ntAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-d1j_3tAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-d1kAXtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5oFSd5nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5oFSeJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5oFSepnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Interface" href="TapiNotification.uml#_2HbQwC0UEeah7qIgVNfKeA"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-d1kAHtAEemfSIWqmJMEQA" x="196" y="-115"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5oFSeZnrEemrjrtN9v_T1A" x="196" y="-115"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-eu703tAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-eu71HtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-eu71ntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5p3bI5nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5p3bJJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5p3bJpnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_aQ9x8E8bEea3rq3M7G3w3w"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-eu71XtAEemfSIWqmJMEQA" x="258" y="707"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5p3bJZnrEemrjrtN9v_T1A" x="258" y="707"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-feisHtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-feisXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-feis3tAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5qd4EJnrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5qd4EZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5qd4E5nrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_mWGkkMh5EeaVlemTikmRHw"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-feisntAEemfSIWqmJMEQA" x="387" y="75"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5qd4EpnrEemrjrtN9v_T1A" x="387" y="75"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-f7OoHtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-f7OoXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-f7Oo3tAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5qwzA5nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5qwzBJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5qwzBpnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Abstraction" href="TapiNotification.uml#_qrNLMBM5Eee0L_IMWjydgQ"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-f7OontAEemfSIWqmJMEQA" x="387" y="-25"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5qwzBZnrEemrjrtN9v_T1A" x="387" y="-25"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-f7Os3tAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-f7OtHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-f7OtntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5qwzFpnrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5qwzF5nrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5qwzGZnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_weSVgMh5EeaVlemTikmRHw"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-f7OtXtAEemfSIWqmJMEQA" x="387" y="-25"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5qwzGJnrEemrjrtN9v_T1A" x="387" y="-25"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-gEYl3tAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-gEYmHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-gEYmntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5q5895nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5q58-JnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5q58-pnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_AGv4IMh6EeaVlemTikmRHw"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-gEYmXtAEemfSIWqmJMEQA" x="387" y="-25"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5q58-ZnrEemrjrtN9v_T1A" x="387" y="-25"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-hacYHtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-hacYXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-hacY3tAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5r9F05nrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5r9F1JnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5r9F1pnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-hacYntAEemfSIWqmJMEQA" x="911" y="83"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5r9F1ZnrEemrjrtN9v_T1A" x="911" y="83"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_-iASQHtAEemfSIWqmJMEQA" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_-iASQXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-iASQ3tAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <children xmi:type="notation:Shape" xmi:id="_5s12oJnrEemrjrtN9v_T1A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_5s12oZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5s12o5nrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Abstraction" href="TapiNotification.uml#_Ua97MFonEemu443YKSGnxQ"/>
     </styles>
     <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-iASQntAEemfSIWqmJMEQA" x="1112" y="165"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5s12opnrEemrjrtN9v_T1A" x="1112" y="165"/>
   </children>
   <styles xmi:type="notation:StringValueStyle" xmi:id="_tIFpETBHEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
   <styles xmi:type="notation:DiagramStyle" xmi:id="_tIFpEjBHEeam35bpdXJzEw"/>
@@ -1079,144 +1079,144 @@
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o3VYEFovEemu443YKSGnxQ" id="(0.0915032679738562,0.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o3VYEVovEemu443YKSGnxQ" id="(0.07982832618025751,1.0)"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-YyE13tAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_whCiJjBHEeam35bpdXJzEw" target="_-YyE03tAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-YyE2HtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-YyE3HtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5ikgV5nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_whCiJjBHEeam35bpdXJzEw" target="_5ikgU5nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5ikgWJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5ikgXJnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-YyE2XtAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-YyE2ntAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-YyE23tAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5ikgWZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ikgWpnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ikgW5nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-Zhrt3tAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_whCixzBHEeam35bpdXJzEw" target="_-Zhrs3tAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-ZhruHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-ZhrvHtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5jdRJJnrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_whCixzBHEeam35bpdXJzEw" target="_5jdRIJnrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5jdRJZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5jdRKZnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_phsNMCzxEeaYO8M_h7XJ5A"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-ZhruXtAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ZhruntAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Zhru3tAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5jdRJpnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5jdRJ5nrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5jdRKJnrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-akNh3tAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_whMS9zBHEeam35bpdXJzEw" target="_-akNg3tAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-akNiHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-akNjHtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5kpj9JnrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_whMS9zBHEeam35bpdXJzEw" target="_5kpj8JnrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5kpj9ZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5kpj-ZnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_oVDs4CzvEeaYO8M_h7XJ5A"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-akNiXtAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-akNintAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-akNi3tAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5kpj9pnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5kpj95nrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5kpj-JnrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-cDbRHtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_9GaWEIuSEeiu6boZkiJHCA" target="_-cDbQHtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-cDbRXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-cDbSXtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5li715nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_9GaWEIuSEeiu6boZkiJHCA" target="_5li705nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5li72JnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5li73JnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_rZ7rwCzyEeaYO8M_h7XJ5A"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-cDbRntAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-cDbR3tAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-cDbSHtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5li72ZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5li72pnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5li725nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-cDbVXtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__rY0QIuSEeiu6boZkiJHCA" target="_-cDbUXtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-cDbVntAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-cDbWntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5lsFx5nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__rY0QIuSEeiu6boZkiJHCA" target="_5lsFw5nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5lsFyJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5lsFzJnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_Nsg9cE8cEea3rq3M7G3w3w"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-cDbV3tAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-cDbWHtAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-cDbWXtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5lsFyZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5lsFypnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5lsFy5nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-cWWPXtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_whMUSDBHEeam35bpdXJzEw" target="_-cWWOXtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-cWWPntAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-cWWQntAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5l_n0ZnrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_whMUSDBHEeam35bpdXJzEw" target="_5l_nzZnrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5l_n0pnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5l_n1pnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Signal" href="TapiNotification.uml#_7CEIsC1qEeair-8ZDvf8jw"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-cWWP3tAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-cWWQHtAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-cWWQXtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5l_n05nrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5l_n1JnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5l_n1ZnrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-d_U8HtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_whMV2zBHEeam35bpdXJzEw" target="_-d1j_ntAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-d_U8XtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-d_U9XtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5oFSe5nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_whMV2zBHEeam35bpdXJzEw" target="_5oFSd5nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5oFSfJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5oPDcpnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Interface" href="TapiNotification.uml#_2HbQwC0UEeah7qIgVNfKeA"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-d_U8ntAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-d_U83tAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-d_U9HtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5oFSfZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5oPDcJnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5oPDcZnrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-eu713tAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_q_PtIE8bEea3rq3M7G3w3w" target="_-eu703tAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-eu72HtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-eu73HtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5p3bJ5nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_q_PtIE8bEea3rq3M7G3w3w" target="_5p3bI5nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5p3bKJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5p3bLJnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_aQ9x8E8bEea3rq3M7G3w3w"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-eu72XtAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-eu72ntAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-eu723tAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5p3bKZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5p3bKpnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5p3bK5nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-feitHtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_mX0b0Mh5EeaVlemTikmRHw" target="_-feisHtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-feitXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-feiuXtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5qd4FJnrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_mX0b0Mh5EeaVlemTikmRHw" target="_5qd4EJnrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5qd4FZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5qd4GZnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiNotification.uml#_mWGkkMh5EeaVlemTikmRHw"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-feitntAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-feit3tAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-feiuHtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5qd4FpnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5qd4F5nrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5qd4GJnrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-f7OpHtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_qsWasBM5Eee0L_IMWjydgQ" target="_-f7OoHtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-f7OpXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-f7OqXtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5qwzB5nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_qsWasBM5Eee0L_IMWjydgQ" target="_5qwzA5nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5qwzCJnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5qwzDJnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Abstraction" href="TapiNotification.uml#_qrNLMBM5Eee0L_IMWjydgQ"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-f7OpntAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-f7Op3tAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-f7OqHtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5qwzCZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5qwzCpnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5qwzC5nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-f7Ot3tAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_27UFwIuSEeiu6boZkiJHCA" target="_-f7Os3tAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-f7OuHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-f7OvHtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5qwzGpnrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_27UFwIuSEeiu6boZkiJHCA" target="_5qwzFpnrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5qwzG5nrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5qwzH5nrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_weSVgMh5EeaVlemTikmRHw"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-f7OuXtAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-f7OuntAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-f7Ou3tAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5qwzHJnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5qwzHZnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5qwzHpnrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-gEYm3tAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_5zVbwIuSEeiu6boZkiJHCA" target="_-gEYl3tAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-gEYnHtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-gEYoHtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5q58-5nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_5zVbwIuSEeiu6boZkiJHCA" target="_5q5895nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5q58_JnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5q59AJnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_AGv4IMh6EeaVlemTikmRHw"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-gEYnXtAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-gEYnntAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-gEYn3tAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5q58_ZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5q58_pnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5q58_5nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-hacZHtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_oDXmQBM5Eee0L_IMWjydgQ" target="_-hacYHtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-hacZXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-hacaXtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5r9F15nrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_oDXmQBM5Eee0L_IMWjydgQ" target="_5r9F05nrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5r9F2JnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5r9F3JnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-hacZntAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-hacZ3tAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-hacaHtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5r9F2ZnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5r9F2pnrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5r9F25nrEemrjrtN9v_T1A"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_-iASRHtAEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Ua97MVonEemu443YKSGnxQ" target="_-iASQHtAEemfSIWqmJMEQA">
-    <styles xmi:type="notation:FontStyle" xmi:id="_-iASRXtAEemfSIWqmJMEQA"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-iASSXtAEemfSIWqmJMEQA" name="BASE_ELEMENT">
+  <edges xmi:type="notation:Connector" xmi:id="_5s12pJnrEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Ua97MVonEemu443YKSGnxQ" target="_5s12oJnrEemrjrtN9v_T1A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_5s12pZnrEemrjrtN9v_T1A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5s12qZnrEemrjrtN9v_T1A" name="BASE_ELEMENT">
       <eObjectValue xmi:type="uml:Abstraction" href="TapiNotification.uml#_Ua97MFonEemu443YKSGnxQ"/>
     </styles>
     <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-iASRntAEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-iASR3tAEemfSIWqmJMEQA"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-iASSHtAEemfSIWqmJMEQA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5s12ppnrEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5s12p5nrEemrjrtN9v_T1A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5s12qJnrEemrjrtN9v_T1A"/>
   </edges>
 </notation:Diagram>

--- a/UML/TapiNotification.uml
+++ b/UML/TapiNotification.uml
@@ -88,26 +88,75 @@ Copyright: 2018 Open Networking Foundation (ONF).</body>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_2Iz7YC0VEeah7qIgVNfKeA" name="createNotificationSubscriptionService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_KZKuMJnlEemrjrtN9v_T1A" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_KZKuMZnlEemrjrtN9v_T1A" annotatedElement="_KZKuMJnlEemrjrtN9v_T1A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_QMmscJnlEemrjrtN9v_T1A" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_XGdG4JnqEemrjrtN9v_T1A" annotatedElement="_QMmscJnlEemrjrtN9v_T1A">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_SVSQMJnlEemrjrtN9v_T1A"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_SVlLIJnlEemrjrtN9v_T1A" value="*"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_juqM4C0YEeah7qIgVNfKeA" name="subscriptionFilter" type="_phsNMCzxEeaYO8M_h7XJ5A" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_LNaH0C0cEeah7qIgVNfKeA" name="subscriptionState" type="_Rjd84C0aEeah7qIgVNfKeA" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_qyYuUC0YEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_Sgs2oC0ZEeah7qIgVNfKeA" name="updateNotificationSubscriptionService" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YSIpwC0ZEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YSIpwC0ZEeah7qIgVNfKeA" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_VpRwgJnlEemrjrtN9v_T1A" annotatedElement="_YSIpwC0ZEeah7qIgVNfKeA">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YS8hcJnlEemrjrtN9v_T1A" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_VaetQJnqEemrjrtN9v_T1A" annotatedElement="_YS8hcJnlEemrjrtN9v_T1A">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Z5IcIJnlEemrjrtN9v_T1A"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Z5lIEJnlEemrjrtN9v_T1A" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Sgs2oS0ZEeah7qIgVNfKeA" name="subscriptionFilter" type="_phsNMCzxEeaYO8M_h7XJ5A" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_HalWcC0cEeah7qIgVNfKeA" name="subscriptionState" type="_Rjd84C0aEeah7qIgVNfKeA" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Sgs2oi0ZEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_o5NJsC0ZEeah7qIgVNfKeA" name="deleteNotificationSubscriptionService" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_o5NJsS0ZEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_o5NJsS0ZEeah7qIgVNfKeA" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_dnUlIJnlEemrjrtN9v_T1A" annotatedElement="_o5NJsS0ZEeah7qIgVNfKeA">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_BDuFkC0dEeah7qIgVNfKeA" name="getNotificationSubscriptionServiceDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_BDuFkS0dEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_BDuFkS0dEeah7qIgVNfKeA" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_gU93IJnlEemrjrtN9v_T1A" annotatedElement="_BDuFkS0dEeah7qIgVNfKeA">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_BDuFlC0dEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out" effect="read"/>
         </ownedOperation>
@@ -118,8 +167,15 @@ Copyright: 2018 Open Networking Foundation (ONF).</body>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_SumL4C0dEeah7qIgVNfKeA" name="getNotificationList" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SumL4S0dEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SumL4S0dEeah7qIgVNfKeA" name="subscriptionId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_jbrwcJnlEemrjrtN9v_T1A" annotatedElement="_SumL4S0dEeah7qIgVNfKeA">
+              <body>UUID of the associated Notification Subscription Service: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_4zwy0C0iEeah7qIgVNfKeA" name="timeRange" effect="read">
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_-ijf4FtVEeexvMtO2oNM9g"/>
@@ -467,4 +523,7 @@ This specifics of this is typically dependent on the implementation protocol &am
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_fcSa8Ut-EemIp5Bbs_BvnQ" base_Property="_fcSa8Et-EemIp5Bbs_BvnQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_fcTCAEt-EemIp5Bbs_BvnQ" base_StructuralFeature="_fcSa8Et-EemIp5Bbs_BvnQ"/>
   <OpenModel_Profile:Specify xmi:id="_Vjtr8FonEemu443YKSGnxQ" base_Abstraction="_Ua97MFonEemu443YKSGnxQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_KZLVQJnlEemrjrtN9v_T1A" base_Parameter="_KZKuMJnlEemrjrtN9v_T1A"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_QMmscZnlEemrjrtN9v_T1A" base_Parameter="_QMmscJnlEemrjrtN9v_T1A"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_YS8hcZnlEemrjrtN9v_T1A" base_Parameter="_YS8hcJnlEemrjrtN9v_T1A"/>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -1088,158 +1088,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tpzqsl1zEemG57ABxBTHSA" x="226" y="-187"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_bUuk12BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bUuk2GBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUuk2mBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bUuk2WBoEemmf8tAu_V-ow" x="-109" y="20"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bVBfx2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bVBfyGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVBfymBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bVBfyWBoEemmf8tAu_V-ow" x="-255" y="-148"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bVUasGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bVUasWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVUas2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bVUasmBoEemmf8tAu_V-ow" x="-255" y="-248"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bVUawWBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bVUawmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVUaxGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bVUaw2BoEemmf8tAu_V-ow" x="-255" y="-248"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bVn8s2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bVn8tGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVn8tmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bVn8tWBoEemmf8tAu_V-ow" x="-270" y="20"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bV63p2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bV63qGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bV63qmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bV63qWBoEemmf8tAu_V-ow" x="-161" y="-529"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bWEBr2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bWEBsGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWEBsmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWEBsWBoEemmf8tAu_V-ow" x="-161" y="-629"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bWNymWBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bWNymmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWNynGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWNym2BoEemmf8tAu_V-ow" x="-161" y="-629"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bWXjk2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bWXjlGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWXjlmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWXjlWBoEemmf8tAu_V-ow" x="-161" y="-629"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bWgtgGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bWgtgWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWgtg2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWgtgmBoEemmf8tAu_V-ow" x="-161" y="-629"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bWgtkWBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bWgtkmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWgtlGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWgtk2BoEemmf8tAu_V-ow" x="-161" y="-629"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bWzod2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bWzoeGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWzoemBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWzoeWBoEemmf8tAu_V-ow" x="-101" y="-317"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bW9Zf2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bW9ZgGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bW9ZgmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bW9ZgWBoEemmf8tAu_V-ow" x="-101" y="-417"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bXHKd2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bXHKeGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXHKemBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bXHKeWBoEemmf8tAu_V-ow" x="-101" y="-417"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bXjPU2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bXjPVGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXjPVmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bXjPVWBoEemmf8tAu_V-ow" x="-327" y="-408"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bX_7R2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bX_7SGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bX_7SmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bX_7SWBoEemmf8tAu_V-ow" x="13" y="-145"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bYmYMGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bYmYMWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bYmYM2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYmYMmBoEemmf8tAu_V-ow" x="317" y="-317"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bZo6AGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bZo6AWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bZo6A2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bZo6AmBoEemmf8tAu_V-ow" x="115" y="-317"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bZ7082BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bZ709GBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bZ709mBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bZ709WBoEemmf8tAu_V-ow" x="115" y="-417"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_baYg42BoEemmf8tAu_V-ow" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_baYg5GBoEemmf8tAu_V-ow"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_baYg5mBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
@@ -1255,6 +1103,174 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wYVSQmtwEembs75vhmFVVA" x="226" y="-187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zHB745nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zHB75JnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zHB75pnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zHB75ZnNEemVaY_egjrbOQ" x="226" y="-187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D4T7MJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D4T7MZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D4T7M5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D4T7MpnjEemrjrtN9v_T1A" x="-109" y="20"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D49bcJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D49bcZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D49bc5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D49bcpnjEemrjrtN9v_T1A" x="-255" y="-148"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D5JosJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D5JosZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5Jos5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D5JospnjEemrjrtN9v_T1A" x="-255" y="-248"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D5QWYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D5QWYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5QWY5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D5QWYpnjEemrjrtN9v_T1A" x="-255" y="-248"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D5lGgJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D5lGgZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5lGg5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D5lGgpnjEemrjrtN9v_T1A" x="-270" y="20"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D5_WMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D5_WMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5_WM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D5_WMpnjEemrjrtN9v_T1A" x="-161" y="-529"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6K8YJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6K8YZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6K8Y5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6K8YpnjEemrjrtN9v_T1A" x="-161" y="-629"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6Qb8JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6Qb8ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6RDAJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6Qb8pnjEemrjrtN9v_T1A" x="-161" y="-629"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6XwsJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6XwsZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6Xws5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6XwspnjEemrjrtN9v_T1A" x="-161" y="-629"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6eeYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6eeYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6eeY5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6eeYpnjEemrjrtN9v_T1A" x="-161" y="-629"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6lMEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6lMEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6lME5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6lMEpnjEemrjrtN9v_T1A" x="-161" y="-629"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D658MJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D658MZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D658M5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D658MpnjEemrjrtN9v_T1A" x="-101" y="-317"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D7GJcJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D7GJcZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7GJc5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D7GJcpnjEemrjrtN9v_T1A" x="-101" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D7M3IJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D7M3IZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7M3I5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D7M3IpnjEemrjrtN9v_T1A" x="-101" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D7t0gJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D7t0gZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7t0g5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D7t0gpnjEemrjrtN9v_T1A" x="-327" y="-408"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D8Ox4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D8Ox4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D8Ox45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D8Ox4pnjEemrjrtN9v_T1A" x="13" y="-145"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D80nwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D80nwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D80nw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D80nwpnjEemrjrtN9v_T1A" x="317" y="-317"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D9f9MJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D9f9MZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D9f9M5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D9f9MpnjEemrjrtN9v_T1A" x="115" y="-317"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D9y4IJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D9y4IZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D9y4I5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D9y4IpnjEemrjrtN9v_T1A" x="115" y="-417"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D-IPUJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D-IPUZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D-IPU5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D-IPUpnjEemrjrtN9v_T1A" x="226" y="-187"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_dPf-21dMEeejsLaQeGcDdg"/>
@@ -2207,196 +2223,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tpzqt11zEemG57ABxBTHSA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tpzquF1zEemG57ABxBTHSA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bUuk22BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPewEVdMEeejsLaQeGcDdg" target="_bUuk12BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bUuk3GBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUuk4GBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bUuk3WBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUuk3mBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUuk32BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bVBfy2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPewT1dMEeejsLaQeGcDdg" target="_bVBfx2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bVBfzGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVBf0GBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bVBfzWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVBfzmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVBfz2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bVUatGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_kGunYIt8Eeiu6boZkiJHCA" target="_bVUasGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bVUatWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVUauWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bVUatmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVUat2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVUauGBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bVUaxWBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_mZQqsIt8Eeiu6boZkiJHCA" target="_bVUawWBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bVUaxmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVUaymBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bVUax2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVUayGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVUayWBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bVn8t2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPewy1dMEeejsLaQeGcDdg" target="_bVn8s2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bVn8uGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bVn8vGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bVn8uWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVn8umBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bVn8u2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bV63q2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPexXVdMEeejsLaQeGcDdg" target="_bV63p2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bV63rGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bV63sGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bV63rWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bV63rmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bV63r2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bWEBs2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPgAeFdMEeejsLaQeGcDdg" target="_bWEBr2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bWEBtGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWEBuGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWEBtWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWEBtmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWEBt2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bWNynWBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DB9l8It8Eeiu6boZkiJHCA" target="_bWNymWBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bWNynmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWNyomBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWNyn2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWNyoGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWNyoWBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bWXjl2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_FiH1kIt8Eeiu6boZkiJHCA" target="_bWXjk2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bWXjmGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWXjnGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWXjmWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWXjmmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWXjm2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bWgthGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_QgdycIt8Eeiu6boZkiJHCA" target="_bWgtgGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bWgthWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWgtiWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWgthmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWgth2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWgtiGBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bWgtlWBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_S430QIt8Eeiu6boZkiJHCA" target="_bWgtkWBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bWgtlmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWgtmmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWgtl2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWgtmGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWgtmWBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bWzoe2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPeyH1dMEeejsLaQeGcDdg" target="_bWzod2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bWzofGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWzogGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWzofWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWzofmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWzof2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bW9Zg2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_eeLDcIt8Eeiu6boZkiJHCA" target="_bW9Zf2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bW9ZhGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bW9ZiGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bW9ZhWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bW9ZhmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bW9Zh2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bXHKe2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_f8xvcIt8Eeiu6boZkiJHCA" target="_bXHKd2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bXHKfGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXHKgGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bXHKfWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXHKfmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXHKf2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bXjPV2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPfYEVdMEeejsLaQeGcDdg" target="_bXjPU2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bXjPWGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXjPXGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bXjPWWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXjPWmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXjPW2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bX_7S2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dPfZJldMEeejsLaQeGcDdg" target="_bX_7R2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bX_7TGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bX_7UGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bX_7TWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bX_7TmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bX_7T2BoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bYmYNGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_x860YE4hEeiMYveOdt1-rQ" target="_bYmYMGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bYmYNWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bYmYOWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bYmYNmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYmYN2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYmYOGBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bZo6BGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_bZo6AGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bZo6BWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bZo6CWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bZo6BmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bZo6B2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bZo6CGBoEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bZ7092BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_hVVd0It8Eeiu6boZkiJHCA" target="_bZ7082BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bZ70-GBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bZ70_GBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bZ70-WBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bZ70-mBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bZ70-2BoEemmf8tAu_V-ow"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_baYg52BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_baYg42BoEemmf8tAu_V-ow">
       <styles xmi:type="notation:FontStyle" xmi:id="_baYg6GBoEemmf8tAu_V-ow"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_baYg7GBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
@@ -2416,6 +2242,216 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wYVSRmtwEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVSR2twEembs75vhmFVVA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVSSGtwEembs75vhmFVVA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zHB755nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_zHB745nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zHB76JnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zHB77JnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zHB76ZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zHB76pnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zHB765nNEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D4T7NJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPewEVdMEeejsLaQeGcDdg" target="_D4T7MJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D4T7NZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D4T7OZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D4T7NpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D4T7N5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D4T7OJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D49bdJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPewT1dMEeejsLaQeGcDdg" target="_D49bcJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D49bdZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D49beZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D49bdpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D49bd5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D49beJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D5JotJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_kGunYIt8Eeiu6boZkiJHCA" target="_D5JosJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D5JotZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5JouZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D5JotpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5Jot5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5JouJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D5QWZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_mZQqsIt8Eeiu6boZkiJHCA" target="_D5QWYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D5QWZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5QWaZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D5QWZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5QWZ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5QWaJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D5lGhJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPewy1dMEeejsLaQeGcDdg" target="_D5lGgJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D5lGhZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5ltkZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D5lGhpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5lGh5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5ltkJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D5_WNJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPexXVdMEeejsLaQeGcDdg" target="_D5_WMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D5_WNZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D5_WOZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D5_WNpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5_WN5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D5_WOJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6K8ZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPgAeFdMEeejsLaQeGcDdg" target="_D6K8YJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6K8ZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6K8aZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6K8ZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6K8Z5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6K8aJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6RDAZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DB9l8It8Eeiu6boZkiJHCA" target="_D6Qb8JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6RDApnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6RDBpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6RDA5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6RDBJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6RDBZnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6XwtJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_FiH1kIt8Eeiu6boZkiJHCA" target="_D6XwsJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6XwtZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6XwuZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6XwtpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6Xwt5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6XwuJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6eeZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_QgdycIt8Eeiu6boZkiJHCA" target="_D6eeYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6eeZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6eeaZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6eeZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6eeZ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6eeaJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6lMFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_S430QIt8Eeiu6boZkiJHCA" target="_D6lMEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6lMFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6lMGZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6lMFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6lMF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6lMGJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D658NJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPeyH1dMEeejsLaQeGcDdg" target="_D658MJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D658NZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D658OZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D658NpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D658N5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D658OJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D7GJdJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_eeLDcIt8Eeiu6boZkiJHCA" target="_D7GJcJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D7GJdZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7GJeZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D7GJdpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7GJd5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7GJeJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D7M3JJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_f8xvcIt8Eeiu6boZkiJHCA" target="_D7M3IJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D7M3JZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7M3KZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D7M3JpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7M3J5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7M3KJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D7t0hJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPfYEVdMEeejsLaQeGcDdg" target="_D7t0gJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D7t0hZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7t0iZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D7t0hpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7t0h5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7t0iJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D8Ox5JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dPfZJldMEeejsLaQeGcDdg" target="_D8Ox4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D8Ox5ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D8Ox6ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D8Ox5pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8Ox55njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8Ox6JnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D80nxJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_x860YE4hEeiMYveOdt1-rQ" target="_D80nwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D80nxZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D80nyZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D80nxpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D80nx5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D80nyJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D9f9NJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_bmZfAIUvEeiYFOBVMQg1QQ" target="_D9f9MJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D9f9NZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D9f9OZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D9f9NpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9f9N5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9f9OJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D9y4JJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_hVVd0It8Eeiu6boZkiJHCA" target="_D9y4IJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D9y4JZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D9y4KZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D9y4JpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9y4J5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9y4KJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D-IPVJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_CD_w4IUxEeiYFOBVMQg1QQ" target="_D-IPUJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D-IPVZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D-IPWZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D-IPVpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D-IPV5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D-IPWJnjEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_LeWqMHMLEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamDetails" measurementUnit="Pixel">
@@ -4541,126 +4577,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6WrXMpgREemfbpUjK-Jv3g" x="748" y="-471"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_H4RFMJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H4RFMZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H4RFM5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H4RFMpgYEemfbpUjK-Jv3g" x="-184" y="-58"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H5kswJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H5kswZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H5ksw5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H5kswpgYEemfbpUjK-Jv3g" x="-184" y="-158"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H50kYJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H50kYZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H50kY5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H50kYpgYEemfbpUjK-Jv3g" x="-184" y="-158"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H6i9IJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H6i9IZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H6i9I5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H6i9IpgYEemfbpUjK-Jv3g" x="-170" y="-443"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H7n7MJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H7n7MZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H7n7M5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H7n7MpgYEemfbpUjK-Jv3g" x="-170" y="-543"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H72ksJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H72ksZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H72ks5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H72kspgYEemfbpUjK-Jv3g" x="-170" y="-543"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H8FOMJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H8FOMZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H8FOM5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8FOMpgYEemfbpUjK-Jv3g" x="-170" y="-543"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H8T3sJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H8T3sZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H8T3s5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8T3spgYEemfbpUjK-Jv3g" x="-170" y="-543"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H9AbQJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H9AbQZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H9BCUJgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H9AbQpgYEemfbpUjK-Jv3g" x="-110" y="-276"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H_S6QJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H_S6QZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H_S6Q5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H_S6QpgYEemfbpUjK-Jv3g" x="-110" y="-376"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H_fukJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H_fukZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H_fuk5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H_fukpgYEemfbpUjK-Jv3g" x="-110" y="-376"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_H_3iAJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_H_3iAZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H_3iA5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H_3iApgYEemfbpUjK-Jv3g" x="-184" y="-980"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_IBNl0JgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_IBNl0ZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IBOM4JgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IBNl0pgYEemfbpUjK-Jv3g" x="391" y="-241"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_IDuuUJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_IDuuUZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IDuuU5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IDuuUpgYEemfbpUjK-Jv3g" x="524" y="39"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_IFOjIJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_IFOjIZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IFOjI5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IFOjIpgYEemfbpUjK-Jv3g" x="216" y="15"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_IGypYJgYEemfbpUjK-Jv3g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_IGypYZgYEemfbpUjK-Jv3g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IGypY5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
@@ -4669,37 +4585,197 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IGypYpgYEemfbpUjK-Jv3g" x="748" y="-471"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_IJxr8JgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_IJxr8ZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IJxr85gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_-nOiQJnFEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-nOiQZnFEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-nOiQ5nFEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-nOiQpnFEemVaY_egjrbOQ" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0Ehe4JnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_0Ehe4ZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0Ehe45nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0Ehe4pnNEemVaY_egjrbOQ" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SA3r8JnQEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SA3r8ZnQEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SA3r85nQEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SA3r8pnQEemVaY_egjrbOQ" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_212jwJndEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_212jwZndEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_212jw5ndEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_212jwpndEemVaY_egjrbOQ" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EygSkJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EygSkZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EygSk5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EygSkpnjEemrjrtN9v_T1A" x="-184" y="-58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EzJLwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EzJLwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EzJLw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EzJLwpnjEemrjrtN9v_T1A" x="-184" y="-158"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EzQggJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EzQggZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EzQgg5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EzQggpnjEemrjrtN9v_T1A" x="-184" y="-158"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ezns4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ezns4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ezns45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ezns4pnjEemrjrtN9v_T1A" x="-170" y="-443"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E0KfcJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E0KfcZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0Kfc5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E0KfcpnjEemrjrtN9v_T1A" x="-170" y="-543"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E0TCUJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E0TCUZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0TCU5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E0TCUpnjEemrjrtN9v_T1A" x="-170" y="-543"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E0blMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E0blMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0blM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E0blMpnjEemrjrtN9v_T1A" x="-170" y="-543"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E0kvIJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E0kvIZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0lWMJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E0kvIpnjEemrjrtN9v_T1A" x="-170" y="-543"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E1EeYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E1EeYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E1EeY5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E1EeYpnjEemrjrtN9v_T1A" x="-110" y="-276"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E14WsJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E14WsZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E14Ws5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E14WspnjEemrjrtN9v_T1A" x="-110" y="-376"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E2BgoJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E2BgoZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E2Bgo5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E2BgopnjEemrjrtN9v_T1A" x="-110" y="-376"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E2wgcJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E2wgcZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E2wgc5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E2wgcpnjEemrjrtN9v_T1A" x="-184" y="-980"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E3m1AJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E3m1AZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E3m1A5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E3m1ApnjEemrjrtN9v_T1A" x="391" y="-241"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E4zH0JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E4zH0ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E4zH05njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E4zH0pnjEemrjrtN9v_T1A" x="524" y="39"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E5hgkJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E5hgkZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E5hgk5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E5hgkpnjEemrjrtN9v_T1A" x="216" y="15"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E6VY4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E6VY4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6VY45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6VY4pnjEemrjrtN9v_T1A" x="748" y="-471"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_E7sDwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E7sDwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7sDw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IJxr8pgYEemfbpUjK-Jv3g" x="326" y="-390"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7sDwpnjEemrjrtN9v_T1A" x="326" y="-390"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ILCQMJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ILCQMZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ILCQM5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_E8WLEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E8WLEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8WLE5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_rH__wBKJEemxeNG9TDCtFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ILCQMpgYEemfbpUjK-Jv3g" x="167" y="-758"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E8WLEpnjEemrjrtN9v_T1A" x="167" y="-758"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ILzsQJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ILzsQZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ILzsQ5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_E8vzsJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E8vzsZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8vzs5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Db62oBKKEemxeNG9TDCtFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ILzsQpgYEemfbpUjK-Jv3g" x="19" y="-614"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E8vzspnjEemrjrtN9v_T1A" x="19" y="-614"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_IMclcJgYEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_IMclcZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IMclc5gYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_E9GZAJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_E9GZAZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9HAEJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_iq_VIFowEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IMclcpgYEemfbpUjK-Jv3g" x="1124" y="-525"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E9GZApnjEemrjrtN9v_T1A" x="1124" y="-525"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_LeXWvHMLEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_LeXWvXMLEeeSiaQ95-6r9w"/>
@@ -5755,156 +5831,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WrXN5gREemfbpUjK-Jv3g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WrXOJgREemfbpUjK-Jv3g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H4RFNJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_LeWqknMLEeeSiaQ95-6r9w" target="_H4RFMJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H4RFNZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H4RFOZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H4RFNpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H4RFN5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H4RFOJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H5ksxJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_XUwpYIt_Eeiu6boZkiJHCA" target="_H5kswJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H5ksxZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H5lT0pgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H5ksxpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H5lT0JgYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H5lT0ZgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H50kZJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_fRyKUIt_Eeiu6boZkiJHCA" target="_H50kYJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H50kZZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H50kaZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H50kZpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H50kZ5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H50kaJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H6i9JJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_LeWsAXMLEeeSiaQ95-6r9w" target="_H6i9IJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H6i9JZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H6jkMpgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H6i9JpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H6jkMJgYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H6jkMZgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H7n7NJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_c2FZYIt-Eeiu6boZkiJHCA" target="_H7n7MJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H7n7NZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H7n7OZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H7n7NpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H7n7N5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H7n7OJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H73LwJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_h_2IgIt-Eeiu6boZkiJHCA" target="_H72ksJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H73LwZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H73LxZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H73LwpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H73Lw5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H73LxJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H8FONJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_mfj1EIt-Eeiu6boZkiJHCA" target="_H8FOMJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H8FONZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H8FOOZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H8FONpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H8FON5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H8FOOJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H8T3tJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_qoO6oIt-Eeiu6boZkiJHCA" target="_H8T3sJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H8T3tZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H8T3uZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H8T3tpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H8T3t5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H8T3uJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H9BCUZgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_LeWsy3MLEeeSiaQ95-6r9w" target="_H9AbQJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H9BCUpgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H9BCVpgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H9BCU5gYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H9BCVJgYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H9BCVZgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H_S6RJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_9bSJ8It-Eeiu6boZkiJHCA" target="_H_S6QJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H_S6RZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H_S6SZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H_S6RpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H_S6R5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H_S6SJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H_fulJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_IT9jsIt_Eeiu6boZkiJHCA" target="_H_fukJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H_fulZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H_gVoZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H_fulpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H_ful5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H_gVoJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_H_4JEJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_LeXRSHMLEeeSiaQ95-6r9w" target="_H_3iAJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_H_4JEZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_H_4JFZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_H_4JEpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H_4JE5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_H_4JFJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IBOM4ZgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_LeXSYHMLEeeSiaQ95-6r9w" target="_IBNl0JgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_IBOM4pgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IBOM5pgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IBOM45gYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IBOM5JgYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IBOM5ZgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IDuuVJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_4QU_AHMeEeeSiaQ95-6r9w" target="_IDuuUJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_IDuuVZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IDuuWZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IDuuVpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IDuuV5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IDuuWJgYEemfbpUjK-Jv3g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IFPKMJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_416YUHMeEeeSiaQ95-6r9w" target="_IFOjIJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_IFPKMZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IFPKNZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IFPKMpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IFPKM5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IFPKNJgYEemfbpUjK-Jv3g"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IGypZJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_IGypYJgYEemfbpUjK-Jv3g">
       <styles xmi:type="notation:FontStyle" xmi:id="_IGypZZgYEemfbpUjK-Jv3g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IGzQcpgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
@@ -5915,45 +5841,245 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IGzQcJgYEemfbpUjK-Jv3g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IGzQcZgYEemfbpUjK-Jv3g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IJyTAJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_l_ZsoIVPEeiYFOBVMQg1QQ" target="_IJxr8JgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_IJyTAZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IJyTBZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_-nOiRJnFEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_-nOiQJnFEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-nOiRZnFEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-nOiSZnFEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-nOiRpnFEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-nOiR5nFEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-nOiSJnFEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0Ehe5JnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_0Ehe4JnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0Ehe5ZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0Ehe6ZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0Ehe5pnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0Ehe55nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0Ehe6JnNEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SA3r9JnQEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_SA3r8JnQEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SA3r9ZnQEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SA3r-ZnQEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SA3r9pnQEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SA3r95nQEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SA3r-JnQEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_212jxJndEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_212jwJndEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_212jxZndEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_212jyZndEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_212jxpndEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_212jx5ndEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_212jyJndEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EygSlJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_LeWqknMLEeeSiaQ95-6r9w" target="_EygSkJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EygSlZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eyg5opnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EygSlpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eyg5oJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eyg5oZnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EzJLxJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_XUwpYIt_Eeiu6boZkiJHCA" target="_EzJLwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EzJLxZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EzJLyZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EzJLxpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EzJLx5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EzJLyJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EzQghJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_fRyKUIt_Eeiu6boZkiJHCA" target="_EzQggJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EzQghZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EzQgiZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EzQghpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EzQgh5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EzQgiJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ezns5JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_LeWsAXMLEeeSiaQ95-6r9w" target="_Ezns4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ezns5ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ezns6ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ezns5pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ezns55njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ezns6JnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E0KfdJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_c2FZYIt-Eeiu6boZkiJHCA" target="_E0KfcJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E0KfdZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0KfeZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E0KfdpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0Kfd5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0KfeJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E0TCVJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_h_2IgIt-Eeiu6boZkiJHCA" target="_E0TCUJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E0TCVZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0TCWZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E0TCVpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0TCV5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0TCWJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E0blNJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_mfj1EIt-Eeiu6boZkiJHCA" target="_E0blMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E0blNZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0blOZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E0blNpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0blN5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0blOJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E0lWMZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_qoO6oIt-Eeiu6boZkiJHCA" target="_E0kvIJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E0lWMpnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E0lWNpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E0lWM5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0lWNJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E0lWNZnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E1EeZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_LeWsy3MLEeeSiaQ95-6r9w" target="_E1EeYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E1EeZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E1EeaZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E1EeZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E1EeZ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E1EeaJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E14WtJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_9bSJ8It-Eeiu6boZkiJHCA" target="_E14WsJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E14WtZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E14WuZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E14WtpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E14Wt5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E14WuJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E2BgpJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_IT9jsIt_Eeiu6boZkiJHCA" target="_E2BgoJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E2BgpZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E2BgqZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E2BgppnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E2Bgp5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E2BgqJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E2wgdJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_LeXRSHMLEeeSiaQ95-6r9w" target="_E2wgcJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E2wgdZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E2wgeZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E2wgdpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E2wgd5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E2wgeJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E3m1BJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_LeXSYHMLEeeSiaQ95-6r9w" target="_E3m1AJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E3m1BZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E3m1CZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E3m1BpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E3m1B5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E3m1CJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E4zH1JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_4QU_AHMeEeeSiaQ95-6r9w" target="_E4zH0JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E4zH1ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E4zH2ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E4zH1pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E4zH15njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E4zH2JnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E5hglJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_416YUHMeEeeSiaQ95-6r9w" target="_E5hgkJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E5hglZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E5hgmZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E5hglpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E5hgl5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E5hgmJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E6V_8JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_GDqiYE4xEeiMYveOdt1-rQ" target="_E6VY4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E6V_8ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6V_9ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6V_8pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6V_85njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6V_9JnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_E7sDxJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_l_ZsoIVPEeiYFOBVMQg1QQ" target="_E7sDwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E7sDxZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7sDyZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IJyTApgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IJyTA5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IJyTBJgYEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E7sDxpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7sDx5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7sDyJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ILCQNJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_rIPQUBKJEemxeNG9TDCtFQ" target="_ILCQMJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ILCQNZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ILC3QJgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_E8WLFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_rIPQUBKJEemxeNG9TDCtFQ" target="_E8WLEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E8WLFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8WLGZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_rH__wBKJEemxeNG9TDCtFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ILCQNpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ILCQN5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ILCQOJgYEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E8WLFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8WLF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8WLGJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ILzsRJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_Db9S4BKKEemxeNG9TDCtFQ" target="_ILzsQJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ILzsRZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ILzsSZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_E8vztJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Db9S4BKKEemxeNG9TDCtFQ" target="_E8vzsJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E8vztZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8vzuZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Db62oBKKEemxeNG9TDCtFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ILzsRpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ILzsR5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ILzsSJgYEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E8vztpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8vzt5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8vzuJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IMcldJgYEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_iq_VIVowEemu443YKSGnxQ" target="_IMclcJgYEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_IMcldZgYEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IMcleZgYEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_E9HAEZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_iq_VIVowEemu443YKSGnxQ" target="_E9GZAJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E9HAEpnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9HAFpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_iq_VIFowEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IMcldpgYEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IMcld5gYEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IMcleJgYEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E9HAE5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9HAFJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9HAFZnjEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_QUOkQHMcEeeSiaQ95-6r9w" type="PapyrusUMLClassDiagram" name="OamJobDetails" measurementUnit="Pixel">
@@ -7198,126 +7324,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NJgRsmBnEemmf8tAu_V-ow" x="300" y="47"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_NK1uc2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NK1udGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NK1udmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NK1udWBnEemmf8tAu_V-ow" x="300" y="-53"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NK_fc2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NK_fdGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NK_fdmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_KAXjIE4eEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NK_fdWBnEemmf8tAu_V-ow" x="300" y="-53"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NLSaZ2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NLSaaGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NLSaamBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NLSaaWBnEemmf8tAu_V-ow" x="664" y="299"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NMCBR2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NMCBSGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NMLyQGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NMCBSWBnEemmf8tAu_V-ow" x="301" y="313"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NMxoI2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NMxoJGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NMxoJmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NMxoJWBnEemmf8tAu_V-ow" x="301" y="213"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NM7ZIGBnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NM7ZIWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NM7ZI2BnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NM7ZImBnEemmf8tAu_V-ow" x="301" y="213"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NOHr8GBnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NOHr8WBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NOHr82BnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NOHr8mBnEemmf8tAu_V-ow" x="301" y="524"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NO3S02BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NO3S1GBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NO3S1mBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NO3S1WBnEemmf8tAu_V-ow" x="301" y="424"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NQC-kGBnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NQC-kWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NQC-k2BnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NQC-kmBnEemmf8tAu_V-ow" x="307" y="-131"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NQfqg2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NQfqhGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NQfqhmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NQfqhWBnEemmf8tAu_V-ow" x="307" y="-231"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NQpbgGBnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NQpbgWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NQpbg2BnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NQpbgmBnEemmf8tAu_V-ow" x="307" y="-231"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NRGHc2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NRGHdGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NRGHdmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NRGHdWBnEemmf8tAu_V-ow" x="772" y="-131"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NR1uU2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NR1uVGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NR1uVmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NR1uVWBnEemmf8tAu_V-ow" x="772" y="-231"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NSRzMGBnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NSRzMWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NSRzM2BnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NSRzMmBnEemmf8tAu_V-ow" x="782" y="80"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NTU8E2BnEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NTU8FGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NTU8FmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NTU8FWBnEemmf8tAu_V-ow" x="636" y="467"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_K7JzkGblEemNo6KemN3z2w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_K7JzkWblEemNo6KemN3z2w"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K7Jzk2blEemNo6KemN3z2w" name="BASE_ELEMENT">
@@ -7333,6 +7339,142 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DvFiAmtlEembs75vhmFVVA" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zgMCw5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zgMCxJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zgMCxpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zgMCxZnNEemVaY_egjrbOQ" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EWQbcJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EWQbcZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EWQbc5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EWQbcpnjEemrjrtN9v_T1A" x="300" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EXvCIJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EXvCIZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EXvCI5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EXvCIpnjEemrjrtN9v_T1A" x="300" y="-53"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EX5aMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EX5aMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EX5aM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_KAXjIE4eEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EX5aMpnjEemrjrtN9v_T1A" x="300" y="-53"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EYXUQJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EYXUQZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EYXUQ5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EYXUQpnjEemrjrtN9v_T1A" x="664" y="299"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EZLMkJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EZLMkZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EZLMk5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EZLMkpnjEemrjrtN9v_T1A" x="301" y="313"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EaNuYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EaNuYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EaNuY5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EaNuYpnjEemrjrtN9v_T1A" x="301" y="213"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EaVqMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EaVqMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EaVqM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EaVqMpnjEemrjrtN9v_T1A" x="301" y="213"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ea1ZcJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ea1ZcZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ea1Zc5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ea1ZcpnjEemrjrtN9v_T1A" x="301" y="524"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EbgH0JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EbgH0ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ebgu4JnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EbgH0pnjEemrjrtN9v_T1A" x="301" y="424"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EdXwEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EdXwEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EdXwE5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EdXwEpnjEemrjrtN9v_T1A" x="307" y="-131"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ed24QJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ed24QZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ed3fUJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ed24QpnjEemrjrtN9v_T1A" x="307" y="-231"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ed-0EJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ed-0EZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ed-0E5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ed-0EpnjEemrjrtN9v_T1A" x="307" y="-231"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EebgAJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EebgAZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EebgA5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EebgApnjEemrjrtN9v_T1A" x="772" y="-131"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ee9rgJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ee9rgZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ee9rg5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ee9rgpnjEemrjrtN9v_T1A" x="772" y="-231"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EfTpwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EfTpwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EfTpw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EfTpwpnjEemrjrtN9v_T1A" x="782" y="80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EgJXQJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgJXQZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgJXQ5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgJXQpnjEemrjrtN9v_T1A" x="636" y="467"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_QUOkQXMcEeeSiaQ95-6r9w" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_QUOkQnMcEeeSiaQ95-6r9w"/>
@@ -8232,156 +8374,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NJgRt2BnEemmf8tAu_V-ow"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NJgRuGBnEemmf8tAu_V-ow"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NK1ud2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_G87X8IuCEeiu6boZkiJHCA" target="_NK1uc2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NK1ueGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NK1ufGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NK1ueWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NK1uemBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NK1ue2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NK_fd2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_JcS9YIuCEeiu6boZkiJHCA" target="_NK_fc2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NK_feGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NK_ffGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_KAXjIE4eEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NK_feWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NK_femBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NK_fe2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NLSaa2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_qvArEE8EEeiW8t12GIRjqQ" target="_NLSaZ2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NLSabGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NLSacGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NLSabWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NLSabmBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NLSab2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NMLyQWBnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_vn-swF0IEeipas1p-rFJBA" target="_NMCBR2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NMLyQmBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NMLyRmBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NMLyQ2BnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NMLyRGBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NMLyRWBnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NMxoJ2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_PUQPQIuCEeiu6boZkiJHCA" target="_NMxoI2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NMxoKGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NMxoLGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NMxoKWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NMxoKmBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NMxoK2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NM7ZJGBnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_b_yegDU7Eem_pr37XaewKQ" target="_NM7ZIGBnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NM7ZJWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NM7ZKWBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NM7ZJmBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NM7ZJ2BnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NM7ZKGBnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NOHr9GBnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_-2fMY10KEeipas1p-rFJBA" target="_NOHr8GBnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NOHr9WBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NOHr-WBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NOHr9mBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NOHr92BnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NOHr-GBnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NO3S12BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_upSwQDU7Eem_pr37XaewKQ" target="_NO3S02BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NO3S2GBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NO3S3GBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NO3S2WBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NO3S2mBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NO3S22BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NQC-lGBnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_J4rLIIVSEeiYFOBVMQg1QQ" target="_NQC-kGBnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NQC-lWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NQC-mWBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NQC-lmBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NQC-l2BnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NQC-mGBnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NQfqh2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_zPpVAIuBEeiu6boZkiJHCA" target="_NQfqg2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NQfqiGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NQfqjGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NQfqiWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NQfqimBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NQfqi2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NQpbhGBnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_4XVAgIuBEeiu6boZkiJHCA" target="_NQpbgGBnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NQpbhWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NQpbiWBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NQpbhmBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NQpbh2BnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NQpbiGBnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NRGHd2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_03rBEIVSEeiYFOBVMQg1QQ" target="_NRGHc2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NRGHeGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NRGHfGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NRGHeWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NRGHemBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NRGHe2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NR1uV2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_AVz6AIuCEeiu6boZkiJHCA" target="_NR1uU2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NR1uWGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NR1uXGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NR1uWWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NR1uWmBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NR1uW2BnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NSRzNGBnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_3MGFUIVTEeiYFOBVMQg1QQ" target="_NSRzMGBnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NSRzNWBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NSRzOWBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NSRzNmBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NSRzN2BnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NSRzOGBnEemmf8tAu_V-ow"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NTU8F2BnEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_RVrsQDU7Eem_pr37XaewKQ" target="_NTU8E2BnEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NTU8GGBnEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NTU8HGBnEemmf8tAu_V-ow" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NTU8GWBnEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NTU8GmBnEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NTU8G2BnEemmf8tAu_V-ow"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_K7KaoGblEemNo6KemN3z2w" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_K7JzkGblEemNo6KemN3z2w">
       <styles xmi:type="notation:FontStyle" xmi:id="_K7KaoWblEemNo6KemN3z2w"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_K7KapWblEemNo6KemN3z2w" name="BASE_ELEMENT">
@@ -8401,6 +8393,176 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DvGJE2tlEembs75vhmFVVA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvGwIGtlEembs75vhmFVVA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DvGwIWtlEembs75vhmFVVA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zgMCx5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_zgMCw5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zgMCyJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zgMCzJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zgMCyZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zgMCypnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zgMCy5nNEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EWQbdJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_2-6yMEI6EeiDweqmZm-ZXQ" target="_EWQbcJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EWQbdZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EWQbeZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EWQbdpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EWQbd5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EWQbeJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EXvCJJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_G87X8IuCEeiu6boZkiJHCA" target="_EXvCIJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EXvCJZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EXvCKZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ufJVEF0LEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EXvCJpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EXvCJ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EXvCKJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EX6BQJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_JcS9YIuCEeiu6boZkiJHCA" target="_EX5aMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EX6BQZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EX6BRZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_KAXjIE4eEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EX6BQpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EX6BQ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EX6BRJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EYXURJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_qvArEE8EEeiW8t12GIRjqQ" target="_EYXUQJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EYXURZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EYXUSZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EYXURpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYXUR5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYXUSJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EZLMlJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_vn-swF0IEeipas1p-rFJBA" target="_EZLMkJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EZLMlZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EZLMmZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EZLMlpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EZLMl5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EZLMmJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EaNuZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_PUQPQIuCEeiu6boZkiJHCA" target="_EaNuYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EaNuZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EaNuaZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_d_K7oF0LEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EaNuZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EaNuZ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EaNuaJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EaVqNJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_b_yegDU7Eem_pr37XaewKQ" target="_EaVqMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EaVqNZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EaVqOZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_b2xscDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EaVqNpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EaVqN5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EaVqOJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ea1ZdJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_-2fMY10KEeipas1p-rFJBA" target="_Ea1ZcJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ea1ZdZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ea1ZeZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ea1ZdpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ea1Zd5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ea1ZeJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ebgu4ZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_upSwQDU7Eem_pr37XaewKQ" target="_EbgH0JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ebgu4pnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ebgu5pnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ugxtcDU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ebgu45njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ebgu5JnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ebgu5ZnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EdXwFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_J4rLIIVSEeiYFOBVMQg1QQ" target="_EdXwEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EdXwFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EdYXIJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EdXwFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EdXwF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EdXwGJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ed3fUZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_zPpVAIuBEeiu6boZkiJHCA" target="_Ed24QJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ed3fUpnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ed3fVpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_04fNoE4hEeiMYveOdt1-rQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ed3fU5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ed3fVJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ed3fVZnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ed-0FJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_4XVAgIuBEeiu6boZkiJHCA" target="_Ed-0EJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ed-0FZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ed-0GZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kFi1kIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ed-0FpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ed-0F5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ed-0GJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EebgBJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_03rBEIVSEeiYFOBVMQg1QQ" target="_EebgAJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EebgBZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EebgCZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EebgBpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EebgB5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EebgCJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ee9rhJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_AVz6AIuCEeiu6boZkiJHCA" target="_Ee9rgJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ee9rhZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ee-SkpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ee9rhpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ee-SkJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ee-SkZnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EfTpxJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_3MGFUIVTEeiYFOBVMQg1QQ" target="_EfTpwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EfTpxZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EfTpyZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EfTpxpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EfTpx5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EfTpyJnjEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EgJXRJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_RVrsQDU7Eem_pr37XaewKQ" target="_EgJXQJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EgJXRZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgJXSZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EgJXRpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgJXR5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgJXSJnjEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_DvMJsINfEeelF8AE_WZtHQ" type="PapyrusUMLClassDiagram" name="OamConnSkeleton" measurementUnit="Pixel">
@@ -9556,245 +9718,245 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O1LnQot6Eeiu6boZkiJHCA" x="-255" y="-275"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZC7hUGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZC7hUWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZC7hU2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EDw9QJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EDw9QZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EDw9Q5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZC7hUmBoEemmf8tAu_V-ow" x="-266" y="-2"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EDw9QpnjEemrjrtN9v_T1A" x="-266" y="-2"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZDYNQ2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZDYNRGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZDYNRmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EEO3UJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EEO3UZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EEO3U5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZDYNRWBoEemmf8tAu_V-ow" x="-255" y="-175"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EEO3UpnjEemrjrtN9v_T1A" x="-255" y="-175"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZDrIN2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZDrIOGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZDrIOmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EEbEkJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EEbEkZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EEbEk5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZDrIOWBoEemmf8tAu_V-ow" x="-255" y="-275"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EEbEkpnjEemrjrtN9v_T1A" x="-255" y="-275"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZD0SIGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZD0SIWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZD0SI2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EEhyQJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EEhyQZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EEhyQ5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZD0SImBoEemmf8tAu_V-ow" x="-255" y="-275"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EEhyQpnjEemrjrtN9v_T1A" x="-255" y="-275"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZEH0I2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZEH0JGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZEH0JmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EE4-oJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EE4-oZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EE4-o5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZEH0JWBoEemmf8tAu_V-ow" x="-106" y="-1"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EE4-opnjEemrjrtN9v_T1A" x="-106" y="-1"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZEj5A2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZEj5BGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZEtqAGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EFVDgJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EFVDgZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFVDg5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZEj5BWBoEemmf8tAu_V-ow" x="-173" y="-457"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EFVDgpnjEemrjrtN9v_T1A" x="-173" y="-457"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZE3bB2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZE3bCGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZE3bCmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EFh30JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EFh30ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFh305njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZE3bCWBoEemmf8tAu_V-ow" x="-173" y="-557"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EFh30pnjEemrjrtN9v_T1A" x="-173" y="-557"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZFAk-WBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZFAk-mBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZFAk_GBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EFn-cJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EFn-cZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFn-c5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZFAk-2BoEemmf8tAu_V-ow" x="-173" y="-557"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EFn-cpnjEemrjrtN9v_T1A" x="-173" y="-557"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZFKV8GBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZFKV8WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZFKV82BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EFvTMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EFvTMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFvTM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZFKV8mBoEemmf8tAu_V-ow" x="-173" y="-557"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EFvTMpnjEemrjrtN9v_T1A" x="-173" y="-557"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZFwL0GBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZFwL0WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZFwL02BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EGKJ8JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EGKJ8ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EGKJ85njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZFwL0mBoEemmf8tAu_V-ow" x="-111" y="-317"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EGKJ8pnjEemrjrtN9v_T1A" x="-111" y="-317"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZGDGx2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZGDGyGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZGDGymBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EGYMYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EGYMYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EGYMY5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZGDGyWBoEemmf8tAu_V-ow" x="-111" y="-417"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EGYMYpnjEemrjrtN9v_T1A" x="-111" y="-417"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZGWowGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZGWowWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZGWow2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EGgIMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EGgIMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EGgIM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZGWowmBoEemmf8tAu_V-ow" x="-111" y="-417"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EGgIMpnjEemrjrtN9v_T1A" x="-111" y="-417"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZG8eoGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZG8eoWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZG8eo2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EHGlIJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EHGlIZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EHGlI5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZG8eomBoEemmf8tAu_V-ow" x="243" y="-458"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EHGlIpnjEemrjrtN9v_T1A" x="243" y="-458"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZHPZoWBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZHPZomBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZHPZpGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EHcjYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EHcjYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EHdKcJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZHPZo2BoEemmf8tAu_V-ow" x="243" y="-558"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EHcjYpnjEemrjrtN9v_T1A" x="243" y="-558"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZHsFgGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZHsFgWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZHsFg2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EH5PUJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EH5PUZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EH5PU5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZHsFgmBoEemmf8tAu_V-ow" x="75" y="-174"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EH5PUpnjEemrjrtN9v_T1A" x="75" y="-174"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZIR7Y2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZIR7ZGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZIR7ZmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EIazwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EIazwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EIazw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_XTF4sGNWEee0bPnI-Gt-mQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZIR7ZWBoEemmf8tAu_V-ow" x="-237" y="166"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EIazwpnjEemrjrtN9v_T1A" x="-237" y="166"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZIldZ2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZIldaGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZIldamBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EIo2MJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EIo2MZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EIo2M5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_GyHvYGY4EeeB_84HvuxJBw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZIldaWBoEemmf8tAu_V-ow" x="-237" y="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EIo2MpnjEemrjrtN9v_T1A" x="-237" y="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZIunWWBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZIunWmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZIunXGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EIxZEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EIxZEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EIxZE5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_mncXEGNXEee0bPnI-Gt-mQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZIunW2BoEemmf8tAu_V-ow" x="-237" y="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EIxZEpnjEemrjrtN9v_T1A" x="-237" y="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZI4YU2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZI4YVGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZI4YVmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EI5U4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EI5U4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EI5U45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GrFIIGNXEee0bPnI-Gt-mQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZI4YVWBoEemmf8tAu_V-ow" x="-237" y="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EI5U4pnjEemrjrtN9v_T1A" x="-237" y="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZJVEQGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZJVEQWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZJVEQ2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EJOsEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EJOsEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EJOsE5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZJVEQmBoEemmf8tAu_V-ow" x="307" y="-179"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EJOsEpnjEemrjrtN9v_T1A" x="307" y="-179"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZJxJIGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZJxJIWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZJxJI2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EJoUsJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EJoUsZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EJoUs5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZJxJImBoEemmf8tAu_V-ow" x="509" y="-180"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EJoUspnjEemrjrtN9v_T1A" x="509" y="-180"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZKN1E2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZKN1FGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZKN1FmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EKFnsJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EKFnsZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKFns5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZKN1FWBoEemmf8tAu_V-ow" x="533" y="-321"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EKFnspnjEemrjrtN9v_T1A" x="533" y="-321"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZKgwAGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZKgwAWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZKgwA2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EKR08JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EKR08ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKScAJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZKgwAmBoEemmf8tAu_V-ow" x="533" y="-421"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EKR08pnjEemrjrtN9v_T1A" x="533" y="-421"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZKqhAGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZKqhAWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZKqhA2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EKZwwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EKZwwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKaX0JnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZKqhAmBoEemmf8tAu_V-ow" x="533" y="-421"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EKZwwpnjEemrjrtN9v_T1A" x="533" y="-421"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZLHM8GBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZLHM8WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZLHM82BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EKug4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EKug4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKug45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZLHM8mBoEemmf8tAu_V-ow" x="543" y="-459"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EKug4pnjEemrjrtN9v_T1A" x="543" y="-459"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZLaH4GBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZLaH4WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZLaH42BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EK6uIJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EK6uIZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EK6uI5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZLaH4mBoEemmf8tAu_V-ow" x="543" y="-559"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EK6uIpnjEemrjrtN9v_T1A" x="543" y="-559"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZLj44GBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZLj44WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZLj442BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ELA0wJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ELA0wZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ELA0w5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZLj44mBoEemmf8tAu_V-ow" x="543" y="-559"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ELA0wpnjEemrjrtN9v_T1A" x="543" y="-559"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZL_9wGBoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZL_9wWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZL_9w2BoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ELVk4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ELVk4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ELVk45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZL_9wmBoEemmf8tAu_V-ow" x="176" y="153"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ELVk4pnjEemrjrtN9v_T1A" x="176" y="153"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZMvko2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZMvkpGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZMvkpmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ELv0kJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ELv0kZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ELv0k5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZMvkpWBoEemmf8tAu_V-ow" x="727" y="-181"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ELv0kpnjEemrjrtN9v_T1A" x="727" y="-181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZM5Vr2BoEemmf8tAu_V-ow" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZM5VsGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZM5VsmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EL8o4JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EL8o4ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EL8o45njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZM5VsWBoEemmf8tAu_V-ow" x="727" y="-281"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EL8o4pnjEemrjrtN9v_T1A" x="727" y="-281"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_DvNcGYNfEeelF8AE_WZtHQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_DvNcGoNfEeelF8AE_WZtHQ"/>
@@ -10544,305 +10706,305 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VWSQMWUEeiWCKGKl1wb8w" id="(0.4941860465116279,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VWSQcWUEeiWCKGKl1wb8w" id="(1.0,0.7068965517241379)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZC7hVGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvMJsYNfEeelF8AE_WZtHQ" target="_ZC7hUGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZC7hVWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZC7hWWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EDw9RJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvMJsYNfEeelF8AE_WZtHQ" target="_EDw9QJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EDw9RZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EDxkUZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZC7hVmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZC7hV2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZC7hWGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EDw9RpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EDw9R5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EDxkUJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZDYNR2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvMxFYNfEeelF8AE_WZtHQ" target="_ZDYNQ2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZDYNSGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZDYNTGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EEPeYJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvMxFYNfEeelF8AE_WZtHQ" target="_EEO3UJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EEPeYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EEPeZZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZDYNSWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZDYNSmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZDYNS2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EEPeYpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EEPeY5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EEPeZJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZDrIO2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_2fZZEIuCEeiu6boZkiJHCA" target="_ZDrIN2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZDrIPGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZDrIQGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EEbElJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_2fZZEIuCEeiu6boZkiJHCA" target="_EEbEkJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EEbElZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EEbEmZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZDrIPWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZDrIPmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZDrIP2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EEbElpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EEbEl5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EEbEmJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZD0SJGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_93PwYIuCEeiu6boZkiJHCA" target="_ZD0SIGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZD0SJWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZD0SKWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EEhyRJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_93PwYIuCEeiu6boZkiJHCA" target="_EEhyQJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EEhyRZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EEiZUZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZD0SJmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZD0SJ2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZD0SKGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EEhyRpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EEhyR5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EEiZUJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZEH0J2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvMx14NfEeelF8AE_WZtHQ" target="_ZEH0I2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZEH0KGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZEH0LGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EE4-pJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvMx14NfEeelF8AE_WZtHQ" target="_EE4-oJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EE4-pZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EE4-qZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZEH0KWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZEH0KmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZEH0K2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EE4-ppnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EE4-p5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EE4-qJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZEtqAWBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvMyhINfEeelF8AE_WZtHQ" target="_ZEj5A2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZEtqAmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZEtqBmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EFVDhJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvMyhINfEeelF8AE_WZtHQ" target="_EFVDgJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EFVDhZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFVDiZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZEtqA2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZEtqBGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZEtqBWBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EFVDhpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFVDh5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFVDiJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZE3bC2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvN_joNfEeelF8AE_WZtHQ" target="_ZE3bB2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZE3bDGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZE3bEGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EFh31JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvN_joNfEeelF8AE_WZtHQ" target="_EFh30JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EFh31ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFh32ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZE3bDWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZE3bDmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZE3bD2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EFh31pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFh315njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFh32JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZFAk_WBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_VBoo0IuCEeiu6boZkiJHCA" target="_ZFAk-WBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZFAk_mBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZFAlAmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EFn-dJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_VBoo0IuCEeiu6boZkiJHCA" target="_EFn-cJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EFn-dZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFn-eZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZFAk_2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZFAlAGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZFAlAWBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EFn-dpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFn-d5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFn-eJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZFKV9GBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_aET4gIuCEeiu6boZkiJHCA" target="_ZFKV8GBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZFKV9WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZFKV-WBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EFvTNJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_aET4gIuCEeiu6boZkiJHCA" target="_EFvTMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EFvTNZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EFvTOZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZFKV9mBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZFKV92BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZFKV-GBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EFvTNpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFvTN5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EFvTOJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZFwL1GBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvMy7YNfEeelF8AE_WZtHQ" target="_ZFwL0GBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZFwL1WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZFwL2WBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EGKJ9JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvMy7YNfEeelF8AE_WZtHQ" target="_EGKJ8JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EGKJ9ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EGKJ-ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZFwL1mBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZFwL12BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZFwL2GBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EGKJ9pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EGKJ95njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EGKJ-JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZGDGy2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_dCb2gIuCEeiu6boZkiJHCA" target="_ZGDGx2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZGDGzGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZGDG0GBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EGYMZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dCb2gIuCEeiu6boZkiJHCA" target="_EGYMYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EGYMZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EGYMaZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZGDGzWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZGDGzmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZGDGz2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EGYMZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EGYMZ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EGYMaJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZGWoxGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_gRVbcIuCEeiu6boZkiJHCA" target="_ZGWowGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZGWoxWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZGWoyWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EGgINJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_gRVbcIuCEeiu6boZkiJHCA" target="_EGgIMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EGgINZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EGgIOZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZGWoxmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZGWox2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZGWoyGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EGgINpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EGgIN5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EGgIOJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZG8epGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvMz4oNfEeelF8AE_WZtHQ" target="_ZG8eoGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZG8epWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZG8eqWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EHGlJJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvMz4oNfEeelF8AE_WZtHQ" target="_EHGlIJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EHGlJZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EHGlKZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZG8epmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZG8ep2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZG8eqGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EHGlJpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EHGlJ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EHGlKJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZHPZpWBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_j283QIuCEeiu6boZkiJHCA" target="_ZHPZoWBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZHPZpmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZHPZqmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EHdKcZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_j283QIuCEeiu6boZkiJHCA" target="_EHcjYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EHdKcpnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EHdKdpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZHPZp2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZHPZqGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZHPZqWBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EHdKc5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EHdKdJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EHdKdZnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZHsFhGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvM0foNfEeelF8AE_WZtHQ" target="_ZHsFgGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZHsFhWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZHsFiWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EH5PVJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvM0foNfEeelF8AE_WZtHQ" target="_EH5PUJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EH5PVZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EH52YpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZHsFhmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZHsFh2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZHsFiGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EH5PVpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EH52YJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EH52YZnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZIR7Z2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNYIINfEeelF8AE_WZtHQ" target="_ZIR7Y2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZIR7aGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZIR7bGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EIazxJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNYIINfEeelF8AE_WZtHQ" target="_EIazwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EIazxZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EIazyZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_XTF4sGNWEee0bPnI-Gt-mQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZIR7aWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZIR7amBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZIR7a2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EIazxpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIazx5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIazyJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZIlda2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvOA4INfEeelF8AE_WZtHQ" target="_ZIldZ2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZIldbGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZIldcGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EIo2NJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvOA4INfEeelF8AE_WZtHQ" target="_EIo2MJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EIo2NZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EIo2OZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_GyHvYGY4EeeB_84HvuxJBw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZIldbWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZIldbmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZIldb2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EIo2NpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIo2N5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIo2OJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZIunXWBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_Iq4SEIuDEeiu6boZkiJHCA" target="_ZIunWWBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZIunXmBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZIunYmBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EIxZFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Iq4SEIuDEeiu6boZkiJHCA" target="_EIxZEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EIxZFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EIxZGZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_mncXEGNXEee0bPnI-Gt-mQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZIunX2BoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZIunYGBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZIunYWBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EIxZFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIxZF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EIxZGJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZI4YV2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_LlY7YIuDEeiu6boZkiJHCA" target="_ZI4YU2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZI4YWGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZI4YXGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EI5U5JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_LlY7YIuDEeiu6boZkiJHCA" target="_EI5U4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EI5U5ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EI578ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GrFIIGNXEee0bPnI-Gt-mQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZI4YWWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZI4YWmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZI4YW2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EI5U5pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EI5U55njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EI578JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZJVERGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNYqYNfEeelF8AE_WZtHQ" target="_ZJVEQGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZJVERWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZJVESWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EJOsFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNYqYNfEeelF8AE_WZtHQ" target="_EJOsEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EJOsFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EJOsGZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZJVERmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZJVER2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZJVESGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EJOsFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EJOsF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EJOsGJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZJxJJGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNZCoNfEeelF8AE_WZtHQ" target="_ZJxJIGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZJxJJWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZJxJKWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EJoUtJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNZCoNfEeelF8AE_WZtHQ" target="_EJoUsJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EJoUtZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EJoUuZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZJxJJmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZJxJJ2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZJxJKGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EJoUtpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EJoUt5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EJoUuJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZKN1F2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNZa4NfEeelF8AE_WZtHQ" target="_ZKN1E2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZKN1GGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZKN1HGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EKFntJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNZa4NfEeelF8AE_WZtHQ" target="_EKFnsJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EKFntZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKFnuZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZKN1GWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZKN1GmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZKN1G2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EKFntpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKFnt5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKFnuJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZKgwBGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_qziO4IuCEeiu6boZkiJHCA" target="_ZKgwAGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZKgwBWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZKgwCWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EKScAZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_qziO4IuCEeiu6boZkiJHCA" target="_EKR08JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EKScApnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKScBpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZKgwBmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZKgwB2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZKgwCGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EKScA5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKScBJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKScBZnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZKqhBGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_u8wHAIuCEeiu6boZkiJHCA" target="_ZKqhAGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZKqhBWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZKqhCWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EKaX0ZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_u8wHAIuCEeiu6boZkiJHCA" target="_EKZwwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EKaX0pnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKaX1pnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZKqhBmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZKqhB2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZKqhCGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EKaX05njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKaX1JnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKaX1ZnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZLHM9GBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNZzINfEeelF8AE_WZtHQ" target="_ZLHM8GBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZLHM9WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZLHM-WBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EKug5JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNZzINfEeelF8AE_WZtHQ" target="_EKug4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EKug5ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EKug6ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZLHM9mBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZLHM92BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZLHM-GBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EKug5pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKug55njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EKug6JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZLaH5GBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvOAfYNfEeelF8AE_WZtHQ" target="_ZLaH4GBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZLaH5WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZLaH6WBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EK6uJJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvOAfYNfEeelF8AE_WZtHQ" target="_EK6uIJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EK6uJZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EK6uKZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZLaH5mBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZLaH52BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZLaH6GBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EK6uJpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EK6uJ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EK6uKJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZLj45GBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_oJSPIIuCEeiu6boZkiJHCA" target="_ZLj44GBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZLj45WBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZLj46WBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ELA0xJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_oJSPIIuCEeiu6boZkiJHCA" target="_ELA0wJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ELA0xZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ELA0yZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZLj45mBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZLj452BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZLj46GBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ELA0xpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ELA0x5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ELA0yJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZL_9xGBoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNaaYNfEeelF8AE_WZtHQ" target="_ZL_9wGBoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZL_9xWBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZL_9yWBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ELVk5JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNaaYNfEeelF8AE_WZtHQ" target="_ELVk4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ELVk5ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ELVk6ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZL_9xmBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZL_9x2BoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZL_9yGBoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ELVk5pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ELVk55njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ELVk6JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZMvkp2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_DvNbP4NfEeelF8AE_WZtHQ" target="_ZMvko2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZMvkqGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZMvkrGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ELwboJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_DvNbP4NfEeelF8AE_WZtHQ" target="_ELv0kJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ELwboZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ELwbpZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZMvkqWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZMvkqmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZMvkq2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ELwbopnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ELwbo5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ELwbpJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZM5Vs2BoEemmf8tAu_V-ow" type="StereotypeCommentLink" source="_U-pJwIuDEeiu6boZkiJHCA" target="_ZM5Vr2BoEemmf8tAu_V-ow">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZM5VtGBoEemmf8tAu_V-ow"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZM5VuGBoEemmf8tAu_V-ow" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EL8o5JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_U-pJwIuDEeiu6boZkiJHCA" target="_EL8o4JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EL8o5ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EL8o6ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZM5VtWBoEemmf8tAu_V-ow" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZM5VtmBoEemmf8tAu_V-ow"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZM5Vt2BoEemmf8tAu_V-ow"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EL8o5pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EL8o55njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EL8o6JnjEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_G1BSgEqHEempws6eXu44Eg" type="PapyrusUMLClassDiagram" name="AlarmTcaDetails" measurementUnit="Pixel">
@@ -11389,109 +11551,109 @@
       <element xmi:type="uml:DataType" href="TapiOam.uml#_yDEGkGvwEembs75vhmFVVA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yDT-MWvwEembs75vhmFVVA" x="860" y="500" width="261" height="81"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BCVlcHjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BCVlcXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BCVlc3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_El6oEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_El6oEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_El7PIJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Signal" href="TapiNotification.uml#_7CEIsC1qEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BCVlcnjuEemfSIWqmJMEQA" x="580" y="-123"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_El6oEpnjEemrjrtN9v_T1A" x="580" y="-123"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BDhRJnjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BDhRJ3juEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BDhRKXjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Eo0yIJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Eo0yIZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eo0yI5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_OSbfQEqHEempws6eXu44Eg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDhRKHjuEemfSIWqmJMEQA" x="264" y="-24"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eo0yIpnjEemrjrtN9v_T1A" x="264" y="-24"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BD0zI3juEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BD0zJHjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BD0zJnjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EpT6UJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EpT6UZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EpT6U5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_K1S7ICCCEeeWCKlkirNtnw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BD0zJXjuEemfSIWqmJMEQA" x="469" y="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EpT6UpnjEemrjrtN9v_T1A" x="469" y="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BEQ4LXjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BEQ4LnjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BEQ4MHjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Epx0YJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Epx0YZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Epx0Y5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_u60twEqHEempws6eXu44Eg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BEQ4L3juEemfSIWqmJMEQA" x="469" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Epx0YpnjEemrjrtN9v_T1A" x="469" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BEapAHjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BEapAXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BEapA3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ep2F0JnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ep2F0ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ep2F05njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_34ZJ8F1EEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BEapAnjuEemfSIWqmJMEQA" x="469" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ep2F0pnjEemrjrtN9v_T1A" x="469" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BE3U8HjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BE3U8XjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BE3U83juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EqJAwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EqJAwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EqJAw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_MQft0CCCEeeWCKlkirNtnw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BE3U8njuEemfSIWqmJMEQA" x="760" y="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EqJAwpnjEemrjrtN9v_T1A" x="760" y="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BFdK8njuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BFdK83juEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BFdK9XjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EqpXEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EqpXEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EqpXE5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_vhuVsEqHEempws6eXu44Eg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BFdK9HjuEemfSIWqmJMEQA" x="760" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EqpXEpnjEemrjrtN9v_T1A" x="760" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BFm703juEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BFm71HjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BFm71njuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EqwEwJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EqwEwZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EqwEw5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_6TdeMF1EEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BFm71XjuEemfSIWqmJMEQA" x="760" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EqwEwpnjEemrjrtN9v_T1A" x="760" y="100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BGfsoHjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BGfsoXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BGfso3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ErbaMJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ErbaMZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ErbaM5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BGfsonjuEemfSIWqmJMEQA" x="964" y="-127"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ErbaMpnjEemrjrtN9v_T1A" x="964" y="-127"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BG8Yk3juEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BG8YlHjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BG8YlnjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Er8XkJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Er8XkZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Er8Xk5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BG8YlXjuEemfSIWqmJMEQA" x="964" y="-227"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er8XkpnjEemrjrtN9v_T1A" x="964" y="-227"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BHPTg3juEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BHPThHjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BHPThnjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EsP5kJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EsP5kZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EsP5k5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BHPThXjuEemfSIWqmJMEQA" x="953" y="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EsP5kpnjEemrjrtN9v_T1A" x="953" y="58"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BJCDQHjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BJCDQXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BJCDQ3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EtsrEJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EtsrEZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtsrE5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BJCDQnjuEemfSIWqmJMEQA" x="760" y="360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtsrEpnjEemrjrtN9v_T1A" x="760" y="360"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BJU-QnjuEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BJU-Q3juEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BJU-RXjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EuDQYJnjEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EuDQYZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EuDQY5njEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiNotification.uml#_SumL4C0dEeah7qIgVNfKeA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BJU-RHjuEemfSIWqmJMEQA" x="480" y="360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EuDQYpnjEemrjrtN9v_T1A" x="480" y="360"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_G1BSgUqHEempws6eXu44Eg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_G1BSgkqHEempws6eXu44Eg"/>
@@ -11634,135 +11796,135 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6dzF8F1EEemG57ABxBTHSA" id="(0.14869888475836432,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6dztAF1EEemG57ABxBTHSA" id="(0.8144796380090498,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BCVldHjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_IeDF0EqHEempws6eXu44Eg" target="_BCVlcHjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BCVldXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BCVleXjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_El7PIZnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_IeDF0EqHEempws6eXu44Eg" target="_El6oEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_El7PIpnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_El7PJpnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Signal" href="TapiNotification.uml#_7CEIsC1qEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BCVldnjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BCVld3juEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BCVleHjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_El7PI5njEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_El7PJJnjEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_El7PJZnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BDhRKnjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_OSlQQEqHEempws6eXu44Eg" target="_BDhRJnjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BDhRK3juEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BDhRL3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Eo0yJJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_OSlQQEqHEempws6eXu44Eg" target="_Eo0yIJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Eo0yJZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eo0yKZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_OSbfQEqHEempws6eXu44Eg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BDhRLHjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BDhRLXjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BDhRLnjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Eo0yJpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eo0yJ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eo0yKJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BD0zJ3juEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_dyeFsEqHEempws6eXu44Eg" target="_BD0zI3juEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BD0zKHjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BD0zLHjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EpT6VJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_dyeFsEqHEempws6eXu44Eg" target="_EpT6UJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EpT6VZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EpUhYJnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_K1S7ICCCEeeWCKlkirNtnw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BD0zKXjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BD0zKnjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BD0zK3juEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EpT6VpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EpT6V5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EpT6WJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BEQ4MXjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_u60twUqHEempws6eXu44Eg" target="_BEQ4LXjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BEQ4MnjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BEQ4NnjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Epx0ZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_u60twUqHEempws6eXu44Eg" target="_Epx0YJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Epx0ZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Epx0aZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_u60twEqHEempws6eXu44Eg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BEQ4M3juEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEQ4NHjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEQ4NXjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Epx0ZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Epx0Z5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Epx0aJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BEapBHjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_34epgF1EEemG57ABxBTHSA" target="_BEapAHjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BEapBXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BEapCXjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ep2F1JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_34epgF1EEemG57ABxBTHSA" target="_Ep2F0JnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ep2F1ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ep2F2ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_34ZJ8F1EEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BEapBnjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEapB3juEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BEapCHjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ep2F1pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ep2F15njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ep2F2JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BE3U9HjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_eaV-AEqHEempws6eXu44Eg" target="_BE3U8HjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BE3U9XjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BE3U-XjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EqJn0JnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_eaV-AEqHEempws6eXu44Eg" target="_EqJAwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EqJn0ZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EqJn1ZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_MQft0CCCEeeWCKlkirNtnw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BE3U9njuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BE3U93juEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BE3U-HjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EqJn0pnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EqJn05njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EqJn1JnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BFdK9njuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_vhuVsUqHEempws6eXu44Eg" target="_BFdK8njuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BFdK93juEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BFdK-3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EqpXFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_vhuVsUqHEempws6eXu44Eg" target="_EqpXEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EqpXFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EqpXGZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_vhuVsEqHEempws6eXu44Eg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BFdK-HjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BFdK-XjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BFdK-njuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EqpXFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EqpXF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EqpXGJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BFm713juEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_6TesUF1EEemG57ABxBTHSA" target="_BFm703juEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BFm72HjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BFm73HjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EqwExJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_6TesUF1EEemG57ABxBTHSA" target="_EqwEwJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EqwExZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EqwEyZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_6TdeMF1EEemG57ABxBTHSA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BFm72XjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BFm72njuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BFm723juEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EqwExpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EqwEx5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EqwEyJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BGfspHjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Y_CEgEqKEempws6eXu44Eg" target="_BGfsoHjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BGfspXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BGfsqXjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ErbaNJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Y_CEgEqKEempws6eXu44Eg" target="_ErbaMJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ErbaNZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ErbaOZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_bgGpwIUvEeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BGfspnjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BGfsp3juEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BGfsqHjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ErbaNpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ErbaN5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ErbaOJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BG8Yl3juEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZC5Q0EqKEempws6eXu44Eg" target="_BG8Yk3juEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BG8YmHjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BG8YnHjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Er8XlJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZC5Q0EqKEempws6eXu44Eg" target="_Er8XkJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Er8XlZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Er8XmZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_GGYEYIU1EeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BG8YmXjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BG8YmnjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BG8Ym3juEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Er8XlpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Er8Xl5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Er8XmJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BHPTh3juEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZA0NMEqKEempws6eXu44Eg" target="_BHPTg3juEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BHPTiHjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BHPTjHjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EsQgoJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZA0NMEqKEempws6eXu44Eg" target="_EsP5kJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EsQgoZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EsQgpZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CD5qQIUxEeiYFOBVMQg1QQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BHPTiXjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BHPTinjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BHPTi3juEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EsQgopnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EsQgo5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EsQgpJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BJCDRHjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_weSFoF1AEemG57ABxBTHSA" target="_BJCDQHjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BJCDRXjuEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BJCDSXjuEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EtsrFJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_weSFoF1AEemG57ABxBTHSA" target="_EtsrEJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EtsrFZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtsrGZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_2-15sEI6EeiDweqmZm-ZXQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BJCDRnjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BJCDR3juEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BJCDSHjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EtsrFpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtsrF5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtsrGJnjEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BJU-RnjuEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_m--80F1EEemG57ABxBTHSA" target="_BJU-QnjuEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BJU-R3juEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BJU-S3juEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EuDQZJnjEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_m--80F1EEemG57ABxBTHSA" target="_EuDQYJnjEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EuDQZZnjEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EuDQaZnjEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiNotification.uml#_SumL4C0dEeah7qIgVNfKeA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BJU-SHjuEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BJU-SXjuEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BJU-SnjuEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EuDQZpnjEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EuDQZ5njEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EuDQaJnjEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -312,17 +312,31 @@ Identification of the PM Session for which the TCA Function was configured.</bod
     <packagedElement xmi:type="uml:Package" xmi:id="_zf2PwMOcEeaFfJxGCRaf4A" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_Nm0qoOxYEeaTUPmcu3rLwA" name="OamService">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_r-PDAMOdEeaFfJxGCRaf4A" name="createOamService">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_F4BwMJnjEemrjrtN9v_T1A" annotatedElement="_r-PDAMOdEeaFfJxGCRaf4A">
+            <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+          </ownedComment>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="__VlhMJgREemfbpUjK-Jv3g" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_RSOtMJnkEemrjrtN9v_T1A" annotatedElement="__VlhMJgREemfbpUjK-Jv3g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_s3jR4JgMEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_5IkNQJndEemVaY_egjrbOQ" annotatedElement="_s3jR4JgMEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uTu8AJgMEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uUfxAJgMEemfbpUjK-Jv3g" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_nNQpEE-oEeitY7qZgkO_XQ" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s39iEE-oEeitY7qZgkO_XQ" value="2"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s3_-UE-oEeitY7qZgkO_XQ" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_uTCfUDoQEemSPvPXzEQ11A" name="layerProtocolName">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
@@ -330,15 +344,33 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_1gB5ME-qEeitY7qZgkO_XQ" name="state">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
           </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_nNQpEE-oEeitY7qZgkO_XQ" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s39iEE-oEeitY7qZgkO_XQ" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s3_-UE-oEeitY7qZgkO_XQ" value="*"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_65htcE-qEeitY7qZgkO_XQ" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_NbJpQMOfEeaFfJxGCRaf4A" name="deleteOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_knARIE-rEeitY7qZgkO_XQ" name="oamServiceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_knARIE-rEeitY7qZgkO_XQ" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_JkKqwJnjEemrjrtN9v_T1A" annotatedElement="_knARIE-rEeitY7qZgkO_XQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_zn1cMMOeEeaFfJxGCRaf4A" name="getOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_grnEAFg6Eei9GrLbn4i8vw" name="oamServiceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_grnEAFg6Eei9GrLbn4i8vw" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_LJTckJnjEemrjrtN9v_T1A" annotatedElement="_grnEAFg6Eei9GrLbn4i8vw">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_UjLSkFg6Eei9GrLbn4i8vw" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="read"/>
@@ -350,7 +382,14 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_ssZqINzDEeaMV83ubDcSig" name="getMeg">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_hFaOoFg7Eei9GrLbn4i8vw" name="oamServiceId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_hFaOoFg7Eei9GrLbn4i8vw" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_SbdbkJnjEemrjrtN9v_T1A" annotatedElement="_hFaOoFg7Eei9GrLbn4i8vw">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_nVxZcFg7Eei9GrLbn4i8vw" name="meg" type="_zR-agMbLEeaVKq30FmMykA" direction="out">
@@ -359,46 +398,89 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_FHkjAE4wEeiMYveOdt1-rQ" name="updateOamService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2xUFcE-rEeitY7qZgkO_XQ" name="oamServiceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2xUFcE-rEeitY7qZgkO_XQ" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_HV4OQJnjEemrjrtN9v_T1A" annotatedElement="_2xUFcE-rEeitY7qZgkO_XQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_4xRR4JgMEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_6-5cwJndEemVaY_egjrbOQ" annotatedElement="_4xRR4JgMEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_59w6MJgMEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5-fS8JgMEemfbpUjK-Jv3g" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_6GkKAE-rEeitY7qZgkO_XQ" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" effect="update">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PuVOEFg7Eei9GrLbn4i8vw"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PuVOEVg7Eei9GrLbn4i8vw" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Ev1OwE-sEeitY7qZgkO_XQ" name="state" effect="update">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UM0LkFg7Eei9GrLbn4i8vw"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UM0LkVg7Eei9GrLbn4i8vw" value="1"/>
           </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_6GkKAE-rEeitY7qZgkO_XQ" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" effect="update">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PuVOEFg7Eei9GrLbn4i8vw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PuVOEVg7Eei9GrLbn4i8vw" value="*"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_HAebsE-sEeitY7qZgkO_XQ" name="oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_CXyBUE5DEeiMYveOdt1-rQ" name="createOamServicePoint">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Ghd5EJgSEemfbpUjK-Jv3g" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_M7o84JnjEemrjrtN9v_T1A" annotatedElement="_Ghd5EJgSEemfbpUjK-Jv3g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_HTKOAJgNEemfbpUjK-Jv3g" name="name">
-            <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Iurw0JgNEemfbpUjK-Jv3g"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Iv2OcJgNEemfbpUjK-Jv3g" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_AnXO8Fg7Eei9GrLbn4i8vw" name="oamServiceId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_ZEWbIJnjEemrjrtN9v_T1A" annotatedElement="_AnXO8Fg7Eei9GrLbn4i8vw">
+              <body>UUID of the parent OamService: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_PETkMFg8Eei9GrLbn4i8vw" name="sipId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_PETkMFg8Eei9GrLbn4i8vw" name="serviceInterfacePointId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_daVj8JnjEemrjrtN9v_T1A" annotatedElement="_PETkMFg8Eei9GrLbn4i8vw">
+              <body>UUID of the associated SIP to be monitored: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_W413gFg8Eei9GrLbn4i8vw" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_W413gVg8Eei9GrLbn4i8vw" value="1"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_j9HbwFrREeiuav4HkQjbcQ" name="cSepId">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_j9HbwFrREeiuav4HkQjbcQ" name="connectivityServiceEndPointId">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_iNcGkJnjEemrjrtN9v_T1A" annotatedElement="_j9HbwFrREeiuav4HkQjbcQ">
+              <body>UUID of the CSEP to be monitored: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kqXjUFrREeiuav4HkQjbcQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kqXjUVrREeiuav4HkQjbcQ" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_HTKOAJgNEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_835lwJndEemVaY_egjrbOQ" annotatedElement="_HTKOAJgNEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Iurw0JgNEemfbpUjK-Jv3g"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Iv2OcJgNEemfbpUjK-Jv3g" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_C4LJEFg9Eei9GrLbn4i8vw" name="layerProtocolName">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
@@ -409,24 +491,36 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_I2LDcFg7Eei9GrLbn4i8vw" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_GGP3IE5DEeiMYveOdt1-rQ" name="deleteOamServicePoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5J47UFg7Eei9GrLbn4i8vw" name="oamServicePointId" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_e_xs8Fg9Eei9GrLbn4i8vw" name="oamServiceId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5J47UFg7Eei9GrLbn4i8vw" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Pxw1cJnjEemrjrtN9v_T1A" annotatedElement="_5J47UFg7Eei9GrLbn4i8vw">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_JRx_AE5DEeiMYveOdt1-rQ" name="updateOamServicePoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_ZrwsMFkaEei2nODetmeP6A" name="oamServicePointId" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_ZrwsMFkaEei2nODetmeP6A" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_OWRH0JnjEemrjrtN9v_T1A" annotatedElement="_ZrwsMFkaEei2nODetmeP6A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_QkZv4JgNEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_-fRMMJndEemVaY_egjrbOQ" annotatedElement="_QkZv4JgNEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RYs6oJgNEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RZb6cJgNEemfbpUjK-Jv3g" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WegGAFkaEei2nODetmeP6A" name="oamServiceId" effect="read">
-            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_dNUHYFkaEei2nODetmeP6A" name="state" effect="update">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
@@ -436,10 +530,14 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_tbTY8FkaEei2nODetmeP6A" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_M-C1YE5DEeiMYveOdt1-rQ" name="getOamServicePoint">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_A5gwAFkZEei2nODetmeP6A" name="oamServicePointId" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_99OlEFkYEei2nODetmeP6A" name="oamServiceId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_A5gwAFkZEei2nODetmeP6A" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_RKpT8JnjEemrjrtN9v_T1A" annotatedElement="_A5gwAFkZEei2nODetmeP6A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_GY6_AFkZEei2nODetmeP6A" name="oamServicePoint" type="_W48McBP7EeepnPPr_BcZKg" direction="out" effect="read"/>
@@ -448,25 +546,57 @@ Identification of the PM Session for which the TCA Function was configured.</bod
       <packagedElement xmi:type="uml:Interface" xmi:id="_rH__wBKJEemxeNG9TDCtFQ" name="OamJob">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_mF1sQMOdEeaFfJxGCRaf4A" name="createOamJob">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_X9z0IJgSEemfbpUjK-Jv3g" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_V0GV4JnkEemrjrtN9v_T1A" annotatedElement="_X9z0IJgSEemfbpUjK-Jv3g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_i7Ow4DkQEemjx6Nna_xyog" name="oamServiceId">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_kaFu4JnkEemrjrtN9v_T1A" annotatedElement="_i7Ow4DkQEemjx6Nna_xyog">
+              <body>UUID of the associated OamService: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0LKokJsYEeid4dfn4JFJZg" name="oamServicePointId">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pzFz4JnkEemrjrtN9v_T1A" annotatedElement="_0LKokJsYEeid4dfn4JFJZg">
+              <body>UUID of the associated OSEPs: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CtmUJsYEeid4dfn4JFJZg" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5C_6MJsYEeid4dfn4JFJZg" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_bdSkIJsZEeid4dfn4JFJZg" name="oamProfileId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_tbGcYJnkEemrjrtN9v_T1A" annotatedElement="_bdSkIJsZEeid4dfn4JFJZg">
+              <body>UUID of the OamProfile to be applied: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_dDX8kJgOEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_AeTrwJneEemVaY_egjrbOQ" annotatedElement="_dDX8kJgOEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d5sgkJgOEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d68dwJgOEemfbpUjK-Jv3g" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_VJFbIJsZEeid4dfn4JFJZg" name="oamJobType" type="_tqiDYF3eEeit4-HSxnZlvw" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_i7Ow4DkQEemjx6Nna_xyog" name="oamServiceId">
-            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0LKokJsYEeid4dfn4JFJZg" name="oamServicePointId">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5CtmUJsYEeid4dfn4JFJZg" value="1"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5C_6MJsYEeid4dfn4JFJZg" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_bdSkIJsZEeid4dfn4JFJZg" name="oamProfileId" effect="read">
-            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
-          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_C140oFg-Eei9GrLbn4i8vw" name="state">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
           </ownedParameter>
@@ -476,15 +606,37 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_HxvqoFg-Eei9GrLbn4i8vw" name="oamJob" type="_2-15sEI6EeiDweqmZm-ZXQ" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_5HQ4ME5CEeiMYveOdt1-rQ" name="updateOamJob">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_j56-wFkZEei2nODetmeP6A" name="oamJobId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_j56-wFkZEei2nODetmeP6A" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_XJSAIJnkEemrjrtN9v_T1A" annotatedElement="_j56-wFkZEei2nODetmeP6A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_kgDlIJsZEeid4dfn4JFJZg" name="oamProfileId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_wcMO0JnkEemrjrtN9v_T1A" annotatedElement="_kgDlIJsZEeid4dfn4JFJZg">
+              <body>UUID of the OamProfile to be applied: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Yqvi8JnQEemVaY_egjrbOQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YrCd4JnQEemVaY_egjrbOQ" value="1"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_mHnkQJgOEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_B4oUsJneEemVaY_egjrbOQ" annotatedElement="_mHnkQJgOEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_n0cScJgOEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_n1VqUJgOEemfbpUjK-Jv3g" value="*"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_kgDlIJsZEeid4dfn4JFJZg" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_qlKuwFkZEei2nODetmeP6A" name="state" effect="update">
             <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_zSpnYNnjEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rU3tYFkZEei2nODetmeP6A"/>
@@ -498,12 +650,26 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_yCmJoFkZEei2nODetmeP6A" name="oamJob" type="_2-15sEI6EeiDweqmZm-ZXQ" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_zpm8sE5CEeiMYveOdt1-rQ" name="deleteOamJob">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_z-ENQFkYEei2nODetmeP6A" name="oamJobId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_z-ENQFkYEei2nODetmeP6A" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Yjuk4JnkEemrjrtN9v_T1A" annotatedElement="_z-ENQFkYEei2nODetmeP6A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_SrzDgMOfEeaFfJxGCRaf4A" name="getOamJob" visibility="public">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Es2zUFisEei2nODetmeP6A" name="oamJobId" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Es2zUFisEei2nODetmeP6A" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Z8dSYJnkEemrjrtN9v_T1A" annotatedElement="_Es2zUFisEei2nODetmeP6A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_NCTbUFisEei2nODetmeP6A" name="oamJob" type="_2-15sEI6EeiDweqmZm-ZXQ" direction="out" effect="read"/>
@@ -518,9 +684,20 @@ Identification of the PM Session for which the TCA Function was configured.</bod
       <packagedElement xmi:type="uml:Interface" xmi:id="_Db62oBKKEemxeNG9TDCtFQ" name="OamProfile">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_PgmJcBKKEemxeNG9TDCtFQ" name="createOamProfile">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_2NzA0JgSEemfbpUjK-Jv3g" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_bhJ_UJnkEemrjrtN9v_T1A" annotatedElement="_2NzA0JgSEemfbpUjK-Jv3g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_yAeBkJgOEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_D5LQIJneEemVaY_egjrbOQ" annotatedElement="_yAeBkJgOEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zLMIQJgOEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zL8WMJgOEemfbpUjK-Jv3g" value="*"/>
@@ -535,10 +712,21 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_Q6sI4BKKEemxeNG9TDCtFQ" name="updateOamProfile">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Gdw1ABKgEemxeNG9TDCtFQ" name="oamProfileId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Gdw1ABKgEemxeNG9TDCtFQ" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_c5SP4JnkEemrjrtN9v_T1A" annotatedElement="_Gdw1ABKgEemxeNG9TDCtFQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_3evoIJgOEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_FPlCYJneEemVaY_egjrbOQ" annotatedElement="_3evoIJgOEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_463n4JgOEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_47i9UJgOEemfbpUjK-Jv3g" value="*"/>
@@ -550,12 +738,26 @@ Identification of the PM Session for which the TCA Function was configured.</bod
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_U2jfgBKgEemxeNG9TDCtFQ" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_SIbHUBKKEemxeNG9TDCtFQ" name="deleteOamProfile">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_c5sPgBKgEemxeNG9TDCtFQ" name="oamProfileId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_c5sPgBKgEemxeNG9TDCtFQ" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eOQewJnkEemrjrtN9v_T1A" annotatedElement="_c5sPgBKgEemxeNG9TDCtFQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_ZqMPoBKKEemxeNG9TDCtFQ" name="getOamProfile">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_gNBBcBKgEemxeNG9TDCtFQ" name="oamProfileId">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_gNBBcBKgEemxeNG9TDCtFQ" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_fx2_gJnkEemrjrtN9v_T1A" annotatedElement="_gNBBcBKgEemxeNG9TDCtFQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_pksigBKgEemxeNG9TDCtFQ" name="oamProfile" type="_bgGpwIUvEeiYFOBVMQg1QQ" direction="out"/>
@@ -1054,21 +1256,18 @@ Identification of the PM Session for which the TCA Function was configured.</bod
   <OpenModel_Profile:OpenModelParameter xmi:id="_PETkMVg8Eei9GrLbn4i8vw" base_Parameter="_PETkMFg8Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_86ebkVg8Eei9GrLbn4i8vw" base_Parameter="_86ebkFg8Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_C4LJEVg9Eei9GrLbn4i8vw" base_Parameter="_C4LJEFg9Eei9GrLbn4i8vw"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_e_xs8Vg9Eei9GrLbn4i8vw" base_Parameter="_e_xs8Fg9Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_C140oVg-Eei9GrLbn4i8vw" base_Parameter="_C140oFg-Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_FCcLwVg-Eei9GrLbn4i8vw" base_Parameter="_FCcLwFg-Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_HxvqoVg-Eei9GrLbn4i8vw" base_Parameter="_HxvqoFg-Eei9GrLbn4i8vw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_Eu2-cFisEei2nODetmeP6A" base_Parameter="_Es2zUFisEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_NCTbUVisEei2nODetmeP6A" base_Parameter="_NCTbUFisEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_z-ENQVkYEei2nODetmeP6A" base_Parameter="_z-ENQFkYEei2nODetmeP6A"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_99OlEVkYEei2nODetmeP6A" base_Parameter="_99OlEFkYEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_A5gwAVkZEei2nODetmeP6A" base_Parameter="_A5gwAFkZEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_GY6_AVkZEei2nODetmeP6A" base_Parameter="_GY6_AFkZEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_j56-wVkZEei2nODetmeP6A" base_Parameter="_j56-wFkZEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_qlKuwVkZEei2nODetmeP6A" base_Parameter="_qlKuwFkZEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_vhb0cVkZEei2nODetmeP6A" base_Parameter="_vhb0cFkZEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_yCmJoVkZEei2nODetmeP6A" base_Parameter="_yCmJoFkZEei2nODetmeP6A"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_WegGAVkaEei2nODetmeP6A" base_Parameter="_WegGAFkaEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_ZrwsMVkaEei2nODetmeP6A" base_Parameter="_ZrwsMFkaEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_dNUHYVkaEei2nODetmeP6A" base_Parameter="_dNUHYFkaEei2nODetmeP6A"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_tbTY8VkaEei2nODetmeP6A" base_Parameter="_tbTY8FkaEei2nODetmeP6A"/>

--- a/UML/TapiPathComputation.notation
+++ b/UML/TapiPathComputation.notation
@@ -735,221 +735,229 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pgnxUpgXEemfbpUjK-Jv3g" x="948" y="507"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pg-9sJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pg-9sZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pg-9s5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SJBpw5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SJBpxJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SJBpxpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SJBpxZnNEemVaY_egjrbOQ" x="948" y="507"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SJUkt5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SJUkuJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SJUkupnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pg-9spgXEemfbpUjK-Jv3g" x="948" y="407"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SJUkuZnNEemVaY_egjrbOQ" x="948" y="407"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_phpsEJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_phpsEZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_phpsE5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SJ7Bo5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SJ7BpJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SJ7BppnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_phpsEpgXEemfbpUjK-Jv3g" x="571" y="510"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SJ7BpZnNEemVaY_egjrbOQ" x="571" y="510"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pidkYJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pidkYZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pidkY5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SKqogJnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SKqogZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SKqog5nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pidkYpgXEemfbpUjK-Jv3g" x="975" y="-78"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SKqogpnNEemVaY_egjrbOQ" x="975" y="-78"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pjRcsJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pjRcsZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pjRcs5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SLHUd5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SLHUeJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SLHUepnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pjRcspgXEemfbpUjK-Jv3g" x="319" y="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SLHUeZnNEemVaY_egjrbOQ" x="319" y="286"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pkIYUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pkIYUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pkIYU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SLtKU5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SLtKVJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SLtKVpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pkIYUpgXEemfbpUjK-Jv3g" x="974" y="-11"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SLtKVZnNEemVaY_egjrbOQ" x="974" y="-11"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pk-s4JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pk-s4ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pk-s45gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SMJ2R5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SMJ2SJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMJ2SpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pk-s4pgXEemfbpUjK-Jv3g" x="543" y="-70"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SMJ2SZnNEemVaY_egjrbOQ" x="543" y="-70"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_plVSMJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_plVSMZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plVSM5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SMcxN5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SMcxOJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMcxOpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_plVSMpgXEemfbpUjK-Jv3g" x="543" y="-170"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SMcxOZnNEemVaY_egjrbOQ" x="543" y="-170"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_plgRUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_plgRUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plgRU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SMmiMJnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SMmiMZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMmiM5nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_plgRUpgXEemfbpUjK-Jv3g" x="543" y="-170"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SMmiMpnNEemVaY_egjrbOQ" x="543" y="-170"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_plpbQJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_plpbQZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plqCUJgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SMmiQZnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SMmiQpnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMmiRJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_plpbQpgXEemfbpUjK-Jv3g" x="543" y="-170"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SMmiQ5nNEemVaY_egjrbOQ" x="543" y="-170"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_plzzUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_plzzUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plzzU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SMvsJ5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SMvsKJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMvsKpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_plzzUpgXEemfbpUjK-Jv3g" x="543" y="-170"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SMvsKZnNEemVaY_egjrbOQ" x="543" y="-170"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pl9kUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pl9kUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pl9kU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SM5dJ5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SM5dKJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SM5dKpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pl9kUpgXEemfbpUjK-Jv3g" x="543" y="-170"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SM5dKZnNEemVaY_egjrbOQ" x="543" y="-170"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pmHVUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pmHVUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pmHVU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SNCnE5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SNCnFJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SNCnFpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pmHVUpgXEemfbpUjK-Jv3g" x="543" y="-170"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SNCnFZnNEemVaY_egjrbOQ" x="543" y="-170"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pmvncJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pmvncZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pmvnc5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SNpEA5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SNpEBJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SNpEBpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pmvncpgXEemfbpUjK-Jv3g" x="541" y="192"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SNpEBZnNEemVaY_egjrbOQ" x="541" y="192"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pnE-oJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pnE-oZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pnE-o5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SN7-8JnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SN7-8ZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SN7-85nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pnE-opgXEemfbpUjK-Jv3g" x="541" y="92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SN7-8pnNEemVaY_egjrbOQ" x="541" y="92"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pnw7IJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pnw7IZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pnw7I5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SOYq45nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SOYq5JnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SOYq5pnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pnw7IpgXEemfbpUjK-Jv3g" x="928" y="164"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SOYq5ZnNEemVaY_egjrbOQ" x="928" y="164"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pon2wJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pon2wZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pon2w5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SPIRw5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SPIRxJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SPIRxpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pon2wpgXEemfbpUjK-Jv3g" x="945" y="331"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SPIRxZnNEemVaY_egjrbOQ" x="945" y="331"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_po_qMJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_po_qMZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppARQJgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SPbMt5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SPbMuJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SPbMupnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_po_qMpgXEemfbpUjK-Jv3g" x="945" y="231"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SPbMuZnNEemVaY_egjrbOQ" x="945" y="231"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ppLQYJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ppLQYZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppLQY5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SPk9s5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SPk9tJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SPk9tpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ppLQYpgXEemfbpUjK-Jv3g" x="945" y="231"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SPk9tZnNEemVaY_egjrbOQ" x="945" y="231"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pp3M4JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pp3M4ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pp3M45gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SQBCl5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SQBCmJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SQBCmpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pp3M4pgXEemfbpUjK-Jv3g" x="305" y="510"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SQBCmZnNEemVaY_egjrbOQ" x="305" y="510"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pqvWoJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pqvWoZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pqvWo5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SRELcJnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SRELcZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SRELc5nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pqvWopgXEemfbpUjK-Jv3g" x="190" y="-157"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SRELcpnNEemVaY_egjrbOQ" x="190" y="-157"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_prFU4JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_prFU4ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_prFU45gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SSGtR5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SSGtSJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSGtSpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_prFU4pgXEemfbpUjK-Jv3g" x="190" y="-257"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SSGtSZnNEemVaY_egjrbOQ" x="190" y="-257"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_prOe0JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_prOe0ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_prOe05gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SSGtWpnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SSGtW5nNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSGtXZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_prOe0pgXEemfbpUjK-Jv3g" x="190" y="-257"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SSGtXJnNEemVaY_egjrbOQ" x="190" y="-257"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_prY24JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_prY24ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_prY245gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SSP3OJnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SSP3OZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSP3O5nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_prY24pgXEemfbpUjK-Jv3g" x="190" y="-257"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SSP3OpnNEemVaY_egjrbOQ" x="190" y="-257"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_psBJAJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_psBJAZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_psBwEJgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SSjZNpnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SSjZN5nNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSjZOZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_psBJApgXEemfbpUjK-Jv3g" x="545" y="325"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SSjZOJnNEemVaY_egjrbOQ" x="545" y="325"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ptUJgJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ptUJgZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ptUJg5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_STTAE5nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_STTAFJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_STTAFpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ptUJgpgXEemfbpUjK-Jv3g" x="544" y="-162"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_STTAFZnNEemVaY_egjrbOQ" x="544" y="-162"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pvQqQJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pvQqQZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pvQqQ5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SUMX85nNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SUMX9JnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SUMX9pnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pvQqQpgXEemfbpUjK-Jv3g" x="930" y="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SUMX9ZnNEemVaY_egjrbOQ" x="930" y="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pv3uQJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pv3uQZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pv3uQ5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_SUfS4JnNEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_SUfS4ZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SUfS45nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pv3uQpgXEemfbpUjK-Jv3g" x="827" y="-166"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SUfS4pnNEemVaY_egjrbOQ" x="827" y="-166"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_8OGbYTBGEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_8OGbYjBGEeam35bpdXJzEw"/>
@@ -1797,275 +1805,285 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pgoYYJgXEemfbpUjK-Jv3g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pgoYYZgXEemfbpUjK-Jv3g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pg-9tJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_h_F8oFopEemu443YKSGnxQ" target="_pg-9sJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pg-9tZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pg-9uZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SJBpx5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_SJBpw5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SJBpyJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SJBpzJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SJBpyZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SJBpypnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SJBpy5nNEemVaY_egjrbOQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SJUku5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_h_F8oFopEemu443YKSGnxQ" target="_SJUkt5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SJUkvJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SJUkwJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pg-9tpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pg-9t5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pg-9uJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SJUkvZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SJUkvpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SJUkv5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_phpsFJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7bpATBGEeam35bpdXJzEw" target="_phpsEJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_phpsFZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_phqTIJgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SJ7Bp5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7bpATBGEeam35bpdXJzEw" target="_SJ7Bo5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SJ7BqJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SJ7BrJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_phpsFpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_phpsF5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_phpsGJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SJ7BqZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SJ7BqpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SJ7Bq5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pidkZJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7bqJjBGEeam35bpdXJzEw" target="_pidkYJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pidkZZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pidkaZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SKqohJnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7bqJjBGEeam35bpdXJzEw" target="_SKqogJnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SKqohZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SKqoiZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pidkZpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pidkZ5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pidkaJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SKqohpnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SKqoh5nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SKqoiJnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pjSDwJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7bqZzBGEeam35bpdXJzEw" target="_pjRcsJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pjSDwZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pjSDxZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SLHUe5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7bqZzBGEeam35bpdXJzEw" target="_SLHUd5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SLHUfJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SLHUgJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pjSDwpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pjSDw5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pjSDxJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SLHUfZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SLHUfpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SLHUf5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pkIYVJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7kzETBGEeam35bpdXJzEw" target="_pkIYUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pkIYVZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pkIYWZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SLtKV5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7kzETBGEeam35bpdXJzEw" target="_SLtKU5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SLtKWJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SLtKXJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pkIYVpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pkIYV5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pkIYWJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SLtKWZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SLtKWpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SLtKW5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pk_T8JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7kz7zBGEeam35bpdXJzEw" target="_pk-s4JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pk_T8ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pk_T9ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SMJ2S5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7kz7zBGEeam35bpdXJzEw" target="_SMJ2R5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SMJ2TJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMJ2UJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pk_T8pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pk_T85gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pk_T9JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SMJ2TZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMJ2TpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMJ2T5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_plVSNJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_-qURcIuVEeiu6boZkiJHCA" target="_plVSMJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_plVSNZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plVSOZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SMcxO5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_-qURcIuVEeiu6boZkiJHCA" target="_SMcxN5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SMcxPJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMcxQJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_plVSNpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plVSN5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plVSOJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SMcxPZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMcxPpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMcxP5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_plgRVJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_IDVPQIuWEeiu6boZkiJHCA" target="_plgRUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_plgRVZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plgRWZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SMmiNJnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_IDVPQIuWEeiu6boZkiJHCA" target="_SMmiMJnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SMmiNZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMmiOZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_plgRVpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plgRV5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plgRWJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SMmiNpnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMmiN5nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMmiOJnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_plqCUZgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_KwZScIuWEeiu6boZkiJHCA" target="_plpbQJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_plqCUpgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plqCVpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SMmiRZnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_KwZScIuWEeiu6boZkiJHCA" target="_SMmiQZnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SMmiRpnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMmiSpnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_plqCU5gXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plqCVJgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plqCVZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SMmiR5nNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMmiSJnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMmiSZnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_plzzVJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_O44KwIuWEeiu6boZkiJHCA" target="_plzzUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_plzzVZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_plzzWZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SMvsK5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_O44KwIuWEeiu6boZkiJHCA" target="_SMvsJ5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SMvsLJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SMvsMJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_plzzVpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plzzV5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_plzzWJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SMvsLZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMvsLpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SMvsL5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pl9kVJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_YF9lYIuWEeiu6boZkiJHCA" target="_pl9kUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pl9kVZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pl9kWZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SM5dK5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_YF9lYIuWEeiu6boZkiJHCA" target="_SM5dJ5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SM5dLJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SM5dMJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pl9kVpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pl9kV5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pl9kWJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SM5dLZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SM5dLpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SM5dL5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pmH8YJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_BZo84K1gEeiIjuV0HZnJAQ" target="_pmHVUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pmH8YZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pmH8ZZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SNCnF5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_BZo84K1gEeiIjuV0HZnJAQ" target="_SNCnE5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SNCnGJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SNCnHJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pmH8YpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pmH8Y5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pmH8ZJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SNCnGZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SNCnGpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SNCnG5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pmvndJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7k0RDBGEeam35bpdXJzEw" target="_pmvncJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pmvndZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pmwOgJgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SNpEB5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7k0RDBGEeam35bpdXJzEw" target="_SNpEA5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SNpECJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SNpEDJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pmvndpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pmvnd5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pmvneJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SNpECZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SNpECpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SNpEC5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pnE-pJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="__7bq1TBGEeam35bpdXJzEw" target="_pnE-oJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pnE-pZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pnE-qZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SN7-9JnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="__7bq1TBGEeam35bpdXJzEw" target="_SN7-8JnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SN7-9ZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SN7--ZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pnE-ppgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pnE-p5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pnE-qJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SN7-9pnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SN7-95nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SN7--JnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pnw7JJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_jCJFgDJEEeamvfKYyWmELQ" target="_pnw7IJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pnw7JZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pnw7KZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SOYq55nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_jCJFgDJEEeamvfKYyWmELQ" target="_SOYq45nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SOYq6JnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SOYq7JnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pnw7JpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pnw7J5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pnw7KJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SOYq6ZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SOYq6pnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SOYq65nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pon2xJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_Jm3rgDM1EeaULOmJRJKM0Q" target="_pon2wJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pood0JgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pood1JgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SPIRx5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_Jm3rgDM1EeaULOmJRJKM0Q" target="_SPIRw5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SPIRyJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SPIRzJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pood0ZgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pood0pgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pood05gXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SPIRyZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SPIRypnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SPIRy5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ppARQZgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_kEvrkIuWEeiu6boZkiJHCA" target="_po_qMJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ppARQpgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppARRpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SPbMu5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_kEvrkIuWEeiu6boZkiJHCA" target="_SPbMt5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SPbMvJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SPbMwJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ppARQ5gXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppARRJgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppARRZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SPbMvZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SPbMvpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SPbMv5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ppL3cJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_mb5JIIuWEeiu6boZkiJHCA" target="_ppLQYJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ppL3cZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppL3dZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SPk9t5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_mb5JIIuWEeiu6boZkiJHCA" target="_SPk9s5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SPk9uJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SPk9vJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ppL3cpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppL3c5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppL3dJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SPk9uZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SPk9upnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SPk9u5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pp3M5JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_sBVWcE0REeaqn4OIuRCwEg" target="_pp3M4JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pp3M5ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pp3z8pgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SQBCm5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_sBVWcE0REeaqn4OIuRCwEg" target="_SQBCl5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SQBCnJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SQKzkJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pp3M5pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pp3z8JgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pp3z8ZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SQBCnZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SQBCnpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SQBCn5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pqvWpJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_hxP6UMhuEeaVlemTikmRHw" target="_pqvWoJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pqvWpZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pqvWqZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SRELdJnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_hxP6UMhuEeaVlemTikmRHw" target="_SRELcJnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SRELdZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SRELeZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_hv0W8MhuEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pqvWppgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pqvWp5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pqvWqJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SRELdpnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SRELd5nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SRELeJnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_prF78JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_EAOn0BM8Eee0L_IMWjydgQ" target="_prFU4JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_prF78ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_prF79ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SSGtS5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_EAOn0BM8Eee0L_IMWjydgQ" target="_SSGtR5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SSGtTJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSGtUJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_D_ExQBM8Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_prF78pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_prF785gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_prF79JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SSGtTZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSGtTpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSGtT5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_prOe1JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_0f9WQIuVEeiu6boZkiJHCA" target="_prOe0JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_prOe1ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_prOe2ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SSGtXpnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_0f9WQIuVEeiu6boZkiJHCA" target="_SSGtWpnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SSGtX5nNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSP3MJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_UdrWAMhvEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_prOe1pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_prOe15gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_prOe2JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SSGtYJnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSGtYZnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSGtYpnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_prY25JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_37ea4IuVEeiu6boZkiJHCA" target="_prY24JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_prY25ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_prY26ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SSP3PJnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_37ea4IuVEeiu6boZkiJHCA" target="_SSP3OJnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SSP3PZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSP3QZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_JEyyMMhvEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_prY25pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_prY255gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_prY26JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SSP3PpnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSP3P5nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSP3QJnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_psBwEZgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_RFVnkP4tEea_VPdGG2-szQ" target="_psBJAJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_psBwEpgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_psBwFpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SSjZOpnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_RFVnkP4tEea_VPdGG2-szQ" target="_SSjZNpnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SSjZO5nNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SSjZP5nNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_psBwE5gXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_psBwFJgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_psBwFZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SSjZPJnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSjZPZnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SSjZPpnNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ptUJhJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_Ax_xQBM8Eee0L_IMWjydgQ" target="_ptUJgJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ptUJhZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ptUJiZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_STTAF5nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_Ax_xQBM8Eee0L_IMWjydgQ" target="_STTAE5nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_STTAGJnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_STTAHJnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ptUJhpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ptUJh5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ptUJiJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_STTAGZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_STTAGpnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_STTAG5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pvQqRJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_pBdREK1fEeiIjuV0HZnJAQ" target="_pvQqQJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pvQqRZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pvQqSZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SUMX95nNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_pBdREK1fEeiIjuV0HZnJAQ" target="_SUMX85nNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SUMX-JnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SUMX_JnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pvQqRpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pvQqR5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pvQqSJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SUMX-ZnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SUMX-pnNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SUMX-5nNEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pv3uRJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_LsEiUFowEemu443YKSGnxQ" target="_pv3uQJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pv3uRZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pv3uSZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_SUfS5JnNEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_LsEiUFowEemu443YKSGnxQ" target="_SUfS4JnNEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_SUfS5ZnNEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_SUfS6ZnNEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pv3uRpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pv3uR5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pv3uSJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SUfS5pnNEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SUfS55nNEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SUfS6JnNEemVaY_egjrbOQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SwLpIEQ7EeaktYCiiVTurg" type="PapyrusUMLClassDiagram" name="PathComputationServiceDetails" measurementUnit="Pixel">
@@ -2121,7 +2139,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx0sY0Q7EeaktYCiiVTurg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx0sUUQ7EeaktYCiiVTurg" x="620" y="-120" height="167"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tx0sUUQ7EeaktYCiiVTurg" x="620" y="-120" width="341" height="167"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_UdQ2AEQ7EeaktYCiiVTurg" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_UdQ2AkQ7EeaktYCiiVTurg" type="Class_NameLabel"/>
@@ -2621,125 +2639,198 @@
       <element xmi:type="uml:Enumeration" href="TapiPathComputation.uml#_uLelgFofEemu443YKSGnxQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dLxiIVoqEemu443YKSGnxQ" x="-218" y="55"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pKxdIJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pKxdIZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pKxdI5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Vz0ggJnNEemVaY_egjrbOQ" type="Interface_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Vz0ggpnNEemVaY_egjrbOQ" type="Interface_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Vz0gg5nNEemVaY_egjrbOQ" type="Interface_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Vz0ghJnNEemVaY_egjrbOQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Vz0ghZnNEemVaY_egjrbOQ" type="Interface_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Vz0ghpnNEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Vz0gh5nNEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Vz0giJnNEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vz0giZnNEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Vz0gipnNEemVaY_egjrbOQ" type="Interface_OperationCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_XyNf0JnNEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_jEg6gJnNEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiPathComputation.uml#_5ASPmt6MEeWd9KDn6x5Skg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XyNf0ZnNEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_XyNf0pnNEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_jf52AJnNEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiPathComputation.uml#_5ASPqN6MEeWd9KDn6x5Skg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XyNf05nNEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_XyNf1JnNEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_j_THwJnNEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiPathComputation.uml#_Z9I7IC2qEeair-8ZDvf8jw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XyNf1ZnNEemVaY_egjrbOQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Vz0gi5nNEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Vz0gjJnNEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Vz0gjZnNEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vz0gjpnNEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Vz0gj5nNEemVaY_egjrbOQ" type="Interface_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Vz0gkJnNEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Vz0gkZnNEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Vz0gkpnNEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vz0gk5nNEemVaY_egjrbOQ"/>
+      </children>
+      <element xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vz0ggZnNEemVaY_egjrbOQ" x="-210" y="-221" height="93"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1GkTQJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1GkTQZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1GkTQ5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pKxdIpgXEemfbpUjK-Jv3g" x="820" y="-120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1GkTQpnkEemrjrtN9v_T1A" x="820" y="-120"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pMjl0JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pMjl0ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pMjl05gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1HybQJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1HybQZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1HybQ5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pMjl0pgXEemfbpUjK-Jv3g" x="820" y="420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1HybQpnkEemrjrtN9v_T1A" x="820" y="420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pOYKwJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pOYKwZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pOYKw5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1JDmkJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1JDmkZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JDmk5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pOYKwpgXEemfbpUjK-Jv3g" x="820" y="340"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1JDmkpnkEemrjrtN9v_T1A" x="820" y="340"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pPng4JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pPng4ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pPng45gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1J5UEJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1J5UEZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1J5UE5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pPng4pgXEemfbpUjK-Jv3g" x="260" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1J5UEpnkEemrjrtN9v_T1A" x="260" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pRX0YJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pRX0YZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pRX0Y5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1LIqMJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1LIqMZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LIqM5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pRX0YpgXEemfbpUjK-Jv3g" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LIqMpnkEemrjrtN9v_T1A" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pRiMcJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pRiMcZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pRiMc5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1LR0IJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1LR0IZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LR0I5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pRiMcpgXEemfbpUjK-Jv3g" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LR0IpnkEemrjrtN9v_T1A" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pRr9cJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pRr9cZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pRr9c5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1LZI4JnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1LZI4ZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LZI45nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pRr9cpgXEemfbpUjK-Jv3g" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LZI4pnkEemrjrtN9v_T1A" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pR1ucJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pR1ucZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pR1uc5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1LhrwJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1LhrwZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Lhrw5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pR1ucpgXEemfbpUjK-Jv3g" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LhrwpnkEemrjrtN9v_T1A" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pR9qQJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pR-RUJgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pR-RUpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1LpnkJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1LpnkZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Lpnk5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pR-RUZgXEemfbpUjK-Jv3g" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LpnkpnkEemrjrtN9v_T1A" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pSICUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pSICUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pSICU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1LxjYJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1LxjYZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LxjY5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pSICUpgXEemfbpUjK-Jv3g" x="260" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LxjYpnkEemrjrtN9v_T1A" x="260" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pSvGUJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pSvGUZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pSvGU5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1MNBMJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1MNBMZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1MNoQJnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pSvGUpgXEemfbpUjK-Jv3g" x="449" y="492"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1MNBMpnkEemrjrtN9v_T1A" x="449" y="492"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pT3uwJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pT3uwZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pT4V0JgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1NCusJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1NCusZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NCus5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pT3uwpgXEemfbpUjK-Jv3g" x="449" y="392"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1NCuspnkEemrjrtN9v_T1A" x="449" y="392"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pUeLsJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pUeLsZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pUeLs5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1NgowJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1NgowZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NhP0JnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pUeLspgXEemfbpUjK-Jv3g" x="231" y="320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1NgowpnkEemrjrtN9v_T1A" x="231" y="320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pWdvwJgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pWdvwZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pWdvw5gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1PTYgJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1PTYgZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1PTYg5nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pWdvwpgXEemfbpUjK-Jv3g" x="819" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1PTYgpnkEemrjrtN9v_T1A" x="819" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_pacQ0JgXEemfbpUjK-Jv3g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pacQ0ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pacQ05gXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1RM18JnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1RM18ZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1RM185nkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_e2APUFoqEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pacQ0pgXEemfbpUjK-Jv3g" x="-18" y="-45"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1RM18pnkEemrjrtN9v_T1A" x="-18" y="-45"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1Ra4YJnkEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1Ra4YZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1RbfcJnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1Ra4YpnkEemrjrtN9v_T1A" x="-10" y="-221"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_SwLpIUQ7EeaktYCiiVTurg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_SwLpIkQ7EeaktYCiiVTurg"/>
@@ -2807,7 +2898,7 @@
       <element xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GsUIsq1mEeiqCPid09Hqfw" points="[514, 580, -643984, -643984]$[940, 580, -643984, -643984]$[940, 67, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwvaIK1mEeiqCPid09Hqfw" id="(1.0,0.7394957983193278)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwvaIa1mEeiqCPid09Hqfw" id="(0.9907120743034056,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwvaIa1mEeiqCPid09Hqfw" id="(0.9384164222873901,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Th-MgK1mEeiqCPid09Hqfw" type="Association_Edge" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_U9GzsEQ7EeaktYCiiVTurg" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_Th-Mg61mEeiqCPid09Hqfw" type="Association_StereotypeLabel">
@@ -2979,155 +3070,165 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_h-wFoqEemu443YKSGnxQ" id="(0.3970037453183521,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_h-wVoqEemu443YKSGnxQ" id="(0.4180790960451977,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pKxdJJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_Tx0sUEQ7EeaktYCiiVTurg" target="_pKxdIJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pKxdJZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pKxdKZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1GkTRJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Tx0sUEQ7EeaktYCiiVTurg" target="_1GkTQJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1GkTRZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1GkTSZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_qXAPsDJDEeamvfKYyWmELQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pKxdJpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pKxdJ5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pKxdKJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1GkTRpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1GkTR5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1GkTSJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pMjl1JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_UdQ2AEQ7EeaktYCiiVTurg" target="_pMjl0JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pMjl1ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pMjl2ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1HybRJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_UdQ2AEQ7EeaktYCiiVTurg" target="_1HybQJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1HybRZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1HybSZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pMjl1pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pMjl15gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pMjl2JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1HybRpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1HybR5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1HybSJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pOYKxJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_U9GzsEQ7EeaktYCiiVTurg" target="_pOYKwJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pOYKxZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pOYKyZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1JDmlJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_U9GzsEQ7EeaktYCiiVTurg" target="_1JDmkJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1JDmlZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1JDmmZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pOYKxpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pOYKx5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pOYKyJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1JDmlpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JDml5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1JDmmJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pPng5JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_pPng4JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pPng5ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pPng6ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1J5UFJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_x_hQ4K1iEeiqCPid09Hqfw" target="_1J5UEJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1J5UFZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1J5UGZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_IUF7cC2XEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pPng5pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pPng55gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pPng6JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1J5UFpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1J5UF5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1J5UGJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pRX0ZJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_pRX0YJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pRX0ZZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pRYbcpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1LIqNJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_EZQg8K1mEeiqCPid09Hqfw" target="_1LIqMJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1LIqNZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LIqOZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_1EaBMC2bEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pRX0ZpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pRYbcJgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pRYbcZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1LIqNpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LIqN5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LIqOJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pRiMdJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_pRiMcJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pRiMdZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pRiMeZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1LR0JJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Th-MgK1mEeiqCPid09Hqfw" target="_1LR0IJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1LR0JZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LR0KZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pRiMdpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pRiMd5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pRiMeJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1LR0JpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LR0J5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LR0KJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pRr9dJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_pRr9cJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pRr9dZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pRskgpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1LZI5JnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_V21LEK1mEeiqCPid09Hqfw" target="_1LZI4JnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1LZI5ZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LZI6ZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pRr9dpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pRskgJgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pRskgZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1LZI5pnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LZI55nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LZI6JnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pR1udJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_pR1ucJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pR1udZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pR1ueZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1LhrxJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZDO1oK1mEeiqCPid09Hqfw" target="_1LhrwJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1LhrxZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LhryZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_7s7p0C2aEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pR1udpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pR1ud5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pR1ueJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1LhrxpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Lhrx5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LhryJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pR-RU5gXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_pR9qQJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pR-RVJgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pR-RWJgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1LpnlJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZcUrEK1mEeiqCPid09Hqfw" target="_1LpnkJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1LpnlZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LpnmZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_BX0_AK1gEeiIjuV0HZnJAQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pR-RVZgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pR-RVpgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pR-RV5gXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1LpnlpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Lpnl5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LpnmJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pSICVJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_pSICUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pSICVZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pSICWZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1LxjZJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZtTtYK1mEeiqCPid09Hqfw" target="_1LxjYJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1LxjZZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1LxjaZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_f8XbAC2cEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pSICVpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pSICV5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pSICWJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1LxjZpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LxjZ5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1LxjaJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pSvtYJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_pSvGUJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pSvtYZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pSvtZZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1MNoQZnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_6HtgAK1iEeiqCPid09Hqfw" target="_1MNBMJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1MNoQpnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1MNoRpnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pSvtYpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pSvtY5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pSvtZJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1MNoQ5nkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1MNoRJnkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1MNoRZnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pT4V0ZgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_pT3uwJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pT4V0pgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pT4V1pgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1NCutJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_GsUIsK1mEeiqCPid09Hqfw" target="_1NCusJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1NCutZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NDVwpnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPathComputation.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pT4V05gXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pT4V1JgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pT4V1ZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1NCutpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NDVwJnkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NDVwZnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pUeLtJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_pUeLsJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pUeLtZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pUeywpgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1NhP0ZnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_MzH2QK1jEeiqCPid09Hqfw" target="_1NgowJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1NhP0pnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1NhP1pnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_yYDusC2mEeair-8ZDvf8jw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pUeLtpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pUeywJgXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pUeywZgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1NhP05nkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NhP1JnkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1NhP1ZnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pWdvxJgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_pWdvwJgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pWdvxZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pWdvyZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1PT_kJnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_YifAYK1jEeiqCPid09Hqfw" target="_1PTYgJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1PT_kZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1PT_lZnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPathComputation.uml#_-fei4P4wEea_VPdGG2-szQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pWdvxpgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pWdvx5gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pWdvyJgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1PT_kpnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1PT_k5nkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1PT_lJnkEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pacQ1JgXEemfbpUjK-Jv3g" type="StereotypeCommentLink" source="_e2APUVoqEemu443YKSGnxQ" target="_pacQ0JgXEemfbpUjK-Jv3g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pacQ1ZgXEemfbpUjK-Jv3g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pacQ2ZgXEemfbpUjK-Jv3g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1RM19JnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_e2APUVoqEemu443YKSGnxQ" target="_1RM18JnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1RM19ZnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1RNdApnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPathComputation.uml#_e2APUFoqEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pacQ1pgXEemfbpUjK-Jv3g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pacQ15gXEemfbpUjK-Jv3g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pacQ2JgXEemfbpUjK-Jv3g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1RM19pnkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1RNdAJnkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1RNdAZnkEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1RbfcZnkEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Vz0ggJnNEemVaY_egjrbOQ" target="_1Ra4YJnkEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1RbfcpnkEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1RbfdpnkEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiPathComputation.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1Rbfc5nkEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1RbfdJnkEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1RbfdZnkEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -101,16 +101,23 @@ License: This module is distributed under the Apache License 2.0</body>
       <packagedElement xmi:type="uml:Interface" xmi:id="_5ASPgN6MEeWd9KDn6x5Skg" name="PathComputationService" isLeaf="true">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_5ASPmt6MEeWd9KDn6x5Skg" name="computeP2PPath" isLeaf="true">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_nwo7EJgPEemfbpUjK-Jv3g" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_l4IsIJniEemrjrtN9v_T1A" annotatedElement="_nwo7EJgPEemfbpUjK-Jv3g">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_SaYvMJgPEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_0IpWoJndEemVaY_egjrbOQ" annotatedElement="_SaYvMJgPEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TKZP0JgPEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TLrpQJgPEemfbpUjK-Jv3g" value="*"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_LxwagC2qEeair-8ZDvf8jw" name="sep" type="_yYDusC2mEeair-8ZDvf8jw" effect="read">
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NKeg8C2qEeair-8ZDvf8jw" value="2"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NKeg8i2qEeair-8ZDvf8jw" value="2"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPn96MEeWd9KDn6x5Skg" name="routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" isUnique="false" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_jQBd8K1fEeiIjuV0HZnJAQ" name="topologyConstraint" type="_-fei4P4wEea_VPdGG2-szQ">
@@ -118,13 +125,28 @@ License: This module is distributed under the Apache License 2.0</body>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lCbPsK1fEeiIjuV0HZnJAQ" value="1"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_8XQOgN6QEeWd9KDn6x5Skg" name="objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_LxwagC2qEeair-8ZDvf8jw" name="endPoint" type="_yYDusC2mEeair-8ZDvf8jw" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NKeg8C2qEeair-8ZDvf8jw" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NKeg8i2qEeair-8ZDvf8jw" value="2"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_zhR6MC2eEeair-8ZDvf8jw" name="service" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_5ASPqN6MEeWd9KDn6x5Skg" name="optimizeP2PPath" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPqt6MEeWd9KDn6x5Skg" name="pathIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPqt6MEeWd9KDn6x5Skg" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_nga4kJniEemrjrtN9v_T1A" annotatedElement="_5ASPqt6MEeWd9KDn6x5Skg">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Y5tjEJgPEemfbpUjK-Jv3g" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_1uHfoJndEemVaY_egjrbOQ" annotatedElement="_Y5tjEJgPEemfbpUjK-Jv3g">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
             <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZqjKIJgPEemfbpUjK-Jv3g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZrbT4JgPEemfbpUjK-Jv3g" value="*"/>
@@ -135,8 +157,15 @@ License: This module is distributed under the Apache License 2.0</body>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_tH7ygC2eEeair-8ZDvf8jw" name="service" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_Z9I7IC2qEeair-8ZDvf8jw" name="deleteP2PPath" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Z9I7IS2qEeair-8ZDvf8jw" name="pathIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Z9I7IS2qEeair-8ZDvf8jw" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_o03jAJniEemrjrtN9v_T1A" annotatedElement="_Z9I7IS2qEeair-8ZDvf8jw">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Z9I7JS2qEeair-8ZDvf8jw" name="service" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out" effect="delete"/>
         </ownedOperation>

--- a/UML/TapiPhotonicMedia.notation
+++ b/UML/TapiPhotonicMedia.notation
@@ -30,7 +30,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnKzGY6QEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnJk8Y6QEeeyZasfnNSonw" x="232" y="23" height="104"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xnJk8Y6QEeeyZasfnNSonw" x="216" y="24" height="104"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BsudMI6YEeeyZasfnNSonw" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_BsudMo6YEeeyZasfnNSonw" type="Enumeration_NameLabel"/>
@@ -64,7 +64,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsudOY6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsudMY6YEeeyZasfnNSonw" x="317" y="291"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsudMY6YEeeyZasfnNSonw" x="253" y="281"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GaDH8I6YEeeyZasfnNSonw" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_GaDH8o6YEeeyZasfnNSonw" type="Enumeration_NameLabel"/>
@@ -106,7 +106,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GaDH-Y6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GaDH8Y6YEeeyZasfnNSonw" x="464" y="279"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GaDH8Y6YEeeyZasfnNSonw" x="377" y="278"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_I9O2YI6YEeeyZasfnNSonw" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_I9O2Yo6YEeeyZasfnNSonw" type="Enumeration_NameLabel"/>
@@ -172,7 +172,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lm8DlI6YEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lm61cY6YEeeyZasfnNSonw" x="817" y="19" width="378" height="113"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lm61cY6YEeeyZasfnNSonw" x="535" y="343" width="378" height="96"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xu7CoI8ZEeedErNofqJXiw" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_xvBJQI8ZEeedErNofqJXiw" type="Enumeration_NameLabel"/>
@@ -241,7 +241,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jL3PYEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jInPYEeiPPoPDo3q5jA" x="520" y="21" width="290" height="106"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wB7jInPYEeiPPoPDo3q5jA" x="791" y="26" width="290" height="106"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__ZU_8XkzEeiO-c_khjKlFQ" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="__ZU_83kzEeiO-c_khjKlFQ" type="Enumeration_NameLabel"/>
@@ -301,7 +301,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZU_-nkzEeiO-c_khjKlFQ"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZU_8nkzEeiO-c_khjKlFQ" x="956" y="163" height="222"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZU_8nkzEeiO-c_khjKlFQ" x="937" y="249" height="222"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_2zBhY3lHEeiW-bN1POS5zg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_2zBhZHlHEeiW-bN1POS5zg" showTitle="true"/>
@@ -493,125 +493,165 @@
       <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nCyqQcG-EeiAg83ctgK3eQ" x="279" y="145"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G4xn4FVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G4xn4VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G4yO8FVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bScLgJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bScLgZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bScLg5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G4xn4lVNEemD67R2QwZykA" x="422" y="25"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bScLgpmwEemSg_rU1VNuUQ" x="432" y="23"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G5I0QFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G5I0QVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5JbUFVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bS_lIJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bS_lIZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bTAMMJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G5I0QlVNEemD67R2QwZykA" x="517" y="291"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bS_lIpmwEemSg_rU1VNuUQ" x="517" y="291"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G5YE0FVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G5YE0VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5ZS8FVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bTX_oJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bTX_oZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bTYmsJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G5YE0lVNEemD67R2QwZykA" x="664" y="279"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bTX_opmwEemSg_rU1VNuUQ" x="664" y="279"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G5pxoFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G5pxoVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5pxo1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bTrhoJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bTrhoZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bTrho5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G5pxolVNEemD67R2QwZykA" x="941" y="159"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bTrhopmwEemSg_rU1VNuUQ" x="941" y="159"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G51X0FVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G51X0VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G51X01VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bUCG8JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bUCG8ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUCG85mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G51X0lVNEemD67R2QwZykA" x="1017" y="19"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bUCG8pmwEemSg_rU1VNuUQ" x="1017" y="19"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G6TR4FVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G6TR4VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6TR41VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bUidQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bUidQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUjEUJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G6TR4lVNEemD67R2QwZykA" x="257" y="485"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bUidQpmwEemSg_rU1VNuUQ" x="257" y="485"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G6e4EFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G6e4EVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6e4E1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bUxGwJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bUxGwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUxGw5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G6e4ElVNEemD67R2QwZykA" x="707" y="21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bUxGwpmwEemSg_rU1VNuUQ" x="720" y="21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G6_1cFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G6_1cVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6_1c1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bWBD8JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bWBD8ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWBD85mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G6_1clVNEemD67R2QwZykA" x="1156" y="163"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWBD8pmwEemSg_rU1VNuUQ" x="1156" y="163"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G7RiQFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G7RiQVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7RiQ1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bWchwJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bWchwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWdI0JmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G7RiQlVNEemD67R2QwZykA" x="601" y="494"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bWchwpmwEemSg_rU1VNuUQ" x="601" y="494"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G7jPEFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G7jPEVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7jPE1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bW4moJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bW4moZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bW4mo5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G7jPElVNEemD67R2QwZykA" x="252" y="34"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bW4mopmwEemSg_rU1VNuUQ" x="252" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G7uOMFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G7uOMVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7uOM1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bXS2UJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bXTdYJmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXTdYpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G7uOMlVNEemD67R2QwZykA" x="249" y="214"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bXTdYZmwEemSg_rU1VNuUQ" x="249" y="214"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G750YFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G750YVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G750Y1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bXjVAJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bXjVAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXj8EJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G750YlVNEemD67R2QwZykA" x="249" y="114"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bXjVApmwEemSg_rU1VNuUQ" x="249" y="114"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G8GosFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G8GosVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8Gos1VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bX5TQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bX5TQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bX5TQ5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G8GoslVNEemD67R2QwZykA" x="727" y="494"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bX5TQpmwEemSg_rU1VNuUQ" x="727" y="494"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G8lJ0FVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G8lJ0VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8lJ01VNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bYS74JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bYS74ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bYS745mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G8lJ0lVNEemD67R2QwZykA" x="968" y="492"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYS74pmwEemSg_rU1VNuUQ" x="968" y="492"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_G8_ZgFVNEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_G8_ZgVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G9AAkFVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bYrWYJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bYrWYZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bYrWY5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G8_ZglVNEemD67R2QwZykA" x="479" y="145"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYrWYpmwEemSg_rU1VNuUQ" x="479" y="145"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_fWKfoJmwEemSg_rU1VNuUQ" type="DataType_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_fWMU0JmwEemSg_rU1VNuUQ" type="DataType_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_fWMU0ZmwEemSg_rU1VNuUQ" type="DataType_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_fWMU0pmwEemSg_rU1VNuUQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_fWM74JmwEemSg_rU1VNuUQ" type="DataType_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_tqPz0JmxEemSg_rU1VNuUQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_7AvJQJmwEemSg_rU1VNuUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tqPz0ZmxEemSg_rU1VNuUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tqay8JmxEemSg_rU1VNuUQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_GAfbYJmxEemSg_rU1VNuUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tqay8ZmxEemSg_rU1VNuUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tqbaAJmxEemSg_rU1VNuUQ" type="Property_DataTypeAttributeLabel">
+          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_nYVw4JmxEemSg_rU1VNuUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tqbaAZmxEemSg_rU1VNuUQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_fWM74ZmwEemSg_rU1VNuUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_fWM74pmwEemSg_rU1VNuUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_fWM745mwEemSg_rU1VNuUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fWM75JmwEemSg_rU1VNuUQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_fWM75ZmwEemSg_rU1VNuUQ" type="DataType_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_fWM75pmwEemSg_rU1VNuUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_fWM755mwEemSg_rU1VNuUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_fWM76JmwEemSg_rU1VNuUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fWM76ZmwEemSg_rU1VNuUQ"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_fV6oAJmwEemSg_rU1VNuUQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fWKfoZmwEemSg_rU1VNuUQ" x="500" y="26" height="109"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UcD3oJmyEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UcD3oZmyEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UcD3o5myEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_fV6oAJmwEemSg_rU1VNuUQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UcD3opmyEemSg_rU1VNuUQ" x="700" y="26"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_w3tFAY6QEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_w3tFAo6QEeeyZasfnNSonw"/>
@@ -642,155 +682,165 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMIoJEeivCevppATXng" id="(0.5032679738562091,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Li9KMYoJEeivCevppATXng" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G4yO8VVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_G4xn4FVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G4yO8lVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G4yO9lVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bScLhJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xnJk8I6QEeeyZasfnNSonw" target="_bScLgJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bScLhZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bScykZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3xBKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G4yO81VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G4yO9FVNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G4yO9VVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bScLhpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bScLh5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bScykJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G5JbUVVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_BsudMI6YEeeyZasfnNSonw" target="_G5I0QFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G5JbUlVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5JbVlVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bTAMMZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_BsudMI6YEeeyZasfnNSonw" target="_bS_lIJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bTAMMpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bTAMNpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_iHIbYI6KEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5JbU1VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5JbVFVNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5JbVVVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bTAMM5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bTAMNJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bTAMNZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G5ZS8VVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_GaDH8I6YEeeyZasfnNSonw" target="_G5YE0FVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G5ZS8lVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5ZS9lVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bTYmsZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_GaDH8I6YEeeyZasfnNSonw" target="_bTX_oJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bTYmspmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bTYmtpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_htJmYI6QEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5ZS81VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5ZS9FVNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5ZS9VVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bTYms5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bTYmtJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bTYmtZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G5pxpFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_I9O2YI6YEeeyZasfnNSonw" target="_G5pxoFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G5pxpVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G5pxqVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bTrhpJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_I9O2YI6YEeeyZasfnNSonw" target="_bTrhoJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bTrhpZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bTrhqZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_E7uYgI6HEeeyZasfnNSonw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G5pxplVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5pxp1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G5pxqFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bTrhppmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bTrhp5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bTrhqJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G51X1FVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_Lm61cI6YEeeyZasfnNSonw" target="_G51X0FVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G51X1VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G51X2VVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bUCG9JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_Lm61cI6YEeeyZasfnNSonw" target="_bUCG8JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bUCG9ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUCG-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_KjQ3vRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G51X1lVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G51X11VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G51X2FVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bUCG9pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUCG95mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUCG-JmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G6TR5FVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_xu7CoI8ZEeedErNofqJXiw" target="_G6TR4FVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G6TR5VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6TR6VVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bUjEUZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xu7CoI8ZEeedErNofqJXiw" target="_bUidQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bUjEUpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUjEVpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ujOyoC_2EeeAJ6VQzZ2ulw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G6TR5lVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6TR51VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6TR6FVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bUjEU5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUjEVJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUjEVZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G6e4FFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_wB7jIXPYEeiPPoPDo3q5jA" target="_G6e4EFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G6e4FVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6e4GVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bUxGxJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_wB7jIXPYEeiPPoPDo3q5jA" target="_bUxGwJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bUxGxZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bUxGyZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_wB7jIHPYEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G6e4FlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6e4F1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6e4GFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bUxGxpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUxGx5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bUxGyJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G6_1dFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="__ZU_8XkzEeiO-c_khjKlFQ" target="_G6_1cFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G6_1dVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G6_1eVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bWBD9JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="__ZU_8XkzEeiO-c_khjKlFQ" target="_bWBD8JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bWBD9ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWBD-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#__ZU_8HkzEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G6_1dlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6_1d1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6_1eFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWBD9pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWBD95mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWBD-JmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G7RiRFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_G7RiQFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G7RiRVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7RiSVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bWdI0ZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_3YLeMHpKEei5LIrjJTgegQ" target="_bWchwJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bWdI0pmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bWdv4JmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_01yZ8HpKEei5LIrjJTgegQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G7RiRlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7RiR1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7RiSFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bWdI05mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWdI1JmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bWdI1ZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G7jPFFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_DY-LUIoJEeivCevppATXng" target="_G7jPEFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G7jPFVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7jPGVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bW4mpJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_DY-LUIoJEeivCevppATXng" target="_bW4moJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bW4mpZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bW5NspmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiCommon.uml#_-eq88Ik2Eeil5oKL3Vgl-g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G7jPFlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7jPF1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7jPGFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bW4mppmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bW5NsJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bW5NsZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G7uONFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_Er39oIoJEeivCevppATXng" target="_G7uOMFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G7uONVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G7uOOVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bXTdY5mwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_Er39oIoJEeivCevppATXng" target="_bXS2UJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bXTdZJmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXTdaJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_ErlpwIoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G7uONlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7uON1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G7uOOFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bXTdZZmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXTdZpmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXTdZ5mwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G750ZFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_G750YFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G750ZVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G750aVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bXj8EZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_LhPS8YoJEeivCevppATXng" target="_bXjVAJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bXj8EpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bXj8FpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_LhPS8IoJEeivCevppATXng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G750ZlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G750Z1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G750aFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bXj8E5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXj8FJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bXj8FZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G8GotFVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_EMsiYLqdEeimKvjOEffRIA" target="_G8GosFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G8GotVVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8GouVVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bX5TRJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_EMsiYLqdEeimKvjOEffRIA" target="_bX5TQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bX5TRZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bX5TSZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_4qTT8LKeEei69qzpcujF2A"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G8GotlVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8Got1VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8GouFVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bX5TRpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bX5TR5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bX5TSJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G8lw4FVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_lnxLALqdEeimKvjOEffRIA" target="_G8lJ0FVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G8lw4VVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G8lw5VVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bYS75JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_lnxLALqdEeimKvjOEffRIA" target="_bYS74JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bYS75ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bYTi8pmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Enumeration" href="TapiPhotonicMedia.uml#_lnk9wLqdEeimKvjOEffRIA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G8lw4lVNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8lw41VNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G8lw5FVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bYS75pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYTi8JmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYTi8ZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_G9AAkVVNEemD67R2QwZykA" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_G8_ZgFVNEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_G9AAklVNEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_G9AAllVNEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bYrWZJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_nCyqQMG-EeiAg83ctgK3eQ" target="_bYrWYJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bYrWZZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bYrWaZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_nCmdAMG-EeiAg83ctgK3eQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G9AAk1VNEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G9AAlFVNEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G9AAlVVNEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bYrWZpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYrWZ5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYrWaJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UcD3pJmyEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_fWKfoJmwEemSg_rU1VNuUQ" target="_UcD3oJmyEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UcD3pZmyEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UcEesZmyEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:DataType" href="TapiPhotonicMedia.uml#_fV6oAJmwEemSg_rU1VNuUQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UcD3ppmyEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UcD3p5myEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UcEesJmyEemSg_rU1VNuUQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_gKM6AI6dEeeyZasfnNSonw" type="layersTree" name="Layers Tree Editor"/>
@@ -896,13 +946,13 @@
         </children>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4rH_DHjAEeixydPRZ8lIKA" x="-259" y="-447" width="159" height="62"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_UM6IAFZsEemtU7otE81P8g" type="StereotypeComment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_UM6IAVZsEemtU7otE81P8g"/>
-        <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UM6IA1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+      <children xmi:type="notation:Shape" xmi:id="_9ZiCEJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9ZiCEZmvEemSg_rU1VNuUQ"/>
+        <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9ZiCE5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
           <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
         </styles>
         <element xsi:nil="true"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UM6IAlZsEemtU7otE81P8g" x="-59" y="-447"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9ZiCEpmvEemSg_rU1VNuUQ" x="-59" y="-447"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8QyEXiGEeiPPoPDo3q5jA" x="-210" y="-456" width="575" height="62"/>
@@ -917,7 +967,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_fhbGYHiHEeiPPoPDo3q5jA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_EFhiMXiYEeixydPRZ8lIKA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rL1f0FJkEemV99d_1db7sQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_rL1f0FJkEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LcaG8JmwEemSg_rU1VNuUQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_LcaG8ZmwEemSg_rU1VNuUQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_IGOA8FJkEemV99d_1db7sQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_rL1f0VJkEemV99d_1db7sQ"/>
         </children>
@@ -951,10 +1004,6 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_x9XaUJJmEee26o4qs2D5Ig"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_UKIvUXZpEeiPPoPDo3q5jA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UKIvUnZpEeiPPoPDo3q5jA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_t2oxcI50EeeyZasfnNSonw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UKIvU3ZpEeiPPoPDo3q5jA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_UKIvVHZpEeiPPoPDo3q5jA" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_7gkK0I50EeeyZasfnNSonw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_UKIvVXZpEeiPPoPDo3q5jA"/>
@@ -981,7 +1030,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nhv0yXiHEeiPPoPDo3q5jA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-312" y="-117" height="112"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NhvNsXiHEeiPPoPDo3q5jA" x="-322" y="-117" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_aIaS8HiKEeixydPRZ8lIKA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_aIaS8XiKEeixydPRZ8lIKA" showTitle="true"/>
@@ -1173,7 +1222,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_8Tky45mTEeiOmuqNbykpsw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_FbD70ZmUEeiOmuqNbykpsw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_si7OkFJkEemV99d_1db7sQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_si7OkFJkEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MCfPgJmwEemSg_rU1VNuUQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MCfPgZmwEemSg_rU1VNuUQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_UStL8lJkEemV99d_1db7sQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_si7OkVJkEemV99d_1db7sQ"/>
         </children>
@@ -1207,7 +1259,10 @@
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_nWzrw5mYEeiOmuqNbykpsw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_zAoOkZmYEeiOmuqNbykpsw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RUwXoFJlEemV99d_1db7sQ" type="Property_ClassAttributeLabel" fontColor="255">
+        <children xmi:type="notation:Shape" xmi:id="_RUwXoFJlEemV99d_1db7sQ" type="Property_ClassAttributeLabel">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MnvRoJmwEemSg_rU1VNuUQ" source="PapyrusCSSForceValue">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MnvRoZmwEemSg_rU1VNuUQ" key="fontColor" value="true"/>
+          </eAnnotations>
           <element xmi:type="uml:Property" href="TapiPhotonicMedia.uml#_HbzVgFJlEemV99d_1db7sQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_RUwXoVJlEemV99d_1db7sQ"/>
         </children>
@@ -1323,7 +1378,10 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gP2P0bq4EeimKvjOEffRIA" x="-320" y="67" height="142"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KblyUFJjEemV99d_1db7sQ" type="Class_Shape" fontColor="255" lineColor="255">
+    <children xmi:type="notation:Shape" xmi:id="_KblyUFJjEemV99d_1db7sQ" type="Class_Shape" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_KHGg4JmwEemSg_rU1VNuUQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_KHHH8JmwEemSg_rU1VNuUQ" key="fontColor" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_KblyUlJjEemV99d_1db7sQ" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_KblyU1JjEemV99d_1db7sQ" type="Class_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_KblyVFJjEemV99d_1db7sQ" y="15"/>
@@ -1365,7 +1423,10 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KblyUVJjEemV99d_1db7sQ" x="6" y="48" width="342" height="112"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BnMvEFJkEemV99d_1db7sQ" type="Class_Shape" fontColor="255" lineColor="255">
+    <children xmi:type="notation:Shape" xmi:id="_BnMvEFJkEemV99d_1db7sQ" type="Class_Shape" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_NHOqAJmwEemSg_rU1VNuUQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_NHPREJmwEemSg_rU1VNuUQ" key="fontColor" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_BnNWIFJkEemV99d_1db7sQ" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_BnNWIVJkEemV99d_1db7sQ" type="Class_FloatingNameLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BnNWIlJkEemV99d_1db7sQ" y="15"/>
@@ -1407,205 +1468,205 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BnMvEVJkEemV99d_1db7sQ" x="884" y="-62" width="324" height="116"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UMl-8FZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UMl-8VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UMl-81ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9YkYwJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9YkYwZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9Yk_0JmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UMl-8lZsEemtU7otE81P8g" x="-10" y="-456"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9YkYwpmvEemSg_rU1VNuUQ" x="-10" y="-456"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UN5mgFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UN5mgVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UN5mg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9bz6AJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9bz6AZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9b0hEJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UN5mglZsEemtU7otE81P8g" x="-116" y="-308"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9bz6ApmvEemSg_rU1VNuUQ" x="-116" y="-308"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UOp0cFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UOp0cVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOp0c1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9det8JmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9det8ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9det85mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UOp0clZsEemtU7otE81P8g" x="-116" y="-408"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9det8pmvEemSg_rU1VNuUQ" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UOyXUFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UOyXUVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOyXU1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9d3vgJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9d3vgZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9d3vg5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UOyXUlZsEemtU7otE81P8g" x="-116" y="-408"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9d3vgpmvEemSg_rU1VNuUQ" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UO8IUFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UO8IUVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UO8IU1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9evSMJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9evSMZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9evSM5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UO8IUlZsEemtU7otE81P8g" x="-116" y="-408"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9evSMpmvEemSg_rU1VNuUQ" x="-116" y="-408"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UP5xoFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UP5xoVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UP6YsFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9gV0sJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9gV0sZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9gV0s5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UP5xolZsEemtU7otE81P8g" x="-112" y="-117"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9gV0spmvEemSg_rU1VNuUQ" x="-112" y="-117"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_URH5oFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_URH5oVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URIgsFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9jM7cJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9jM7cZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9jNigJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_URH5olZsEemtU7otE81P8g" x="-112" y="-217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jM7cpmvEemSg_rU1VNuUQ" x="-112" y="-217"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_URno4FZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_URno4VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URno41ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9koe0JmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9koe0ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9koe05mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_URno4lZsEemtU7otE81P8g" x="874" y="-459"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9koe0pmvEemSg_rU1VNuUQ" x="874" y="-459"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_USfyoFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_USfyoVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USfyo1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9mJhwJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9mJhwZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9mJhw5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_USfyolZsEemtU7otE81P8g" x="767" y="-299"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9mJhwpmvEemSg_rU1VNuUQ" x="767" y="-299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UTBXEFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UTBXEVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTBXE1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9neXcJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9neXcZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9neXc5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UTBXElZsEemtU7otE81P8g" x="767" y="-399"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9neXcpmvEemSg_rU1VNuUQ" x="767" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UTIEwFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UTIEwVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTIEw1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9n1j0JmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9n1j0ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9n1j05mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UTIEwlZsEemtU7otE81P8g" x="767" y="-399"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9n1j0pmvEemSg_rU1VNuUQ" x="767" y="-399"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UUAOgFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UUAOgVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UUAOg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9pxdgJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9pxdgZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9pxdg5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UUAOglZsEemtU7otE81P8g" x="423" y="-100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9pxdgpmvEemSg_rU1VNuUQ" x="423" y="-100"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UVT2EFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UVT2EVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UVUdIFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9sn9MJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9sn9MZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9sn9M5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UVT2ElZsEemtU7otE81P8g" x="744" y="-131"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9sn9MpmvEemSg_rU1VNuUQ" x="744" y="-131"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UXwGEFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UXwGEVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UXwGE1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9wE50JmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9wE50ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9wFg4JmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UXwGElZsEemtU7otE81P8g" x="307" y="-306"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9wE50pmvEemSg_rU1VNuUQ" x="307" y="-306"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UYXKEFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UYXKEVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYXKE1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9ynQcJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9ynQcZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9ynQc5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UYXKElZsEemtU7otE81P8g" x="307" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9ynQcpmvEemSg_rU1VNuUQ" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UYfs8FZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UYfs8VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYfs81ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9y8noJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9y8noZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9y9OsJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UYfs8lZsEemtU7otE81P8g" x="307" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9y8nopmvEemSg_rU1VNuUQ" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UYlMgFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UYlMgVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYlMg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9zKqEJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9zKqEZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9zKqE5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UYlMglZsEemtU7otE81P8g" x="307" y="-406"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9zKqEpmvEemSg_rU1VNuUQ" x="307" y="-406"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UZLpcFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UZLpcVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZLpc1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_91JnEJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_91JnEZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_91KOIJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UZLpclZsEemtU7otE81P8g" x="1044" y="-295"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_91JnEpmvEemSg_rU1VNuUQ" x="1044" y="-295"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UZ5bIFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UZ5bIVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZ5bI1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_92g5AJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_92g5AZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_92g5A5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UZ5bIlZsEemtU7otE81P8g" x="1044" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_92g5ApmvEemSg_rU1VNuUQ" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UaB-AFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UaB-AVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaClEFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_921CEJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_921CEZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_921CE5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UaB-AlZsEemtU7otE81P8g" x="1044" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_921CEpmvEemSg_rU1VNuUQ" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UaKg4FZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UaKg4VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaKg41ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_93B2YJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_93B2YZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_93CdcJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UaKg4lZsEemtU7otE81P8g" x="1044" y="-395"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_93B2YpmvEemSg_rU1VNuUQ" x="1044" y="-395"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Ua9yIFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Ua9yIVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ua9yI1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_94YhQJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_94YhQZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_94ZIUJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ua9yIlZsEemtU7otE81P8g" x="1203" y="-149"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_94YhQpmvEemSg_rU1VNuUQ" x="1203" y="-149"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UcSn0FZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UcSn0VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UcSn01ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_97F3AJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_97F3AZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_97GeEJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UcSn0lZsEemtU7otE81P8g" x="-120" y="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_97F3ApmvEemSg_rU1VNuUQ" x="-120" y="67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UdzDsFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UdzDsVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UdzDs1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_99ecoJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_99ecoZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_99eco5mvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UdzDslZsEemtU7otE81P8g" x="206" y="48"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_99ecopmvEemSg_rU1VNuUQ" x="206" y="48"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_UfwLgFZsEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_UfwLgVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UfwLg1ZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_9_yJwJmvEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9_yJwZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9_yw0JmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UfwLglZsEemtU7otE81P8g" x="1084" y="-62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9_yJwpmvEemSg_rU1VNuUQ" x="1084" y="-62"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
@@ -1670,9 +1731,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7cWEIYuWEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-164, -229, -643984, -643984]$[-164, -117, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.37254901960784315,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.4378698224852071,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7cWEIouWEeiu6boZkiJHCA" points="[-194, -229, -643984, -643984]$[-194, -117, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9HZQsIuWEeiu6boZkiJHCA" id="(0.29901960784313725,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8gaJMIuWEeiu6boZkiJHCA" id="(0.35555555555555557,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BDZzQIuXEeiu6boZkiJHCA" type="Association_Edge" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_XVnyQHk6EeiO-c_khjKlFQ" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_BDZzQ4uXEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1824,9 +1885,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_eVdssbs6Eeiljfl0umr-iQ"/>
       <element xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVdssrs6Eeiljfl0umr-iQ" points="[-166, -5, -643984, -643984]$[-166, 67, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQLs6Eeiljfl0umr-iQ" id="(0.4289940828402367,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQbs6Eeiljfl0umr-iQ" id="(0.53125,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVdssrs6Eeiljfl0umr-iQ" points="[-193, -24, -643984, -643984]$[-193, 67, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQLs6Eeiljfl0umr-iQ" id="(0.35833333333333334,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ek9hQbs6Eeiljfl0umr-iQ" id="(0.4409722222222222,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_zY6jAMMqEei3gLXE4_XcoA" type="Association_Edge" source="_7NoX0HjAEeixydPRZ8lIKA" target="_-8QyEHiGEeiPPoPDo3q5jA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_zY6jA8MqEei3gLXE4_XcoA" type="Association_StereotypeLabel">
@@ -1859,7 +1920,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a32gwDRkEemXiOBFvSRVzQ" id="(0.0,0.5373134328358209)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_07ESQMMqEei3gLXE4_XcoA" id="(1.0,0.532258064516129)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_IKgrEFJkEemV99d_1db7sQ" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_KblyUFJjEemV99d_1db7sQ" routing="Rectilinear" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_IKgrEFJkEemV99d_1db7sQ" type="Association_Edge" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_KblyUFJjEemV99d_1db7sQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_IKhSIFJkEemV99d_1db7sQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Jbz64FJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_IKhSIVJkEemV99d_1db7sQ" x="-82" y="14"/>
@@ -1890,7 +1951,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IRA7sFJkEemV99d_1db7sQ" id="(0.8921568627450981,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IRA7sVJkEemV99d_1db7sQ" id="(0.12280701754385964,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UYJsoFJkEemV99d_1db7sQ" type="Association_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_KblyUFJjEemV99d_1db7sQ" routing="Rectilinear" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_UYJsoFJkEemV99d_1db7sQ" type="Association_Edge" source="_s3mNEJmTEeiOmuqNbykpsw" target="_KblyUFJjEemV99d_1db7sQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_UYKTsFJkEemV99d_1db7sQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_5AN1sFJkEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_UYKTsVJkEemV99d_1db7sQ" x="-36" y="-3"/>
@@ -1921,7 +1982,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeV0MFJkEemV99d_1db7sQ" id="(0.24509803921568626,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeV0MVJkEemV99d_1db7sQ" id="(0.5877192982456141,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_HfzEsFJlEemV99d_1db7sQ" type="Association_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_BnMvEFJkEemV99d_1db7sQ" routing="Rectilinear" lineColor="255">
+    <edges xmi:type="notation:Connector" xmi:id="_HfzEsFJlEemV99d_1db7sQ" type="Association_Edge" source="_EtIM4JmWEeiOmuqNbykpsw" target="_BnMvEFJkEemV99d_1db7sQ" routing="Rectilinear" lineColor="0">
       <children xmi:type="notation:DecorationNode" xmi:id="_HfzrwFJlEemV99d_1db7sQ" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_WhOcgFJlEemV99d_1db7sQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_HfzrwVJlEemV99d_1db7sQ" x="-24" y="1"/>
@@ -1952,265 +2013,265 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmBogFJlEemV99d_1db7sQ" id="(0.24,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmBogVJlEemV99d_1db7sQ" id="(0.15432098765432098,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UMl-9FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_-8QyEHiGEeiPPoPDo3q5jA" target="_UMl-8FZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UMl-9VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UMmmAFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9Ylm4JmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_-8QyEHiGEeiPPoPDo3q5jA" target="_9YkYwJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9Ylm4ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9YmN8pmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UMl-9lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl-91ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl--FZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9Ylm4pmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9YmN8JmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9YmN8ZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UM6IBFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_4rH-0HjAEeixydPRZ8lIKA" target="_UM6IAFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UM6IBVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UM6ICVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9ZipIJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_4rH-0HjAEeixydPRZ8lIKA" target="_9ZiCEJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9ZipIZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9ZipJZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UM6IBlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UM6IB1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UM6ICFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9ZipIpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ZipI5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ZipJJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UN5mhFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_UN5mgFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UN5mhVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UN5miVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9b0hEZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_EqrGYHiHEeiPPoPDo3q5jA" target="_9bz6AJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9b0hEpmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9b0hFpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UN5mhlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UN5mh1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UN5miFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9b0hE5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9b0hFJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9b0hFZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UOp0dFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_UOp0cFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UOp0dVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOp0eVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9det9JmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_Y9rskHiHEeiPPoPDo3q5jA" target="_9det8JmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9det9ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9dnQ0pmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Y9qecHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UOp0dlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOp0d1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOp0eFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9det9pmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9dnQ0JmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9dnQ0ZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UOyXVFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_UOyXUFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UOyXVVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UOyXWVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9d3vhJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_7cWEIIuWEeiu6boZkiJHCA" target="_9d3vgJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9d3vhZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9d3viZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_fhWN4HiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UOyXVlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOyXV1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UOyXWFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9d3vhpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9d3vh5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9d3viJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UO8IVFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_IKgrEFJkEemV99d_1db7sQ" target="_UO8IUFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UO8IVVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UO8vYlZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9evSNJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_IKgrEFJkEemV99d_1db7sQ" target="_9evSMJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9evSNZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9evSOZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_IGJvgFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UO8IVlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UO8vYFZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UO8vYVZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9evSNpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9evSN5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9evSOJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UP6YsVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_UP5xoFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UP6YslZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UP6YtlZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9gV0tJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_NhvNsHiHEeiPPoPDo3q5jA" target="_9gV0sJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9gV0tZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9gV0uZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_NhrjUHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UP6Ys1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UP6YtFZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UP6YtVZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9gV0tpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9gV0t5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9gV0uJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_URIgsVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_eVdssLs6Eeiljfl0umr-iQ" target="_URH5oFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_URIgslZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URIgtlZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9jNigZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_eVdssLs6Eeiljfl0umr-iQ" target="_9jM7cJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9jNigpmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9jNihpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_eDYeMLs6Eeiljfl0umr-iQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_URIgs1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URIgtFZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URIgtVZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9jNig5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9jNihJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9jNihZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_URno5FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_7NoX0HjAEeixydPRZ8lIKA" target="_URno4FZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_URno5VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_URno6VZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9koe1JmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_7NoX0HjAEeixydPRZ8lIKA" target="_9koe0JmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9koe1ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9kpF4JmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_URno5lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URno51ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_URno6FZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9koe1pmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9koe15mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9koe2JmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_USfypFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_USfyoFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_USfypVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USfyqVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9mJhxJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_O0VSMHkwEeiO-c_khjKlFQ" target="_9mJhwJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9mJhxZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9mJhyZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_USfyplZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USfyp1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USfyqFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9mJhxpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9mJhx5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9mJhyJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UTBXFFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_UTBXEFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UTBXFVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTBXGVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9neXdJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_Xq0xwHkwEeiO-c_khjKlFQ" target="_9neXcJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9neXdZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9neXeZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XqurIHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UTBXFlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTBXF1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTBXGFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9neXdpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9neXd5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9neXeJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UTIr0FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_UTIEwFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UTIr0VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UTIr1VZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9n1j1JmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_BDZzQIuXEeiu6boZkiJHCA" target="_9n1j0JmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9n1j1ZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9n1j2ZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_aZjdUHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UTIr0lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTIr01ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UTIr1FZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9n1j1pmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9n1j15mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9n1j2JmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UUAOhFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_-Be4sHkyEeiO-c_khjKlFQ" target="_UUAOgFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UUAOhVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UUAOiVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9pxdhJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_-Be4sHkyEeiO-c_khjKlFQ" target="_9pxdgJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9pxdhZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9pxdiZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UUAOhlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUAOh1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUAOiFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9pxdhpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9pxdh5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9pxdiJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UVUdIVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_UVT2EFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UVUdIlZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UVUdJlZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9sn9NJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_XVnyQHk6EeiO-c_khjKlFQ" target="_9sn9MJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9sn9NZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9sn9OZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_XVi5wHk6EeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UVUdI1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVUdJFZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UVUdJVZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9sn9NpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9sn9N5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9sn9OJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UXwGFFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_UXwGEFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UXwGFVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UXwGGVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9wFg4ZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_s3mNEJmTEeiOmuqNbykpsw" target="_9wE50JmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9wFg4pmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9wFg5pmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UXwGFlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UXwGF1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UXwGGFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9wFg45mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9wFg5JmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9wFg5ZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UYXKFFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_UYXKEFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UYXKFVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYXKGVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9ynQdJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_8V3R4JmTEeiOmuqNbykpsw" target="_9ynQcJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9ynQdZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9ynQeZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_8Tky4JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYXKFlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYXKF1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYXKGFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9ynQdpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ynQd5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ynQeJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UYgUAFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_UYfs8FZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UYgUAVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYgUBVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9y9OsZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_VE_BkJmVEeiOmuqNbykpsw" target="_9y8noJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9y9OspmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9y9OtpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_VE468JmVEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYgUAlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYgUA1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYgUBFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9y9Os5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9y9OtJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9y9OtZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UYlzkFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_UYJsoFJkEemV99d_1db7sQ" target="_UYlMgFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UYlzkVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UYlzlVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9zKqFJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_UYJsoFJkEemV99d_1db7sQ" target="_9zKqEJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9zKqFZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9zLRIpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_USr90FJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UYlzklZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYlzk1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UYlzlFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9zKqFpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9zLRIJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9zLRIZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UZLpdFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_UZLpcFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UZLpdVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZMQgFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_91KOIZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_EtIM4JmWEeiOmuqNbykpsw" target="_91JnEJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_91KOIpmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_91KOJpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UZLpdlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZLpd1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZLpeFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_91KOI5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_91KOJJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_91KOJZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UZ5bJFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_UZ5bIFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UZ5bJVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UZ5bKVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_92g5BJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_nZkr4JmYEeiOmuqNbykpsw" target="_92g5AJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_92g5BZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_92hgEJmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_nWzrwJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UZ5bJlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZ5bJ1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UZ5bKFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_92g5BpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_92g5B5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_92g5CJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UaClEVZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_UaB-AFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UaClElZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaClFlZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_921CFJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_ObaTQJmaEeiOmuqNbykpsw" target="_921CEJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_921CFZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_921pIpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_ObUMoJmaEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UaClE1ZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaClFFZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaClFVZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_921CFpmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_921pIJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_921pIZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UaKg5FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_HfzEsFJlEemV99d_1db7sQ" target="_UaKg4FZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UaKg5VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaKg6VZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_93CdcZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_HfzEsFJlEemV99d_1db7sQ" target="_93B2YJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_93CdcpmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_93CddpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_HbvrIFJlEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UaKg5lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaKg51ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaKg6FZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_93Cdc5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_93CddJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_93CddZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ua9yJFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_Ua9yIFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ua9yJVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ua9yKVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_94ZIUZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_aw4GAJmYEeiOmuqNbykpsw" target="_94YhQJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_94ZIUpmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_94ZIVpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_awx_YJmYEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ua9yJlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ua9yJ1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ua9yKFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_94ZIU5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_94ZIVJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_94ZIVZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UcSn1FZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_UcSn0FZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UcSn1VZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UcSn2VZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_97GeEZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_gP2P0Lq4EeimKvjOEffRIA" target="_97F3AJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_97GeEpmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_97GeFpmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_sPmrcLTbEeiF8sBzK2t1Sw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UcSn1lZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UcSn11ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UcSn2FZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_97GeE5mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_97GeFJmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_97GeFZmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UdzDtFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_KblyUFJjEemV99d_1db7sQ" target="_UdzDsFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UdzDtVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UdzqwFZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_99ecpJmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_KblyUFJjEemV99d_1db7sQ" target="_99ecoJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_99ecpZmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_99ecqZmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KbiH8FJjEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UdzDtlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UdzDt1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UdzDuFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_99ecppmvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_99ecp5mvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_99ecqJmvEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UfwLhFZsEemtU7otE81P8g" type="StereotypeCommentLink" source="_BnMvEFJkEemV99d_1db7sQ" target="_UfwLgFZsEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UfwLhVZsEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UfwLiVZsEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_9_yw0ZmvEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_BnMvEFJkEemV99d_1db7sQ" target="_9_yJwJmvEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9_yw0pmvEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9_yw1pmvEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_BnH2kFJkEemV99d_1db7sQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UfwLhlZsEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfwLh1ZsEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UfwLiFZsEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9_yw05mvEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9_yw1JmvEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9_yw1ZmvEemSg_rU1VNuUQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_xbRtgHkvEeiO-c_khjKlFQ" type="PapyrusUMLClassDiagram" name="ResourceSpec" measurementUnit="Pixel">
@@ -2855,78 +2916,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z_3Rsrs8Eeiljfl0umr-iQ" x="781" y="-133"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="__DTGcFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__DTGcVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__DTGc1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__DTGclZqEemtU7otE81P8g" x="321" y="-135"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__EhOcFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__EhOcVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Eh1gFZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__EhOclZqEemtU7otE81P8g" x="321" y="-235"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__FPnMFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__FPnMVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__FQOQFZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__FPnMlZqEemtU7otE81P8g" x="409" y="-443"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__HN9IFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__HN9IVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__HN9I1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__HN9IlZqEemtU7otE81P8g" x="672" y="-133"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__J1MQFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__J1MQVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__J1zUFZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__J1MQlZqEemtU7otE81P8g" x="672" y="-233"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__LcV0FZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__LcV0VZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__LcV01ZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__LcV0lZqEemtU7otE81P8g" x="688" y="-299"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__MKukFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__MKukVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__MLVoFZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__MKuklZqEemtU7otE81P8g" x="688" y="-399"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__Ou6YFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__Ou6YVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Ou6Y1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Ou6YlZqEemtU7otE81P8g" x="303" y="-298"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__PfvYFZqEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__PfvYVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__PfvY1ZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__PfvYlZqEemtU7otE81P8g" x="303" y="-398"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_JT9eB1ZrEemtU7otE81P8g" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_JT9eCFZrEemtU7otE81P8g" type="Class_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_JT9eCVZrEemtU7otE81P8g" type="Class_FloatingNameLabel">
@@ -3095,77 +3084,149 @@
       <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUBvx1ZrEemtU7otE81P8g" x="-185" y="-451" width="212" height="65"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_JVhkMFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JVhkMVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JVhkM1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_D2TRMJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D2TRMZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D2TRM5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D2TRMpmwEemSg_rU1VNuUQ" x="321" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D3bSkJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D3bSkZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D3bSk5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D3bSkpmwEemSg_rU1VNuUQ" x="321" y="-234"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D383AJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D383AZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D383A5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D383ApmwEemSg_rU1VNuUQ" x="409" y="-448"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D4tE8JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D4tE8ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D4tE85mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D4tE8pmwEemSg_rU1VNuUQ" x="557" y="-135"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6IBQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6IBQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6IBQ5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6IBQpmwEemSg_rU1VNuUQ" x="557" y="-235"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D6t3IJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D6t3IZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6t3I5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D6t3IpmwEemSg_rU1VNuUQ" x="592" y="-301"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D7QpsJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D7QpsZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7Qps5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D7QpspmwEemSg_rU1VNuUQ" x="592" y="-401"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D71RcJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D71RcZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D71Rc5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D71RcpmwEemSg_rU1VNuUQ" x="303" y="-297"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D8fYwJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D8fYwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D8f_0JmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D8fYwpmwEemSg_rU1VNuUQ" x="303" y="-397"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D9O_oJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D9O_oZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D9O_o5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JVhkMlZrEemtU7otE81P8g" x="114" y="-136"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D9O_opmwEemSg_rU1VNuUQ" x="-10" y="-149"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_JWmiQFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JWmiQVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JWnJUFZrEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_D-qjAJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D-qjAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D-qjA5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JWmiQlZrEemtU7otE81P8g" x="594" y="-294"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D-qjApmwEemSg_rU1VNuUQ" x="895" y="-296"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_JW1LwFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JW1LwVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JW1Lw1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_D_cmIJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D_cmIZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D_cmI5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JW1LwlZrEemtU7otE81P8g" x="594" y="-394"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D_cmIpmwEemSg_rU1VNuUQ" x="895" y="-396"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_JXf6IFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JXghMFZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXghMlZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXghMVZrEemtU7otE81P8g" x="119" y="-284"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JXqSMFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JXqSMVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXq5QFZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXqSMlZrEemtU7otE81P8g" x="119" y="-384"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JXsHYFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JXsHYVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXsHY1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXsHYlZrEemtU7otE81P8g" x="119" y="-384"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JYq-0FZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JYq-0VZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JYq-01ZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JYq-0lZrEemtU7otE81P8g" x="577" y="-124"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JZh6cFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JZh6cVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JZh6c1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JZh6clZrEemtU7otE81P8g" x="127" y="-438"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_-Nm_IFZrEemtU7otE81P8g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_-Nm_IVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-Nm_I1ZrEemtU7otE81P8g" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_D_oMUJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D_oMUZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D_oMU5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-Nm_IlZrEemtU7otE81P8g" x="895" y="-396"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D_oMUpmwEemSg_rU1VNuUQ" x="895" y="-396"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EAS6sJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EAS6sZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EAS6s5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EAS6spmwEemSg_rU1VNuUQ" x="-5" y="-297"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EA4wkJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EA4wkZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EA5XoJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EA4wkpmwEemSg_rU1VNuUQ" x="-5" y="-397"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EBHaEJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EBHaEZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EBHaE5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EBHaEpmwEemSg_rU1VNuUQ" x="-5" y="-397"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EB3A8JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EB3A8ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EB3A85mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EB3A8pmwEemSg_rU1VNuUQ" x="895" y="-135"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_EDlfQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EDlfQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EDlfQ5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EDlfQpmwEemSg_rU1VNuUQ" x="15" y="-451"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_xbR3JHkvEeiO-c_khjKlFQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_xbR3JXkvEeiO-c_khjKlFQ"/>
@@ -3301,96 +3362,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SIuVcIuXEeiu6boZkiJHCA" id="(0.4662576687116564,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RzyAMIuXEeiu6boZkiJHCA" id="(0.44150943396226416,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__DTtgFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="__DTGcFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__DTtgVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__DTthVZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__DTtglZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__DTtg1ZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__DTthFZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__Eh1gVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="__EhOcFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__Eh1glZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Eh1hlZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Eh1g1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Eh1hFZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Eh1hVZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__FQOQVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="__FPnMFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__FQOQlZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__FQORlZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__FQOQ1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__FQORFZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__FQORVZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__HN9JFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRu43kvEeiO-c_khjKlFQ" target="__HN9IFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__HN9JVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__HN9KVZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__HN9JlZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__HN9J1ZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__HN9KFZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__J1zUVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_QoX9AIuXEeiu6boZkiJHCA" target="__J1MQFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__J1zUlZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__J1zVlZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__J1zU1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__J1zVFZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__J1zVVZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__LcV1FZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRvg3kvEeiO-c_khjKlFQ" target="__LcV0FZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__LcV1VZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__LcV2VZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__LcV1lZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__LcV11ZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__LcV2FZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__MLVoVZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="__MKukFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__MLVolZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__MLVplZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MLVo1ZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__MLVpFZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__MLVpVZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__Ou6ZFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="__Ou6YFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__Ou6ZVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__Ou6aVZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Ou6ZlZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Ou6Z1ZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Ou6aFZqEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__PfvZFZqEemtU7otE81P8g" type="StereotypeCommentLink" source="_xbR393kvEeiO-c_khjKlFQ" target="__PfvYFZqEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="__PfvZVZqEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__PgWcFZqEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__PfvZlZqEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__PfvZ1ZqEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__PfvaFZqEemtU7otE81P8g"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JUBvYFZrEemtU7otE81P8g" type="Association_Edge" source="_JT_TJVZrEemtU7otE81P8g" target="_JT9eB1ZrEemtU7otE81P8g" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_JUBvYVZrEemtU7otE81P8g" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JUBvYlZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -3471,86 +3442,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUCWmFZrEemtU7otE81P8g" id="(0.5224913494809689,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUCWmVZrEemtU7otE81P8g" id="(0.5224913494809689,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JVhkNFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JT9eB1ZrEemtU7otE81P8g" target="_JVhkMFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JVhkNVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JViLQlZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JVhkNlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JViLQFZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JViLQVZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JWnwYFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JT-sEVZrEemtU7otE81P8g" target="_JWmiQFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JWnwYVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JWoXcFZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JWnwYlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWnwY1ZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JWnwZFZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JW1LxFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUCWflZrEemtU7otE81P8g" target="_JW1LwFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JW1LxVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JW1y0FZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JW1LxlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JW1Lx1ZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JW1LyFZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JXghM1ZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JT_TJVZrEemtU7otE81P8g" target="_JXf6IFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JXghNFZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXghOFZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXghNVZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXghNlZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXghN1ZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JXq5QVZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUCWcFZrEemtU7otE81P8g" target="_JXqSMFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JXq5QlZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXq5RlZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXq5Q1ZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXq5RFZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXq5RVZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JXsHZFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUBvYFZrEemtU7otE81P8g" target="_JXsHYFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JXsHZVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXsHaVZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXsHZlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXsHZ1ZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXsHaFZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JYq-1FZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUAhQVZrEemtU7otE81P8g" target="_JYq-0FZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JYq-1VZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JYq-2VZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JYq-1lZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JYq-11ZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JYq-2FZrEemtU7otE81P8g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JZihgFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_JUBvi1ZrEemtU7otE81P8g" target="_JZh6cFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JZihgVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JZihhVZrEemtU7otE81P8g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JZihglZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JZihg1ZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JZihhFZrEemtU7otE81P8g"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lB49kFZrEemtU7otE81P8g" type="Association_Edge" source="_JUBvi1ZrEemtU7otE81P8g" target="_xbRupnkvEeiO-c_khjKlFQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_lB5koFZrEemtU7otE81P8g" type="Association_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ltoCMFZrEemtU7otE81P8g" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -3597,15 +3488,185 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oPxIFZrEemtU7otE81P8g" id="(0.35294117647058826,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oQYMFZrEemtU7otE81P8g" id="(0.8909090909090909,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_-Nm_JFZrEemtU7otE81P8g" type="StereotypeCommentLink" source="_-LxMEFZrEemtU7otE81P8g" target="_-Nm_IFZrEemtU7otE81P8g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_-Nm_JVZrEemtU7otE81P8g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-Nm_KVZrEemtU7otE81P8g" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_D2TRNJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbRtvnkvEeiO-c_khjKlFQ" target="_D2TRMJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D2TRNZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D2T4QpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3qhKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D2TRNpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D2T4QJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D2T4QZmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D3bSlJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_MtNH8IuXEeiu6boZkiJHCA" target="_D3bSkJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D3bSlZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D3bSmZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D3bSlpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D3bSl5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D3bSmJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D383BJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbRupnkvEeiO-c_khjKlFQ" target="_D383AJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D383BZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D383CZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D383BpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D383B5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D383CJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D4tE9JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbRu43kvEeiO-c_khjKlFQ" target="_D4tE8JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D4tE9ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D4tE-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D4tE9pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D4tE95mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D4tE-JmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6IBRJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_QoX9AIuXEeiu6boZkiJHCA" target="_D6IBQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6IBRZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6IBSZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_KjQ3phKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6IBRpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6IBR5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6IBSJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D6t3JJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbRvg3kvEeiO-c_khjKlFQ" target="_D6t3IJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D6t3JZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D6ueMJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D6t3JpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6t3J5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D6t3KJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D7QptJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbR3SXkvEeiO-c_khjKlFQ" target="_D7QpsJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D7QptZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D7QpuZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_wY7M4BNCEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D7QptpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7Qpt5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D7QpuJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D71RdJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbRyc3kvEeiO-c_khjKlFQ" target="_D71RcJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D71RdZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D71ReZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D71RdpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D71Rd5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D71ReJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D8f_0ZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_xbR393kvEeiO-c_khjKlFQ" target="_D8fYwJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D8f_0pmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D8f_1pmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_XCHpEHZpEeiPPoPDo3q5jA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D8f_05mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8f_1JmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8f_1ZmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D9O_pJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JT9eB1ZrEemtU7otE81P8g" target="_D9O_oJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D9O_pZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D9O_qZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_PKMDsEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D9O_ppmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9O_p5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D9O_qJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D-qjBJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JT-sEVZrEemtU7otE81P8g" target="_D-qjAJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D-qjBZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D-qjCZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D-qjBpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D-qjB5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D-qjCJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D_cmJJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JUCWflZrEemtU7otE81P8g" target="_D_cmIJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D_cmJZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D_cmKZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_qOr0YJozEeiOmuqNbykpsw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D_cmJpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D_cmJ5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D_cmKJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D_oMVJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_-LxMEFZrEemtU7otE81P8g" target="_D_oMUJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D_oMVZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D_oMWZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_c-z5wJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-Nm_JlZrEemtU7otE81P8g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Nm_J1ZrEemtU7otE81P8g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-Nm_KFZrEemtU7otE81P8g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D_oMVpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D_oMV5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D_oMWJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EAS6tJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JT_TJVZrEemtU7otE81P8g" target="_EAS6sJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EAS6tZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EAS6uZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EAS6tpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EAS6t5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EAS6uJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EA5XoZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JUBvYFZrEemtU7otE81P8g" target="_EA4wkJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EA5XopmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EA5XppmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiPhotonicMedia.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EA5Xo5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EA5XpJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EA5XpZmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EBIBIJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JUCWcFZrEemtU7otE81P8g" target="_EBHaEJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EBIBIZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EBIBJZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Z6tlUBNAEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EBIBIpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EBIBI5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EBIBJJmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EB3A9JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JUAhQVZrEemtU7otE81P8g" target="_EB3A8JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EB3A9ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EB3A-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_nBhMkI6cEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EB3A9pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EB3A95mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EB3A-JmwEemSg_rU1VNuUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EDlfRJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_JUBvi1ZrEemtU7otE81P8g" target="_EDlfQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EDlfRZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EDlfSZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EDlfRpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EDlfR5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EDlfSJmwEemSg_rU1VNuUQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_47kdwPJSEeiTnqcAgKK24Q" type="PapyrusUMLClassDiagram" name="ServiceInterfaceSpec" measurementUnit="Pixel">
@@ -3743,213 +3804,213 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_byzeEfPiEeinaYo1FpF9OA" x="31" y="8" width="299" height="66"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6QfRsFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6QfRsVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Qf4wFVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EZkWUJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EZkWUZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EZk9YJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6QfRslVMEemD67R2QwZykA" x="380" y="154"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EZkWUpmwEemSg_rU1VNuUQ" x="380" y="154"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6Qre8FVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6Qre8VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Qre81VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EZ-mAJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EZ-mAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EZ-mA5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Qre8lVMEemD67R2QwZykA" x="195" y="151"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EZ-mApmwEemSg_rU1VNuUQ" x="195" y="151"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6Q79oFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6Q79oVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Q79o1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EaXnkJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EaXnkZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EaXnk5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Q79olVMEemD67R2QwZykA" x="1173" y="-32"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EaXnkpmwEemSg_rU1VNuUQ" x="1173" y="-32"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6RewMFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6RewMVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6RewM1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Eauz8JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Eauz8ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eauz85mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6RewMlVMEemD67R2QwZykA" x="683" y="-21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eauz8pmwEemSg_rU1VNuUQ" x="683" y="-21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6Ry5QFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6Ry5QVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ry5Q1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ea_5sJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ea_5sZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ea_5s5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Ry5QlVMEemD67R2QwZykA" x="662" y="391"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ea_5spmwEemSg_rU1VNuUQ" x="662" y="391"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6R_tkFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6R_tkVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6R_tk1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EbQ_cJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EbQ_cZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EbQ_c5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6R_tklVMEemD67R2QwZykA" x="1166" y="389"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EbQ_cpmwEemSg_rU1VNuUQ" x="1166" y="389"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6SmKgFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6SmKgVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6SmxkFVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EcJwQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EcJwQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EcJwQ5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6SmKglVMEemD67R2QwZykA" x="225" y="281"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EcJwQpmwEemSg_rU1VNuUQ" x="225" y="281"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6TCPYFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6TCPYVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6TCPY1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EcuYAJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EcuYAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EcuYA5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z05pcPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6TCPYlVMEemD67R2QwZykA" x="225" y="181"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EcuYApmwEemSg_rU1VNuUQ" x="225" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6TGg0FVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6TGg0VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6THH4FVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ec264JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ec264ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ec2645mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0gaEkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6TGg0lVMEemD67R2QwZykA" x="225" y="181"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ec264pmwEemSg_rU1VNuUQ" x="225" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6TsWsFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6TsWsVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6TsWs1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EdjecJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EdjecZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Edjec5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6TsWslVMEemD67R2QwZykA" x="668" y="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EdjecpmwEemSg_rU1VNuUQ" x="668" y="135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6UEKIFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6UEKIVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UEKI1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EeX90JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EeX90ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EeX905mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_2olSAPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UEKIlVMEemD67R2QwZykA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EeX90pmwEemSg_rU1VNuUQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6ULe4FVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6ULe4VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6ULe41VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EeddYJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EeddYZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EeddY5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_3PqgIPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ULe4lVMEemD67R2QwZykA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EeddYpmwEemSg_rU1VNuUQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6UTasFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6UTasVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UTas1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Eei88JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Eei88ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eei885mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_8ryxoPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UTaslVMEemD67R2QwZykA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eei88pmwEemSg_rU1VNuUQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6UaIYFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6UaIYVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UaIY1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EeocgJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EeocgZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eeocg5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_-HZ0APJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UaIYlVMEemD67R2QwZykA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EeocgpmwEemSg_rU1VNuUQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6Ufn8FVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6Ufn8VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ufn81VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Eet8EJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Eet8EZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EeujIJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_OuQmoPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Ufn8lVMEemD67R2QwZykA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eet8EpmwEemSg_rU1VNuUQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6UlHgFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6UlHgVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UlHg1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ee1Q0JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ee1Q0ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ee1Q05mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Qv8xkPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UlHglVMEemD67R2QwZykA" x="668" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ee1Q0pmwEemSg_rU1VNuUQ" x="668" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6VK9YFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6VLkcFVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VLkclVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EfyTEJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EfyTEZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EfyTE5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VLkcVVMEemD67R2QwZykA" x="1157" y="135"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EfyTEpmwEemSg_rU1VNuUQ" x="1157" y="135"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6VnCQFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6VnCQVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VnCQ1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EgI4YJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgI4YZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgI4Y5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_32fPkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VnCQlVMEemD67R2QwZykA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgI4YpmwEemSg_rU1VNuUQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6VrTsFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6VrTsVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VrTs1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EgPmEJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgPmEZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgQNIJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_4V4hUPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VrTslVMEemD67R2QwZykA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgPmEpmwEemSg_rU1VNuUQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6VwMMFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6VwMMVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VwMM1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EgYwAJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgYwAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgYwA5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_5DM6UPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6VwMMlVMEemD67R2QwZykA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgYwApmwEemSg_rU1VNuUQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6V1rwFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6V1rwVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V1rw1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EgePkJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgePkZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgePk5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_56YZ8PJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6V1rwlVMEemD67R2QwZykA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgePkpmwEemSg_rU1VNuUQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6V-OoFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6V-OoVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V-Oo1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EgjvIJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgjvIZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgkWMJmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_GZ48sPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6V-OolVMEemD67R2QwZykA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgjvIpmwEemSg_rU1VNuUQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6WGKcFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6WGKcVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WGKc1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EgpOsJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EgpOsZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgpOs5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_P7X6APJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6WGKclVMEemD67R2QwZykA" x="1157" y="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgpOspmwEemSg_rU1VNuUQ" x="1157" y="35"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6WsnYFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6WsnYVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WsnY1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EhI98JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EhI98ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EhI985mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6WsnYlVMEemD67R2QwZykA" x="231" y="8"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EhI98pmwEemSg_rU1VNuUQ" x="231" y="8"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6XB-kFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6XB-kVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XB-k1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EhkbwJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EhkbwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ehkbw5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_gfAHcPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6XB-klVMEemD67R2QwZykA" x="231" y="-92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EhkbwpmwEemSg_rU1VNuUQ" x="231" y="-92"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_6XG3EFVMEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_6XG3EVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XG3E1VMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ehp7UJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ehp7UZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ehp7U5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_hQjgMPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6XG3ElVMEemD67R2QwZykA" x="231" y="-92"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ehp7UpmwEemSg_rU1VNuUQ" x="231" y="-92"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_47kdwfJSEeiTnqcAgKK24Q" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_47kdwvJSEeiTnqcAgKK24Q"/>
@@ -4197,265 +4258,265 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hUMqEPPiEeinaYo1FpF9OA" id="(0.842809364548495,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hUMqEfPiEeinaYo1FpF9OA" id="(0.5282051282051282,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6Qf4wVVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_76u9kPJSEeiTnqcAgKK24Q" target="_6QfRsFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6Qf4wlVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Qf4xlVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EZk9YZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_76u9kPJSEeiTnqcAgKK24Q" target="_EZkWUJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EZk9YpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EZk9ZpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPN8FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Qf4w1VMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Qf4xFVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Qf4xVVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EZk9Y5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EZk9ZJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EZk9ZZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6Qre9FVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_8W-NoPJSEeiTnqcAgKK24Q" target="_6Qre8FVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6Qre9VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6QsGAlVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EZ_NEJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_8W-NoPJSEeiTnqcAgKK24Q" target="_EZ-mAJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EZ_NEZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EZ_NFZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiCommon.uml#_WHPOAFJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Qre9lVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6QsGAFVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6QsGAVVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EZ_NEpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EZ_NE5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EZ_NFJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6Q79pFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_RmCMYPJTEeiTnqcAgKK24Q" target="_6Q79oFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6Q79pVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Q79qVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EaXnlJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_RmCMYPJTEeiTnqcAgKK24Q" target="_EaXnkJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EaXnlZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EaYOopmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN81JvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Q79plVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Q79p1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Q79qFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EaXnlpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EaYOoJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EaYOoZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6RewNFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_R6EisPJTEeiTnqcAgKK24Q" target="_6RewMFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6RewNVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6RfXQFVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EavbAJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_R6EisPJTEeiTnqcAgKK24Q" target="_Eauz8JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EavbAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EavbBZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_WHPN6FJvEeWcs7ZjyujtOg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6RewNlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6RewN1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6RewOFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EavbApmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EavbA5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EavbBJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6Ry5RFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_TEZn0PJTEeiTnqcAgKK24Q" target="_6Ry5QFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6Ry5RVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ry5SVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EbAgwJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_TEZn0PJTEeiTnqcAgKK24Q" target="_Ea_5sJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EbAgwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EbAgxZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_AnTcAKU5EeWkWNPM1BHzGA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Ry5RlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ry5R1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ry5SFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EbAgwpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EbAgw5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EbAgxJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6R_tlFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_UOifsPJTEeiTnqcAgKK24Q" target="_6R_tkFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6R_tlVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6R_tmVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EbQ_dJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_UOifsPJTEeiTnqcAgKK24Q" target="_EbQ_cJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EbQ_dZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EbRmgpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_qH8fkL2NEeWdore3Cxez9g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6R_tllVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6R_tl1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6R_tmFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EbQ_dpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EbRmgJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EbRmgZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6SmxkVVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_aYe5cPJTEeiTnqcAgKK24Q" target="_6SmKgFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6SmxklVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6SmxllVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EcJwRJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_aYe5cPJTEeiTnqcAgKK24Q" target="_EcJwQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EcJwRZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EcJwSZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_EqncAHiHEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Smxk1VMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6SmxlFVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6SmxlVVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EcJwRpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EcJwR5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EcJwSJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6TCPZFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_z0_wEPJTEeiTnqcAgKK24Q" target="_6TCPYFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6TCPZVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6TCPaVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ecu_EJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_z0_wEPJTEeiTnqcAgKK24Q" target="_EcuYAJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ecu_EZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ecu_FZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z05pcPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6TCPZlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6TCPZ1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6TCPaFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ecu_EpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ecu_E5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ecu_FJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6THH4VVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_0ggLMPJTEeiTnqcAgKK24Q" target="_6TGg0FVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6THH4lVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6THH5lVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ec265JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_0ggLMPJTEeiTnqcAgKK24Q" target="_Ec264JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ec265ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ec3h8pmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0gaEkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6THH41VMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6THH5FVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6THH5VVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ec265pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ec3h8JmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ec3h8ZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6TsWtFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_lm3dcPJTEeiTnqcAgKK24Q" target="_6TsWsFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6TsWtVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ts9wlVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EdjedJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_lm3dcPJTEeiTnqcAgKK24Q" target="_EdjecJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EdjedZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EdjeeZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_O0PLkHkwEeiO-c_khjKlFQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6TsWtlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ts9wFVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ts9wVVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EdjedpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Edjed5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EdjeeJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6UEKJFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_2olSAfJTEeiTnqcAgKK24Q" target="_6UEKIFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6UEKJVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UEKKVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EeX91JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_2olSAfJTEeiTnqcAgKK24Q" target="_EeX90JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EeX91ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EeYk4pmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_2olSAPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UEKJlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UEKJ1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UEKKFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EeX91pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EeYk4JmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EeYk4ZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6ULe5FVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_3PqgIfJTEeiTnqcAgKK24Q" target="_6ULe4FVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6ULe5VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UMF8VVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EeeEcJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_3PqgIfJTEeiTnqcAgKK24Q" target="_EeddYJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EeeEcZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EeeEdZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_3PqgIPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6ULe5lVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ULe51VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UMF8FVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EeeEcpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EeeEc5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EeeEdJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6UTatFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_8ryxofJTEeiTnqcAgKK24Q" target="_6UTasFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6UTatVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UTauVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Eei89JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_8ryxofJTEeiTnqcAgKK24Q" target="_Eei88JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Eei89ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eei8-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_8ryxoPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UTatlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UTat1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UTauFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Eei89pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eei895mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eei8-JmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6UaIZFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_-HZ0AfJTEeiTnqcAgKK24Q" target="_6UaIYFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6UaIZVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UaIaVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EeochJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_-HZ0AfJTEeiTnqcAgKK24Q" target="_EeocgJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EeochZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EepDkpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_-HZ0APJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UaIZlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UaIZ1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UaIaFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EeochpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EepDkJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EepDkZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6Ufn9FVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_OuQmofJWEeiTnqcAgKK24Q" target="_6Ufn8FVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6Ufn9VVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Ufn-VVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EeujIZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_OuQmofJWEeiTnqcAgKK24Q" target="_Eet8EJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EeujIpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EeujJpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_OuQmoPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6Ufn9lVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ufn91VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Ufn-FVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EeujI5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EeujJJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EeujJZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6UlHhFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_Qv8xkfJWEeiTnqcAgKK24Q" target="_6UlHgFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6UlHhVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UlukVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ee1Q1JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_Qv8xkfJWEeiTnqcAgKK24Q" target="_Ee1Q0JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ee1Q1ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ee134pmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_Qv8xkPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UlHhlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UlHh1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UlukFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ee1Q1pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ee134JmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ee134ZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6VLkc1VMEemD67R2QwZykA" type="StereotypeCommentLink" source="_tNB9kPJTEeiTnqcAgKK24Q" target="_6VK9YFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6VLkdFVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VLkeFVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EfyTFJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_tNB9kPJTEeiTnqcAgKK24Q" target="_EfyTEJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EfyTFZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EfyTGZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_Es15AJmWEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VLkdVVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VLkdlVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VLkd1VMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EfyTFpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EfyTF5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EfyTGJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6VnCRFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_32fPkfJTEeiTnqcAgKK24Q" target="_6VnCQFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6VnCRVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VnCSVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EgI4ZJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_32fPkfJTEeiTnqcAgKK24Q" target="_EgI4YJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EgI4ZZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgJfcpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_32fPkPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VnCRlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VnCR1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VnCSFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EgI4ZpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgJfcJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgJfcZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6VrTtFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_4V-n8PJTEeiTnqcAgKK24Q" target="_6VrTsFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6VrTtVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VrTuVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EgQNIZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_4V-n8PJTEeiTnqcAgKK24Q" target="_EgPmEJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EgQNIpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgQNJpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_4V4hUPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VrTtlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VrTt1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VrTuFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EgQNI5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgQNJJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgQNJZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6VwMNFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_5DM6UfJTEeiTnqcAgKK24Q" target="_6VwMMFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6VwMNVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6VwMOVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EgYwBJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_5DM6UfJTEeiTnqcAgKK24Q" target="_EgYwAJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EgYwBZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgZXEpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_5DM6UPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6VwMNlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VwMN1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6VwMOFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EgYwBpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgZXEJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgZXEZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6V1rxFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_56YZ8fJTEeiTnqcAgKK24Q" target="_6V1rwFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6V1rxVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V1ryVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EgePlJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_56YZ8fJTEeiTnqcAgKK24Q" target="_EgePkJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EgePlZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgePmZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_56YZ8PJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6V1rxlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V1rx1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V1ryFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EgePlpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgePl5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgePmJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6V-OpFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_GZ_DUPJWEeiTnqcAgKK24Q" target="_6V-OoFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6V-OpVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6V-OqVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EgkWMZmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_GZ_DUPJWEeiTnqcAgKK24Q" target="_EgjvIJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EgkWMpmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EgkWNpmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_GZ48sPJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6V-OplVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V-Op1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6V-OqFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EgkWM5mwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgkWNJmwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EgkWNZmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6WGKdFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_P7X6AfJWEeiTnqcAgKK24Q" target="_6WGKcFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6WGKdVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WGKeVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Egp1wJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_P7X6AfJWEeiTnqcAgKK24Q" target="_EgpOsJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Egp1wZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Egp1xZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_P7X6APJWEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6WGKdlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WGKd1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WGKeFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Egp1wpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Egp1w5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Egp1xJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6WsnZFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_byzeEPPiEeinaYo1FpF9OA" target="_6WsnYFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6WsnZVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6WtOclVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EhI99JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_byzeEPPiEeinaYo1FpF9OA" target="_EhI98JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EhI99ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EhI9-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_syPL8JmTEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6WsnZlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WtOcFVMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6WtOcVVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EhI99pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EhI995mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EhI9-JmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6XB-lFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_gfM7wPPiEeinaYo1FpF9OA" target="_6XB-kFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6XB-lVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XB-mVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EhkbxJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_gfM7wPPiEeinaYo1FpF9OA" target="_EhkbwJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EhkbxZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EhkbyZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_gfAHcPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6XB-llVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XB-l1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XB-mFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EhkbxpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ehkbx5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EhkbyJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6XG3FFVMEemD67R2QwZykA" type="StereotypeCommentLink" source="_hQmjgPPiEeinaYo1FpF9OA" target="_6XG3EFVMEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6XG3FVVMEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6XG3GVVMEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ehp7VJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_hQmjgPPiEeinaYo1FpF9OA" target="_Ehp7UJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ehp7VZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ehp7WZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_hQjgMPPiEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6XG3FlVMEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XG3F1VMEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6XG3GFVMEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ehp7VpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ehp7V5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ehp7WJmwEemSg_rU1VNuUQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_1hK84PPmEeinaYo1FpF9OA" type="PapyrusUMLClassDiagram" name="ResourceInterfaceSpec" measurementUnit="Pixel">
@@ -4573,85 +4634,85 @@
       <element xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s45qEfPnEeinaYo1FpF9OA" x="590" y="298" width="253" height="70"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TzDbEFVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TzDbEVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzDbE1VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EusRwJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EusRwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EusRw5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzDbElVPEemD67R2QwZykA" x="222" y="153"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EusRwpmwEemSg_rU1VNuUQ" x="222" y="153"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tze44FVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tze44VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tze441VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EvUj4JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EvUj4ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Evyd8JmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tze44lVPEemD67R2QwZykA" x="222" y="53"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EvUj4pmwEemSg_rU1VNuUQ" x="222" y="53"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TzpQ8FVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TzpQ8VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzpQ81VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Ev_5UJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ev_5UZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ev_5U5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzpQ8lVPEemD67R2QwZykA" x="240" y="34"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ev_5UpmwEemSg_rU1VNuUQ" x="240" y="34"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tz7k0FVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tz7k0VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tz7k01VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EwMtoJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EwMtoZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EwMto5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tz7k0lVPEemD67R2QwZykA" x="602" y="142"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EwMtopmwEemSg_rU1VNuUQ" x="602" y="142"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T0qkoFVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T0qkoVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0qko1VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EwwHQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EwwHQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EwwHQ5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T0qkolVPEemD67R2QwZykA" x="616" y="-2"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EwwHQpmwEemSg_rU1VNuUQ" x="616" y="-2"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T0_UwFVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T0_UwVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0_Uw1VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ExIhwJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ExIhwZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ExIhw5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_yw4xIPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T0_UwlVPEemD67R2QwZykA" x="616" y="-102"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ExIhwpmwEemSg_rU1VNuUQ" x="616" y="-102"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T1m_0FVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T1m_0VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1nm4FVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Exmb0JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Exmb0ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Exmb05mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T1m_0lVPEemD67R2QwZykA" x="505" y="299"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Exmb0pmwEemSg_rU1VNuUQ" x="505" y="299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T2ABYFVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T2ABYVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2ABY1VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EyIAQJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EyIAQZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EyIAQ5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T2ABYlVPEemD67R2QwZykA" x="505" y="199"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EyIAQpmwEemSg_rU1VNuUQ" x="505" y="199"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T2sk8FVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T2sk8VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2sk81VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EyzVsJmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EyzVsZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EyzVs5mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T2sk8lVPEemD67R2QwZykA" x="790" y="298"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EyzVspmwEemSg_rU1VNuUQ" x="790" y="298"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_T3J38FVPEemD67R2QwZykA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T3J38VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T3J381VPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EzTE8JmwEemSg_rU1VNuUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EzTE8ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EzTE85mwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T3J38lVPEemD67R2QwZykA" x="790" y="198"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EzTE8pmwEemSg_rU1VNuUQ" x="790" y="198"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_1hK84fPmEeinaYo1FpF9OA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_1hK84vPmEeinaYo1FpF9OA"/>
@@ -4719,105 +4780,105 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z82N8PPnEeinaYo1FpF9OA" id="(0.43478260869565216,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_z82N8fPnEeinaYo1FpF9OA" id="(0.8032345013477089,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TzDbFFVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_82Bqn_PmEeinaYo1FpF9OA" target="_TzDbEFVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TzDbFVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzDbGVVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EusRxJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_82Bqn_PmEeinaYo1FpF9OA" target="_EusRwJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EusRxZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EusRyZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_VvSIYEUIEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TzDbFlVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzDbF1VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzDbGFVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EusRxpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EusRx5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EusRyJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tze45FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_82BqkfPmEeinaYo1FpF9OA" target="_Tze44FVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tze45VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tze46VVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EvzFAJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_82BqkfPmEeinaYo1FpF9OA" target="_EvUj4JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EvzFAZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EvzFBZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_0_aUwPJTEeiTnqcAgKK24Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tze45lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tze451VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tze46FVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EvzFApmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EvzFA5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EvzFBJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TzpQ9FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_82Bq5_PmEeinaYo1FpF9OA" target="_TzpQ8FVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TzpQ9VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TzpQ-VVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Ev_5VJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_82Bq5_PmEeinaYo1FpF9OA" target="_Ev_5UJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ev_5VZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ev_5WZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TzpQ9lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzpQ91VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TzpQ-FVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ev_5VpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ev_5V5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ev_5WJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tz7k1FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_ccsWUPPnEeinaYo1FpF9OA" target="_Tz7k0FVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tz7k1VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tz8L4FVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EwMtpJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_ccsWUPPnEeinaYo1FpF9OA" target="_EwMtoJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EwMtpZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EwMtqZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Operation" href="TapiConnectivity.uml#_ARtOoPPkEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tz7k1lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tz7k11VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tz7k2FVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EwMtppmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EwMtp5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EwMtqJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T0qkpFVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_fxd5wPPnEeinaYo1FpF9OA" target="_T0qkoFVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T0qkpVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0qkqVVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EwwHRJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_fxd5wPPnEeinaYo1FpF9OA" target="_EwwHQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EwwHRZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EwwHSZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_aiExkJozEeiOmuqNbykpsw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T0qkplVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0qkp1VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0qkqFVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EwwHRpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EwwHR5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EwwHSJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T0_70FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_yw4xIfPnEeinaYo1FpF9OA" target="_T0_UwFVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T0_70VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0_71VVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ExIhxJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_yw4xIfPnEeinaYo1FpF9OA" target="_ExIhwJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ExIhxZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ExIhyZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_yw4xIPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T0_70lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0_701VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0_71FVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ExIhxpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ExIhx5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ExIhyJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T1nm4VVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_qeHpsPPnEeinaYo1FpF9OA" target="_T1m_0FVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T1nm4lVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T1nm5lVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ExnC4JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_qeHpsPPnEeinaYo1FpF9OA" target="_Exmb0JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ExnC4ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ExnC5ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_mXvsEHZlEeiPPoPDo3q5jA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T1nm41VPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1nm5FVPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T1nm5VVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ExnC4pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ExnC45mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ExnC5JmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T2ABZFVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_zUAsUfPnEeinaYo1FpF9OA" target="_T2ABYFVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T2ABZVVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2ABaVVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EyIARJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_zUAsUfPnEeinaYo1FpF9OA" target="_EyIAQJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EyIARZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EyIASZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_zUAsUPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T2ABZlVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2ABZ1VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2ABaFVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EyIARpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EyIAR5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EyIASJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T2sk9FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_s45qEPPnEeinaYo1FpF9OA" target="_T2sk8FVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T2sk9VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T2sk-VVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EyzVtJmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_s45qEPPnEeinaYo1FpF9OA" target="_EyzVsJmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EyzVtZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EyzVuZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiPhotonicMedia.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T2sk9lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2sk91VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2sk-FVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EyzVtpmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EyzVt5mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EyzVuJmwEemSg_rU1VNuUQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T3J39FVPEemD67R2QwZykA" type="StereotypeCommentLink" source="_z7yeAPPnEeinaYo1FpF9OA" target="_T3J38FVPEemD67R2QwZykA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T3J39VVPEemD67R2QwZykA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T3J3-VVPEemD67R2QwZykA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EzTE9JmwEemSg_rU1VNuUQ" type="StereotypeCommentLink" source="_z7yeAPPnEeinaYo1FpF9OA" target="_EzTE8JmwEemSg_rU1VNuUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EzTE9ZmwEemSg_rU1VNuUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EzTE-ZmwEemSg_rU1VNuUQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiPhotonicMedia.uml#_z7sXYPPnEeinaYo1FpF9OA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T3J39lVPEemD67R2QwZykA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T3J391VPEemD67R2QwZykA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T3J3-FVPEemD67R2QwZykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EzTE9pmwEemSg_rU1VNuUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EzTE95mwEemSg_rU1VNuUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EzTE-JmwEemSg_rU1VNuUQ"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiPhotonicMedia.uml
+++ b/UML/TapiPhotonicMedia.uml
@@ -328,19 +328,15 @@ License: This module is distributed under the Apache License 2.0</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_CosS4LKjEei69qzpcujF2A" annotatedElement="_NhrjUHiHEeiPPoPDo3q5jA">
           <body>Can read the status of the warning for the upper value that the power can reach.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9XaUJJmEee26o4qs2D5Ig" name="supportableLowerCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9XaUJJmEee26o4qs2D5Ig" name="supportableCentralFrequencyBand" type="_fV6oAJmwEemSg_rU1VNuUQ" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_pXy3ULDqEeiUZaG2JnNtGQ" annotatedElement="_x9XaUJJmEee26o4qs2D5Ig">
-            <body>The lower frequency of the channel spectrum</body>
+            <body>Each spectrum band supported for otsi trasmitter to be tuned on, is specified&#xD;
+as per it's lower and upper central frequencies supported and its frequency constraints,&#xD;
+consisting in the frequency Grid and the AdjustmentGranularity, used to uniquely identify all&#xD;
+central frequencies supported within the band.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KgckgM4xEeehIvzuBRCtZQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KgdyoM4xEeehIvzuBRCtZQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_t2oxcI50EeeyZasfnNSonw" name="supportableUpperCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_qWfUMLDqEeiUZaG2JnNtGQ" annotatedElement="_t2oxcI50EeeyZasfnNSonw">
-            <body>The Upper frequency of the channel spectrum</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LI65wM4xEeehIvzuBRCtZQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LI8H4M4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7gkK0I50EeeyZasfnNSonw" name="supportableApplicationIdentifier" type="_KjQ3vRKOEeajhbtskMXJfw" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Jh7cgLDrEeiUZaG2JnNtGQ" annotatedElement="_7gkK0I50EeeyZasfnNSonw">
@@ -823,6 +819,27 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_fV6oAJmwEemSg_rU1VNuUQ" name="CentralFrequencyBand">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_MNM1QJmxEemSg_rU1VNuUQ" annotatedElement="_fV6oAJmwEemSg_rU1VNuUQ">
+          <body>This data-type represents a range of central frequency spectrum band specified as lower and upper bounds, inclusive of the bound values.&#xD;
+It also holds frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7AvJQJmwEemSg_rU1VNuUQ" name="lowerCentralFrequency">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__bxxMJmwEemSg_rU1VNuUQ" annotatedElement="_7AvJQJmwEemSg_rU1VNuUQ">
+            <body>The lower central frequency that can be tuned in the laser specified in MHz.&#xD;
+It is the oscillation frequency of the corresponding electromagnetic wave. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GAfbYJmxEemSg_rU1VNuUQ" name="upperCentralFrequency">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GAfbYZmxEemSg_rU1VNuUQ" annotatedElement="_GAfbYJmxEemSg_rU1VNuUQ">
+            <body>The upper central frequency that can be tuned in the laser specified in MHz.&#xD;
+ It is the oscillation frequency of the corresponding electromagnetic wave. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nYVw4JmxEemSg_rU1VNuUQ" name="frequencyConstraint" type="_nCmdAMG-EeiAg83ctgK3eQ"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_MSvNkBMEEeaOevPmmmHXcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_eTzcwDK1Eeau3Z0jZdArnw">
@@ -903,8 +920,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YKbQA1qoEeexvMtO2oNM9g" base_Class="_PKMDsEUIEead1bezhJG4aw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KjT68BKOEeajhbtskMXJfw" base_Class="_KjQ3tBKOEeajhbtskMXJfw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_YKbQAlqoEeexvMtO2oNM9g" base_Class="_KjQ3tBKOEeajhbtskMXJfw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_t2pYgI50EeeyZasfnNSonw" base_Property="_t2oxcI50EeeyZasfnNSonw" attributeValueChangeNotification="YES" bitLength="LENGTH_64_BIT"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_t2p_kI50EeeyZasfnNSonw" base_StructuralFeature="_t2oxcI50EeeyZasfnNSonw" valueRange="" unit=""/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7gkx4I50EeeyZasfnNSonw" base_Property="_7gkK0I50EeeyZasfnNSonw" attributeValueChangeNotification="YES"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_7gkx4Y50EeeyZasfnNSonw" base_StructuralFeature="_7gkK0I50EeeyZasfnNSonw" valueRange="255"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MpI1UI51EeeyZasfnNSonw" base_Property="_MpIOQI51EeeyZasfnNSonw"/>
@@ -1231,4 +1246,11 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_oFiyYlJmEemV99d_1db7sQ" base_Property="_oFiyYFJmEemV99d_1db7sQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_vVoU0VJmEemV99d_1db7sQ" base_StructuralFeature="_vVoU0FJmEemV99d_1db7sQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_vVo74FJmEemV99d_1db7sQ" base_Property="_vVoU0FJmEemV99d_1db7sQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7AvwUJmwEemSg_rU1VNuUQ" base_Property="_7AvJQJmwEemSg_rU1VNuUQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7Aw-cJmwEemSg_rU1VNuUQ" base_StructuralFeature="_7AvJQJmwEemSg_rU1VNuUQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_GAgCcJmxEemSg_rU1VNuUQ" base_Property="_GAfbYJmxEemSg_rU1VNuUQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GAh3oJmxEemSg_rU1VNuUQ" base_StructuralFeature="_GAfbYJmxEemSg_rU1VNuUQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nYVw4ZmxEemSg_rU1VNuUQ" base_Property="_nYVw4JmxEemSg_rU1VNuUQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nYWX8JmxEemSg_rU1VNuUQ" base_StructuralFeature="_nYVw4JmxEemSg_rU1VNuUQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_UaYcoJmyEemSg_rU1VNuUQ" base_Element="_fV6oAJmwEemSg_rU1VNuUQ"/>
 </xmi:XMI>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -1657,213 +1657,312 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r05PgUwCEeewALXL7BvPYw" x="172" y="-6" height="88"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_L-txM3jfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_L-txNHjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L-txNnjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_5KEA4JnDEemVaY_egjrbOQ" type="Interface_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KEA4pnDEemVaY_egjrbOQ" type="Interface_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5KEA45nDEemVaY_egjrbOQ" type="Interface_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5KEA5JnDEemVaY_egjrbOQ" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5KEA5ZnDEemVaY_egjrbOQ" type="Interface_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5KEA5pnDEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5KEA55nDEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5KEA6JnDEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KEA6ZnDEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5KEA6pnDEemVaY_egjrbOQ" type="Interface_OperationCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_7SvkoJnDEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="__u4YwJnDEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiTopology.uml#_taDjMPMvEeSb-q8_djA2ng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7SvkoZnDEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7SvkopnDEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Ae78sJnEEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiTopology.uml#_N-W74PMwEeSb-q8_djA2ng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7Svko5nDEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7SvkpJnDEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_BARvMJnEEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiTopology.uml#_dACyYPMwEeSb-q8_djA2ng"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7SvkpZnDEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7SvkppnDEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_BymkAJnEEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiTopology.uml#_AgHtkFJFEeWDQNzGZgIgfQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7Svkp5nDEemVaY_egjrbOQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7SvkqJnDEemVaY_egjrbOQ" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_CdAy8JnEEemVaY_egjrbOQ" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiTopology.uml#_M2tAQPVKEeWQB8HQFBfkJQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7SvkqZnDEemVaY_egjrbOQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5KEA65nDEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5KEA7JnDEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5KEA7ZnDEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KEA7pnDEemVaY_egjrbOQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5KEA75nDEemVaY_egjrbOQ" type="Interface_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5KEA8JnDEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5KEA8ZnDEemVaY_egjrbOQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5KEA8pnDEemVaY_egjrbOQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KEA85nDEemVaY_egjrbOQ"/>
+      </children>
+      <element xmi:type="uml:Interface" href="TapiTopology.uml#_-ht5oPMtEeSb-q8_djA2ng"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5KEA4ZnDEemVaY_egjrbOQ" x="-320" y="-180" height="126"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rZgwYJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rZgwYZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rZgwY5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L-txNXjfEemfSIWqmJMEQA" x="781" y="-29"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rZgwYpnqEemrjrtN9v_T1A" x="781" y="-29"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MAWv8HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MAWv8XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MAWv83jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ra3bQJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ra3bQZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ra3bQ5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MAWv8njfEemfSIWqmJMEQA" x="781" y="-129"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ra3bQpnqEemrjrtN9v_T1A" x="781" y="-129"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MBGW0HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MBGW0XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MBGW03jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rc8e4JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rc8e4ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rc8e45nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZW8dyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MBGW0njfEemfSIWqmJMEQA" x="331" y="116"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rc8e4pnqEemrjrtN9v_T1A" x="331" y="116"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MCI4oHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MCI4oXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MCI4o3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_reldoJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_reldoZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_reldo5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MCI4onjfEemfSIWqmJMEQA" x="788" y="177"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_reldopnqEemrjrtN9v_T1A" x="788" y="177"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MEXtQHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MEXtQXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MEXtQ3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_riAlE5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_riAlFJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_riAlFpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MEXtQnjfEemfSIWqmJMEQA" x="788" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_riAlFZnqEemrjrtN9v_T1A" x="788" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ME0ZMHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ME0ZMXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ME0ZM3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_riTgAJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_riTgAZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_riTgA5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ME0ZMnjfEemfSIWqmJMEQA" x="788" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_riTgApnqEemrjrtN9v_T1A" x="788" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MFHUIHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MFHUIXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFHUI3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ridRAJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ridRAZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ridRA5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_7DdfMN7vEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MFHUInjfEemfSIWqmJMEQA" x="788" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ridRApnqEemrjrtN9v_T1A" x="788" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MFRFIHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MFRFIXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFRFI3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rima8JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rima8ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rima85nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MFRFInjfEemfSIWqmJMEQA" x="788" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rima8pnqEemrjrtN9v_T1A" x="788" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MFaPEHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MFaPEXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFaPE3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_riwL8JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_riwL8ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_riwL85nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_lqLYAN7wEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MFaPEnjfEemfSIWqmJMEQA" x="788" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_riwL8pnqEemrjrtN9v_T1A" x="788" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MFkAEHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MFkAEXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFkAE3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ri5V4JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ri5V4ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ri5V45nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_W9zh0N7-EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MFkAEnjfEemfSIWqmJMEQA" x="788" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ri5V4pnqEemrjrtN9v_T1A" x="788" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MGJ18HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MGJ18XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MGJ183jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rkFosJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rkFosZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rkFos5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZW_dyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGJ18njfEemfSIWqmJMEQA" x="-128" y="-33"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rkFospnqEemrjrtN9v_T1A" x="-128" y="-33"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MHM-0HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MHM-0XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MHM-03jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rlvOgJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rlvOgZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rlvOg5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXB9yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MHM-0njfEemfSIWqmJMEQA" x="330" y="211"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rlvOgpnqEemrjrtN9v_T1A" x="330" y="211"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MIYqkHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MIYqkXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MIYqk3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rnrIMJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rnrIMZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rnrIM5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIYqknjfEemfSIWqmJMEQA" x="-133" y="106"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rnrIMpnqEemrjrtN9v_T1A" x="-133" y="106"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MLELIHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MLELIXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLELI3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rrZKk5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rrZKlJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rrZKlpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_CM28EN72EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MLELInjfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rrZKlZnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MLN8IHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MLN8IXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLN8I3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rriUg5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rriUhJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rriUhpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_rJUvAN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MLN8InjfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rriUhZnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MLXGEHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MLXGEXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLXGE3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rrsFg5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rrsFhJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rrsFhpnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#__ET2wN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MLXGEnjfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rrsFhZnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MLzyAHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MLzyAXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLzyA3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rr1PcJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rr1PcZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rr1Pc5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MLzyAnjfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rr1PcpnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MMGs8HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MMGs8XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MMGs83jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rr_AcJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rr_AcZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rr_Ac5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_cQkyEN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MMGs8njfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rr_AcpnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MMQd8HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MMQd8XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MMQd83jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rsIxcJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rsIxcZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rsIxc5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_kZ4bgN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MMQd8njfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rsIxcpnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MMjY4HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MMjY4XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MMjY43jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rsIxgZnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rsIxgpnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rsIxhJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_gJx4QN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MMjY4njfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rsIxg5nqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MM2T0HjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MM2T0XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MM2T03jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rsR7Z5nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rsR7aJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rsR7apnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IZggAN8AEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MM2T0njfEemfSIWqmJMEQA" x="-133" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rsR7aZnqEemrjrtN9v_T1A" x="-133" y="6"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MNvrsHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MNvrsXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MNvrs3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rteOMJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rteOMZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rteOM5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXXNyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MNvrsnjfEemfSIWqmJMEQA" x="-66" y="515"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rteOMpnqEemrjrtN9v_T1A" x="-66" y="515"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MPO5cHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MPO5cXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MPO5c3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rvtC0JnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rvtC0ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rvtC05nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MPO5cnjfEemfSIWqmJMEQA" x="343" y="480"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rvtC0pnqEemrjrtN9v_T1A" x="343" y="480"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MRwpAHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MRwpAXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MRwpA3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_rxMQkJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rxMQkZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rxMQk5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXGdyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MRwpAnjfEemfSIWqmJMEQA" x="333" y="318"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rxMQkpnqEemrjrtN9v_T1A" x="333" y="318"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MVLwcHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MVLwcXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MVLwc3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ry-ZQJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ry-ZQZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ry-ZQ5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZW99yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MVLwcnjfEemfSIWqmJMEQA" x="-131" y="447"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ry-ZQpnqEemrjrtN9v_T1A" x="-131" y="447"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_MWq-MHjfEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MWq-MXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MWq-M3jfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r0nYAJnqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r0nYAZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r0nYA5nqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MWq-MnjfEemfSIWqmJMEQA" x="372" y="-6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r0nYApnqEemrjrtN9v_T1A" x="372" y="-6"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_r1gI05nqEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r1gI1JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r1gI1pnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiTopology.uml#_-ht5oPMtEeSb-q8_djA2ng"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r1gI1ZnqEemrjrtN9v_T1A" x="-120" y="-180"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_SFF5oTBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_SFF5ojBDEea4fKwSGMr6CA"/>
@@ -2248,265 +2347,275 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6U9jIIuHEeiu6boZkiJHCA" id="(0.0,0.9918367346938776)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7VAD0IuHEeiu6boZkiJHCA" id="(1.0,0.3626373626373626)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_L-txN3jfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvSX4DBDEea4fKwSGMr6CA" target="_L-txM3jfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_L-txOHjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L-txPHjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rZgwZJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvSX4DBDEea4fKwSGMr6CA" target="_rZgwYJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rZgwZZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rZgwaZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L-txOXjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L-txOnjfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L-txO3jfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rZgwZpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rZgwZ5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rZgwaJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MAWv9HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_G_CegIuHEeiu6boZkiJHCA" target="_MAWv8HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MAWv9XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MAWv-XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ra3bRJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_G_CegIuHEeiu6boZkiJHCA" target="_ra3bQJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ra3bRZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ra3bSZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MAWv9njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MAWv93jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MAWv-HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ra3bRpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ra3bR5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ra3bSJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MBGW1HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvSYxjBDEea4fKwSGMr6CA" target="_MBGW0HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MBGW1XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MBGW2XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rc8e5JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvSYxjBDEea4fKwSGMr6CA" target="_rc8e4JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rc8e5ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rc8e6ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZW8dyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MBGW1njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MBGW13jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MBGW2HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rc8e5pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rc8e55nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rc8e6JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MCI4pHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvSZKTBDEea4fKwSGMr6CA" target="_MCI4oHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MCI4pXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MCI4qXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_reldpJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvSZKTBDEea4fKwSGMr6CA" target="_reldoJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_reldpZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_reldqZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MCI4pnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MCI4p3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MCI4qHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_reldppnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_reldp5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_reldqJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MEXtRHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_JpiV4IuHEeiu6boZkiJHCA" target="_MEXtQHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MEXtRXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MEXtSXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_riAlF5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_JpiV4IuHEeiu6boZkiJHCA" target="_riAlE5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_riAlGJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_riAlHJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MEXtRnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MEXtR3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MEXtSHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_riAlGZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_riAlGpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_riAlG5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ME0ZNHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_jltkAIuHEeiu6boZkiJHCA" target="_ME0ZMHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ME0ZNXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ME0ZOXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_riTgBJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_jltkAIuHEeiu6boZkiJHCA" target="_riTgAJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_riTgBZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_riTgCZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ME0ZNnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ME0ZN3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ME0ZOHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_riTgBpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_riTgB5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_riTgCJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MFHUJHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_tDE2UIuHEeiu6boZkiJHCA" target="_MFHUIHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MFHUJXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFHUKXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ridRBJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_tDE2UIuHEeiu6boZkiJHCA" target="_ridRAJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ridRBZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ridRCZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_7DdfMN7vEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MFHUJnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFHUJ3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFHUKHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ridRBpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ridRB5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ridRCJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MFRFJHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_wlHZsIuHEeiu6boZkiJHCA" target="_MFRFIHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MFRFJXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFRFKXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rima9JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_wlHZsIuHEeiu6boZkiJHCA" target="_rima8JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rima9ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rima-ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MFRFJnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFRFJ3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFRFKHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rima9pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rima95nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rima-JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MFaPFHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_2A9XUIuHEeiu6boZkiJHCA" target="_MFaPEHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MFaPFXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFaPGXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_riwL9JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_2A9XUIuHEeiu6boZkiJHCA" target="_riwL8JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_riwL9ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_riwL-ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_lqLYAN7wEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MFaPFnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFaPF3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFaPGHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_riwL9pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_riwL95nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_riwL-JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MFkAFHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_5Y3HQIuHEeiu6boZkiJHCA" target="_MFkAEHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MFkAFXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MFkAGXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ri5V5JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_5Y3HQIuHEeiu6boZkiJHCA" target="_ri5V4JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ri5V5ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ri5V6ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_W9zh0N7-EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MFkAFnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFkAF3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MFkAGHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ri5V5pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ri5V55nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ri5V6JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MGJ19HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvSaojBDEea4fKwSGMr6CA" target="_MGJ18HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MGJ19XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MGJ1-XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rkFotJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvSaojBDEea4fKwSGMr6CA" target="_rkFosJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rkFotZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rkFouZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZW_dyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MGJ19njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MGJ193jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MGJ1-HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rkFotpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rkFot5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rkFouJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MHM-1HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_Wvbh0DBDEea4fKwSGMr6CA" target="_MHM-0HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MHM-1XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MHM-2XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rlvOhJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Wvbh0DBDEea4fKwSGMr6CA" target="_rlvOgJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rlvOhZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rlvOiZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXB9yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MHM-1njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MHM-13jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MHM-2HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rlvOhpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rlvOh5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rlvOiJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MIYqlHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvbikTBDEea4fKwSGMr6CA" target="_MIYqkHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MIYqlXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MIYqmXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rnrINJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvbikTBDEea4fKwSGMr6CA" target="_rnrIMJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rnrINZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rnrIOZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MIYqlnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MIYql3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MIYqmHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rnrINpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rnrIN5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rnrIOJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MLELJHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_7c87YIuGEeiu6boZkiJHCA" target="_MLELIHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MLELJXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLELKXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rrZKl5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_7c87YIuGEeiu6boZkiJHCA" target="_rrZKk5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rrZKmJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rrZKnJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_CM28EN72EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MLELJnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLELJ3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLELKHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rrZKmZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rrZKmpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rrZKm5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MLN8JHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="__ZY7wIuGEeiu6boZkiJHCA" target="_MLN8IHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MLN8JXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLN8KXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rriUh5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="__ZY7wIuGEeiu6boZkiJHCA" target="_rriUg5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rriUiJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rriUjJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_rJUvAN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MLN8JnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLN8J3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLN8KHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rriUiZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rriUipnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rriUi5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MLXGFHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_CtslIIuHEeiu6boZkiJHCA" target="_MLXGEHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MLXGFXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLXGGXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rrsFh5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_CtslIIuHEeiu6boZkiJHCA" target="_rrsFg5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rrsFiJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rrsFjJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#__ET2wN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MLXGFnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLXGF3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLXGGHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rrsFiZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rrsFipnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rrsFi5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MLzyBHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_OkjeYIuHEeiu6boZkiJHCA" target="_MLzyAHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MLzyBXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MLzyCXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rr1PdJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_OkjeYIuHEeiu6boZkiJHCA" target="_rr1PcJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rr1PdZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rr1PeZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MLzyBnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLzyB3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MLzyCHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rr1PdpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rr1Pd5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rr1PeJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MMGs9HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_RNDKoIuHEeiu6boZkiJHCA" target="_MMGs8HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MMGs9XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MMGs-XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rr_AdJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_RNDKoIuHEeiu6boZkiJHCA" target="_rr_AcJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rr_AdZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rr_AeZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_cQkyEN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MMGs9njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MMGs93jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MMGs-HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rr_AdpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rr_Ad5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rr_AeJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MMQd9HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_ZCnYsIuHEeiu6boZkiJHCA" target="_MMQd8HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MMQd9XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MMQd-XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rsIxdJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZCnYsIuHEeiu6boZkiJHCA" target="_rsIxcJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rsIxdZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rsIxeZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_kZ4bgN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MMQd9njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MMQd93jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MMQd-HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rsIxdpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rsIxd5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rsIxeJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MMjY5HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_b4wfYIuHEeiu6boZkiJHCA" target="_MMjY4HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MMjY5XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MMjY6XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rsIxhZnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_b4wfYIuHEeiu6boZkiJHCA" target="_rsIxgZnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rsIxhpnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rsIxipnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_gJx4QN71EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MMjY5njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MMjY53jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MMjY6HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rsIxh5nqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rsIxiJnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rsIxiZnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MM2T1HjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_e2FMIIuHEeiu6boZkiJHCA" target="_MM2T0HjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MM2T1XjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MM2T2XjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rsR7a5nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_e2FMIIuHEeiu6boZkiJHCA" target="_rsR7Z5nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rsR7bJnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rsR7cJnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IZggAN8AEeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MM2T1njfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MM2T13jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MM2T2HjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rsR7bZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rsR7bpnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rsR7b5nqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MNvrtHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvblRTBDEea4fKwSGMr6CA" target="_MNvrsHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MNvrtXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MNvruXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rteONJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvblRTBDEea4fKwSGMr6CA" target="_rteOMJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rteONZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rteOOZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXXNyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MNvrtnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MNvrt3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MNvruHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rteONpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rteON5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rteOOJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MPO5dHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvlS0DBDEea4fKwSGMr6CA" target="_MPO5cHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MPO5dXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MPO5eXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rvtC1JnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvlS0DBDEea4fKwSGMr6CA" target="_rvtC0JnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rvtC1ZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rvtC2ZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MPO5dnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPO5d3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPO5eHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rvtC1pnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rvtC15nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rvtC2JnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MRwpBHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvlTcTBDEea4fKwSGMr6CA" target="_MRwpAHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MRwpBXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MRwpCXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_rxMQlJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvlTcTBDEea4fKwSGMr6CA" target="_rxMQkJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rxMQlZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rxMQmZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXGdyKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MRwpBnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MRwpB3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MRwpCHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rxMQlpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rxMQl5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rxMQmJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MVLwdHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_WvlUkzBDEea4fKwSGMr6CA" target="_MVLwcHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MVLwdXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MVLweXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ry-ZRJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_WvlUkzBDEea4fKwSGMr6CA" target="_ry-ZQJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ry-ZRZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ry-ZSZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZW99yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MVLwdnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MVLwd3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MVLweHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ry-ZRpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ry-ZR5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ry-ZSJnqEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MWq-NHjfEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_r05PgEwCEeewALXL7BvPYw" target="_MWq-MHjfEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MWq-NXjfEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MWq-OXjfEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_r0nYBJnqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_r05PgEwCEeewALXL7BvPYw" target="_r0nYAJnqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r0nYBZnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r0nYCZnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MWq-NnjfEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MWq-N3jfEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MWq-OHjfEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r0nYBpnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r0nYB5nqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r0nYCJnqEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r1gI15nqEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_5KEA4JnDEemVaY_egjrbOQ" target="_r1gI05nqEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r1gI2JnqEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r1gI3JnqEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiTopology.uml#_-ht5oPMtEeSb-q8_djA2ng"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r1gI2ZnqEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r1gI2pnqEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r1gI25nqEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_d6faUDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="TopologyServiceSkeleton" measurementUnit="Pixel">
@@ -2783,133 +2892,133 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpoRM3Eee0L_IMWjydgQ" x="412" y="-206" width="213" height="71"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TjIS8HjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TjIS8XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TjIS83jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c4nkgJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c4nkgZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c4nkg5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TjIS8njhEemfSIWqmJMEQA" x="418" y="-26"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c4nkgpnDEemVaY_egjrbOQ" x="418" y="-26"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tjb08HjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tjb08XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tjb083jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c5EQc5nDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c5EQdJnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c5EQdpnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tjb08njhEemfSIWqmJMEQA" x="418" y="-126"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c5EQdZnDEemVaY_egjrbOQ" x="418" y="-126"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tjb1AXjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tjb1AnjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tjb1BHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c5XLYJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c5XLYZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c5XLY5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tjb1A3jhEemfSIWqmJMEQA" x="418" y="-126"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c5XLYpnDEemVaY_egjrbOQ" x="418" y="-126"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tj350HjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tj350XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tj3503jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c6P8M5nDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c6P8NJnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c6P8NpnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiTopology.uml#_-ht5oPMtEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tj350njhEemfSIWqmJMEQA" x="60" y="88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c6P8NZnDEemVaY_egjrbOQ" x="60" y="88"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TlEMo3jhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TlEMpHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TlEMpnjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c6_jEJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c6_jEZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c6_jE5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TlEMpXjhEemfSIWqmJMEQA" x="667" y="342"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c6_jEpnDEemVaY_egjrbOQ" x="667" y="342"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TlzzgHjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TlzzgXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tlzzg3jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c8Vm4JnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c8Vm4ZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c8Vm45nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TlzzgnjhEemfSIWqmJMEQA" x="568" y="158"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c8Vm4pnDEemVaY_egjrbOQ" x="568" y="158"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tl9kh3jhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tl9kiHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tl9kinjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c87cwJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c87cwZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c87cw5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tl9kiXjhEemfSIWqmJMEQA" x="568" y="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c87cwpnDEemVaY_egjrbOQ" x="568" y="58"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TmGud3jhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TmGueHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TmGuenjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c9FNwJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c9FNwZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c9FNw5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TmGueXjhEemfSIWqmJMEQA" x="568" y="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9FNwpnDEemVaY_egjrbOQ" x="568" y="58"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TmtLY3jhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TmtLZHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TmtLZnjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c99-kJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c99-kZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c99-k5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TmtLZXjhEemfSIWqmJMEQA" x="345" y="339"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c99-kpnDEemVaY_egjrbOQ" x="345" y="339"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TncyQHjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TncyQXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TncyQ3jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c-3WcJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c-3WcZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c-3Wc5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_oCmjAETtEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TncyQnjhEemfSIWqmJMEQA" x="57" y="-20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c-3WcpnDEemVaY_egjrbOQ" x="57" y="-20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TnvtMHjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TnvtMXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TnvtM3jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_c_KRYJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_c_KRYZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c_KRY5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_v4NNUETtEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TnvtMnjhEemfSIWqmJMEQA" x="57" y="-120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c_KRYpnDEemVaY_egjrbOQ" x="57" y="-120"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ToMZIHjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ToMZIXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ToMZI3jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_dAMzMJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dAMzMZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dAMzM5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ToMZInjhEemfSIWqmJMEQA" x="119" y="-214"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dAMzMpnDEemVaY_egjrbOQ" x="119" y="-214"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TofUEHjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TofUEXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TofUE3jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_dA8aEJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dA8aEZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dA8aE5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TofUEnjhEemfSIWqmJMEQA" x="119" y="-314"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dA8aEpnDEemVaY_egjrbOQ" x="119" y="-314"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TofUI3jhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TofUJHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TofUJnjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_dBGLEJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dBGLEZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dBGLE5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_SoY-cMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TofUJXjhEemfSIWqmJMEQA" x="119" y="-314"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dBGLEpnDEemVaY_egjrbOQ" x="119" y="-314"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_TopFF3jhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TopFGHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TopFGnjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_dBi3AJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dBi3AZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dBi3A5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TopFGXjhEemfSIWqmJMEQA" x="119" y="-314"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dBi3ApnDEemVaY_egjrbOQ" x="119" y="-314"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Tph14HjhEemfSIWqmJMEQA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Tph14XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tph143jhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_dDLOsJnDEemVaY_egjrbOQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dDLOsZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dDLOs5nDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Tph14njhEemfSIWqmJMEQA" x="612" y="-206"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dDLOspnDEemVaY_egjrbOQ" x="612" y="-206"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_d6faUTBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_d6faUjBDEea4fKwSGMr6CA"/>
@@ -3273,165 +3382,165 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2IgxYGBdEemmf8tAu_V-ow" id="(1.0,0.41509433962264153)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2IhYcGBdEemmf8tAu_V-ow" id="(0.5837837837837838,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TjIS9HjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_i9BgRjBDEea4fKwSGMr6CA" target="_TjIS8HjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TjIS9XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TjIS-XjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c4nkhJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_i9BgRjBDEea4fKwSGMr6CA" target="_c4nkgJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c4nkhZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c4nkiZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TjIS9njhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TjIS93jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TjIS-HjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c4nkhpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c4nkh5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c4nkiJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tjb09HjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_GdOAUIuGEeiu6boZkiJHCA" target="_Tjb08HjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tjb09XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tjb0-XjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c5EQd5nDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_GdOAUIuGEeiu6boZkiJHCA" target="_c5EQc5nDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c5EQeJnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c5EQfJnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tjb09njhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tjb093jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tjb0-HjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c5EQeZnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c5EQepnDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c5EQe5nDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tjb1BXjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_KCgE8IuGEeiu6boZkiJHCA" target="_Tjb1AXjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tjb1BnjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tjb1CnjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c5XLZJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_KCgE8IuGEeiu6boZkiJHCA" target="_c5XLYJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c5XLZZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c5XLaZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tjb1B3jhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tjb1CHjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tjb1CXjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c5XLZpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c5XLZ5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c5XLaJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tj351HjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_i9BgkzBDEea4fKwSGMr6CA" target="_Tj350HjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tj351XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tj352XjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c6P8N5nDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_i9BgkzBDEea4fKwSGMr6CA" target="_c6P8M5nDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c6P8OJnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c6P8PJnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiTopology.uml#_-ht5oPMtEeSb-q8_djA2ng"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tj351njhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tj3513jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tj352HjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c6P8OZnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c6P8OpnDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c6P8O5nDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TlEMp3jhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_i9LREDBDEea4fKwSGMr6CA" target="_TlEMo3jhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TlEMqHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TlEMrHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c6_jFJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_i9LREDBDEea4fKwSGMr6CA" target="_c6_jEJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c6_jFZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c6_jGZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TlEMqXjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TlEMqnjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TlEMq3jhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c6_jFpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c6_jF5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c6_jGJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TlzzhHjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_i9LRtzBDEea4fKwSGMr6CA" target="_TlzzgHjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TlzzhXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TlzziXjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c8Vm5JnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_i9LRtzBDEea4fKwSGMr6CA" target="_c8Vm4JnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c8Vm5ZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c8Vm6ZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TlzzhnjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tlzzh3jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TlzziHjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c8Vm5pnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c8Vm55nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c8Vm6JnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tl9ki3jhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_N4TR0IuGEeiu6boZkiJHCA" target="_Tl9kh3jhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tl9kjHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tl9kkHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c87cxJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_N4TR0IuGEeiu6boZkiJHCA" target="_c87cwJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c87cxZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c87cyZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tl9kjXjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tl9kjnjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tl9kj3jhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c87cxpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c87cx5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c87cyJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TmGue3jhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_aE_4MIuGEeiu6boZkiJHCA" target="_TmGud3jhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TmGufHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TmGugHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c9FNxJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_aE_4MIuGEeiu6boZkiJHCA" target="_c9FNwJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c9FNxZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c9FNyZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TmGufXjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TmGufnjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TmGuf3jhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c9FNxpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c9FNx5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c9FNyJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TmtLZ3jhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_i9LSWTBDEea4fKwSGMr6CA" target="_TmtLY3jhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TmtLaHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TmtLbHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c99-lJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_i9LSWTBDEea4fKwSGMr6CA" target="_c99-kJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c99-lZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c99-mZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TmtLaXjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TmtLanjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TmtLa3jhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c99-lpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c99-l5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c99-mJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TncyRHjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_q5U4gETtEead1bezhJG4aw" target="_TncyQHjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TncyRXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TncySXjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c-3WdJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_q5U4gETtEead1bezhJG4aw" target="_c-3WcJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c-3WdZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c-3WeZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_oCmjAETtEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TncyRnjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TncyR3jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TncySHjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c-3WdpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c-3Wd5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c-3WeJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TnvtNHjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_At2pwIuGEeiu6boZkiJHCA" target="_TnvtMHjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TnvtNXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TnvtOXjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_c_KRZJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_At2pwIuGEeiu6boZkiJHCA" target="_c_KRYJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_c_KRZZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_c_KRaZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_v4NNUETtEead1bezhJG4aw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TnvtNnjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TnvtN3jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TnvtOHjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c_KRZpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c_KRZ5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c_KRaJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ToMZJHjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_PTdqAshmEeaVlemTikmRHw" target="_ToMZIHjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ToMZJXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ToMZKXjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_dAMzNJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_PTdqAshmEeaVlemTikmRHw" target="_dAMzMJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dAMzNZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dAMzOZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ToMZJnjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ToMZJ3jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ToMZKHjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dAMzNpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dAMzN5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dAMzOJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TofUFHjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_tkf-cBM3Eee0L_IMWjydgQ" target="_TofUEHjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TofUFXjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TofUGXjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_dA8aFJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_tkf-cBM3Eee0L_IMWjydgQ" target="_dA8aEJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dA8aFZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dA8aGZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TofUFnjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TofUF3jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TofUGHjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dA8aFpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dA8aF5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dA8aGJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TofUJ3jhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_4NSW4IuFEeiu6boZkiJHCA" target="_TofUI3jhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TofUKHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TofULHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_dBGLFJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_4NSW4IuFEeiu6boZkiJHCA" target="_dBGLEJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dBGLFZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dBGLGZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_SoY-cMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TofUKXjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TofUKnjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TofUK3jhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dBGLFpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dBGLF5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dBGLGJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TopFG3jhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_7PbSMIuFEeiu6boZkiJHCA" target="_TopFF3jhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TopFHHjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TopFIHjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_dBi3BJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_7PbSMIuFEeiu6boZkiJHCA" target="_dBi3AJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dBi3BZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dBi3CZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TopFHXjhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TopFHnjhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TopFH3jhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dBi3BpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dBi3B5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dBi3CJnDEemVaY_egjrbOQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Tph15HjhEemfSIWqmJMEQA" type="StereotypeCommentLink" source="_p9gpoBM3Eee0L_IMWjydgQ" target="_Tph14HjhEemfSIWqmJMEQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Tph15XjhEemfSIWqmJMEQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Tph16XjhEemfSIWqmJMEQA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_dDLOtJnDEemVaY_egjrbOQ" type="StereotypeCommentLink" source="_p9gpoBM3Eee0L_IMWjydgQ" target="_dDLOsJnDEemVaY_egjrbOQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dDLOtZnDEemVaY_egjrbOQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dDLOuZnDEemVaY_egjrbOQ" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Tph15njhEemfSIWqmJMEQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tph153jhEemfSIWqmJMEQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Tph16HjhEemfSIWqmJMEQA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dDLOtpnDEemVaY_egjrbOQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dDLOt5nDEemVaY_egjrbOQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dDLOuJnDEemVaY_egjrbOQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_vy9qUBk7EeeV4o0osG5stg" type="PapyrusUMLClassDiagram" name="NodeConstraints" measurementUnit="Pixel">

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -328,39 +328,95 @@ License: This module is distributed under the Apache License 2.0</body>
     <packagedElement xmi:type="uml:Package" xmi:id="_UWAzIC5xEea0_JngOlSKcA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_-ht5oPMtEeSb-q8_djA2ng" name="TopologyService" isLeaf="true">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_taDjMPMvEeSb-q8_djA2ng" name="getTopologyDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0HRXMPMxEeSb-q8_djA2ng" name="topologyIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0HRXMPMxEeSb-q8_djA2ng" name="topologyId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_zl1RkJnqEemrjrtN9v_T1A" annotatedElement="_0HRXMPMxEeSb-q8_djA2ng">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
             <defaultValue xmi:type="uml:LiteralNull" xmi:id="_0HRXMfMxEeSb-q8_djA2ng"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_l8oKkEpeEeW7b92SEnwDVg" name="topology" type="_ejyEgOKyEeSq5fATALSQkQ" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_N-W74PMwEeSb-q8_djA2ng" name="getNodeDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qRQggLsEEeWYrqoqXLgguw" name="topologyIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qRQggLsEEeWYrqoqXLgguw" name="topologyId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_5H2IoJnqEemrjrtN9v_T1A" annotatedElement="_qRQggLsEEeWYrqoqXLgguw">
+              <body>UUID of the parent Topology: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_B2HeEPM4EeSb-q8_djA2ng" name="nodeIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_B2HeEPM4EeSb-q8_djA2ng" name="nodeId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_9lR9QJnqEemrjrtN9v_T1A" annotatedElement="_B2HeEPM4EeSb-q8_djA2ng">
+              <body>UUID of the Node: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_FmxFMPM4EeSb-q8_djA2ng" name="node" type="_xImb0OK4EeSq5fATALSQkQ" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_dACyYPMwEeSb-q8_djA2ng" name="getNodeEdgePointDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_mNsdwN6NEeWd9KDn6x5Skg" name="topologyIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_mNsdwN6NEeWd9KDn6x5Skg" name="topologyId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_DGRgoJnrEemrjrtN9v_T1A" annotatedElement="_mNsdwN6NEeWd9KDn6x5Skg">
+              <body>UUID of the parent Node's Topology: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2nCKYLsEEeWYrqoqXLgguw" name="nodeIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2nCKYLsEEeWYrqoqXLgguw" name="nodeId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_HFK_IJnrEemrjrtN9v_T1A" annotatedElement="_2nCKYLsEEeWYrqoqXLgguw">
+              <body>UUID of the parent Node: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_QDy9YPM7EeSb-q8_djA2ng" name="epIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_QDy9YPM7EeSb-q8_djA2ng" name="nodeEdgePointId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_IlSuEJnrEemrjrtN9v_T1A" annotatedElement="_QDy9YPM7EeSb-q8_djA2ng">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_bH8AQPM7EeSb-q8_djA2ng" name="nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_AgHtkFJFEeWDQNzGZgIgfQ" name="getLinkDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_yctfALsEEeWYrqoqXLgguw" name="topologyIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_yctfALsEEeWYrqoqXLgguw" name="topologyId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_PQzj0JnrEemrjrtN9v_T1A" annotatedElement="_yctfALsEEeWYrqoqXLgguw">
+              <body>UUID of the parent Topology: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_AgHtkVJFEeWDQNzGZgIgfQ" name="linkIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_AgHtkVJFEeWDQNzGZgIgfQ" name="linkId" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_RjTK4JnrEemrjrtN9v_T1A" annotatedElement="_AgHtkVJFEeWDQNzGZgIgfQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_AgHtklJFEeWDQNzGZgIgfQ" name="link" type="_37fFQOMCEeSdZOEXoN8VDQ" direction="out" effect="read"/>
         </ownedOperation>
@@ -509,7 +565,7 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ejyEheKyEeSq5fATALSQkQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ejyEhuKyEeSq5fATALSQkQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_UOQlcEjPEemQk4cp72JbZA" name="_boundaryNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" aggregation="shared" association="_UN7OQEjPEemQk4cp72JbZA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UOQlcEjPEemQk4cp72JbZA" name="_boundaryNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" aggregation="shared" association="_UN7OQEjPEemQk4cp72JbZA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gXt1IEjQEemQk4cp72JbZA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UOXTIEjPEemQk4cp72JbZA" value="*"/>
         </ownedAttribute>

--- a/UML/TapiVirtualNetwork.notation
+++ b/UML/TapiVirtualNetwork.notation
@@ -371,157 +371,157 @@
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kN8sgRM8Eee0L_IMWjydgQ" x="548" y="-41" width="202" height="73"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BovRoFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BovRoVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BovRo1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r6VXwJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r6VXwZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r6VXw5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BovRolovEemu443YKSGnxQ" x="875" y="79"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r6VXwpnlEemrjrtN9v_T1A" x="875" y="79"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bo5CoFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Bo5CoVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bo5Co1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r6oSsJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r6oSsZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r6oSs5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bo5ColovEemu443YKSGnxQ" x="875" y="-21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r6oSspnlEemrjrtN9v_T1A" x="875" y="-21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bo5CsVovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Bo5CslovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bo5CtFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r6yDsJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r6yDsZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r6yDs5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bo5Cs1ovEemu443YKSGnxQ" x="875" y="-21"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r6yDspnlEemrjrtN9v_T1A" x="875" y="-21"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BpL9l1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BpL9mFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpL9mlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r7OIk5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r7OIlJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r7OIlpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_pbiZgPTYEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BpL9mVovEemu443YKSGnxQ" x="493" y="252"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r7OIlZnlEemrjrtN9v_T1A" x="493" y="252"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bpopg1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BpophFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpophlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r8kMYJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r8kMYZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r8kMY5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BpophVovEemu443YKSGnxQ" x="501" y="75"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r8kMYpnlEemrjrtN9v_T1A" x="501" y="75"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bpxzd1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BpxzeFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpxzelovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r8tWX5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r8tWYJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r8tWYpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_9CCfAPTYEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BpxzeVovEemu443YKSGnxQ" x="501" y="-25"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r8tWYZnlEemrjrtN9v_T1A" x="501" y="-25"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bp7kcFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Bp7kcVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bp7kc1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r83HU5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r83HVJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r83HVpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bp7kclovEemu443YKSGnxQ" x="501" y="-25"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r83HVZnlEemrjrtN9v_T1A" x="501" y="-25"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bp7kgVovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Bp7kglovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bp7khFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r9A4UJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r9A4UZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9A4U5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_oWBRAPTaEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bp7kg1ovEemu443YKSGnxQ" x="501" y="-25"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r9A4UpnlEemrjrtN9v_T1A" x="501" y="-25"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BqFVflovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BqFVf1ovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BqFVgVovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r9KCQ5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r9KCRJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9KCRpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiVirtualNetwork.uml#_02QCUPUlEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BqFVgFovEemu443YKSGnxQ" x="174" y="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r9KCRZnlEemrjrtN9v_T1A" x="174" y="77"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BqYQa1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BqYQbFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BqYQblovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r9c9M5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r9c9NJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9c9NpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BqYQbVovEemu443YKSGnxQ" x="874" y="383"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r9c9NZnlEemrjrtN9v_T1A" x="874" y="383"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BrRBN1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BrRBOFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BrRBOlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r95pIJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r95pIZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r95pI5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BrRBOVovEemu443YKSGnxQ" x="865" y="259"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r95pIpnlEemrjrtN9v_T1A" x="865" y="259"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BrttIFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BrttIVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BrttI1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r-DaI5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r-DaJJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r-DaJpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BrttIlovEemu443YKSGnxQ" x="865" y="159"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r-DaJZnlEemrjrtN9v_T1A" x="865" y="159"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BsAoEFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BsAoEVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BsAoE1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r-WVE5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r-WVFJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r-WVFpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_BBDOEPTgEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsAoElovEemu443YKSGnxQ" x="177" y="208"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r-WVFZnlEemrjrtN9v_T1A" x="177" y="208"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BsdUAFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BsdUAVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BsdUA1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r-zBA5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r-zBBJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r-zBBpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsdUAlovEemu443YKSGnxQ" x="1075" y="151"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r-zBBZnlEemrjrtN9v_T1A" x="1075" y="151"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BsxdE1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BsxdFFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BsxdFlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_r_Ps8JnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r_Ps8ZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r_Ps85nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BsxdFVovEemu443YKSGnxQ" x="496" y="387"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r_Ps8pnlEemrjrtN9v_T1A" x="496" y="387"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bt0l91ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Bt0l-FovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bt0l-lovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_sASOwJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_sASOwZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sASOw5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_FKbC0Mh5EeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bt0l-VovEemu443YKSGnxQ" x="189" y="-40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sASOwpnlEemrjrtN9v_T1A" x="189" y="-40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BuHg41ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BuHg5FovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BuHg5lovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_sAlJs5nlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_sAlJtJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sAlJtpnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiVirtualNetwork.uml#_m5z10BM8Eee0L_IMWjydgQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BuHg5VovEemu443YKSGnxQ" x="189" y="-140"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sAlJtZnlEemrjrtN9v_T1A" x="189" y="-140"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_BuHg9lovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BuHg91ovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BuHg-VovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_sAlJxpnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_sAlJx5nlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sAlJyZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_S3gd4Mh5EeaVlemTikmRHw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BuHg-FovEemu443YKSGnxQ" x="189" y="-140"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sAlJyJnlEemrjrtN9v_T1A" x="189" y="-140"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ButWwFovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ButWwVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ButWw1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_sBK_kJnlEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_sBK_kZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sBK_k5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ButWwlovEemu443YKSGnxQ" x="748" y="-41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sBK_kpnlEemrjrtN9v_T1A" x="748" y="-41"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_g5NmgTBJEeaSroGqGbZ6jg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_g5NmgjBJEeaSroGqGbZ6jg"/>
@@ -866,196 +866,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GuspgouUEeiu6boZkiJHCA" points="[517, 112, -643984, -643984]$[675, 107, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JaKxQIuUEeiu6boZkiJHCA" id="(1.0,0.2891566265060241)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BovRpFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lfOIUDBJEeaSroGqGbZ6jg" target="_BovRoFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BovRpVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BovRqVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BovRplovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BovRp1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BovRqFovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bo5CpFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_AHxY0IuUEeiu6boZkiJHCA" target="_Bo5CoFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Bo5CpVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bo5CqVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bo5CplovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bo5Cp1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bo5CqFovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bo5CtVovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_D7StwIuUEeiu6boZkiJHCA" target="_Bo5CsVovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Bo5CtlovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bo5CulovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bo5Ct1ovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bo5CuFovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bo5CuVovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BpL9m1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lfOIkTBJEeaSroGqGbZ6jg" target="_BpL9l1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BpL9nFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpL9oFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_pbiZgPTYEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BpL9nVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BpL9nlovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BpL9n1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bpoph1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lfOI0jBJEeaSroGqGbZ6jg" target="_Bpopg1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BpopiFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpopjFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BpopiVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BpopilovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bpopi1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bpxze1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_oCZUQIuTEeiu6boZkiJHCA" target="_Bpxzd1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BpxzfFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BpxzgFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_9CCfAPTYEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BpxzfVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BpxzflovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bpxzf1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bp7kdFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_qDzLUIuTEeiu6boZkiJHCA" target="_Bp7kcFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Bp7kdVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bp7keVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bp7kdlovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bp7kd1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bp7keFovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bp7khVovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_GuspgIuUEeiu6boZkiJHCA" target="_Bp7kgVovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Bp7khlovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bp7kilovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_oWBRAPTaEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bp7kh1ovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bp7kiFovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bp7kiVovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BqFVglovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lfX5hTBJEeaSroGqGbZ6jg" target="_BqFVflovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BqFVg1ovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BqFVh1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Interface" href="TapiVirtualNetwork.uml#_02QCUPUlEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BqFVhFovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BqFVhVovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BqFVhlovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BqYQb1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lfX6KTBJEeaSroGqGbZ6jg" target="_BqYQa1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BqYQcFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BqYQdFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BqYQcVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BqYQclovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BqYQc1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BrRBO1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_lfX6kjBJEeaSroGqGbZ6jg" target="_BrRBN1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BrRBPFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BrRBQFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BrRBPVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BrRBPlovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BrRBP1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BrttJFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_96EyMIuTEeiu6boZkiJHCA" target="_BrttIFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BrttJVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BrttKVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BrttJlovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BrttJ1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BrttKFovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BsAoFFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_M5-vQD3vEea-1_BGg-qcjQ" target="_BsAoEFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BsAoFVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BsAoGVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_BBDOEPTgEeWQB8HQFBfkJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BsAoFlovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BsAoF1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BsAoGFovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BsdUBFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_7ro1kEJwEea-2Meh9kw1kA" target="_BsdUAFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BsdUBVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BsdUCVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BsdUBlovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BsdUB1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BsdUCFovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BsxdF1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_N-VAYE0SEeaqn4OIuRCwEg" target="_BsxdE1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BsxdGFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BsxdHFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BsxdGVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BsxdGlovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BsxdG1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bt0l-1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_FMDagsh5EeaVlemTikmRHw" target="_Bt0l91ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Bt0l_FovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bt0mAFovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_FKbC0Mh5EeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bt0l_VovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bt0l_lovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bt0l_1ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BuHg51ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_m50c4BM8Eee0L_IMWjydgQ" target="_BuHg41ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BuHg6FovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BuHg7FovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiVirtualNetwork.uml#_m5z10BM8Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BuHg6VovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BuHg6lovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BuHg61ovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BuHg-lovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_ksw1MIuTEeiu6boZkiJHCA" target="_BuHg9lovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BuHg-1ovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BuHg_1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_S3gd4Mh5EeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BuHg_FovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BuHg_VovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BuHg_lovEemu443YKSGnxQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ButWxFovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_kN8sgBM8Eee0L_IMWjydgQ" target="_ButWwFovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ButWxVovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ButWyVovEemu443YKSGnxQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ButWxlovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ButWx1ovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ButWyFovEemu443YKSGnxQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IpeJcFovEemu443YKSGnxQ" type="InterfaceRealization_Edge" source="_lfOI0jBJEeaSroGqGbZ6jg" target="_lfX5hTBJEeaSroGqGbZ6jg">
       <children xmi:type="notation:DecorationNode" xmi:id="_IpeJc1ovEemu443YKSGnxQ" type="InterfaceRealization_StereotypeLabel">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_IpeJdFovEemu443YKSGnxQ" y="40"/>
@@ -1068,6 +878,196 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IpeJclovEemu443YKSGnxQ" points="[301, 122, -643984, -643984]$[120, 122, -643984, -643984]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IswG8FovEemu443YKSGnxQ" id="(0.0,0.5662650602409639)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IswG8VovEemu443YKSGnxQ" id="(1.0,0.4838709677419355)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r6VXxJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lfOIUDBJEeaSroGqGbZ6jg" target="_r6VXwJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r6VXxZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r6VXyZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r6VXxpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r6VXx5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r6VXyJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r6oStJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_AHxY0IuUEeiu6boZkiJHCA" target="_r6oSsJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r6oStZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r6oSuZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r6oStpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r6oSt5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r6oSuJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r6yDtJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_D7StwIuUEeiu6boZkiJHCA" target="_r6yDsJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r6yDtZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r6yDuZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r6yDtpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r6yDt5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r6yDuJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r7OIl5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lfOIkTBJEeaSroGqGbZ6jg" target="_r7OIk5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r7OImJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r7OInJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_pbiZgPTYEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r7OImZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r7OImpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r7OIm5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r8kMZJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lfOI0jBJEeaSroGqGbZ6jg" target="_r8kMYJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r8kMZZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r8kMaZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r8kMZpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r8kMZ5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r8kMaJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r8tWY5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_oCZUQIuTEeiu6boZkiJHCA" target="_r8tWX5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r8tWZJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r8tWaJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_9CCfAPTYEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r8tWZZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r8tWZpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r8tWZ5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r83HV5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_qDzLUIuTEeiu6boZkiJHCA" target="_r83HU5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r83HWJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r83HXJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r83HWZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r83HWpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r83HW5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r9A4VJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_GuspgIuUEeiu6boZkiJHCA" target="_r9A4UJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r9A4VZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9A4WZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_oWBRAPTaEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r9A4VpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9A4V5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9A4WJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r9KCR5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lfX5hTBJEeaSroGqGbZ6jg" target="_r9KCQ5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r9KCSJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9KCTJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiVirtualNetwork.uml#_02QCUPUlEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r9KCSZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9KCSpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9KCS5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r9c9N5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lfX6KTBJEeaSroGqGbZ6jg" target="_r9c9M5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r9c9OJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r9c9PJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r9c9OZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9c9OpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r9c9O5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r95pJJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_lfX6kjBJEeaSroGqGbZ6jg" target="_r95pIJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r95pJZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r95pKZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r95pJpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r95pJ5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r95pKJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r-DaJ5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_96EyMIuTEeiu6boZkiJHCA" target="_r-DaI5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r-DaKJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r-DaLJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r-DaKZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r-DaKpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r-DaK5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r-WVF5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_M5-vQD3vEea-1_BGg-qcjQ" target="_r-WVE5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r-WVGJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r-WVHJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_BBDOEPTgEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r-WVGZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r-WVGpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r-WVG5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r-zBB5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_7ro1kEJwEea-2Meh9kw1kA" target="_r-zBA5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r-zBCJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r-zBDJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r-zBCZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r-zBCpnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r-zBC5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r_Ps9JnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_N-VAYE0SEeaqn4OIuRCwEg" target="_r_Ps8JnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r_Ps9ZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r_Ps-ZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r_Ps9pnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r_Ps95nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r_Ps-JnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sASOxJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_FMDagsh5EeaVlemTikmRHw" target="_sASOwJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sASOxZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sASOyZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_FKbC0Mh5EeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sASOxpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sASOx5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sASOyJnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sAlJt5nlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_m50c4BM8Eee0L_IMWjydgQ" target="_sAlJs5nlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sAlJuJnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sAlJvJnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiVirtualNetwork.uml#_m5z10BM8Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sAlJuZnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sAlJupnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sAlJu5nlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sAlJypnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ksw1MIuTEeiu6boZkiJHCA" target="_sAlJxpnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sAlJy5nlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sAlJz5nlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_S3gd4Mh5EeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sAlJzJnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sAlJzZnlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sAlJzpnlEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sBK_lJnlEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_kN8sgBM8Eee0L_IMWjydgQ" target="_sBK_kJnlEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sBK_lZnlEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sBK_mZnlEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sBK_lpnlEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sBK_l5nlEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sBK_mJnlEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_IjOs8EQ7EeaktYCiiVTurg" type="PapyrusUMLClassDiagram" name="VirtualNwDetails" measurementUnit="Pixel">
@@ -1183,10 +1183,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_X0rgMxMwEee0L_IMWjydgQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_X0rgNBMwEee0L_IMWjydgQ" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_X0rgNRMwEee0L_IMWjydgQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_YOkmhkXSEeaB8vMnkFQLXQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_YOkmh0XSEeaB8vMnkFQLXQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_YOkmiEXSEeaB8vMnkFQLXQ"/>
@@ -1205,7 +1201,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOkmk0XSEeaB8vMnkFQLXQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOkmgUXSEeaB8vMnkFQLXQ" x="10" y="33" width="454" height="194"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOkmgUXSEeaB8vMnkFQLXQ" x="10" y="33" width="454" height="159"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ZTws8EXSEeaB8vMnkFQLXQ" type="Class_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_ZTws8kXSEeaB8vMnkFQLXQ" type="Class_NameLabel"/>
@@ -1297,53 +1293,139 @@
       <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_FFtS8CzeEeaYO8M_h7XJ5A"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Kt6qQVorEemu443YKSGnxQ" x="23" y="256" height="72"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_AQg6c1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_AQg6dFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AQg6dlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_XX6fwJnpEemrjrtN9v_T1A" type="Interface_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_XYEQwJnpEemrjrtN9v_T1A" type="Interface_NameLabel"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_XYEQwZnpEemrjrtN9v_T1A" type="Interface_FloatingNameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XYEQwpnpEemrjrtN9v_T1A" y="15"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_XYEQw5npEemrjrtN9v_T1A" type="Interface_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_XYEQxJnpEemrjrtN9v_T1A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_XYEQxZnpEemrjrtN9v_T1A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_XYEQxpnpEemrjrtN9v_T1A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XYEQx5npEemrjrtN9v_T1A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_XYEQyJnpEemrjrtN9v_T1A" type="Interface_OperationCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_YkH0MJnpEemrjrtN9v_T1A" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_xuz7AJnpEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiVirtualNetwork.uml#_02QCaPUlEeWQB8HQFBfkJQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YkH0MZnpEemrjrtN9v_T1A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YkH0MpnpEemrjrtN9v_T1A" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_yN644JnpEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiVirtualNetwork.uml#_02QCdPUlEeWQB8HQFBfkJQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YkH0M5npEemrjrtN9v_T1A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YkH0NJnpEemrjrtN9v_T1A" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ysSP4JnpEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiVirtualNetwork.uml#_CK3tgPU7EeWQB8HQFBfkJQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YkH0NZnpEemrjrtN9v_T1A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YkH0NpnpEemrjrtN9v_T1A" type="Operation_InterfaceOperationLabel">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_zIlKUJnpEemrjrtN9v_T1A" name="maskLabel">
+            <stringListValue>parametersName</stringListValue>
+            <stringListValue>parametersDirection</stringListValue>
+            <stringListValue>parametersMultiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>parametersType</stringListValue>
+            <stringListValue>returnType</stringListValue>
+          </styles>
+          <element xmi:type="uml:Operation" href="TapiVirtualNetwork.uml#_KfrcUPU7EeWQB8HQFBfkJQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YkH0N5npEemrjrtN9v_T1A"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_XYEQyZnpEemrjrtN9v_T1A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_XYEQypnpEemrjrtN9v_T1A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_XYEQy5npEemrjrtN9v_T1A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XYEQzJnpEemrjrtN9v_T1A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_XYEQzZnpEemrjrtN9v_T1A" type="Interface_NestedClassifierCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_XYEQzpnpEemrjrtN9v_T1A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_XYEQz5npEemrjrtN9v_T1A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_XYEQ0JnpEemrjrtN9v_T1A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XYEQ0ZnpEemrjrtN9v_T1A"/>
+      </children>
+      <element xmi:type="uml:Interface" href="TapiVirtualNetwork.uml#_02QCUPUlEeWQB8HQFBfkJQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XX6fwZnpEemrjrtN9v_T1A" x="14" y="-109" height="110"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bKKFgJntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bKKFgZntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bKKFg5ntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_BBDOEPTgEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AQg6dVovEemu443YKSGnxQ" x="848" y="24"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bKKFgpntEemrjrtN9v_T1A" x="848" y="24"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ARkDV1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ARkDWFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ARkDWlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bL8OMJntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bL8OMZntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bL8OM5ntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ARkDWVovEemu443YKSGnxQ" x="210" y="33"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bL8OMpntEemrjrtN9v_T1A" x="210" y="33"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ASTqXVovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ASTqXlovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ASTqYFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bM1mE5ntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bM1mFJntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bM1mFpntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ASTqX1ovEemu443YKSGnxQ" x="210" y="-67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bM1mFZntEemrjrtN9v_T1A" x="210" y="-67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ASc0J1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ASc0KFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ASc0KlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bM-wA5ntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bM-wBJntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bM-wBpntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_9CCfAPTYEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ASc0KVovEemu443YKSGnxQ" x="210" y="-67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bM-wBZntEemrjrtN9v_T1A" x="210" y="-67"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ASvvE1ovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ASvvFFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ASvvFlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bNbb8JntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bNbb8ZntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bNbb85ntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_pbiZgPTYEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ASvvFVovEemu443YKSGnxQ" x="841" y="276"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bNbb8pntEemrjrtN9v_T1A" x="841" y="276"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_ATWMBlovEemu443YKSGnxQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ATWMB1ovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ATWMCVovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bOUz05ntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bOUz1JntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bOUz1pntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiVirtualNetwork.uml#_Mop4oForEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ATWMCFovEemu443YKSGnxQ" x="221" y="309"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bOUz1ZntEemrjrtN9v_T1A" x="221" y="309"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bOnuw5ntEemrjrtN9v_T1A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bOnuxJntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bOnuxpntEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiVirtualNetwork.uml#_02QCUPUlEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bOnuxZntEemrjrtN9v_T1A" x="214" y="-109"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_IjOs8UQ7EeaktYCiiVTurg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_IjOs8kQ7EeaktYCiiVTurg"/>
@@ -1373,6 +1455,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_ZgZqcYuTEeiu6boZkiJHCA"/>
       <element xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZgZqcouTEeiu6boZkiJHCA" points="[464, 125, -643984, -643984]$[648, 130, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aW8csJnpEemrjrtN9v_T1A" id="(1.0,0.5786163522012578)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_chqcAIuTEeiu6boZkiJHCA" type="Association_Edge" source="_YOkmgEXSEeaB8vMnkFQLXQ" target="_ZTws8EXSEeaB8vMnkFQLXQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_chrDEIuTEeiu6boZkiJHCA" type="Association_StereotypeLabel">
@@ -1451,65 +1534,75 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MudlsForEemu443YKSGnxQ" id="(0.38095238095238093,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MudlsVorEemu443YKSGnxQ" id="(0.5310734463276836,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_AQg6d1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_Jqyx8EQ7EeaktYCiiVTurg" target="_AQg6c1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_AQg6eFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_AQg6fFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bKKFhJntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Jqyx8EQ7EeaktYCiiVTurg" target="_bKKFgJntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bKKFhZntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bKKFiZntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_BBDOEPTgEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AQg6eVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AQg6elovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AQg6e1ovEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bKKFhpntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bKKFh5ntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bKKFiJntEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ARkDW1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_YOkmgEXSEeaB8vMnkFQLXQ" target="_ARkDV1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ARkDXFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ARkDYFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bL8ONJntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_YOkmgEXSEeaB8vMnkFQLXQ" target="_bL8OMJntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bL8ONZntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bL8OOZntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ARkDXVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ARkDXlovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ARkDX1ovEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bL8ONpntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bL8ON5ntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bL8OOJntEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ASTqYVovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_ZgZqcIuTEeiu6boZkiJHCA" target="_ASTqXVovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ASTqYlovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ASTqZlovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bM1mF5ntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZgZqcIuTEeiu6boZkiJHCA" target="_bM1mE5ntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bM1mGJntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bM1mHJntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ASTqY1ovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ASTqZFovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ASTqZVovEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bM1mGZntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bM1mGpntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bM1mG5ntEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ASc0K1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_chqcAIuTEeiu6boZkiJHCA" target="_ASc0J1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ASc0LFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ASc0MFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bM-wB5ntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_chqcAIuTEeiu6boZkiJHCA" target="_bM-wA5ntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bM-wCJntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bM-wDJntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_9CCfAPTYEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ASc0LVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ASc0LlovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ASc0L1ovEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bM-wCZntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bM-wCpntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bM-wC5ntEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ASvvF1ovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_ZTws8EXSEeaB8vMnkFQLXQ" target="_ASvvE1ovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ASvvGFovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ASvvHFovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bNbb9JntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_ZTws8EXSEeaB8vMnkFQLXQ" target="_bNbb8JntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bNbb9ZntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bNbb-ZntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_pbiZgPTYEeWQB8HQFBfkJQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ASvvGVovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ASvvGlovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ASvvG1ovEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bNbb9pntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bNbb95ntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bNbb-JntEemrjrtN9v_T1A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ATWMClovEemu443YKSGnxQ" type="StereotypeCommentLink" source="_Mop4oVorEemu443YKSGnxQ" target="_ATWMBlovEemu443YKSGnxQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ATWMC1ovEemu443YKSGnxQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ATWMD1ovEemu443YKSGnxQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bOUz15ntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_Mop4oVorEemu443YKSGnxQ" target="_bOUz05ntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bOUz2JntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bOUz3JntEemrjrtN9v_T1A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiVirtualNetwork.uml#_Mop4oForEemu443YKSGnxQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ATWMDFovEemu443YKSGnxQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATWMDVovEemu443YKSGnxQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATWMDlovEemu443YKSGnxQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bOUz2ZntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bOUz2pntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bOUz25ntEemrjrtN9v_T1A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bOnux5ntEemrjrtN9v_T1A" type="StereotypeCommentLink" source="_XX6fwJnpEemrjrtN9v_T1A" target="_bOnuw5ntEemrjrtN9v_T1A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bOnuyJntEemrjrtN9v_T1A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bOnuzJntEemrjrtN9v_T1A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiVirtualNetwork.uml#_02QCUPUlEeWQB8HQFBfkJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bOnuyZntEemrjrtN9v_T1A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bOnuypntEemrjrtN9v_T1A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bOnuy5ntEemrjrtN9v_T1A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiVirtualNetwork.uml
+++ b/UML/TapiVirtualNetwork.uml
@@ -91,22 +91,59 @@ License: This module is distributed under the Apache License 2.0</body>
     <packagedElement xmi:type="uml:Package" xmi:id="_MJbr4C50Eea0_JngOlSKcA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_02QCUPUlEeWQB8HQFBfkJQ" name="VirtualNetworkService" isLeaf="true">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_02QCaPUlEeWQB8HQFBfkJQ" name="createVirtualNetworkService" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCafUlEeWQB8HQFBfkJQ" name="sep" type="_pbiZgPTYEeWQB8HQFBfkJQ" isUnique="false" effect="read">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_fw15kJnpEemrjrtN9v_T1A" name="uuid">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_u5sIAJnpEemrjrtN9v_T1A" annotatedElement="_fw15kJnpEemrjrtN9v_T1A">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_hUHDIJnpEemrjrtN9v_T1A" name="name">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_35pFkJnpEemrjrtN9v_T1A" annotatedElement="_hUHDIJnpEemrjrtN9v_T1A">
+              <body>List of names. This value is unique in some namespace but may change during the life of the entity.&#xD;
+A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_j20QcJnpEemrjrtN9v_T1A"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_j3HLYJnpEemrjrtN9v_T1A" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCafUlEeWQB8HQFBfkJQ" name="endPoint" type="_pbiZgPTYEeWQB8HQFBfkJQ" isUnique="false" effect="read">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_02QCavUlEeWQB8HQFBfkJQ" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_02QCa_UlEeWQB8HQFBfkJQ" value="*"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbPUlEeWQB8HQFBfkJQ" name="vnwConstraint" type="_BBDOEPTgEeWQB8HQFBfkJQ" isUnique="false" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbfUlEeWQB8HQFBfkJQ" name="connSchedule" isUnique="false" effect="read">
-            <type xmi:type="uml:Class" href="TapiCommon.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbfUlEeWQB8HQFBfkJQ" name="schedule" isUnique="false" effect="read">
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_-ijf4FtVEeexvMtO2oNM9g"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbvUlEeWQB8HQFBfkJQ" name="service" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_02QCdPUlEeWQB8HQFBfkJQ" name="deleteVirtualNetworkService" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCdfUlEeWQB8HQFBfkJQ" name="serviceIdOrName" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCdfUlEeWQB8HQFBfkJQ" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_tP778JnpEemrjrtN9v_T1A" annotatedElement="_02QCdfUlEeWQB8HQFBfkJQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCdvUlEeWQB8HQFBfkJQ" name="service" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out" effect="delete"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_CK3tgPU7EeWQB8HQFBfkJQ" name="getVirtualNetworkServiceDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_CK3tgfU7EeWQB8HQFBfkJQ" name="serviceIdOrName" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_CK3tgfU7EeWQB8HQFBfkJQ" name="uuid" effect="read">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_wTlTIJnpEemrjrtN9v_T1A" annotatedElement="_CK3tgfU7EeWQB8HQFBfkJQ">
+              <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.&#xD;
+An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
+UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
+Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} &#xD;
+Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6</body>
+            </ownedComment>
+            <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_CK3tgvU7EeWQB8HQFBfkJQ" name="service" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_KfrcUPU7EeWQB8HQFBfkJQ" name="getVirtualNetworkServiceList" isLeaf="true">
@@ -188,7 +225,7 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jxy0gD3vEea-1_BGg-qcjQ" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_--7mWvTUEeWQB8HQFBfkJQ" name="_schedule" aggregation="composite">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_-ijf4FtVEeexvMtO2oNM9g"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_--7mW_TUEeWQB8HQFBfkJQ" name="_state" aggregation="composite">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
@@ -369,4 +406,6 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
   <OpenModel_Profile:LifecycleAggregate xmi:id="_LoZCQFrpEeexvMtO2oNM9g" base_Association="_oWBRAPTaEeWQB8HQFBfkJQ"/>
   <OpenModel_Profile:OpenModelStatement xmi:id="_pue-92m2EeiLh_06MH5Rjg" base_Model="_K39JEDA5Eea4fKwSGMr6CA"/>
   <OpenModel_Profile:Specify xmi:id="_OXgAEForEemu443YKSGnxQ" base_Abstraction="_Mop4oForEemu443YKSGnxQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_fw15kZnpEemrjrtN9v_T1A" base_Parameter="_fw15kJnpEemrjrtN9v_T1A"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_hUHDIZnpEemrjrtN9v_T1A" base_Parameter="_hUHDIJnpEemrjrtN9v_T1A"/>
 </xmi:XMI>

--- a/YANG/tapi-common@2019-03-31.tree
+++ b/YANG/tapi-common@2019-03-31.tree
@@ -26,7 +26,7 @@ module: tapi-common
   rpcs:
     +---x get-service-interface-point-details
     |  +---w input
-    |  |  +---w sip-id-or-name?   string
+    |  |  +---w uuid?   uuid
     |  +--ro output
     |     +--ro sip
     |        +--ro layer-protocol-name?                  layer-protocol-name
@@ -68,5 +68,5 @@ module: tapi-common
     |              +--ro unit?    capacity-unit
     +---x update-service-interface-point
        +---w input
-          +---w sip-id-or-name?   string
-          +---w state?            administrative-state
+          +---w uuid?    uuid
+          +---w state?   administrative-state

--- a/YANG/tapi-common@2019-03-31.yang
+++ b/YANG/tapi-common@2019-03-31.yang
@@ -100,7 +100,8 @@ module tapi-common {
     grouping global-class {
         leaf uuid {
             type uuid;
-            description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.
+            description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                An UUID carries no semantics with respect to the purpose or state of the entity.
                 UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
                 Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
                 Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
@@ -108,7 +109,8 @@ module tapi-common {
         list name {
             key 'value-name';
             uses name-and-value;
-            description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
+            description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                A name carries no semantics with respect to the purpose of the entity.";
         }
         description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
     }
@@ -128,7 +130,8 @@ module tapi-common {
         list name {
             key 'value-name';
             uses name-and-value;
-            description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
+            description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                A name carries no semantics with respect to the purpose of the entity.";
         }
         description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
     }
@@ -612,9 +615,13 @@ module tapi-common {
     rpc get-service-interface-point-details {
         description "none";
         input {
-            leaf sip-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -637,9 +644,13 @@ module tapi-common {
     rpc update-service-interface-point {
         description "none";
         input {
-            leaf sip-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
             leaf state {
                 type administrative-state;

--- a/YANG/tapi-connectivity@2019-03-31.tree
+++ b/YANG/tapi-connectivity@2019-03-31.tree
@@ -102,7 +102,7 @@ module: tapi-connectivity
        |  |  +--rw max-switch-times?                     uint64
        |  |  +--rw preferred-restoration-layer*          tapi-common:layer-protocol-name
        |  |  +--rw selection-control?                    selection-control
-       |  +--rw direction?                 tapi-common:forwarding-direction
+       |  +--ro direction?                 tapi-common:forwarding-direction
        |  +--rw layer-protocol-name?       tapi-common:layer-protocol-name
        |  +--rw uuid                       uuid
        |  +--rw name* [value-name]
@@ -213,7 +213,7 @@ module: tapi-connectivity
   rpcs:
     +---x get-connection-details
     |  +---w input
-    |  |  +---w connection-id-or-name?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro connection
     |        +--ro connection-end-point* [topology-uuid node-uuid node-edge-point-uuid connection-end-point-uuid]
@@ -397,7 +397,7 @@ module: tapi-connectivity
     |        +--ro lifecycle-state?           lifecycle-state
     +---x get-connectivity-service-details
     |  +---w input
-    |  |  +---w service-id-or-name?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro service
     |        +--ro end-point* [local-id]
@@ -510,6 +510,11 @@ module: tapi-connectivity
     |        +--ro lifecycle-state?           lifecycle-state
     +---x create-connectivity-service
     |  +---w input
+    |  |  +---w uuid?                      tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
+    |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  +---w end-point* [local-id]
     |  |  |  +---w layer-protocol-name?                         tapi-common:layer-protocol-name
     |  |  |  +---w layer-protocol-qualifier?                    tapi-common:layer-protocol-qualifier
@@ -720,7 +725,10 @@ module: tapi-connectivity
     |        +--ro lifecycle-state?           lifecycle-state
     +---x update-connectivity-service
     |  +---w input
-    |  |  +---w service-id-or-name?        string
+    |  |  +---w uuid?                      tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w end-point* [local-id]
     |  |  |  +---w layer-protocol-name?                         tapi-common:layer-protocol-name
     |  |  |  +---w layer-protocol-qualifier?                    tapi-common:layer-protocol-qualifier
@@ -931,13 +939,10 @@ module: tapi-connectivity
     |        +--ro lifecycle-state?           lifecycle-state
     +---x delete-connectivity-service
     |  +---w input
-    |     +---w service-id-or-name?   string
+    |     +---w uuid?   tapi-common:uuid
     +---x get-connection-end-point-details
        +---w input
-       |  +---w topology-id-or-name?   string
-       |  +---w node-id-or-name?       string
-       |  +---w nep-id-or-name?        string
-       |  +---w cep-id-or-name?        string
+       |  +---w uuid?   tapi-common:uuid
        +--ro output
           +--ro connection-end-point
              +--ro layer-protocol-name?               tapi-common:layer-protocol-name

--- a/YANG/tapi-connectivity@2019-03-31.yang
+++ b/YANG/tapi-connectivity@2019-03-31.yang
@@ -316,6 +316,7 @@ module tapi-connectivity {
         }
         leaf direction {
             type tapi-common:forwarding-direction;
+            config false;
             description "none";
         }
         leaf layer-protocol-name {
@@ -725,9 +726,13 @@ module tapi-connectivity {
     rpc get-connection-details {
         description "none";
         input {
-            leaf connection-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -750,9 +755,13 @@ module tapi-connectivity {
     rpc get-connectivity-service-details {
         description "none";
         input {
-            leaf service-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -765,6 +774,24 @@ module tapi-connectivity {
     rpc create-connectivity-service {
         description "none";
         input {
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
+            }
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
+                description "none";
+            }
             list end-point {
                 key 'local-id';
                 min-elements 2;
@@ -803,9 +830,19 @@ module tapi-connectivity {
     rpc update-connectivity-service {
         description "none";
         input {
-            leaf service-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             list end-point {
                 key 'local-id';
@@ -844,30 +881,26 @@ module tapi-connectivity {
     rpc delete-connectivity-service {
         description "none";
         input {
-            leaf service-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
     }
     rpc get-connection-end-point-details {
         description "none";
         input {
-            leaf topology-id-or-name {
-                type string;
-                description "none";
-            }
-            leaf node-id-or-name {
-                type string;
-                description "none";
-            }
-            leaf nep-id-or-name {
-                type string;
-                description "none";
-            }
-            leaf cep-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {

--- a/YANG/tapi-equipment@2019-03-31.tree
+++ b/YANG/tapi-equipment@2019-03-31.tree
@@ -263,7 +263,7 @@ module: tapi-equipment
     |           +--ro value?        string
     +---x get-device
     |  +---w input
-    |  |  +---w device-id?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro device
     |        +--ro equipment* [uuid]
@@ -361,7 +361,7 @@ module: tapi-equipment
     |           +--ro value?        string
     +---x get-physical-span
        +---w input
-       |  +---w span-id?   string
+       |  +---w uuid?   tapi-common:uuid
        +--ro output
           +--ro physical-span
              +--ro access-port* [device-uuid access-port-uuid]

--- a/YANG/tapi-equipment@2019-03-31.yang
+++ b/YANG/tapi-equipment@2019-03-31.yang
@@ -483,6 +483,7 @@ module tapi-equipment {
     grouping holder {
         container occupying-fru {
             uses equipment-ref;
+            config false;
             description "The FRU that is occupying the holder. 
                 A holder may be unoccupied. 
                 An FRU may occupy more hat one holder (using or blocking are intentionally not distinguished here).";
@@ -516,6 +517,7 @@ module tapi-equipment {
         list access-port {
             uses access-port-ref;
             key "device-uuid access-port-uuid";
+            config false;
             min-elements 2;
             max-elements 2;
             description "none";
@@ -536,11 +538,13 @@ module tapi-equipment {
         list adjacent-strand {
         	uses abstract-strand-ref;
         	key "physical-span-uuid abstract-strand-local-id";
+            config false;
             description "none";
         }
         list spliced-strand {
         	uses abstract-strand-ref;
         	key "physical-span-uuid abstract-strand-local-id";
+            config false;
             max-elements 2;
             description "none";
         }
@@ -645,9 +649,13 @@ module tapi-equipment {
     rpc get-device {
         description "none";
         input {
-            leaf device-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -660,9 +668,13 @@ module tapi-equipment {
     rpc get-physical-span {
         description "none";
         input {
-            leaf span-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {

--- a/YANG/tapi-eth@2019-03-31.tree
+++ b/YANG/tapi-eth@2019-03-31.tree
@@ -1,71 +1,5 @@
 
 module: tapi-eth
-  augment /tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
-    +-- eth-oam-mep-service-point
-       +-- eth-mep-sink
-       |  +-- ais-priority?              uint64
-       |  +-- ais-period?                oam-period
-       |  +-- is-csf-reported?           boolean
-       |  +-- is-csf-rdi-fdi-enabled?    boolean
-       |  +--ro bandwidth-report
-       |  |  +--ro source-mac-address?   mac-address
-       |  |  +--ro port-id?              uint64
-       |  |  +--ro nominal-bandwidth?    uint64
-       |  |  +--ro current-bandwidth?    uint64
-       |  +-- lm-degm?                   uint64
-       |  +-- lm-deg-thr?                uint64
-       |  +-- lm-m?                      uint64
-       |  +-- lm-tf-min?                 uint64
-       |  +-- peer-mep-identifier*       uint64
-       |  +-- unexpected-ltr-received?   uint64
-       +-- eth-mep-source
-       |  +-- aps-priority?   uint64
-       |  +-- csf-priority?   uint64
-       |  +-- csf-period?     oam-period
-       |  +-- csf-config?     csf-config
-       +-- eth-mep-common
-          +-- cc-priority?      uint64
-          +-- lck-period?       oam-period
-          +-- lck-priority?     uint64
-          +-- mep-identifier?   uint64
-          +-- codirectional?    boolean
-  augment /tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
-    +-- eth-oam-mep-service-point
-       +-- eth-mep-sink
-       |  +-- ais-priority?              uint64
-       |  +-- ais-period?                oam-period
-       |  +-- is-csf-reported?           boolean
-       |  +-- is-csf-rdi-fdi-enabled?    boolean
-       |  +--ro bandwidth-report
-       |  |  +--ro source-mac-address?   mac-address
-       |  |  +--ro port-id?              uint64
-       |  |  +--ro nominal-bandwidth?    uint64
-       |  |  +--ro current-bandwidth?    uint64
-       |  +-- lm-degm?                   uint64
-       |  +-- lm-deg-thr?                uint64
-       |  +-- lm-m?                      uint64
-       |  +-- lm-tf-min?                 uint64
-       |  +-- peer-mep-identifier*       uint64
-       |  +-- unexpected-ltr-received?   uint64
-       +-- eth-mep-source
-       |  +-- aps-priority?   uint64
-       |  +-- csf-priority?   uint64
-       |  +-- csf-period?     oam-period
-       |  +-- csf-config?     csf-config
-       +-- eth-mep-common
-          +-- cc-priority?      uint64
-          +-- lck-period?       oam-period
-          +-- lck-priority?     uint64
-          +-- mep-identifier?   uint64
-          +-- codirectional?    boolean
-  augment /tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
-    +-- eth-oam-mip-service-point
-       +-- eth-mip-common
-          +--ro is-full-mip?   boolean
-  augment /tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
-    +-- eth-oam-mip-service-point
-       +-- eth-mip-common
-          +--ro is-full-mip?   boolean
   augment /tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point:
     +--ro eth-connection-end-point-spec
        +--ro ety-term
@@ -2598,3 +2532,69 @@ module: tapi-eth
        +-- eth-test-job-sink-point
        |  +-- source-address?   mac-address
        +-- number?                             uint64
+  augment /tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
+    +-- eth-oam-mep-service-point
+       +-- eth-mep-sink
+       |  +-- ais-priority?              uint64
+       |  +-- ais-period?                oam-period
+       |  +-- is-csf-reported?           boolean
+       |  +-- is-csf-rdi-fdi-enabled?    boolean
+       |  +--ro bandwidth-report
+       |  |  +--ro source-mac-address?   mac-address
+       |  |  +--ro port-id?              uint64
+       |  |  +--ro nominal-bandwidth?    uint64
+       |  |  +--ro current-bandwidth?    uint64
+       |  +-- lm-degm?                   uint64
+       |  +-- lm-deg-thr?                uint64
+       |  +-- lm-m?                      uint64
+       |  +-- lm-tf-min?                 uint64
+       |  +-- peer-mep-identifier*       uint64
+       |  +-- unexpected-ltr-received?   uint64
+       +-- eth-mep-source
+       |  +-- aps-priority?   uint64
+       |  +-- csf-priority?   uint64
+       |  +-- csf-period?     oam-period
+       |  +-- csf-config?     csf-config
+       +-- eth-mep-common
+          +-- cc-priority?      uint64
+          +-- lck-period?       oam-period
+          +-- lck-priority?     uint64
+          +-- mep-identifier?   uint64
+          +-- codirectional?    boolean
+  augment /tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
+    +-- eth-oam-mip-service-point
+       +-- eth-mip-common
+          +--ro is-full-mip?   boolean
+  augment /tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
+    +-- eth-oam-mep-service-point
+       +-- eth-mep-sink
+       |  +-- ais-priority?              uint64
+       |  +-- ais-period?                oam-period
+       |  +-- is-csf-reported?           boolean
+       |  +-- is-csf-rdi-fdi-enabled?    boolean
+       |  +--ro bandwidth-report
+       |  |  +--ro source-mac-address?   mac-address
+       |  |  +--ro port-id?              uint64
+       |  |  +--ro nominal-bandwidth?    uint64
+       |  |  +--ro current-bandwidth?    uint64
+       |  +-- lm-degm?                   uint64
+       |  +-- lm-deg-thr?                uint64
+       |  +-- lm-m?                      uint64
+       |  +-- lm-tf-min?                 uint64
+       |  +-- peer-mep-identifier*       uint64
+       |  +-- unexpected-ltr-received?   uint64
+       +-- eth-mep-source
+       |  +-- aps-priority?   uint64
+       |  +-- csf-priority?   uint64
+       |  +-- csf-period?     oam-period
+       |  +-- csf-config?     csf-config
+       +-- eth-mep-common
+          +-- cc-priority?      uint64
+          +-- lck-period?       oam-period
+          +-- lck-priority?     uint64
+          +-- mep-identifier?   uint64
+          +-- codirectional?    boolean
+  augment /tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point:
+    +-- eth-oam-mip-service-point
+       +-- eth-mip-common
+          +--ro is-full-mip?   boolean

--- a/YANG/tapi-eth@2019-03-31.yang
+++ b/YANG/tapi-eth@2019-03-31.yang
@@ -76,34 +76,6 @@ module tapi-eth {
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020, RFC 6087 and ONF TAPI UML model
                   <https://github.com/OpenNetworkingFoundation/TAPI/tree/v2.0.0/UML>";
     }
-    augment "/tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
-        container eth-oam-mep-service-point {
-            uses eth-oam-mep-service-point;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
-        container eth-oam-mep-service-point {
-            uses eth-oam-mep-service-point;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
-        container eth-oam-mip-service-point {
-            uses eth-oam-mip-service-point;
-            description "none";
-        }
-        description "none";
-    }
-    augment "/tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
-        container eth-oam-mip-service-point {
-            uses eth-oam-mip-service-point;
-            description "none";
-        }
-        description "none";
-    }
     augment "/tapi-common:context/tapi-topology:topology-context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-edge-point/tapi-connectivity:cep-list/tapi-connectivity:connection-end-point" {
         container eth-connection-end-point-spec {
             uses eth-connection-end-point-spec;
@@ -947,6 +919,34 @@ module tapi-eth {
     augment "/tapi-oam:get-oam-job/tapi-oam:output/tapi-oam:oam-job" {
         container eth-test-job {
             uses eth-test-job;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
+        container eth-oam-mep-service-point {
+            uses eth-oam-mep-service-point;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-oam:create-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
+        container eth-oam-mip-service-point {
+            uses eth-oam-mip-service-point;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
+        container eth-oam-mep-service-point {
+            uses eth-oam-mep-service-point;
+            description "none";
+        }
+        description "none";
+    }
+    augment "/tapi-oam:update-oam-service/tapi-oam:input/tapi-oam:oam-service-point" {
+        container eth-oam-mip-service-point {
+            uses eth-oam-mip-service-point;
             description "none";
         }
         description "none";
@@ -2504,6 +2504,105 @@ module tapi-eth {
         base ETH_PM_PARAMETER_NAME;
         description "none";
     }
+    identity ETH_ALARM_CONDITION_NAME {
+        base tapi-oam:ALARM_CONDITION_NAME;
+        description "none";
+    }
+    identity ETH_ALARM_CONDITION_NAME_LOSS_OF_CONTINUITY {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: The loss of continuity defect is calculated at the ETH layer. It monitors the presence of continuity in ETH trails.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_UNEXPECTED_MEL {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of a CCM frame with an invalid MEL value.
+            Monitoring of the connectivity in a maintenance entity group.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_UNEXPECTED_MEP {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of a CCM frame with an invalid MEP value, but with valid MEL and MEG values.
+            Monitoring of the connectivity in a maintenance entity group.
+            ";
+    }
+    identity ETH_ALARM_CONDITION_NAME_MISMERGE_UNEXPECTED_MEG {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of a CCM frame with an invalid MEG value, but with a valid MEL value.
+            Monitoring of the connectivity in a maintenance entity group.
+            ";
+    }
+    identity ETH_ALARM_CONDITION_NAME_UNEXPECTED_PERIODICITY {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of a CCM frame with an invalid periodicity value, but with valid MEL, MEG and MEP values.
+            It detects the configuration of different periodicities at different MEPs belonging to the same MEG.
+            ";
+    }
+    identity ETH_ALARM_CONDITION_NAME_UNEXPECTED_PRIORITY {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of a CCM frame with an invalid priority value, but with valid MEL, MEG, MEP and periodicity values.
+            It detects the configuration of different priorities for CCM at different MEPs belonging to the same MEG.
+            ";
+    }
+    identity ETH_ALARM_CONDITION_NAME_LOCKED {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of a LCK frame.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_AIS {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Reception of an AIS frame.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_DEGRADED {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: The defect is detected if there are MI_LM_DEGM (lmDegm of EthMepSink) consecutive bad seconds and cleared if there are MI_LM_M (lmM of EthMepSink) consecutive good seconds. 
+            In order to declare a bad second the number of transmitted frames must exceed a threshold (MI_LM_TFMIN, lmTfMin of EthMepSink).
+            Furthermore, if the frame loss ratio (lost frames/transmitted frames) is greater than MI_LM_DEGTHR (lmDegThr of EthMepSink), a bad second is declared.
+            This defect is only defined for point-to-point ETH connections. It monitors the connectivity of an ETH trail.
+            ";
+    }
+    identity ETH_ALARM_CONDITION_NAME_RDI {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: Remote defect indicator defect, reception by an MEP (indexed by 'i', this index not included in the 'cause' cRDI) of a CCM frame with valid MEL, MEG, MEP and periodicity values and the RDI flag set to x; where x=0 (remote defect clear) and x=1 (remote defect set).";
+    }
+    identity ETH_ALARM_CONDITION_NAME_CSF {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021 - ETH layer: Reception of a CSF frame that indicates a client loss of signal (dCSF-LOS) or a client forward defect indication (dCSF-FDI) or a client reverse defect indication (dCSF-RDI).
+            The CSF (CSF-LOS, CSF-FDI, and CSF-RDI) defect is calculated at the ETH layer. It monitors the presence of a CSF maintenance signal.
+            G.8021 - GFP: dCSF is Client-specific GFP-F and GFP-T (resp. Frame and Transparent) sink processes.
+            dCSF-RDI: GFP client signal fail-remote defect indication is raised when a GFP client management frame with the RDI UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.
+            dCSF-RDI is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.
+            dCSF-FDI: GFP client signal fail-forward defect indication is raised when a GFP client management frame with the FDI UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.
+            dCSF-FDI is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.
+            dCSF-LOS: GFP client signal fail-loss of signal is raised when a GFP client management frame with the LOS UPI (as defined in Table 6-4 of [ITU-T G.7041]) is received.
+            dCSF-LOS is cleared when no such GFP client management frame is received in N x 1000 ms (a value of 3 is suggested for N), a valid GFP client data frame is received, or a GFP client management frame with the DCI UPI is received.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_TOTAL_LINK_LOSS {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: LAG - fault cause will be raised if no ports are active for an aggregator.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_PARTIAL_LINK_LOSS {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.8021: LAG - fault cause shall be raised if the number of active ports is less than the provisioned threshold.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_PLM {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.806: The payload label mismatch defect (dPLM) shall be detected if the 'accepted TSL' code does not match the 'expected TSL' code. If the 'accepted TSL' is 'equipped non-specific', the mismatch is not detected (TSL: Trail Signal Label).
+            Payload type supervision checks that compatible adaptation functions are used at the source and the sink.
+            This is normally done by adding a signal type identifier at the source adaptation function and comparing it with the expected identifier at the sink.
+            If they do not match, a payload mismatch is detected.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_LFD {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.806 - Server layer-specific GFP sink processes: GFP loss of frame delineation (dLFD) is raised when the frame delineation process (clause 6.3.1 of [ITU-T G.7041]) is not in the 'SYNC' state.
+            dLFD is cleared when the frame delineation process is in the 'SYNC' state.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_EXM {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.806 - Common GFP sink processes: GFP extension header mismatch (dEXM) is raised when the accepted EXI (AcEXI) is different from the expected EXI.
+            dEXM is cleared when AcEXI matches the expected EXI or GFP_SF is active.";
+    }
+    identity ETH_ALARM_CONDITION_NAME_UPM {
+        base ETH_ALARM_CONDITION_NAME;
+        description "G.806 - Client-specific GFP-F (Frame) and GFP-T (Transparent) sink processes: GFP user payload mismatch (dUPM) is raised when the accepted UPI (AcUPI) is different from the expected UPI.
+            dUPM is cleared when AcUPI matches the expected UPI or GFP_SF is active.";
+    }
     grouping priority-configuration {
         leaf priority {
             type uint64 {
@@ -3405,6 +3504,12 @@ module tapi-eth {
     typedef eth-pm-parameter-name {
         type identityref {
             base ETH_PM_PARAMETER_NAME;
+        }
+        description "none";
+    }
+    typedef eth-alarm-condition-name {
+        type identityref {
+            base ETH_ALARM_CONDITION_NAME;
         }
         description "none";
     }

--- a/YANG/tapi-notification@2019-03-31.tree
+++ b/YANG/tapi-notification@2019-03-31.tree
@@ -83,6 +83,10 @@ module: tapi-notification
     |     +--ro supported-object-types*         tapi-common:object-type
     +---x create-notification-subscription-service
     |  +---w input
+    |  |  +---w uuid?                  tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w subscription-filter
     |  |  |  +---w requested-notification-types*   notification-type
     |  |  |  +---w requested-object-types*         tapi-common:object-type
@@ -146,7 +150,10 @@ module: tapi-notification
     |           +--ro value?        string
     +---x update-notification-subscription-service
     |  +---w input
-    |  |  +---w subscription-id-or-name?   string
+    |  |  +---w uuid?                  tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w subscription-filter
     |  |  |  +---w requested-notification-types*   notification-type
     |  |  |  +---w requested-object-types*         tapi-common:object-type
@@ -157,7 +164,7 @@ module: tapi-notification
     |  |  |  +---w name* [value-name]
     |  |  |     +---w value-name    string
     |  |  |     +---w value?        string
-    |  |  +---w subscription-state?        subscription-state
+    |  |  +---w subscription-state?    subscription-state
     |  +--ro output
     |     +--ro subscription-service
     |        +--ro notification* [uuid]
@@ -210,10 +217,10 @@ module: tapi-notification
     |           +--ro value?        string
     +---x delete-notification-subscription-service
     |  +---w input
-    |     +---w subscription-id-or-name?   string
+    |     +---w uuid?   tapi-common:uuid
     +---x get-notification-subscription-service-details
     |  +---w input
-    |  |  +---w subscription-id-or-name?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro subscription-service
     |        +--ro notification* [uuid]
@@ -317,7 +324,7 @@ module: tapi-notification
     |           +--ro value?        string
     +---x get-notification-list
        +---w input
-       |  +---w subscription-id-or-name?   string
+       |  +---w subscription-id?   tapi-common:uuid
        |  +---w time-range
        |     +---w end-time?     date-and-time
        |     +---w start-time?   date-and-time

--- a/YANG/tapi-notification@2019-03-31.yang
+++ b/YANG/tapi-notification@2019-03-31.yang
@@ -332,6 +332,20 @@ module tapi-notification {
     rpc create-notification-subscription-service {
         description "none";
         input {
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
+            }
             container subscription-filter {
                 uses subscription-filter;
                 description "none";
@@ -351,9 +365,19 @@ module tapi-notification {
     rpc update-notification-subscription-service {
         description "none";
         input {
-            leaf subscription-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             container subscription-filter {
                 uses subscription-filter;
@@ -374,18 +398,26 @@ module tapi-notification {
     rpc delete-notification-subscription-service {
         description "none";
         input {
-            leaf subscription-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
     }
     rpc get-notification-subscription-service-details {
         description "none";
         input {
-            leaf subscription-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -408,9 +440,13 @@ module tapi-notification {
     rpc get-notification-list {
         description "none";
         input {
-            leaf subscription-id-or-name {
-                type string;
-                description "none";
+            leaf subscription-id {
+                type tapi-common:uuid;
+                description "UUID of the associated Notification Subscription Service: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
             container time-range {
                 uses tapi-common:time-range;

--- a/YANG/tapi-oam@2019-03-31.tree
+++ b/YANG/tapi-oam@2019-03-31.tree
@@ -192,29 +192,33 @@ module: tapi-oam
   rpcs:
     +---x create-oam-service
     |  +---w input
-    |  |  +---w oam-service-point* [local-id]
-    |  |  |  +---w service-interface-point
-    |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w connectivity-service-end-point
-    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
-    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
-    |  |  |  +---w mep
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
-    |  |  |  +---w mip
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
-    |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
-    |  |  |  +---w is-mip?                           boolean
-    |  |  |  +---w local-id                          string
-    |  |  |  +---w name* [value-name]
-    |  |  |  |  +---w value-name    string
-    |  |  |  |  +---w value?        string
-    |  |  |  +---w administrative-state?             administrative-state
-    |  |  |  +---w operational-state?                operational-state
-    |  |  |  +---w lifecycle-state?                  lifecycle-state
+    |  |  +---w uuid?                  tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w layer-protocol-name?   tapi-common:layer-protocol-name
     |  |  +---w state?                 tapi-common:administrative-state
+    |  |  +---w oam-service-point* [local-id]
+    |  |     +---w service-interface-point
+    |  |     |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+    |  |     +---w connectivity-service-end-point
+    |  |     |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |  |     |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
+    |  |     +---w mep
+    |  |     |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |     |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
+    |  |     +---w mip
+    |  |     |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |     |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
+    |  |     +---w layer-protocol-name?              tapi-common:layer-protocol-name
+    |  |     +---w is-mip?                           boolean
+    |  |     +---w local-id                          string
+    |  |     +---w name* [value-name]
+    |  |     |  +---w value-name    string
+    |  |     |  +---w value?        string
+    |  |     +---w administrative-state?             administrative-state
+    |  |     +---w operational-state?                operational-state
+    |  |     +---w lifecycle-state?                  lifecycle-state
     |  +--ro output
     |     +--ro oam-service
     |        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
@@ -250,10 +254,10 @@ module: tapi-oam
     |        +--ro lifecycle-state?        lifecycle-state
     +---x delete-oam-service
     |  +---w input
-    |     +---w oam-service-id?   string
+    |     +---w uuid?   tapi-common:uuid
     +---x get-oam-service
     |  +---w input
-    |  |  +---w oam-service-id?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro oam-service
     |        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
@@ -323,7 +327,7 @@ module: tapi-oam
     |        +--ro lifecycle-state?        lifecycle-state
     +---x get-meg
     |  +---w input
-    |  |  +---w oam-service-id?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro meg
     |        +--ro mep* [local-id]
@@ -349,29 +353,32 @@ module: tapi-oam
     |        +--ro lifecycle-state?       lifecycle-state
     +---x update-oam-service
     |  +---w input
-    |  |  +---w oam-service-id?      string
-    |  |  +---w oam-service-point* [local-id]
-    |  |  |  +---w service-interface-point
-    |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w connectivity-service-end-point
-    |  |  |  |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
-    |  |  |  |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
-    |  |  |  +---w mep
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-    |  |  |  |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
-    |  |  |  +---w mip
-    |  |  |  |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
-    |  |  |  |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
-    |  |  |  +---w layer-protocol-name?              tapi-common:layer-protocol-name
-    |  |  |  +---w is-mip?                           boolean
-    |  |  |  +---w local-id                          string
-    |  |  |  +---w name* [value-name]
-    |  |  |  |  +---w value-name    string
-    |  |  |  |  +---w value?        string
-    |  |  |  +---w administrative-state?             administrative-state
-    |  |  |  +---w operational-state?                operational-state
-    |  |  |  +---w lifecycle-state?                  lifecycle-state
+    |  |  +---w uuid?                tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w state?               tapi-common:administrative-state
+    |  |  +---w oam-service-point* [local-id]
+    |  |     +---w service-interface-point
+    |  |     |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+    |  |     +---w connectivity-service-end-point
+    |  |     |  +---w connectivity-service-uuid?                 -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/uuid
+    |  |     |  +---w connectivity-service-end-point-local-id?   -> /tapi-common:context/tapi-connectivity:connectivity-context/connectivity-service/end-point/local-id
+    |  |     +---w mep
+    |  |     |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |     |  +---w mep-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mep/local-id
+    |  |     +---w mip
+    |  |     |  +---w meg-uuid?       -> /tapi-common:context/tapi-oam:oam-context/meg/uuid
+    |  |     |  +---w mip-local-id?   -> /tapi-common:context/tapi-oam:oam-context/meg/mip/local-id
+    |  |     +---w layer-protocol-name?              tapi-common:layer-protocol-name
+    |  |     +---w is-mip?                           boolean
+    |  |     +---w local-id                          string
+    |  |     +---w name* [value-name]
+    |  |     |  +---w value-name    string
+    |  |     |  +---w value?        string
+    |  |     +---w administrative-state?             administrative-state
+    |  |     +---w operational-state?                operational-state
+    |  |     +---w lifecycle-state?                  lifecycle-state
     |  +--ro output
     |     +--ro oam-service
     |        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
@@ -407,11 +414,15 @@ module: tapi-oam
     |        +--ro lifecycle-state?        lifecycle-state
     +---x create-oam-service-point
     |  +---w input
-    |  |  +---w oam-service-id?        string
-    |  |  +---w sip-id?                string
-    |  |  +---w c-sep-id?              string
-    |  |  +---w layer-protocol-name?   tapi-common:layer-protocol-name
-    |  |  +---w state?                 tapi-common:administrative-state
+    |  |  +---w uuid?                                tapi-common:uuid
+    |  |  +---w oam-service-id?                      tapi-common:uuid
+    |  |  +---w service-interface-point-id?          tapi-common:uuid
+    |  |  +---w connectivity-service-end-point-id?   tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
+    |  |  +---w layer-protocol-name?                 tapi-common:layer-protocol-name
+    |  |  +---w state?                               tapi-common:administrative-state
     |  +--ro output
     |     +--ro oam-service-point
     |        +--ro service-interface-point
@@ -436,13 +447,14 @@ module: tapi-oam
     |        +--ro lifecycle-state?                  lifecycle-state
     +---x delete-oam-service-point
     |  +---w input
-    |     +---w oam-service-id?         string
-    |     +---w oam-service-point-id?   string
+    |     +---w uuid?   tapi-common:uuid
     +---x update-oam-service-point
     |  +---w input
-    |  |  +---w oam-service-id?         string
-    |  |  +---w oam-service-point-id?   string
-    |  |  +---w state?                  tapi-common:administrative-state
+    |  |  +---w uuid?    tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
+    |  |  +---w state?   tapi-common:administrative-state
     |  +--ro output
     |     +--ro oam-service-point
     |        +--ro service-interface-point
@@ -467,8 +479,7 @@ module: tapi-oam
     |        +--ro lifecycle-state?                  lifecycle-state
     +---x get-oam-service-point
     |  +---w input
-    |  |  +---w oam-service-id?         string
-    |  |  +---w oam-service-point-id?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro oam-service-point
     |        +--ro service-interface-point
@@ -493,12 +504,18 @@ module: tapi-oam
     |        +--ro lifecycle-state?                  lifecycle-state
     +---x create-oam-job
     |  +---w input
+    |  |  +---w uuid?                   tapi-common:uuid
+    |  |  +---w oam-service-id?         tapi-common:uuid
+    |  |  +---w oam-service-point-id?   tapi-common:uuid
+    |  |  +---w oam-profile-id?         tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w oam-job-type?           oam-job-type
-    |  |  +---w oam-service-id?         string
-    |  |  +---w oam-service-point-id*   string
-    |  |  +---w oam-profile-id?         string
     |  |  +---w state?                  tapi-common:administrative-state
-    |  |  +---w schedule?               string
+    |  |  +---w schedule
+    |  |     +---w end-time?     date-and-time
+    |  |     +---w start-time?   date-and-time
     |  +--ro output
     |     +--ro oam-job
     |        +--ro oam-service-point* [oam-service-uuid oam-service-point-local-id]
@@ -547,36 +564,15 @@ module: tapi-oam
     |        +--ro lifecycle-state?        lifecycle-state
     +---x update-oam-job
     |  +---w input
-    |  |  +---w oam-job-id?    string
-    |  |  +---w oam-profile
-    |  |  |  +---w pm-threshold-data* [local-id]
-    |  |  |  |  +---w applicable-job-type*   oam-job-type
-    |  |  |  |  +---w threshold-parameter* [pm-parameter-name threshold-location]
-    |  |  |  |  |  +---w pm-parameter-name          pm-parameter-name
-    |  |  |  |  |  +---w threshold-location         threshold-crossing-qualifier
-    |  |  |  |  |  +---w pm-parameter-above-thrs
-    |  |  |  |  |  |  +---w pm-parameter-int-value?    uint64
-    |  |  |  |  |  |  +---w pm-parameter-real-value?   decimal64
-    |  |  |  |  |  +---w pm-parameter-below-thrs
-    |  |  |  |  |  |  +---w pm-parameter-int-value?    uint64
-    |  |  |  |  |  |  +---w pm-parameter-real-value?   decimal64
-    |  |  |  |  |  +---w pm-parameter-clear-thrs
-    |  |  |  |  |     +---w pm-parameter-int-value?    uint64
-    |  |  |  |  |     +---w pm-parameter-real-value?   decimal64
-    |  |  |  |  +---w granularity-period
-    |  |  |  |  |  +---w value?   uint64
-    |  |  |  |  |  +---w unit?    time-unit
-    |  |  |  |  +---w is-transient?          boolean
-    |  |  |  |  +---w local-id               string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w uuid?                uuid
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w state?         tapi-common:administrative-state
-    |  |  +---w schedule?      string
+    |  |  +---w uuid?             tapi-common:uuid
+    |  |  +---w oam-profile-id?   tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
+    |  |  +---w state?            tapi-common:administrative-state
+    |  |  +---w schedule
+    |  |     +---w end-time?     date-and-time
+    |  |     +---w start-time?   date-and-time
     |  +--ro output
     |     +--ro oam-job
     |        +--ro oam-service-point* [oam-service-uuid oam-service-point-local-id]
@@ -625,10 +621,10 @@ module: tapi-oam
     |        +--ro lifecycle-state?        lifecycle-state
     +---x delete-oam-job
     |  +---w input
-    |     +---w oam-job-id?   string
+    |     +---w uuid?   tapi-common:uuid
     +---x get-oam-job
     |  +---w input
-    |  |  +---w oam-job-id?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro oam-job
     |        +--ro oam-service-point* [oam-service-uuid oam-service-point-local-id]
@@ -724,6 +720,10 @@ module: tapi-oam
     |        +--ro lifecycle-state?        lifecycle-state
     +---x create-oam-profile
     |  +---w input
+    |  |  +---w uuid?                tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w pm-threshold-data* []
     |  |     +---w applicable-job-type*   oam-job-type
     |  |     +---w threshold-parameter* [pm-parameter-name threshold-location]
@@ -776,7 +776,10 @@ module: tapi-oam
     |           +--ro value?        string
     +---x update-oam-profile
     |  +---w input
-    |  |  +---w oam-profile-id?      string
+    |  |  +---w uuid?                tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w pm-threshold-data* []
     |  |     +---w applicable-job-type*   oam-job-type
     |  |     +---w threshold-parameter* [pm-parameter-name threshold-location]
@@ -829,10 +832,10 @@ module: tapi-oam
     |           +--ro value?        string
     +---x delete-oam-profile
     |  +---w input
-    |     +---w oam-profile-id?   string
+    |     +---w uuid?   tapi-common:uuid
     +---x get-oam-profile
     |  +---w input
-    |  |  +---w oam-profile-id?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro oam-profile
     |        +--ro pm-threshold-data* [local-id]

--- a/YANG/tapi-oam@2019-03-31.yang
+++ b/YANG/tapi-oam@2019-03-31.yang
@@ -764,11 +764,19 @@ module tapi-oam {
     rpc create-oam-service {
         description "none";
         input {
-            list oam-service-point {
-            	key 'local-id';
-                min-elements 2;
-                uses oam-service-point;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             leaf layer-protocol-name {
                 type tapi-common:layer-protocol-name;
@@ -776,6 +784,12 @@ module tapi-oam {
             }
             leaf state {
                 type tapi-common:administrative-state;
+                description "none";
+            }
+            list oam-service-point {
+            	key 'local-id';
+                min-elements 2;
+                uses oam-service-point;
                 description "none";
             }
         }
@@ -789,18 +803,26 @@ module tapi-oam {
     rpc delete-oam-service {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
     }
     rpc get-oam-service {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -823,9 +845,13 @@ module tapi-oam {
     rpc get-meg {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -838,17 +864,27 @@ module tapi-oam {
     rpc update-oam-service {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
+            }
+            leaf state {
+                type tapi-common:administrative-state;
                 description "none";
             }
             list oam-service-point {
             	key 'local-id';
                 uses oam-service-point;
-                description "none";
-            }
-            leaf state {
-                type tapi-common:administrative-state;
                 description "none";
             }
         }
@@ -862,17 +898,43 @@ module tapi-oam {
     rpc create-oam-service-point {
         description "none";
         input {
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
             leaf oam-service-id {
-                type string;
-                description "none";
+                type tapi-common:uuid;
+                description "UUID of the parent OamService: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf sip-id {
-                type string;
-                description "none";
+            leaf service-interface-point-id {
+                type tapi-common:uuid;
+                description "UUID of the associated SIP to be monitored: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf c-sep-id {
-                type string;
-                description "none";
+            leaf connectivity-service-end-point-id {
+                type tapi-common:uuid;
+                description "UUID of the CSEP to be monitored: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             leaf layer-protocol-name {
                 type tapi-common:layer-protocol-name;
@@ -893,26 +955,32 @@ module tapi-oam {
     rpc delete-oam-service-point {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
-                description "none";
-            }
-            leaf oam-service-point-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
     }
     rpc update-oam-service-point {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf oam-service-point-id {
-                type string;
-                description "none";
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             leaf state {
                 type tapi-common:administrative-state;
@@ -929,13 +997,13 @@ module tapi-oam {
     rpc get-oam-service-point {
         description "none";
         input {
-            leaf oam-service-id {
-                type string;
-                description "none";
-            }
-            leaf oam-service-point-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -948,29 +1016,54 @@ module tapi-oam {
     rpc create-oam-job {
         description "none";
         input {
-            leaf oam-job-type {
-                type oam-job-type;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
             leaf oam-service-id {
-                type string;
-                description "none";
+                type tapi-common:uuid;
+                description "UUID of the associated OamService: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf-list oam-service-point-id {
-                type string;
-                min-elements 1;
-                description "none";
+            leaf oam-service-point-id {
+                type tapi-common:uuid;
+                description "UUID of the associated OSEPs: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
             leaf oam-profile-id {
-                type string;
+                type tapi-common:uuid;
+                description "UUID of the OamProfile to be applied: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
+            }
+            leaf oam-job-type {
+                type oam-job-type;
                 description "none";
             }
             leaf state {
                 type tapi-common:administrative-state;
                 description "none";
             }
-            leaf schedule {
-                type string;
+            container schedule {
+                uses tapi-common:time-range;
                 description "none";
             }
         }
@@ -984,20 +1077,34 @@ module tapi-oam {
     rpc update-oam-job {
         description "none";
         input {
-            leaf oam-job-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            container oam-profile {
-                uses oam-profile;
-                description "none";
+            leaf oam-profile-id {
+                type tapi-common:uuid;
+                description "UUID of the OamProfile to be applied: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             leaf state {
                 type tapi-common:administrative-state;
                 description "none";
             }
-            leaf schedule {
-                type string;
+            container schedule {
+                uses tapi-common:time-range;
                 description "none";
             }
         }
@@ -1011,18 +1118,26 @@ module tapi-oam {
     rpc delete-oam-job {
         description "none";
         input {
-            leaf oam-job-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
     }
     rpc get-oam-job {
         description "none";
         input {
-            leaf oam-job-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -1045,6 +1160,20 @@ module tapi-oam {
     rpc create-oam-profile {
         description "none";
         input {
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
+            }
             list pm-threshold-data {
                 min-elements 1;
                 uses pm-threshold-data;
@@ -1061,9 +1190,19 @@ module tapi-oam {
     rpc update-oam-profile {
         description "none";
         input {
-            leaf oam-profile-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             list pm-threshold-data {
                 min-elements 1;
@@ -1081,18 +1220,26 @@ module tapi-oam {
     rpc delete-oam-profile {
         description "none";
         input {
-            leaf oam-profile-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
     }
     rpc get-oam-profile {
         description "none";
         input {
-            leaf oam-profile-id {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {

--- a/YANG/tapi-path-computation@2019-03-31.tree
+++ b/YANG/tapi-path-computation@2019-03-31.tree
@@ -109,21 +109,10 @@ module: tapi-path-computation
   rpcs:
     +---x compute-p-2-p-path
     |  +---w input
-    |  |  +---w sep* [local-id]
-    |  |  |  +---w service-interface-point
-    |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w layer-protocol-name?        tapi-common:layer-protocol-name
-    |  |  |  +---w layer-protocol-qualifier?   tapi-common:layer-protocol-qualifier
-    |  |  |  +---w capacity
-    |  |  |  |  +---w total-size
-    |  |  |  |     +---w value?   uint64
-    |  |  |  |     +---w unit?    capacity-unit
-    |  |  |  +---w role?                       tapi-common:port-role
-    |  |  |  +---w direction?                  tapi-common:port-direction
-    |  |  |  +---w local-id                    string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
+    |  |  +---w uuid?                  tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w routing-constraint
     |  |  |  +---w cost-characteristic* [cost-name]
     |  |  |  |  +---w cost-name         string
@@ -160,12 +149,27 @@ module: tapi-path-computation
     |  |  |     +---w value-name    string
     |  |  |     +---w value?        string
     |  |  +---w objective-function
-    |  |     +---w bandwidth-optimization?   tapi-common:directive-value
-    |  |     +---w concurrent-paths?         tapi-common:directive-value
-    |  |     +---w cost-optimization?        tapi-common:directive-value
-    |  |     +---w link-utilization?         tapi-common:directive-value
-    |  |     +---w resource-sharing?         tapi-common:directive-value
-    |  |     +---w local-id?                 string
+    |  |  |  +---w bandwidth-optimization?   tapi-common:directive-value
+    |  |  |  +---w concurrent-paths?         tapi-common:directive-value
+    |  |  |  +---w cost-optimization?        tapi-common:directive-value
+    |  |  |  +---w link-utilization?         tapi-common:directive-value
+    |  |  |  +---w resource-sharing?         tapi-common:directive-value
+    |  |  |  +---w local-id?                 string
+    |  |  |  +---w name* [value-name]
+    |  |  |     +---w value-name    string
+    |  |  |     +---w value?        string
+    |  |  +---w end-point* [local-id]
+    |  |     +---w service-interface-point
+    |  |     |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
+    |  |     +---w layer-protocol-name?        tapi-common:layer-protocol-name
+    |  |     +---w layer-protocol-qualifier?   tapi-common:layer-protocol-qualifier
+    |  |     +---w capacity
+    |  |     |  +---w total-size
+    |  |     |     +---w value?   uint64
+    |  |     |     +---w unit?    capacity-unit
+    |  |     +---w role?                       tapi-common:port-role
+    |  |     +---w direction?                  tapi-common:port-direction
+    |  |     +---w local-id                    string
     |  |     +---w name* [value-name]
     |  |        +---w value-name    string
     |  |        +---w value?        string
@@ -247,7 +251,10 @@ module: tapi-path-computation
     |           +--ro value?        string
     +---x optimize-p-2-p-path
     |  +---w input
-    |  |  +---w path-id-or-name?           string
+    |  |  +---w uuid?                      tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
     |  |  +---w routing-constraint
     |  |  |  +---w cost-characteristic* [cost-name]
     |  |  |  |  +---w cost-name         string
@@ -360,7 +367,7 @@ module: tapi-path-computation
     |           +--ro value?        string
     +---x delete-p-2-p-path
        +---w input
-       |  +---w path-id-or-name?   string
+       |  +---w uuid?   tapi-common:uuid
        +--ro output
           +--ro service
              +--ro path* [path-uuid]

--- a/YANG/tapi-path-computation@2019-03-31.yang
+++ b/YANG/tapi-path-computation@2019-03-31.yang
@@ -445,12 +445,19 @@ module tapi-path-computation {
     rpc compute-p-2-p-path {
         description "none";
         input {
-            list sep {
-                key 'local-id';
-                min-elements 2;
-                max-elements 2;
-                uses path-service-end-point;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             container routing-constraint {
                 uses routing-constraint;
@@ -464,6 +471,13 @@ module tapi-path-computation {
                 uses path-objective-function;
                 description "none";
             }
+            list end-point {
+                key 'local-id';
+                min-elements 2;
+                max-elements 2;
+                uses path-service-end-point;
+                description "none";
+            }
         }
         output {
             container service {
@@ -475,9 +489,19 @@ module tapi-path-computation {
     rpc optimize-p-2-p-path {
         description "none";
         input {
-            leaf path-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
             }
             container routing-constraint {
                 uses routing-constraint;
@@ -502,9 +526,13 @@ module tapi-path-computation {
     rpc delete-p-2-p-path {
         description "none";
         input {
-            leaf path-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {

--- a/YANG/tapi-photonic-media@2019-03-31.tree
+++ b/YANG/tapi-photonic-media@2019-03-31.tree
@@ -64,7 +64,7 @@ module: tapi-photonic-media
   augment /tapi-common:context/tapi-common:service-interface-point:
     +--rw otsi-service-interface-point-spec
        +--ro otsi-capability
-       |  +--ro supportable-central-frequency-spectrum-band* []
+       |  +--ro supportable-central-frequency-band* []
        |  |  +--ro lower-central-frequency?   uint64
        |  |  +--ro upper-central-frequency?   uint64
        |  |  +--ro frequency-constraint
@@ -73,7 +73,7 @@ module: tapi-photonic-media
        |  +--ro supportable-application-identifier* [application-code]
        |  |  +--ro application-identifier-type?   application-identifier-type
        |  |  +--ro application-code               string
-       |  +--ro supportable-modulation*                        modulation-technique
+       |  +--ro supportable-modulation*               modulation-technique
        |  +--ro total-power-warn-threshold
        |     +--ro total-power-upper-warn-threshold-default?   decimal64
        |     +--ro total-power-upper-warn-threshold-min?       decimal64
@@ -557,7 +557,7 @@ module: tapi-photonic-media
   augment /tapi-common:get-service-interface-point-details/tapi-common:output/tapi-common:sip:
     +-- otsi-service-interface-point-spec
        +--ro otsi-capability
-       |  +--ro supportable-central-frequency-spectrum-band* []
+       |  +--ro supportable-central-frequency-band* []
        |  |  +--ro lower-central-frequency?   uint64
        |  |  +--ro upper-central-frequency?   uint64
        |  |  +--ro frequency-constraint
@@ -566,7 +566,7 @@ module: tapi-photonic-media
        |  +--ro supportable-application-identifier* [application-code]
        |  |  +--ro application-identifier-type?   application-identifier-type
        |  |  +--ro application-code               string
-       |  +--ro supportable-modulation*                        modulation-technique
+       |  +--ro supportable-modulation*               modulation-technique
        |  +--ro total-power-warn-threshold
        |     +--ro total-power-upper-warn-threshold-default?   decimal64
        |     +--ro total-power-upper-warn-threshold-min?       decimal64
@@ -590,7 +590,7 @@ module: tapi-photonic-media
   augment /tapi-common:get-service-interface-point-list/tapi-common:output/tapi-common:sip:
     +-- otsi-service-interface-point-spec
        +--ro otsi-capability
-       |  +--ro supportable-central-frequency-spectrum-band* []
+       |  +--ro supportable-central-frequency-band* []
        |  |  +--ro lower-central-frequency?   uint64
        |  |  +--ro upper-central-frequency?   uint64
        |  |  +--ro frequency-constraint
@@ -599,7 +599,7 @@ module: tapi-photonic-media
        |  +--ro supportable-application-identifier* [application-code]
        |  |  +--ro application-identifier-type?   application-identifier-type
        |  |  +--ro application-code               string
-       |  +--ro supportable-modulation*                        modulation-technique
+       |  +--ro supportable-modulation*               modulation-technique
        |  +--ro total-power-warn-threshold
        |     +--ro total-power-upper-warn-threshold-default?   decimal64
        |     +--ro total-power-upper-warn-threshold-min?       decimal64

--- a/YANG/tapi-photonic-media@2019-03-31.yang
+++ b/YANG/tapi-photonic-media@2019-03-31.yang
@@ -271,7 +271,7 @@ module tapi-photonic-media {
     }
     /**************************
     * package object-classes
-    **************************/
+    **************************/ 
     grouping otsi-server-adaptation-pac {
         leaf number-of-otsi {
             type uint64;
@@ -393,26 +393,13 @@ module tapi-photonic-media {
         description "none";
     }
     grouping otsi-capability-pac {
-        list supportable-central-frequency-spectrum-band {
-            leaf lower-central-frequency {
-                type uint64;
-                description "The lower central frequency can be tuned in the laser specified in MHz.
-                It is the oscillation frequency of the corresponding electromagnetic wave. ";
-            }
-            leaf upper-central-frequency {
-                type uint64;
-                description "The lower central frequency can be tuned in the laser specified in MHz.
-                It is the oscillation frequency of the corresponding electromagnetic wave. ";
-            }
-            container frequency-constraint {
-                uses frequency-constraint;
-                description "none";
-            }
+        list supportable-central-frequency-band {
             config false;
+            uses central-frequency-band;
             description "Each spectrum band supported for otsi trasmitter to be tuned on, is specified
-              as per it's lower and upper central frequencies supported and its frequency constraints,
-              consisting in the frequency Grid and the AdjustmentGranularity, used to uniquely identify all
-              central frequencies supported within the band.";
+                as per it's lower and upper central frequencies supported and its frequency constraints,
+                consisting in the frequency Grid and the AdjustmentGranularity, used to uniquely identify all
+                central frequencies supported within the band.";
         }
         list supportable-application-identifier {
             key 'application-code';
@@ -623,9 +610,8 @@ module tapi-photonic-media {
 
     /**************************
     * package type-definitions
-    **************************/
+    **************************/ 
     identity PHOTONIC_LAYER_QUALIFIER {
-        base tapi-common:LAYER_PROTOCOL_QUALIFIER;
         description "none";
     }
     identity PHOTONIC_LAYER_QUALIFIER_OTSi {
@@ -970,6 +956,24 @@ module tapi-photonic-media {
             description "The temperature of the laser";
         }
         description "none";
+    }
+    grouping central-frequency-band {
+        leaf lower-central-frequency {
+            type uint64;
+            description "The lower central frequency that can be tuned in the laser specified in MHz.
+                It is the oscillation frequency of the corresponding electromagnetic wave. ";
+        }
+        leaf upper-central-frequency {
+            type uint64;
+            description "The upper central frequency that can be tuned in the laser specified in MHz.
+                It is the oscillation frequency of the corresponding electromagnetic wave. ";
+        }
+        container frequency-constraint {
+            uses frequency-constraint;
+            description "none";
+        }
+        description "This data-type represents a range of central frequency spectrum band specified as lower and upper bounds, inclusive of the bound values.
+            It also holds frequency constraints in terms of GridType ( FIXED grid (DWDM or CWDM) or FLEX grid) and AdjustmentGranularity.";
     }
 
 }

--- a/YANG/tapi-topology@2019-03-31.tree
+++ b/YANG/tapi-topology@2019-03-31.tree
@@ -220,7 +220,7 @@ module: tapi-topology
   rpcs:
     +---x get-topology-details
     |  +---w input
-    |  |  +---w topology-id-or-name?   string
+    |  |  +---w topology-id?   tapi-common:uuid
     |  +--ro output
     |     +--ro topology
     |        +--ro node* [uuid]
@@ -431,8 +431,8 @@ module: tapi-topology
     |           +--ro value?        string
     +---x get-node-details
     |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  |  +---w node-id-or-name?       string
+    |  |  +---w topology-id?   tapi-common:uuid
+    |  |  +---w node-id?       tapi-common:uuid
     |  +--ro output
     |     +--ro node
     |        +--ro node-edge-point* [uuid]
@@ -585,9 +585,9 @@ module: tapi-topology
     |           +--ro wander-characteristic?           string
     +---x get-node-edge-point-details
     |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  |  +---w node-id-or-name?       string
-    |  |  +---w ep-id-or-name?         string
+    |  |  +---w topology-id?          tapi-common:uuid
+    |  |  +---w node-id?              tapi-common:uuid
+    |  |  +---w node-edge-point-id?   tapi-common:uuid
     |  +--ro output
     |     +--ro node-edge-point
     |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
@@ -621,8 +621,8 @@ module: tapi-topology
     |              +--ro unit?    capacity-unit
     +---x get-link-details
     |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  |  +---w link-id-or-name?       string
+    |  |  +---w topology-id?   tapi-common:uuid
+    |  |  +---w link-id?       tapi-common:uuid
     |  +--ro output
     |     +--ro link
     |        +--ro node-edge-point* [topology-uuid node-uuid node-edge-point-uuid]

--- a/YANG/tapi-topology@2019-03-31.yang
+++ b/YANG/tapi-topology@2019-03-31.yang
@@ -685,9 +685,13 @@ module tapi-topology {
     rpc get-topology-details {
         description "none";
         input {
-            leaf topology-id-or-name {
-                type string;
-                description "none";
+            leaf topology-id {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -700,13 +704,21 @@ module tapi-topology {
     rpc get-node-details {
         description "none";
         input {
-            leaf topology-id-or-name {
-                type string;
-                description "none";
+            leaf topology-id {
+                type tapi-common:uuid;
+                description "UUID of the parent Topology: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf node-id-or-name {
-                type string;
-                description "none";
+            leaf node-id {
+                type tapi-common:uuid;
+                description "UUID of the Node: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -719,17 +731,29 @@ module tapi-topology {
     rpc get-node-edge-point-details {
         description "none";
         input {
-            leaf topology-id-or-name {
-                type string;
-                description "none";
+            leaf topology-id {
+                type tapi-common:uuid;
+                description "UUID of the parent Node's Topology: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf node-id-or-name {
-                type string;
-                description "none";
+            leaf node-id {
+                type tapi-common:uuid;
+                description "UUID of the parent Node: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf ep-id-or-name {
-                type string;
-                description "none";
+            leaf node-edge-point-id {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -742,13 +766,21 @@ module tapi-topology {
     rpc get-link-details {
         description "none";
         input {
-            leaf topology-id-or-name {
-                type string;
-                description "none";
+            leaf topology-id {
+                type tapi-common:uuid;
+                description "UUID of the parent Topology: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
-            leaf link-id-or-name {
-                type string;
-                description "none";
+            leaf link-id {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {

--- a/YANG/tapi-virtual-network@2019-03-31.tree
+++ b/YANG/tapi-virtual-network@2019-03-31.tree
@@ -42,7 +42,9 @@ module: tapi-virtual-network
           |  +--rw name* [value-name]
           |     +--rw value-name    string
           |     +--rw value?        string
-          +--rw schedule?              string
+          +--rw schedule
+          |  +--rw end-time?     date-and-time
+          |  +--rw start-time?   date-and-time
           +--rw state
           |  +--rw administrative-state?   administrative-state
           |  +--ro operational-state?      operational-state
@@ -56,7 +58,11 @@ module: tapi-virtual-network
   rpcs:
     +---x create-virtual-network-service
     |  +---w input
-    |  |  +---w sep* [local-id]
+    |  |  +---w uuid?             tapi-common:uuid
+    |  |  +---w name* [value-name]
+    |  |  |  +---w value-name    string
+    |  |  |  +---w value?        string
+    |  |  +---w end-point* [local-id]
     |  |  |  +---w service-interface-point
     |  |  |  |  +---w service-interface-point-uuid?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w role?                      tapi-common:port-role
@@ -93,7 +99,9 @@ module: tapi-virtual-network
     |  |  |  +---w name* [value-name]
     |  |  |     +---w value-name    string
     |  |  |     +---w value?        string
-    |  |  +---w conn-schedule?    string
+    |  |  +---w schedule
+    |  |     +---w end-time?     date-and-time
+    |  |     +---w start-time?   date-and-time
     |  +--ro output
     |     +--ro service
     |        +--ro topology
@@ -135,7 +143,9 @@ module: tapi-virtual-network
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
-    |        +--ro schedule?              string
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
     |        +--ro state
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
@@ -147,7 +157,7 @@ module: tapi-virtual-network
     |           +--ro value?        string
     +---x delete-virtual-network-service
     |  +---w input
-    |  |  +---w service-id-or-name?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro service
     |        +--ro topology
@@ -189,7 +199,9 @@ module: tapi-virtual-network
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
-    |        +--ro schedule?              string
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
     |        +--ro state
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
@@ -201,7 +213,7 @@ module: tapi-virtual-network
     |           +--ro value?        string
     +---x get-virtual-network-service-details
     |  +---w input
-    |  |  +---w service-id-or-name?   string
+    |  |  +---w uuid?   tapi-common:uuid
     |  +--ro output
     |     +--ro service
     |        +--ro topology
@@ -243,7 +255,9 @@ module: tapi-virtual-network
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
-    |        +--ro schedule?              string
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
     |        +--ro state
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
@@ -295,7 +309,9 @@ module: tapi-virtual-network
              |  +--ro name* [value-name]
              |     +--ro value-name    string
              |     +--ro value?        string
-             +--ro schedule?              string
+             +--ro schedule
+             |  +--ro end-time?     date-and-time
+             |  +--ro start-time?   date-and-time
              +--ro state
              |  +--ro administrative-state?   administrative-state
              |  +--ro operational-state?      operational-state

--- a/YANG/tapi-virtual-network@2019-03-31.yang
+++ b/YANG/tapi-virtual-network@2019-03-31.yang
@@ -153,8 +153,8 @@ module tapi-virtual-network {
             uses virtual-network-constraint;
             description "none";
         }
-        leaf schedule {
-            type string;
+        container schedule {
+            uses tapi-common:time-range;
             description "none";
         }
         container state {
@@ -237,7 +237,21 @@ module tapi-virtual-network {
     rpc create-virtual-network-service {
         description "none";
         input {
-            list sep {
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+            }
+            list name {
+                key 'value-name';
+                uses tapi-common:name-and-value;
+                description "List of names. This value is unique in some namespace but may change during the life of the entity.
+                    A name carries no semantics with respect to the purpose of the entity.";
+            }
+            list end-point {
                 key 'local-id';
                 min-elements 2;
                 uses virtual-network-service-end-point;
@@ -247,8 +261,8 @@ module tapi-virtual-network {
                 uses virtual-network-constraint;
                 description "none";
             }
-            leaf conn-schedule {
-                type string;
+            container schedule {
+                uses tapi-common:time-range;
                 description "none";
             }
         }
@@ -262,9 +276,13 @@ module tapi-virtual-network {
     rpc delete-virtual-network-service {
         description "none";
         input {
-            leaf service-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {
@@ -277,9 +295,13 @@ module tapi-virtual-network {
     rpc get-virtual-network-service-details {
         description "none";
         input {
-            leaf service-id-or-name {
-                type string;
-                description "none";
+            leaf uuid {
+                type tapi-common:uuid;
+                description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable.
+                    An UUID carries no semantics with respect to the purpose or state of the entity.
+                    UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
+                    Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
+                    Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
             }
         }
         output {


### PR DESCRIPTION
- Updated all UML-Operations/YANG-RPCs to use UUIDs so that it is consistent with the REST CRUD data APIs flavor
- used consistent labels (uuid) for the UUID key parameters and fixed parameter type to TapiCommon::Uuid (instead of String)
- other minor bug fixes (explicit config=false statements)
- UML & corresponding Yang updates to align with PR #439 - created an CentralFrequencyBand datatype and using that in OtsiCapability pac instead of in-lining as in previous Yang commit